### PR TITLE
Fix TODOs and improve testing code

### DIFF
--- a/pkg/controller/kfservice/kfservice_controller.go
+++ b/pkg/controller/kfservice/kfservice_controller.go
@@ -159,12 +159,20 @@ func (r *ReconcileService) updateStatus(before *kfservingv1alpha1.KFService, ksv
 	} else {
 		after.Status.Canary.Name = ksvc.Status.LatestCreatedRevisionName
 	}
+	for _, traffic := range ksvc.Status.Traffic {
+		switch traffic.RevisionName {
+		case after.Status.Default.Name:
+			after.Status.Default.Traffic = traffic.Percent
+		case after.Status.Canary.Name:
+			after.Status.Canary.Traffic = traffic.Percent
+		default:
+		}
+	}
 	if equality.Semantic.DeepEqual(before.Status, after.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
-		// cache may be stale and we don't want to overwrite a prior update                                                                                               rwrite a prior update
+		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
-
 	} else if err := r.Update(context.TODO(), after); err != nil {
 		log.Error(err, "Failed to update kfsvc status")
 		r.Recorder.Eventf(after, v1.EventTypeWarning, "UpdateFailed",

--- a/pkg/frameworks/tensorflow/tensorflow_serving.go
+++ b/pkg/frameworks/tensorflow/tensorflow_serving.go
@@ -25,12 +25,13 @@ const (
 	TensorflowEntrypointCommand = "/usr/bin/tensorflow_model_server"
 	TensorflowServingGRPCPort   = "9000"
 	TensorflowServingRestPort   = "8080"
+	TensorflowServingImageName  = "tensorflow/serving"
 )
 
 func CreateTensorflowContainer(modelName string, tfSpec *v1alpha1.TensorflowSpec) *v1.Container {
 	//TODO(@yuzisun) add configmap for image, default resources, readiness/liveness probe
 	return &v1.Container{
-		Image:   "tensorflow/serving:" + tfSpec.RuntimeVersion,
+		Image:   TensorflowServingImageName + ":" + tfSpec.RuntimeVersion,
 		Command: []string{TensorflowEntrypointCommand},
 		Args: []string{
 			"--port=" + TensorflowServingGRPCPort,

--- a/pkg/reconciler/ksvc/resources/knative_service.go
+++ b/pkg/reconciler/ksvc/resources/knative_service.go
@@ -20,7 +20,7 @@ import (
 	knservingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha1"
 	"github.com/kubeflow/kfserving/pkg/frameworks/tensorflow"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,7 +42,6 @@ func CreateKnativeService(kfsvc *v1alpha1.KFService) (*knservingv1alpha1.Service
 		//TODO(@yuzisun) should we add model name to the spec, can be different than service name?
 		container = CreateModelServingContainer(kfsvc.Name, &kfsvc.Spec.Default)
 		revisions = []string{knservingv1alpha1.ReleaseLatestRevisionKeyword}
-		routingPercent = 0
 	} else {
 		container = CreateModelServingContainer(kfsvc.Name, &kfsvc.Spec.Canary.ModelSpec)
 		revisions = []string{kfsvc.Status.Default.Name, knservingv1alpha1.ReleaseLatestRevisionKeyword}


### PR DESCRIPTION
- populate default/canary traffic percent in status
- refactor testing code to reuse some of the boilerplate test types in `knative_service_test.go`
- fix the reconcile status expectation TODOs in `kfservice_controller_test.go`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/31)
<!-- Reviewable:end -->
