### PR TITLE
Remove "default" suffix from generated component name

### DIFF
--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -55,7 +55,7 @@ var (
 type ComponentImplementation interface {
 	Default(config *InferenceServicesConfig)
 	Validate() error
-	GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container
+	GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container
 	GetStorageUri() *string
 	GetProtocol() constants.InferenceServiceProtocol
 	IsMMS(config *InferenceServicesConfig) bool

--- a/pkg/apis/serving/v1beta1/explainer_aix360.go
+++ b/pkg/apis/serving/v1beta1/explainer_aix360.go
@@ -56,7 +56,8 @@ func (s *AIXExplainerSpec) GetResourceRequirements() *v1.ResourceRequirements {
 	return &s.Resources
 }
 
-func (s *AIXExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (s *AIXExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	var args = []string{
 		constants.ArgumentModelName,
 		metadata.Name,
@@ -65,7 +66,7 @@ func (s *AIXExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentPredictorHost) {
 		args = append(args, constants.ArgumentPredictorHost,
-			fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace))
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace))
 
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentWorkers) {

--- a/pkg/apis/serving/v1beta1/explainer_aix360_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_aix360_test.go
@@ -119,7 +119,8 @@ func TestCreateAIXExplainerContainer(t *testing.T) {
 	}
 
 	// Test Create with config
-	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config)
+	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config,
+		"someName-predictor-default")
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
 
@@ -190,7 +191,8 @@ func TestCreateAIXExplainerContainerWithConfig(t *testing.T) {
 	}
 
 	// Test Create with config
-	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config)
+	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config,
+		"someName-predictor-default")
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
 

--- a/pkg/apis/serving/v1beta1/explainer_alibi.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi.go
@@ -84,7 +84,7 @@ func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentPredictorHost) {
 		args = append(args, constants.ArgumentPredictorHost,
-			fmt.Sprintf("%s.%s", predictorHost, metadata.Namespace))
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace))
 
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentWorkers) {

--- a/pkg/apis/serving/v1beta1/explainer_alibi.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi.go
@@ -76,14 +76,15 @@ func (s *AlibiExplainerSpec) GetResourceRequirements() *v1.ResourceRequirements 
 	return &s.Resources
 }
 
-func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	var args = []string{
 		constants.ArgumentModelName, metadata.Name,
 		constants.ArgumentHttpPort, constants.InferenceServiceDefaultHttpPort,
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentPredictorHost) {
 		args = append(args, constants.ArgumentPredictorHost,
-			fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace))
+			fmt.Sprintf("%s.%s", predictorHost, metadata.Namespace))
 
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentWorkers) {

--- a/pkg/apis/serving/v1beta1/explainer_alibi_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi_test.go
@@ -354,7 +354,8 @@ func TestCreateAlibiModelServingContainer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			explainer := scenario.isvc.Spec.Explainer.GetImplementation()
 			explainer.Default(&config)
-			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec, &config)
+			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec,
+				&config, constants.DefaultPredictorServiceName("someName"))
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/explainer_art.go
+++ b/pkg/apis/serving/v1beta1/explainer_art.go
@@ -56,14 +56,15 @@ func (s *ARTExplainerSpec) GetResourceRequirements() *v1.ResourceRequirements {
 	return &s.Resources
 }
 
-func (s *ARTExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (s *ARTExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	var args = []string{
 		constants.ArgumentModelName, metadata.Name,
 		constants.ArgumentHttpPort, constants.InferenceServiceDefaultHttpPort,
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentPredictorHost) {
 		args = append(args, constants.ArgumentPredictorHost,
-			fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace))
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace))
 
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentWorkers) {

--- a/pkg/apis/serving/v1beta1/explainer_art_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_art_test.go
@@ -119,7 +119,8 @@ func TestCreateARTExplainerContainer(t *testing.T) {
 	}
 
 	// Test Create with config
-	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config)
+	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config,
+		"someName-predictor-default")
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
 
@@ -190,7 +191,8 @@ func TestCreateARTExplainerContainerWithConfig(t *testing.T) {
 	}
 
 	// Test Create with config
-	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config)
+	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec,
+		config, "someName-predictor-default")
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
 

--- a/pkg/apis/serving/v1beta1/explainer_custom.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/kubeflow/kfserving/pkg/constants"
@@ -63,7 +64,8 @@ func (c *CustomExplainer) GetStorageUri() *string {
 }
 
 // GetContainer transforms the resource into a container spec
