### PR TITLE
Fix web app serviceLogs for raw deployment

### DIFF
--- a/web-app/backend/apps/common/routes/get.py
+++ b/web-app/backend/apps/common/routes/get.py
@@ -37,7 +37,10 @@ def get_inference_service_logs(svc):
     log.info(components)
 
     # dictionary{component: [pod-names]}
-    component_pods_dict = utils.get_inference_service_pods(svc, components)
+    if svc["metadata"]["annotations"].get("serving.kubeflow.org/raw", "false") == "true":
+        component_pods_dict = utils.get_raw_inference_service_pods(svc, components)
+    else:
+        component_pods_dict = utils.get_inference_service_pods(svc, components)
 
     if len(component_pods_dict.keys()) == 0:
         return {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes a bug  in web-app that happens when we use a raw deployment inference service.

When we use a raw deployment (i.e. `serving.kubeflow.org/raw=true`), we can not get logs by web app. 

It should be fixed in the route `/api/namespaces/<namespace>/inferenceservices/<name>?logs=true`.

When the Inference service has an annotation `serving.kubeflow.org/raw=true`,  we should get pods by label `serving.kubeflow.org/inferenceservice` instead of `serving.knative.dev/revision`




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1775 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
