### PR TITLE
#1593: Remove hard coded isvc default resource requests/limits.

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -189,3 +189,14 @@ data:
     {
       "defaultDeploymentMode": "Serverless"
     }
+  defaults: |-
+    {
+        "request": {
+            "cpu": "1",
+            "memory": "2Gi"
+        },
+        "limit": {
+            "cpu": "1",
+            "memory": "2Gi"
+        }
+    }

--- a/pkg/apis/serving/v1beta1/explainer_aix360.go
+++ b/pkg/apis/serving/v1beta1/explainer_aix360.go
@@ -102,7 +102,7 @@ func (s *AIXExplainerSpec) Default(config *InferenceServicesConfig) {
 	if s.RuntimeVersion == nil {
 		s.RuntimeVersion = proto.String(config.Explainers.AIXExplainer.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&s.Resources)
+	setResourceRequirementDefaults(&s.Resources, config)
 }
 
 // Validate the spec

--- a/pkg/apis/serving/v1beta1/explainer_aix360_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_aix360_test.go
@@ -36,6 +36,16 @@ func TestAIXExplainer(t *testing.T) {
 				DefaultImageVersion: "latest",
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	scenarios := map[string]struct {
@@ -81,6 +91,16 @@ func TestCreateAIXExplainerContainer(t *testing.T) {
 			AIXExplainer: ExplainerConfig{
 				ContainerImage:      "aipipeline/aixexplainer",
 				DefaultImageVersion: "latest",
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -143,6 +163,16 @@ func TestCreateAIXExplainerContainerWithConfig(t *testing.T) {
 				DefaultImageVersion: "latest",
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	ComponentExtensionSpec := ComponentExtensionSpec{
 		MaxReplicas: 2,
@@ -200,6 +230,16 @@ func TestAIXExplainerIsMMS(t *testing.T) {
 			AIXExplainer: ExplainerConfig{
 				ContainerImage:      "aipipeline/aixexplainer",
 				DefaultImageVersion: "latest",
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}

--- a/pkg/apis/serving/v1beta1/explainer_alibi.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi.go
@@ -111,7 +111,7 @@ func (s *AlibiExplainerSpec) Default(config *InferenceServicesConfig) {
 	if s.RuntimeVersion == nil {
 		s.RuntimeVersion = proto.String(config.Explainers.AlibiExplainer.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&s.Resources)
+	setResourceRequirementDefaults(&s.Resources, config)
 }
 
 // Validate the spec

--- a/pkg/apis/serving/v1beta1/explainer_alibi_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi_test.go
@@ -37,6 +37,16 @@ func TestAlibiValidation(t *testing.T) {
 				DefaultImageVersion: "v0.4.0",
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	scenarios := map[string]struct {
 		spec    ExplainerSpec
@@ -124,8 +134,18 @@ func TestAlibiDefaulter(t *testing.T) {
 				DefaultImageVersion: "v0.4.0",
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -208,6 +228,16 @@ func TestCreateAlibiModelServingContainer(t *testing.T) {
 			AlibiExplainer: ExplainerConfig{
 				ContainerImage:      "alibi",
 				DefaultImageVersion: "0.4.0",
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -390,6 +420,16 @@ func TestAlibiIsMMS(t *testing.T) {
 			AlibiExplainer: ExplainerConfig{
 				ContainerImage:      "alibi",
 				DefaultImageVersion: "v0.4.0",
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}

--- a/pkg/apis/serving/v1beta1/explainer_art.go
+++ b/pkg/apis/serving/v1beta1/explainer_art.go
@@ -100,7 +100,7 @@ func (s *ARTExplainerSpec) Default(config *InferenceServicesConfig) {
 	if s.RuntimeVersion == nil {
 		s.RuntimeVersion = proto.String(config.Explainers.ARTExplainer.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&s.Resources)
+	setResourceRequirementDefaults(&s.Resources, config)
 }
 
 // Validate the spec

--- a/pkg/apis/serving/v1beta1/explainer_art_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_art_test.go
@@ -36,6 +36,16 @@ func TestARTExplainer(t *testing.T) {
 				DefaultImageVersion: "latest",
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	scenarios := map[string]struct {
@@ -81,6 +91,16 @@ func TestCreateARTExplainerContainer(t *testing.T) {
 			ARTExplainer: ExplainerConfig{
 				ContainerImage:      "kfserving/art-server",
 				DefaultImageVersion: "latest",
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -143,6 +163,16 @@ func TestCreateARTExplainerContainerWithConfig(t *testing.T) {
 				DefaultImageVersion: "latest",
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	ComponentExtensionSpec := ComponentExtensionSpec{
 		MaxReplicas: 2,
@@ -200,6 +230,16 @@ func TestARTExplainerIsMMS(t *testing.T) {
 			ARTExplainer: ExplainerConfig{
 				ContainerImage:      "kfserving/art-server",
 				DefaultImageVersion: "latest",
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}

--- a/pkg/apis/serving/v1beta1/explainer_custom.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom.go
@@ -48,7 +48,7 @@ func (c *CustomExplainer) Default(config *InferenceServicesConfig) {
 		c.Containers = append(c.Containers, v1.Container{})
 	}
 	c.Containers[0].Name = constants.InferenceServiceContainerName
-	setResourceRequirementDefaults(&c.Containers[0].Resources)
+	setResourceRequirementDefaults(&c.Containers[0].Resources, config)
 }
 
 func (c *CustomExplainer) GetStorageUri() *string {

--- a/pkg/apis/serving/v1beta1/explainer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom_test.go
@@ -32,6 +32,16 @@ func TestCustomExplainerValidation(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	config := InferenceServicesConfig{
 		Explainers: ExplainersConfig{},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	scenarios := map[string]struct {
 		spec    ExplainerSpec
@@ -131,8 +141,18 @@ func TestCustomExplainerDefaulter(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	config := InferenceServicesConfig{
 		Explainers: ExplainersConfig{},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -206,6 +226,16 @@ func TestCreateCustomExplainerContainer(t *testing.T) {
 	}
 	var config = InferenceServicesConfig{
 		Transformers: TransformersConfig{},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	g := gomega.NewGomegaWithT(t)
 	scenarios := map[string]struct {
@@ -346,10 +376,16 @@ func TestCustomExplainerIsMMS(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	config := InferenceServicesConfig{
 		Explainers: ExplainersConfig{},
-	}
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	mmsCase := false
 	scenarios := map[string]struct {

--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -27,10 +26,6 @@ import (
 )
 
 var (
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
 	// logger for the mutating webhook.
 	mutatorLogger = logf.Log.WithName("inferenceservice-v1beta1-mutating-webhook")
 )
@@ -38,11 +33,11 @@ var (
 // +kubebuilder:webhook:path=/mutate-inferenceservices,mutating=true,failurePolicy=fail,groups=serving.kserve.io,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=inferenceservice.kserve-webhook-server.defaulter
 var _ webhook.Defaulter = &InferenceService{}
 
-func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
+func setResourceRequirementDefaults(requirements *v1.ResourceRequirements, config *InferenceServicesConfig) {
 	if requirements.Requests == nil {
 		requirements.Requests = v1.ResourceList{}
 	}
-	for k, v := range defaultResource {
+	for k, v := range config.Defaults.Request {
 		if _, ok := requirements.Requests[k]; !ok {
 			requirements.Requests[k] = v
 		}
@@ -51,7 +46,7 @@ func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
 	if requirements.Limits == nil {
 		requirements.Limits = v1.ResourceList{}
 	}
-	for k, v := range defaultResource {
+	for k, v := range config.Defaults.Limit {
 		if _, ok := requirements.Limits[k]; !ok {
 			requirements.Limits[k] = v
 		}

--- a/pkg/apis/serving/v1beta1/inference_service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,6 +42,20 @@ func TestInferenceServiceDefaults(t *testing.T) {
 				DefaultImageVersion: "v0.4.0",
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
+	}
+	defaultResource := v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("1"),
+		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
 	isvc := InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -107,6 +122,20 @@ func TestCustomPredictorDefaults(t *testing.T) {
 				DefaultImageVersion: "v0.4.0",
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
+	}
+	defaultResource := v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("1"),
+		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
 	isvc := InferenceService{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -66,7 +66,7 @@ func (c *CustomPredictor) Default(config *InferenceServicesConfig) {
 		c.Containers = append(c.Containers, v1.Container{})
 	}
 	c.Containers[0].Name = constants.InferenceServiceContainerName
-	setResourceRequirementDefaults(&c.Containers[0].Resources)
+	setResourceRequirementDefaults(&c.Containers[0].Resources, config)
 }
 
 func (c *CustomPredictor) GetStorageUri() *string {

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -190,8 +190,18 @@ func TestCustomPredictorDefaulter(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	config := InferenceServicesConfig{
 		Predictors: PredictorsConfig{},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -265,6 +275,16 @@ func TestCreateCustomPredictorContainer(t *testing.T) {
 	}
 	var config = InferenceServicesConfig{
 		Predictors: PredictorsConfig{},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	g := gomega.NewGomegaWithT(t)
 	scenarios := map[string]struct {
@@ -336,11 +356,16 @@ func TestCustomPredictorIsMMS(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	config := InferenceServicesConfig{
 		Predictors: PredictorsConfig{},
-	}
-
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	mmsCase := false
@@ -383,11 +408,16 @@ func TestCustomPredictorIsFrameworkSupported(t *testing.T) {
 	framework := "framework"
 	config := InferenceServicesConfig{
 		Predictors: PredictorsConfig{},
-	}
-
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	scenarios := map[string]struct {

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm.go
@@ -50,7 +50,7 @@ func (x *LightGBMSpec) Default(config *InferenceServicesConfig) {
 	if x.RuntimeVersion == nil {
 		x.RuntimeVersion = proto.String(config.Predictors.LightGBM.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&x.Resources)
+	setResourceRequirementDefaults(&x.Resources, config)
 
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm_test.go
@@ -115,8 +115,18 @@ func TestLightGBMDefaulter(t *testing.T) {
 				MultiModelServer:    true,
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -196,6 +206,16 @@ func TestCreateLightGBMModelServingContainer(t *testing.T) {
 				ContainerImage:      "someOtherImage",
 				DefaultImageVersion: "0.1.0",
 				MultiModelServer:    true,
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -365,10 +385,16 @@ func TestLightGBMIsMMS(t *testing.T) {
 					MultiModelServer:    mmsCase,
 				},
 			},
-		}
-		defaultResource = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: resource.MustParse("2Gi"),
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 		scenarios := map[string]struct {
 			spec     PredictorSpec
@@ -418,10 +444,16 @@ func TestLightGBMIsFrameworkSupported(t *testing.T) {
 				SupportedFrameworks: []string{"lightbgm"},
 			},
 		},
-	}
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -63,7 +63,7 @@ func (o *ONNXRuntimeSpec) Default(config *InferenceServicesConfig) {
 	if o.RuntimeVersion == nil {
 		o.RuntimeVersion = proto.String(config.Predictors.ONNX.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&o.Resources)
+	setResourceRequirementDefaults(&o.Resources, config)
 }
 
 // GetContainers transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime_test.go
@@ -135,8 +135,18 @@ func TestONNXRuntimeDefaulter(t *testing.T) {
 				MultiModelServer:    false,
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -220,6 +230,16 @@ func TestCreateONNXRuntimeContainer(t *testing.T) {
 				ContainerImage:      "mcr.microsoft.com/onnxruntime/server",
 				DefaultImageVersion: "v1.0.0",
 				MultiModelServer:    false,
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -376,10 +396,16 @@ func TestONNXRuntimeIsMMS(t *testing.T) {
 					MultiModelServer:    mmsCase,
 				},
 			},
-		}
-		defaultResource = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: resource.MustParse("2Gi"),
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 		scenarios := map[string]struct {
 			spec     PredictorSpec
@@ -429,10 +455,16 @@ func TestONNXRuntimeIsFrameworkSupported(t *testing.T) {
 				SupportedFrameworks: []string{onnx},
 			},
 		},
-	}
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec

--- a/pkg/apis/serving/v1beta1/predictor_paddle.go
+++ b/pkg/apis/serving/v1beta1/predictor_paddle.go
@@ -43,7 +43,7 @@ func (p *PaddleServerSpec) Default(config *InferenceServicesConfig) {
 	if p.RuntimeVersion == nil {
 		p.RuntimeVersion = proto.String(config.Predictors.Paddle.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&p.Resources)
+	setResourceRequirementDefaults(&p.Resources, config)
 }
 
 // GetContainers transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_paddle_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_paddle_test.go
@@ -114,6 +114,21 @@ func TestPaddleDefaulter(t *testing.T) {
 				MultiModelServer:    false,
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
+	}
+
+	defaultResource := v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("1"),
+		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
 
 	scenarios := map[string]struct {
@@ -161,6 +176,16 @@ func TestCreatePaddleContainer(t *testing.T) {
 				ContainerImage:      "paddleserver",
 				DefaultImageVersion: "latest",
 				MultiModelServer:    false,
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -332,10 +357,16 @@ func TestPaddleIsMMS(t *testing.T) {
 					MultiModelServer:    mmsCase,
 				},
 			},
-		}
-		defaultResource = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: resource.MustParse("2Gi"),
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 
 		scenarios := map[string]struct {
@@ -376,12 +407,18 @@ func TestPaddleIsFrameworkSupported(t *testing.T) {
 				SupportedFrameworks: []string{paddle},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec
 		framework string

--- a/pkg/apis/serving/v1beta1/predictor_pmml.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml.go
@@ -50,7 +50,7 @@ func (p *PMMLSpec) Default(config *InferenceServicesConfig) {
 	if p.RuntimeVersion == nil {
 		p.RuntimeVersion = proto.String(config.Predictors.PMML.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&p.Resources)
+	setResourceRequirementDefaults(&p.Resources, config)
 }
 
 // GetContainer transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_pmml_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml_test.go
@@ -115,8 +115,18 @@ func TestPMMLDefaulter(t *testing.T) {
 				MultiModelServer:    false,
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -200,6 +210,16 @@ func TestCreatePMMLModelServingContainer(t *testing.T) {
 				ContainerImage:      "someOtherImage",
 				DefaultImageVersion: "0.1.0",
 				MultiModelServer:    false,
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -364,10 +384,16 @@ func TestPMMLIsMMS(t *testing.T) {
 					MultiModelServer:    mmsCase,
 				},
 			},
-		}
-		defaultResource = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: resource.MustParse("2Gi"),
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 		scenarios := map[string]struct {
 			spec     PredictorSpec
@@ -417,10 +443,16 @@ func TestPMMLIsFrameworkSupported(t *testing.T) {
 				SupportedFrameworks: []string{"pmml"},
 			},
 		},
-	}
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec

--- a/pkg/apis/serving/v1beta1/predictor_sklearn.go
+++ b/pkg/apis/serving/v1beta1/predictor_sklearn.go
@@ -61,7 +61,7 @@ func (k *SKLearnSpec) Default(config *InferenceServicesConfig) {
 		k.ProtocolVersion = &defaultProtocol
 	}
 
-	setResourceRequirementDefaults(&k.Resources)
+	setResourceRequirementDefaults(&k.Resources, config)
 }
 
 // GetContainer transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_sklearn_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_sklearn_test.go
@@ -124,12 +124,22 @@ func TestSKLearnDefaulter(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	protocolV1 := constants.ProtocolV1
 	protocolV2 := constants.ProtocolV2
 
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -240,6 +250,16 @@ func TestCreateSKLearnModelServingContainerV1(t *testing.T) {
 					DefaultImageVersion: "0.2.0",
 					MultiModelServer:    true,
 				},
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -451,6 +471,16 @@ func TestCreateSKLearnModelServingContainerV2(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	g := gomega.NewGomegaWithT(t)
 	scenarios := map[string]struct {
@@ -640,15 +670,21 @@ func TestSKLearnIsMMS(t *testing.T) {
 					},
 				},
 			},
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 
 		protocolV1 := constants.ProtocolV1
 		protocolV2 := constants.ProtocolV2
 
-		defaultResource = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: resource.MustParse("2Gi"),
-		}
 		scenarios := map[string]struct {
 			spec     PredictorSpec
 			expected bool
@@ -714,15 +750,21 @@ func TestSKLearnIsFrameworkSupported(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	protocolV1 := constants.ProtocolV1
 	protocolV2 := constants.ProtocolV2
 
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec
 		framework string

--- a/pkg/apis/serving/v1beta1/predictor_tfserving.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving.go
@@ -77,7 +77,7 @@ func (t *TFServingSpec) Default(config *InferenceServicesConfig) {
 			t.RuntimeVersion = proto.String(config.Predictors.Tensorflow.DefaultImageVersion)
 		}
 	}
-	setResourceRequirementDefaults(&t.Resources)
+	setResourceRequirementDefaults(&t.Resources, config)
 }
 
 func (t *TFServingSpec) GetStorageUri() *string {

--- a/pkg/apis/serving/v1beta1/predictor_tfserving_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving_test.go
@@ -40,6 +40,16 @@ func TestTensorflowValidation(t *testing.T) {
 				MultiModelServer:       false,
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	scenarios := map[string]struct {
 		spec    PredictorSpec
@@ -153,8 +163,18 @@ func TestTensorflowDefaulter(t *testing.T) {
 				MultiModelServer:       false,
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -270,6 +290,16 @@ func TestCreateTFServingContainer(t *testing.T) {
 				DefaultImageVersion: "1.14.0",
 				DefaultTimeout:      60,
 				MultiModelServer:    false,
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -407,10 +437,16 @@ func TestTensorflowIsMMS(t *testing.T) {
 					MultiModelServer:       mmsCase,
 				},
 			},
-		}
-		defaultResource = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: resource.MustParse("2Gi"),
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 		defaultGpuResource := v1.ResourceList{
 			v1.ResourceCPU:                  resource.MustParse("1"),
@@ -480,12 +516,18 @@ func TestTensorflowIsFrameworkSupported(t *testing.T) {
 				SupportedFrameworks:    []string{tensorflow},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec
 		framework string

--- a/pkg/apis/serving/v1beta1/predictor_torchserve.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve.go
@@ -107,7 +107,7 @@ func (t *TorchServeSpec) Default(config *InferenceServicesConfig) {
 		}
 	}
 
-	setResourceRequirementDefaults(&t.Resources)
+	setResourceRequirementDefaults(&t.Resources, config)
 }
 
 // GetContainers transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_torchserve_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve_test.go
@@ -46,6 +46,16 @@ func TestTorchServeValidation(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	scenarios := map[string]struct {
 		spec    PredictorSpec
@@ -164,11 +174,21 @@ func TestTorchServeDefaulter(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	protocolV1 := constants.ProtocolV1
 
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 		v1.ResourceCPU:    resource.MustParse("1"),
 	}
@@ -288,6 +308,16 @@ func TestCreateTorchServeModelServingContainerV1(t *testing.T) {
 					DefaultImageVersion: "0.2.0",
 					MultiModelServer:    false,
 				},
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -471,6 +501,16 @@ func TestCreateTorchServeModelServingContainerV2(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	g := gomega.NewGomegaWithT(t)
 	scenarios := map[string]struct {
@@ -574,15 +614,21 @@ func TestTorchServeIsMMS(t *testing.T) {
 					},
 				},
 			},
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 
 		protocolV1 := constants.ProtocolV1
 		protocolV2 := constants.ProtocolV2
 
-		defaultResource = v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("2Gi"),
-			v1.ResourceCPU:    resource.MustParse("1"),
-		}
 		scenarios := map[string]struct {
 			spec     PredictorSpec
 			expected bool
@@ -651,15 +697,21 @@ func TestTorchServeIsFrameworkSupported(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	protocolV1 := constants.ProtocolV1
 	protocolV2 := constants.ProtocolV2
 
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec
 		framework string

--- a/pkg/apis/serving/v1beta1/predictor_triton.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton.go
@@ -54,7 +54,7 @@ func (t *TritonSpec) Default(config *InferenceServicesConfig) {
 	if t.RuntimeVersion == nil {
 		t.RuntimeVersion = proto.String(config.Predictors.Triton.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&t.Resources)
+	setResourceRequirementDefaults(&t.Resources, config)
 }
 
 // GetContainers transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_triton_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton_test.go
@@ -115,8 +115,18 @@ func TestTritonDefaulter(t *testing.T) {
 				MultiModelServer:    true,
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -200,6 +210,16 @@ func TestCreateTritonContainer(t *testing.T) {
 				ContainerImage:      "tritonserver",
 				DefaultImageVersion: "20.03-py3",
 				MultiModelServer:    true,
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -337,10 +357,16 @@ func TestTritonIsMMS(t *testing.T) {
 					MultiModelServer:    mmsCase,
 				},
 			},
-		}
-		defaultResource = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: resource.MustParse("2Gi"),
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 		scenarios := map[string]struct {
 			spec     PredictorSpec
@@ -390,10 +416,16 @@ func TestTritonIsFrameworkSupported(t *testing.T) {
 				SupportedFrameworks: []string{tensorrt},
 			},
 		},
-	}
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec

--- a/pkg/apis/serving/v1beta1/predictor_xgboost.go
+++ b/pkg/apis/serving/v1beta1/predictor_xgboost.go
@@ -61,7 +61,7 @@ func (x *XGBoostSpec) Default(config *InferenceServicesConfig) {
 		x.RuntimeVersion = &defaultVersion
 	}
 
-	setResourceRequirementDefaults(&x.Resources)
+	setResourceRequirementDefaults(&x.Resources, config)
 
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_xgboost_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_xgboost_test.go
@@ -123,12 +123,22 @@ func TestXGBoostDefaulter(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	protocolV1 := constants.ProtocolV1
 	protocolV2 := constants.ProtocolV2
 
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -237,6 +247,16 @@ func TestCreateXGBoostModelServingContainerV1(t *testing.T) {
 					DefaultImageVersion: "0.1.0",
 					MultiModelServer:    true,
 				},
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -421,6 +441,16 @@ func TestCreateXGBoostModelServingContainerV2(t *testing.T) {
 					DefaultImageVersion: "0.1.2",
 					MultiModelServer:    true,
 				},
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}
@@ -612,15 +642,20 @@ func TestXGBoostIsMMS(t *testing.T) {
 					},
 				},
 			},
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 
 		protocolV1 := constants.ProtocolV1
 		protocolV2 := constants.ProtocolV2
-
-		defaultResource = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("1"),
-			v1.ResourceMemory: resource.MustParse("2Gi"),
-		}
 
 		scenarios := map[string]struct {
 			spec     PredictorSpec
@@ -687,15 +722,21 @@ func TestXGBoostIsFrameworkSupported(t *testing.T) {
 				},
 			},
 		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	protocolV1 := constants.ProtocolV1
 	protocolV2 := constants.ProtocolV2
 
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
 	scenarios := map[string]struct {
 		spec      PredictorSpec
 		framework string

--- a/pkg/apis/serving/v1beta1/transformer_custom.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom.go
@@ -49,7 +49,7 @@ func (c *CustomTransformer) Default(config *InferenceServicesConfig) {
 		c.Containers = append(c.Containers, v1.Container{})
 	}
 	c.Containers[0].Name = constants.InferenceServiceContainerName
-	setResourceRequirementDefaults(&c.Containers[0].Resources)
+	setResourceRequirementDefaults(&c.Containers[0].Resources, config)
 }
 
 func (c *CustomTransformer) GetStorageUri() *string {

--- a/pkg/apis/serving/v1beta1/transformer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom_test.go
@@ -128,8 +128,18 @@ func TestTransformerDefaulter(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	config := InferenceServicesConfig{
 		Transformers: TransformersConfig{},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
-	defaultResource = v1.ResourceList{
+	defaultResource := v1.ResourceList{
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
@@ -203,6 +213,16 @@ func TestCreateTransformerContainer(t *testing.T) {
 	}
 	var config = InferenceServicesConfig{
 		Transformers: TransformersConfig{},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 	g := gomega.NewGomegaWithT(t)
 	scenarios := map[string]struct {
@@ -419,10 +439,16 @@ func TestTransformerIsMMS(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	config := InferenceServicesConfig{
 		Transformers: TransformersConfig{},
-	}
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+		},
 	}
 
 	// MMS for transformer is false

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -110,6 +110,16 @@ func TestIsMMSPredictor(t *testing.T) {
 					},
 				},
 			},
+			Defaults: IsvcDefaultConfig{
+				Request: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Limit: map[v1.ResourceName]resource.Quantity{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
 		}
 
 		scenarios := map[string]struct {
@@ -675,6 +685,16 @@ func TestIsMemoryResourceAvailable(t *testing.T) {
 					ContainerImage:      "mlserver",
 					DefaultImageVersion: "v0.1.2",
 				},
+			},
+		},
+		Defaults: IsvcDefaultConfig{
+			Request: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			Limit: map[v1.ResourceName]resource.Quantity{
+				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("2Gi"),
 			},
 		},
 	}


### PR DESCRIPTION
Removed hard coded isvc default resource requests/limits and extended the inferenceservice-config ConfigMap with these default values.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

fixes #1593

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
