### PR TITLE
Azure Blob Upgrade Bug Fix

### DIFF
--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 import requests
 from pathlib import Path
 from azure.storage.blob import BlobServiceClient
+from azure.storage.blob._list_blobs_helper import BlobPrefix
 
 from botocore.client import Config
 from botocore import UNSIGNED
@@ -177,9 +178,22 @@ The path or model %s does not exist." % uri)
         blob_service_client = BlobServiceClient(account_url, credential=token)
         container_client = blob_service_client.get_container_client(container_name)
         count = 0
-        blobs = container_client.list_blobs(prefix=prefix)
+        blobs = []
+        max_depth = 5
+        stack = [(prefix, max_depth)]
+        while stack:
+            curr_prefix, depth = stack.pop()
+            if depth < 0:
+                continue
+            for item in container_client.walk_blobs(
+                            name_starts_with=curr_prefix):
+                if isinstance(item, BlobPrefix):
+                    stack.append((item.name, depth - 1))
+                else:
+                    blobs += container_client.list_blobs(name_starts_with=item.name,
+                                                         include=['snapshots'])
         for blob in blobs:
-            dest_path = os.path.join(out_dir, blob.name)
+            dest_path = os.path.join(out_dir, blob.name.replace(prefix, ""))
             Path(os.path.dirname(dest_path)).mkdir(parents=True, exist_ok=True)
             logging.info("Downloading: %s to %s", blob.name, dest_path)
             downloader = container_client.download_blob(blob.name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR addresses a bug which was introduced when we upgraded to Azure Blob 12.1.X or greater. Previously we thought that the container_client will filter blobs with a prefix but that's not the case. Per the [documentation](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-list?tabs=python#use-a-hierarchical-listing) you need to implement your own logic. 

This PR introduces the use of a stack to iterate over the blob directories trees, and ensures blobs are saved without the prefix so it can work with inference services which expect certain artifacts to be in a standard format.

Typically you'll see storageUris which are structured like these: 
```
storageUri: https://<account>.blob.core.windows.net/private/models/iris-example/
storageUri: https://<account>.blob.core.windows.net/private/models/ner-tensorflow/1/
```

The prefix will be anything after the container name, the container name in this case is ```private```. Furthermore the artifacts would need to be written to the ```/mnt/models/``` directory without the prefix to ensure that the predictors can read the artifacts in the expected format.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #923 

**Special notes for your reviewer**:

This should be addressed and merged prior the next release.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