-func (c *CustomExplainer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (c *CustomExplainer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	container := &c.Containers[0]
 	if !utils.IncludesArg(container.Args, constants.ArgumentModelName) {
 		container.Args = append(container.Args, []string{
@@ -74,7 +76,7 @@ func (c *CustomExplainer) GetContainer(metadata metav1.ObjectMeta, extensions *C
 	if !utils.IncludesArg(container.Args, constants.ArgumentPredictorHost) {
 		container.Args = append(container.Args, []string{
 			constants.ArgumentPredictorHost,
-			constants.PredictorURL(metadata, false),
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace),
 		}...)
 	}
 	container.Args = append(container.Args, []string{

--- a/pkg/apis/serving/v1beta1/explainer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom_test.go
@@ -335,7 +335,8 @@ func TestCreateCustomExplainerContainer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			explainer := scenario.isvc.Spec.Explainer.GetImplementation()
 			explainer.Default(&config)
-			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec, &config)
+			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec,
+				&config, constants.DefaultPredictorServiceName("someName"))
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/openapi_generated.go
+++ b/pkg/apis/serving/v1beta1/openapi_generated.go
@@ -2624,7 +2624,6 @@ func schema_pkg_apis_serving_v1beta1_ExplainerExtensionSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -3630,7 +3629,6 @@ func schema_pkg_apis_serving_v1beta1_LightGBMSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -3915,7 +3913,6 @@ func schema_pkg_apis_serving_v1beta1_ONNXRuntimeSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -4173,7 +4170,6 @@ func schema_pkg_apis_serving_v1beta1_PMMLSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -4866,7 +4862,6 @@ func schema_pkg_apis_serving_v1beta1_PredictorExtensionSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5670,7 +5665,6 @@ func schema_pkg_apis_serving_v1beta1_SKLearnSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5928,7 +5922,6 @@ func schema_pkg_apis_serving_v1beta1_TFServingSpec(ref common.ReferenceCallback)
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -6193,7 +6186,6 @@ func schema_pkg_apis_serving_v1beta1_TorchServeSpec(ref common.ReferenceCallback
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -6917,7 +6909,6 @@ func schema_pkg_apis_serving_v1beta1_TritonSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -7175,7 +7166,6 @@ func schema_pkg_apis_serving_v1beta1_XGBoostSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -80,7 +80,8 @@ func (c *CustomPredictor) GetStorageUri() *string {
 }
 
 // GetContainers transforms the resource into a container spec
-func (c *CustomPredictor) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (c *CustomPredictor) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	return &c.Containers[0]
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm.go
@@ -56,7 +56,8 @@ func (x *LightGBMSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainer transforms the resource into a container spec
-func (x *LightGBMSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (x *LightGBMSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	cpuLimit := x.Resources.Limits.Cpu()
 	cpuLimit.RoundUp(0)
 	arguments := []string{

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -68,7 +68,8 @@ func (o *ONNXRuntimeSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainers transforms the resource into a container spec
-func (o *ONNXRuntimeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (o *ONNXRuntimeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	filename := DefaultONNXFileName
 
 	if o.GetStorageUri() != nil {

--- a/pkg/apis/serving/v1beta1/predictor_pmml.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml.go
@@ -54,7 +54,8 @@ func (p *PMMLSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainer transforms the resource into a container spec
-func (p *PMMLSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (p *PMMLSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	arguments := []string{
 		fmt.Sprintf("%s=%s", constants.ArgumentModelName, metadata.Name),
 		fmt.Sprintf("%s=%s", constants.ArgumentModelDir, constants.DefaultModelLocalMountPath),

--- a/pkg/apis/serving/v1beta1/predictor_sklearn.go
+++ b/pkg/apis/serving/v1beta1/predictor_sklearn.go
@@ -66,7 +66,8 @@ func (k *SKLearnSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainer transforms the resource into a container spec
-func (k *SKLearnSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (k *SKLearnSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	if k.ProtocolVersion == nil || *k.ProtocolVersion == constants.ProtocolV1 {
 		return k.getContainerV1(metadata, extensions, config)
 	}

--- a/pkg/apis/serving/v1beta1/predictor_tfserving.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving.go
@@ -86,7 +86,8 @@ func (t *TFServingSpec) GetStorageUri() *string {
 }
 
 // GetContainers transforms the resource into a container spec
-func (t *TFServingSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (t *TFServingSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	// Get the timeout from user input or else use the default timeout
 	TimeoutMilliSeconds := 1000 * config.Predictors.Tensorflow.DefaultTimeout
 	if extensions.TimeoutSeconds != nil {

--- a/pkg/apis/serving/v1beta1/predictor_torchserve.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve.go
@@ -112,7 +112,8 @@ func (t *TorchServeSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainers transforms the resource into a container spec
-func (t *TorchServeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (t *TorchServeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	if t.ProtocolVersion == nil || *t.ProtocolVersion == constants.ProtocolV1 {
 		if t.ModelClassName != "" {
 			return t.GetContainerV1(metadata, extensions, config)

--- a/pkg/apis/serving/v1beta1/predictor_triton.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton.go
@@ -59,7 +59,8 @@ func (t *TritonSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainers transforms the resource into a container spec
-func (t *TritonSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (t *TritonSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	arguments := []string{
 		"tritonserver",
 		fmt.Sprintf("%s=%s", "--model-store", constants.DefaultModelLocalMountPath),

--- a/pkg/apis/serving/v1beta1/predictor_xgboost.go
+++ b/pkg/apis/serving/v1beta1/predictor_xgboost.go
@@ -67,7 +67,8 @@ func (x *XGBoostSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainer transforms the resource into a container spec
-func (x *XGBoostSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (x *XGBoostSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	if x.ProtocolVersion == nil || *x.ProtocolVersion == constants.ProtocolV1 {
 		return x.getContainerV1(metadata, extensions, config)
 	}

--- a/pkg/apis/serving/v1beta1/transformer_custom.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom.go
@@ -64,7 +64,8 @@ func (c *CustomTransformer) GetStorageUri() *string {
 }
 
 // GetContainers transforms the resource into a container spec
-func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	container := &c.Containers[0]
 	if !utils.IncludesArg(container.Args, constants.ArgumentModelName) {
 		container.Args = append(container.Args, []string{
@@ -75,7 +76,7 @@ func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions 
 	if !utils.IncludesArg(container.Args, constants.ArgumentPredictorHost) {
 		container.Args = append(container.Args, []string{
 			constants.ArgumentPredictorHost,
-			fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace),
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace),
 		}...)
 	}
 	if !utils.IncludesArg(container.Args, constants.ArgumentHttpPort) {

--- a/pkg/apis/serving/v1beta1/transformer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom_test.go
@@ -408,7 +408,8 @@ func TestCreateTransformerContainer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			transformer := scenario.isvc.Spec.Transformer.GetImplementation()
 			transformer.Default(&config)
-			res := transformer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Transformer.ComponentExtensionSpec, &config)
+			res := transformer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Transformer.ComponentExtensionSpec,
+				&config, constants.DefaultPredictorServiceName("someName"))
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -251,6 +251,10 @@ func DefaultPredictorServiceName(name string) string {
 	return name + "-" + string(Predictor) + "-" + InferenceServiceDefault
 }
 
+func PredictorServiceName(name string) string {
+	return name + "-" + string(Predictor)
+}
+
 func CanaryPredictorServiceName(name string) string {
 	return name + "-" + string(Predictor) + "-" + InferenceServiceCanary
 }
@@ -259,12 +263,20 @@ func DefaultExplainerServiceName(name string) string {
 	return name + "-" + string(Explainer) + "-" + InferenceServiceDefault
 }
 
+func ExplainerServiceName(name string) string {
+	return name + "-" + string(Explainer)
+}
+
 func CanaryExplainerServiceName(name string) string {
 	return name + "-" + string(Explainer) + "-" + InferenceServiceCanary
 }
 
 func DefaultTransformerServiceName(name string) string {
 	return name + "-" + string(Transformer) + "-" + InferenceServiceDefault
+}
+
+func TransformerServiceName(name string) string {
+	return name + "-" + string(Transformer)
 }
 
 func CanaryTransformerServiceName(name string) string {

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -92,7 +92,8 @@ func (p *Explainer) Reconcile(isvc *v1beta1.InferenceService) error {
 			},
 		}
 	} else {
-		container := explainer.GetContainer(isvc.ObjectMeta, isvc.Spec.Explainer.GetExtensions(), p.inferenceServiceConfig)
+		container := explainer.GetContainer(isvc.ObjectMeta, isvc.Spec.Explainer.GetExtensions(), p.inferenceServiceConfig,
+			predictorName)
 		isvc.Spec.Explainer.PodSpec.Containers[0] = *container
 	}
 	if hasInferenceLogging {

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -15,7 +15,6 @@ package components
 
 import (
 	"context"
-	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/kubeflow/kfserving/pkg/controller/v1beta1/inferenceservice/reconcilers/knative"
@@ -87,7 +86,7 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) error {
 	}
 	if len(isvc.Spec.Transformer.PodSpec.Containers) == 0 {
 		container := transformer.GetContainer(isvc.ObjectMeta, isvc.Spec.Transformer.GetExtensions(), p.inferenceServiceConfig,
-			fmt.Sprintf("%s.%s", predictorName, isvc.Namespace))
+			predictorName)
 		isvc.Spec.Transformer.PodSpec = v1beta1.PodSpec{
 			Containers: []corev1.Container{
 				*container,

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -15,7 +15,6 @@ package inferenceservice
 
 import (
 	"context"
-	"fmt"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -381,7 +380,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			transformerService := &knservingv1.Service{}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), transformerServiceKey, transformerService) }, timeout).
 				Should(gomega.Succeed())
-			fmt.Printf("%v", transformerService)
 			expectedTransformerService := &knservingv1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      constants.TransformerServiceName(instance.Name),

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -113,7 +113,7 @@ func getServiceUrl(isvc *v1beta1.InferenceService) string {
 				return strings.Replace(transformerStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Transformer)), "",
 					1)
 			} else {
-				return strings.Replace(transformerStatus.URL.String(), fmt.Sprintf("-%s-default", string(constants.Transformer)), "", 1)
+				return strings.Replace(transformerStatus.URL.String(), fmt.Sprintf("-%s", string(constants.Transformer)), "", 1)
 			}
 		}
 	}
@@ -127,7 +127,7 @@ func getServiceUrl(isvc *v1beta1.InferenceService) string {
 			return strings.Replace(predictorStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Predictor)), "",
 				1)
 		} else {
-			return strings.Replace(predictorStatus.URL.String(), fmt.Sprintf("-%s-default", string(constants.Predictor)), "", 1)
+			return strings.Replace(predictorStatus.URL.String(), fmt.Sprintf("-%s", string(constants.Predictor)), "", 1)
 		}
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -36,6 +36,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/network"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -72,8 +73,13 @@ func getServiceHost(isvc *v1beta1.InferenceService) string {
 		} else if transformerStatus.URL == nil {
 			return ""
 		} else {
-			return strings.Replace(transformerStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Transformer)), "",
-				1)
+			if strings.Contains(transformerStatus.URL.Host, "-default") {
+				return strings.Replace(transformerStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Transformer)), "",
+					1)
+			} else {
+				return strings.Replace(transformerStatus.URL.Host, fmt.Sprintf("-%s", string(constants.Transformer)), "",
+					1)
+			}
 		}
 	}
 
@@ -82,8 +88,13 @@ func getServiceHost(isvc *v1beta1.InferenceService) string {
 	} else if predictorStatus.URL == nil {
 		return ""
 	} else {
-		return strings.Replace(predictorStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Predictor)), "",
-			1)
+		if strings.Contains(predictorStatus.URL.Host, "-default") {
+			return strings.Replace(predictorStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Predictor)), "",
+				1)
+		} else {
+			return strings.Replace(predictorStatus.URL.Host, fmt.Sprintf("-%s", string(constants.Predictor)), "",
+				1)
+		}
 	}
 }
 
@@ -98,7 +109,12 @@ func getServiceUrl(isvc *v1beta1.InferenceService) string {
 		} else if transformerStatus.URL == nil {
 			return ""
 		} else {
-			return strings.Replace(transformerStatus.URL.String(), fmt.Sprintf("-%s-default", string(constants.Transformer)), "", 1)
+			if strings.Contains(transformerStatus.URL.Host, "-default") {
+				return strings.Replace(transformerStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Transformer)), "",
+					1)
+			} else {
+				return strings.Replace(transformerStatus.URL.String(), fmt.Sprintf("-%s-default", string(constants.Transformer)), "", 1)
+			}
 		}
 	}
 
@@ -107,7 +123,12 @@ func getServiceUrl(isvc *v1beta1.InferenceService) string {
 	} else if predictorStatus.URL == nil {
 		return ""
 	} else {
-		return strings.Replace(predictorStatus.URL.String(), fmt.Sprintf("-%s-default", string(constants.Predictor)), "", 1)
+		if strings.Contains(predictorStatus.URL.Host, "-default") {
+			return strings.Replace(predictorStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Predictor)), "",
+				1)
+		} else {
+			return strings.Replace(predictorStatus.URL.String(), fmt.Sprintf("-%s-default", string(constants.Predictor)), "", 1)
+		}
 	}
 }
 
@@ -161,7 +182,7 @@ func (r *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceServ
 	return nil
 }
 
-func createHTTPRouteDestination(targetHost, namespace string, gatewayService string) *istiov1alpha3.HTTPRouteDestination {
+func createHTTPRouteDestination(gatewayService string) *istiov1alpha3.HTTPRouteDestination {
 	httpRouteDestination := &istiov1alpha3.HTTPRouteDestination{
 		Destination: &istiov1alpha3.Destination{
 			Host: gatewayService,
@@ -209,7 +230,7 @@ func createHTTPMatchRequest(prefix, targetHost, internalHost string, isInternal 
 	return matchRequests
 }
 
-func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig) *v1alpha3.VirtualService {
+func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1beta1.IngressConfig) *v1alpha3.VirtualService {
 	serviceHost := getServiceHost(isvc)
 	if serviceHost == "" {
 		return nil
@@ -223,10 +244,16 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 		})
 		return nil
 	}
-	backend := constants.DefaultPredictorServiceName(isvc.Name)
+	backend := constants.PredictorServiceName(isvc.Name)
+	if useDefault {
+		backend = constants.DefaultPredictorServiceName(isvc.Name)
+	}
 
 	if isvc.Spec.Transformer != nil {
-		backend = constants.DefaultTransformerServiceName(isvc.Name)
+		backend = constants.TransformerServiceName(isvc.Name)
+		if useDefault {
+			backend = constants.DefaultTransformerServiceName(isvc.Name)
+		}
 		if !isvc.Status.IsConditionReady(v1beta1.TransformerReady) {
 			isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
 				Type:   v1beta1.IngressReady,
@@ -247,6 +274,10 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 	}
 	httpRoutes := []*istiov1alpha3.HTTPRoute{}
 	// Build explain route
+	expBackend := constants.ExplainerServiceName(isvc.Name)
+	if useDefault {
+		expBackend = constants.DefaultExplainerServiceName(isvc.Name)
+	}
 	if isvc.Spec.Explainer != nil {
 		if !isvc.Status.IsConditionReady(v1beta1.ExplainerReady) {
 			isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
@@ -260,12 +291,12 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 			Match: createHTTPMatchRequest(constants.ExplainPrefix(), serviceHost,
 				network.GetServiceHostname(isvc.Name, isvc.Namespace), isInternal, config),
 			Route: []*istiov1alpha3.HTTPRouteDestination{
-				createHTTPRouteDestination(constants.DefaultExplainerServiceName(isvc.Name), isvc.Namespace, config.LocalGatewayServiceName),
+				createHTTPRouteDestination(config.LocalGatewayServiceName),
 			},
 			Headers: &istiov1alpha3.Headers{
 				Request: &istiov1alpha3.Headers_HeaderOperations{
 					Set: map[string]string{
-						"Host": network.GetServiceHostname(constants.DefaultExplainerServiceName(isvc.Name), isvc.Namespace),
+						"Host": network.GetServiceHostname(expBackend, isvc.Namespace),
 					},
 				},
 			},
@@ -277,7 +308,7 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 		Match: createHTTPMatchRequest("", serviceHost,
 			network.GetServiceHostname(isvc.Name, isvc.Namespace), isInternal, config),
 		Route: []*istiov1alpha3.HTTPRouteDestination{
-			createHTTPRouteDestination(backend, isvc.Namespace, config.LocalGatewayServiceName),
+			createHTTPRouteDestination(config.LocalGatewayServiceName),
 		},
 		Headers: &istiov1alpha3.Headers{
 			Request: &istiov1alpha3.Headers_HeaderOperations{
@@ -323,8 +354,14 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 	if serviceHost == "" || serviceUrl == "" {
 		return nil
 	}
+	defaultNameExisting := &knservingv1.Service{}
+	useDefault := false
+	err := ir.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, defaultNameExisting)
+	if err == nil {
+		useDefault = true
+	}
 	//Create ingress
-	desiredIngress := createIngress(isvc, ir.ingressConfig)
+	desiredIngress := createIngress(isvc, useDefault, ir.ingressConfig)
 	if desiredIngress == nil {
 		return nil
 	}
@@ -339,7 +376,7 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 	}
 
 	existing := &v1alpha3.VirtualService{}
-	err := ir.client.Get(context.TODO(), types.NamespacedName{Name: desiredIngress.Name, Namespace: desiredIngress.Namespace}, existing)
+	err = ir.client.Get(context.TODO(), types.NamespacedName{Name: desiredIngress.Name, Namespace: desiredIngress.Namespace}, existing)
 	if err != nil {
 		if apierr.IsNotFound(err) {
 			log.Info("Creating Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -96,7 +96,7 @@ func TestCreateVirtualService(t *testing.T) {
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace),
+							Host:   network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace),
 						},
 					},
 				},
@@ -118,7 +118,7 @@ func TestCreateVirtualService(t *testing.T) {
 						},
 						Headers: &istiov1alpha3.Headers{
 							Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-								"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)}},
+								"Host": network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace)}},
 						},
 					},
 				},
@@ -139,12 +139,12 @@ func TestCreateVirtualService(t *testing.T) {
 				v1beta1.PredictorComponent: {
 					URL: &apis.URL{
 						Scheme: "http",
-						Host:   network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace),
+						Host:   network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace),
 					},
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace),
+							Host:   network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace),
 						},
 					},
 				},
@@ -175,7 +175,7 @@ func TestCreateVirtualService(t *testing.T) {
 						},
 						Headers: &istiov1alpha3.Headers{
 							Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-								"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)}},
+								"Host": network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace)}},
 						},
 					},
 				},
