### PR TITLE
Remove file type "file://" and message in supported storage type list

### DIFF
--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -32,7 +32,6 @@ from minio import Minio
 _GCS_PREFIX = "gs://"
 _S3_PREFIX = "s3://"
 _BLOB_RE = "https://(.+?).blob.core.windows.net/(.+)"
-_LOCAL_PREFIX = "file://"
 _URI_RE = "https?://(.+)/(.+)"
 _HTTP_PREFIX = "http(s)://"
 
@@ -41,14 +40,10 @@ class Storage(object): # pylint: disable=too-few-public-methods
     def download(uri: str, out_dir: str = None) -> str:
         logging.info("Copying contents of %s to local", uri)
 
-        is_local = False
-        if uri.startswith(_LOCAL_PREFIX) or os.path.exists(uri):
-            is_local = True
+        if not "://" in uri:
+            return Storage._download_local(uri)
 
         if out_dir is None:
-            if is_local:
-                # noop if out_dir is not set and the path is local
-                return Storage._download_local(uri)
             out_dir = tempfile.mkdtemp()
         elif not os.path.exists(out_dir):
             os.mkdir(out_dir)
@@ -59,14 +54,12 @@ class Storage(object): # pylint: disable=too-few-public-methods
             Storage._download_s3(uri, out_dir)
         elif re.search(_BLOB_RE, uri):
             Storage._download_blob(uri, out_dir)
-        elif is_local:
-            return Storage._download_local(uri, out_dir)
         elif re.search(_URI_RE, uri):
             return Storage._download_from_uri(uri, out_dir)
         else:
             raise Exception("Cannot recognize storage type for " + uri +
-                            "\n'%s', '%s', '%s', and '%s' are the current available storage type." %
-                            (_GCS_PREFIX, _S3_PREFIX, _LOCAL_PREFIX, _HTTP_PREFIX))
+                            "\n'%s', '%s', and '%s' are the current available storage type." %
+                            (_GCS_PREFIX, _S3_PREFIX, _HTTP_PREFIX))
 
         logging.info("Successfully copied %s to %s", uri, out_dir)
         return out_dir
@@ -197,10 +190,9 @@ The path or model %s does not exist." % (uri))
         return token_credential
 
     @staticmethod
-    def _download_local(uri, out_dir=None):
-        local_path = uri.replace(_LOCAL_PREFIX, "", 1)
+    def _download_local(local_path, out_dir=None):
         if not os.path.exists(local_path):
-            raise RuntimeError("Local path %s does not exist." % (uri))
+            raise RuntimeError("Local path %s does not exist." % (local_path))
 
         if out_dir is None:
             return local_path

--- a/python/kfserving/test/test_storage.py
+++ b/python/kfserving/test/test_storage.py
@@ -22,20 +22,6 @@ import unittest.mock as mock
 
 STORAGE_MODULE = 'kfserving.storage'
 
-
-def test_storage_local_path():
-    abs_path = 'file:///'
-    relative_path = 'file://.'
-    assert kfserving.Storage.download(abs_path) == abs_path.replace("file://", "", 1)
-    assert kfserving.Storage.download(relative_path) == relative_path.replace("file://", "", 1)
-
-
-def test_storage_local_path_exception():
-    not_exist_path = 'file:///some/random/path'
-    with pytest.raises(Exception):
-        kfserving.Storage.download(not_exist_path)
-
-
 def test_no_prefix_local_path():
     abs_path = '/'
     relative_path = '.'


### PR DESCRIPTION
**What this PR does / why we need it**:
The file type and message is not supported and very confusing, so remove it from code. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1112 

In PR #622 besides remove it from storage initializer, meant to support build it to predictor image, this time remove it since it's not our use case.