### PR TITLE
Enable Istio injection in e2e namespace and add Auth policy

### DIFF
--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -28,15 +28,15 @@ KNATIVE_VERSION="v0.22.0"
 KUBECTL_VERSION="v1.20.2"
 CERT_MANAGER_VERSION="v1.2.0"
 
-echo "Upgrading kubectl ..."
+echo "==========Upgrading kubectl ...=========="
 wget -q -O /usr/local/bin/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 chmod a+x /usr/local/bin/kubectl
 
-echo "Configuring kubectl ..."
+echo "==========Configuring kubectl ...=========="
 pip3 install awscli --upgrade --user
 aws eks update-kubeconfig --region=${AWS_REGION} --name=${CLUSTER_NAME}
 
-echo "Install istio ..."
+echo "==========Install istio ...=========="
 mkdir istio_tmp
 pushd istio_tmp >/dev/null
   curl -L https://git.io/getLatestIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
@@ -72,10 +72,20 @@ EOF
 
 popd
 
-echo "Waiting for istio started ..."
+echo "==========Waiting for istio started ...=========="
 kubectl wait --for=condition=Ready pods --all --timeout=180s -n istio-system
 
-echo "Installing knative serving ..."
+echo "==========Installing Istio Global Deny-All AuthorizationPolicy ...=========="
+cat <<EOF | kubectl apply -f -
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: global-deny-all
+  namespace: istio-system
+spec: {}
+EOF
+
+echo "==========Installing knative serving ...=========="
 kubectl apply -f https://github.com/knative/operator/releases/download/${KNATIVE_VERSION}/operator.yaml
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -92,7 +102,7 @@ metadata:
   namespace: knative-serving
 EOF
 
-echo "Waiting for knative started ..."
+echo "==========Waiting for knative started ...=========="
 kubectl wait --for=condition=Ready knativeservings -n knative-serving knative-serving --timeout=180s
 kubectl wait --for=condition=Ready pods --all --timeout=180s -n knative-serving -l 'app in (activator,autoscaler,autoscaler-hpa,controller,istio-webhook,networking-istio)'
 
@@ -101,15 +111,15 @@ kubectl patch cm config-deployment --patch '{"data":{"registriesSkippingTagResol
 # give longer revision timeout
 kubectl patch cm config-deployment --patch '{"data":{"progressDeadline": "600s"}}' -n knative-serving
 
-echo "Installing cert manager ..."
+echo "==========Installing cert manager ...=========="
 kubectl create namespace cert-manager
 sleep 2
 kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
 
-echo "Waiting for cert manager started ..."
+echo "==========Waiting for cert manager started ...=========="
 kubectl wait --for=condition=ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager
 
-echo "Install KFServing ..."
+echo "==========Install KFServing ...=========="
 export GOPATH="$HOME/go"
 export PATH="${PATH}:${GOPATH}/bin"
 mkdir -p ${GOPATH}/src/github.com/kubeflow
@@ -122,16 +132,16 @@ sed -i -e "s/latest/${PULL_BASE_SHA}/g" config/overlays/test/configmap/inference
 sed -i -e "s/latest/${PULL_BASE_SHA}/g" config/overlays/test/manager_image_patch.yaml
 make deploy-ci
 
-echo "Waiting for KFServing started ..."
+echo "==========Waiting for KFServing started ...=========="
 kubectl wait --for=condition=Ready pods --all --timeout=180s -n kfserving-system
 
-echo "Creating a namespace kfserving-ci-test ..."
+echo "==========Creating a namespace kfserving-ci-test ...=========="
 kubectl create namespace kfserving-ci-e2e-test
 
-echo "Enabling istio injection in kfserving-ci-test namespace ..."
+echo "==========Enabling istio injection in kfserving-ci-test namespace ...=========="
 kubectl label namespace kfserving-ci-e2e-test istio-injection=enabled
 
-echo "Creating istio AuthorizationPolicy in kfserving-ci-test namespace ..."
+echo "==========Creating istio AuthorizationPolicy in kfserving-ci-test namespace ...=========="
 cat <<EOF | kubectl apply -f -
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
@@ -158,9 +168,9 @@ spec:
         - /v1/models/*
 EOF
 
-echo "Istio, Knative and KFServing have been installed and started."
+echo "==========Istio, Knative and KFServing have been installed and started.=========="
 
-echo "Installing KFServing Python SDK ..."
+echo "==========Installing KFServing Python SDK ...=========="
 python3 -m pip install --upgrade pip
 pip3 install pytest==6.0.2 pytest-xdist pytest-rerunfailures
 pip3 install --upgrade pytest-tornasync
@@ -171,7 +181,7 @@ pushd python/kfserving >/dev/null
     python3 setup.py install --force --user
 popd
 
-echo "Starting E2E functional tests ..."
+echo "==========Starting E2E functional tests ...=========="
 pushd test/e2e >/dev/null
   pytest -n 4 --ignore=credentials/test_set_creds.py
 popd

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -43,32 +43,20 @@ pushd istio_tmp >/dev/null
   cd istio-${ISTIO_VERSION}
   export PATH=$PWD/bin:$PATH
   istioctl operator init
-  cat << EOF > ./istio-minimal-operator.yaml
+  echo "==========Waiting for istio-operator started ...=========="
+  kubectl wait --for=condition=Ready pods --all --timeout=180s -n istio-operator
+
+  cat <<EOF | kubectl apply -f -
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: istio
 spec:
-  values:
-    global:
-      proxy:
-        autoInject: enabled
-      useMCP: false
-      # The third-party-jwt is not enabled on all k8s.
-      # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens
-      jwtPolicy: first-party-jwt
-
+  profile: default
   meshConfig:
     accessLogFile: /dev/stdout
-
-  addonComponents:
-    pilot:
-      enabled: true
-
-  components:
-    ingressGateways:
-      - name: istio-ingressgateway
-        enabled: true
 EOF
-  istioctl manifest install -y -f ./istio-minimal-operator.yaml
 
 popd
 

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -90,6 +90,22 @@ metadata:
   namespace: knative-serving
 EOF
 
+echo "==========Installing Istio Allow AuthorizationPolicy for knative-serving namespace ...=========="
+cat <<EOF | kubectl apply -f -
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-knative-serving
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: v0.22.0
+    networking.knative.dev/ingress-provider: istio
+spec:
+  action: ALLOW
+  rules:
+  - {}
+EOF
+
 echo "==========Waiting for knative started ...=========="
 kubectl wait --for=condition=Ready knativeservings -n knative-serving knative-serving --timeout=180s
 kubectl wait --for=condition=Ready pods --all --timeout=180s -n knative-serving -l 'app in (activator,autoscaler,autoscaler-hpa,controller,istio-webhook,networking-istio)'

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -50,7 +50,7 @@ spec:
   values:
     global:
       proxy:
-        autoInject: disabled
+        autoInject: enabled
       useMCP: false
       # The third-party-jwt is not enabled on all k8s.
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enabled Istio injection in the namespace created for KFServing during the E2E tests, and applies the Istio AuthorizationPolicy the profile-controller would deploy from PR https://github.com/kubeflow/kubeflow/pull/6013 to the testing namespace. The AuthorizationPolicy created by the profile-controller from PR https://github.com/kubeflow/kubeflow/pull/6013 differs slightly from the current one, as it adds the `/ready` and `/v1/models/*` paths to the allow array and adds a principal for this array ensuring only the KNative controller can access those paths. Without the selector, users could access those paths in any other user's namespace, breaking multi-user isolation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubeflow/kfserving/issues/1558

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