@@ -226,7 +226,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Address: &duckv1.Addressable{
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+								Host:   network.GetServiceHostname(constants.TransformerServiceName(serviceName), namespace),
 							},
 						},
 					},
@@ -238,7 +238,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Address: &duckv1.Addressable{
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace),
+								Host:   network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace),
 							},
 						},
 					},
@@ -260,7 +260,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-									"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+									"Host": network.GetServiceHostname(constants.TransformerServiceName(serviceName), namespace),
 								}},
 							},
 						},
@@ -291,7 +291,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Address: &duckv1.Addressable{
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+								Host:   network.GetServiceHostname(constants.TransformerServiceName(serviceName), namespace),
 							},
 						},
 					},
@@ -325,7 +325,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-									"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+									"Host": network.GetServiceHostname(constants.TransformerServiceName(serviceName), namespace),
 								}},
 							},
 						},
@@ -376,7 +376,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Address: &duckv1.Addressable{
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   network.GetServiceHostname(constants.DefaultExplainerServiceName(serviceName), namespace),
+								Host:   network.GetServiceHostname(constants.ExplainerServiceName(serviceName), namespace),
 							},
 						},
 					},
@@ -437,7 +437,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-									"Host": network.GetServiceHostname(constants.DefaultExplainerServiceName(serviceName), namespace)},
+									"Host": network.GetServiceHostname(constants.ExplainerServiceName(serviceName), namespace)},
 								},
 							},
 						},
@@ -451,7 +451,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-									"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)},
+									"Host": network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace)},
 								},
 							},
 						},
@@ -490,7 +490,7 @@ func TestCreateVirtualService(t *testing.T) {
 				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
 			}
 
-			actualService := createIngress(testIsvc, ingressConfig)
+			actualService := createIngress(testIsvc, false, ingressConfig)
 			if diff := cmp.Diff(tc.expectedService, actualService); diff != "" {
 				t.Errorf("Test %q unexpected status (-want +got): %v", tc.name, diff)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1397 

**Special notes for your reviewer**:

1. Default name suffix was left from legacy reason when we were creating default/canary pair in v1alpha2, we should remove it now as it adds to the dns name limits
2. In order to to backwards compatible for existing deployed service, we do not change the generated if the controller detects that the service exists.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
