### PR TITLE
Fixed error with e2e due to kfserving reference in test overlay

### DIFF
--- a/config/overlays/test/manager_image_patch.yaml
+++ b/config/overlays/test/manager_image_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: kfserving-controller-manager
+  name: kserve-controller-manager
   namespace: kserve
 spec:
   template:

--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -56,7 +56,7 @@ kubectl wait --for=condition=available --timeout=600s deployment/cert-manager-we
 cd ..
 # Install KFServing
 KSERVE_CONFIG=kfserving.yaml
-if [ ${KSERVE_VERSION:3:1} > 6 ]; then KSERVE_CONFIG=kserve.yaml; fi
+if [ ${KSERVE_VERSION:3:1} -gt 6 ]; then KSERVE_CONFIG=kserve.yaml; fi
 
 # Retry inorder to handle that it may take a minute or so for the TLS assets required for the webhook to function to be provisioned
 for i in 1 2 3 4 5 ; do kubectl apply -f install/${KSERVE_VERSION}/${KSERVE_CONFIG} && break || sleep 15; done

--- a/install/v0.7.0-rc0/kserve.yaml
+++ b/install/v0.7.0-rc0/kserve.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: kfserving-controller-manager
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
     istio-injection: disabled
   name: kserve
@@ -23,7 +23,7 @@ spec:
     webhookClientConfig:
       caBundle: Cg==
       service:
-        name: kfserving-webhook-server-service
+        name: kserve-webhook-server-service
         namespace: kserve
         path: /convert
   group: serving.kserve.io
@@ -16141,9 +16141,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: kfserving-models-web-app
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app.kubernetes.io/component: kserve-models-web-app
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kserve
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16183,7 +16183,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: kfserving-manager-role
+  name: kserve-manager-role
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
@@ -16394,9 +16394,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: kfserving-models-web-app
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app-cluster-role
+    app.kubernetes.io/component: kserve-models-web-app
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app-cluster-role
 rules:
 - apiGroups:
   - authorization.k8s.io
@@ -16446,7 +16446,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kfserving-proxy-role
+  name: kserve-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -16478,11 +16478,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kfserving-manager-rolebinding
+  name: kserve-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfserving-manager-role
+  name: kserve-manager-role
 subjects:
 - kind: ServiceAccount
   name: default
@@ -16492,26 +16492,26 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: kfserving-models-web-app
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app-binding
+    app.kubernetes.io/component: kserve-models-web-app
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfserving-models-web-app-cluster-role
+  name: kserve-models-web-app-cluster-role
 subjects:
 - kind: ServiceAccount
-  name: kfserving-models-web-app
+  name: kserve-models-web-app
   namespace: kserve
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kfserving-proxy-rolebinding
+  name: kserve-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfserving-proxy-role
+  name: kserve-proxy-role
 subjects:
 - kind: ServiceAccount
   name: default
@@ -16599,7 +16599,7 @@ data:
         },
         "sklearn": {
           "v1": {
-            "image": "gcr.io/kfserving/sklearnserver",
+            "image": "kserve/sklearnserver",
             "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "sklearn"
@@ -16617,7 +16617,7 @@ data:
         },
         "xgboost": {
           "v1": {
-            "image": "gcr.io/kfserving/xgbserver",
+            "image": "kserve/xgbserver",
             "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "xgboost"
@@ -16635,7 +16635,7 @@ data:
         },
         "pytorch": {
           "v1" : {
-            "image": "gcr.io/kfserving/pytorchserver",
+            "image": "kserve/pytorchserver",
             "defaultImageVersion": "latest",
             "defaultGpuImageVersion": "latest-gpu",
             "supportedFrameworks": [
@@ -16645,8 +16645,8 @@ data:
           },
           "v2" : {
             "image": "pytorch/torchserve-kfs",
-            "defaultImageVersion": "0.4.0",
-            "defaultGpuImageVersion": "0.4.0-gpu",
+            "defaultImageVersion": "0.4.1",
+            "defaultGpuImageVersion": "0.4.1-gpu",
             "supportedFrameworks": [
               "pytorch"
             ],
@@ -16711,7 +16711,7 @@ data:
   ingressGateway: knative-serving/knative-ingress-gateway
 kind: ConfigMap
 metadata:
-  name: kfserving-config
+  name: kserve-config
   namespace: kserve
 ---
 apiVersion: v1
@@ -16720,15 +16720,15 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: kfserving-models-web-app
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app-config-9kkt28dhgb
+    app.kubernetes.io/component: kserve-models-web-app
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app-config-9kkt28dhgb
   namespace: kserve
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kfserving-webhook-server-secret
+  name: kserve-webhook-server-secret
   namespace: kserve
 ---
 apiVersion: v1
@@ -16739,9 +16739,9 @@ metadata:
     prometheus.io/scheme: https
     prometheus.io/scrape: "true"
   labels:
-    control-plane: kfserving-controller-manager
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
-  name: kfserving-controller-manager-metrics-service
+  name: kserve-controller-manager-metrics-service
   namespace: kserve
 spec:
   ports:
@@ -16749,31 +16749,31 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: kfserving-controller-manager
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: kfserving-controller-manager
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
-  name: kfserving-controller-manager-service
+  name: kserve-controller-manager-service
   namespace: kserve
 spec:
   ports:
   - port: 443
   selector:
-    control-plane: kfserving-controller-manager
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: kfserving-models-web-app
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app.kubernetes.io/component: kserve-models-web-app
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kserve
 spec:
   ports:
@@ -16782,71 +16782,71 @@ spec:
     protocol: TCP
     targetPort: 5000
   selector:
-    app.kubernetes.io/component: kfserving-models-web-app
-    kustomize.component: kfserving-models-web-app
+    app.kubernetes.io/component: kserve-models-web-app
+    kustomize.component: kserve-models-web-app
   type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: kfserving-webhook-server-service
+  name: kserve-webhook-server-service
   namespace: kserve
 spec:
   ports:
   - port: 443
     targetPort: webhook-server
   selector:
-    control-plane: kfserving-controller-manager
+    control-plane: kserve-controller-manager
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: kfserving-models-web-app
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app.kubernetes.io/component: kserve-models-web-app
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kserve
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: kfserving-models-web-app
-      kustomize.component: kfserving-models-web-app
+      app.kubernetes.io/component: kserve-models-web-app
+      kustomize.component: kserve-models-web-app
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: kfserving-models-web-app
-        kustomize.component: kfserving-models-web-app
+        app.kubernetes.io/component: kserve-models-web-app
+        kustomize.component: kserve-models-web-app
     spec:
       containers:
       - envFrom:
         - configMapRef:
-            name: kfserving-models-web-app-config-9kkt28dhgb
-        image: kfserving/models-web-app:v0.7.0-rc0
+            name: kserve-models-web-app-config-9kkt28dhgb
+        image: andyarok/models-web-app:v0.7.0-rc0
         imagePullPolicy: Always
-        name: kfserving-models-web-app
+        name: kserve-models-web-app
         ports:
         - containerPort: 5000
-      serviceAccountName: kfserving-models-web-app
+      serviceAccountName: kserve-models-web-app
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    control-plane: kfserving-controller-manager
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
-  name: kfserving-controller-manager
+  name: kserve-controller-manager
   namespace: kserve
 spec:
   selector:
     matchLabels:
-      control-plane: kfserving-controller-manager
+      control-plane: kserve-controller-manager
       controller-tools.k8s.io: "1.0"
   serviceName: controller-manager-service
   template:
     metadata:
       labels:
-        control-plane: kfserving-controller-manager
+        control-plane: kserve-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
@@ -16860,8 +16860,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: SECRET_NAME
-          value: kfserving-webhook-server-cert
-        image: gcr.io/kfserving/kfserving-controller:v0.7.0-rc0
+          value: kserve-webhook-server-cert
+        image: kserve/kserve-controller:v0.7.0-rc0
         imagePullPolicy: Always
         name: manager
         ports:
@@ -16894,7 +16894,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: kfserving-webhook-server-cert
+          secretName: kserve-webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
@@ -16902,13 +16902,13 @@ metadata:
   name: serving-cert
   namespace: kserve
 spec:
-  commonName: kfserving-webhook-server-service.kserve.svc
+  commonName: kserve-webhook-server-service.kserve.svc
   dnsNames:
-  - kfserving-webhook-server-service.kserve.svc
+  - kserve-webhook-server-service.kserve.svc
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: kfserving-webhook-server-cert
+  secretName: kserve-webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
@@ -16922,9 +16922,9 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   labels:
-    app.kubernetes.io/component: kfserving-models-web-app
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app.kubernetes.io/component: kserve-models-web-app
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kserve
 spec:
   gateways:
@@ -16939,7 +16939,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: kfserving-models-web-app.kserve.svc.cluster.local
+        host: kserve-models-web-app.kserve.svc.cluster.local
         port:
           number: 80
 ---
@@ -16953,11 +16953,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kserve
       path: /mutate-serving-kserve-io-v1alpha2-inferenceservice
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.defaulter
+  name: inferenceservice.kserve-webhook-server.defaulter
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -16971,11 +16971,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kserve
       path: /mutate-serving-kserve-io-v1beta1-inferenceservice
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.v1beta1.defaulter
+  name: inferenceservice.kserve-webhook-server.v1beta1.defaulter
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -16989,11 +16989,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kserve
       path: /mutate-pods
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.pod-mutator
+  name: inferenceservice.kserve-webhook-server.pod-mutator
   namespaceSelector:
     matchExpressions:
     - key: control-plane
@@ -17023,11 +17023,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kserve
       path: /validate-serving-kserve-io-v1alpha2-inferenceservice
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.validator
+  name: inferenceservice.kserve-webhook-server.validator
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -17041,11 +17041,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kserve
       path: /validate-serving-kserve-io-v1beta1-inferenceservice
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.v1beta1.validator
+  name: inferenceservice.kserve-webhook-server.v1beta1.validator
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -17067,11 +17067,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kserve
       path: /validate-serving-kserve-io-v1alpha1-trainedmodel
   failurePolicy: Fail
-  name: trainedmodel.kfserving-webhook-server.validator
+  name: trainedmodel.kserve-webhook-server.validator
   rules:
   - apiGroups:
     - serving.kserve.io

--- a/install/v0.7.0-rc0/kserve_kubeflow.yaml
+++ b/install/v0.7.0-rc0/kserve_kubeflow.yaml
@@ -5,8 +5,8 @@ metadata:
     cert-manager.io/inject-ca-from: kubeflow/serving-cert
     controller-gen.kubebuilder.io/version: v0.3.1-0.20200528125929-5c0c6ae3b64b
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: inferenceservices.serving.kserve.io
 spec:
   conversion:
@@ -17,7 +17,7 @@ spec:
     webhookClientConfig:
       caBundle: Cg==
       service:
-        name: kfserving-webhook-server-service
+        name: kserve-webhook-server-service
         namespace: kubeflow
         path: /convert
   group: serving.kserve.io
@@ -16025,8 +16025,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.3.1-0.20200528125929-5c0c6ae3b64b
   creationTimestamp: null
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: trainedmodels.serving.kserve.io
 spec:
   additionalPrinterColumns:
@@ -16138,19 +16138,19 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kubeflow
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: leader-election-role
   namespace: kubeflow
 rules:
@@ -16186,9 +16186,9 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-  name: kfserving-manager-role
+    app: kserve
+    app.kubernetes.io/name: kserve
+  name: kserve-manager-role
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
@@ -16399,11 +16399,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app-cluster-role
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app-cluster-role
 rules:
 - apiGroups:
   - authorization.k8s.io
@@ -16454,9 +16454,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-  name: kfserving-proxy-role
+    app: kserve
+    app.kubernetes.io/name: kserve
+  name: kserve-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -16474,26 +16474,26 @@ rules:
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kserve-admin: "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-  name: kubeflow-kfserving-admin
+  name: kubeflow-kserve-admin
 rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
-  name: kubeflow-kfserving-edit
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kserve-admin: "true"
+  name: kubeflow-kserve-edit
 rules:
 - apiGroups:
   - serving.kserve.io
@@ -16533,10 +16533,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
-  name: kubeflow-kfserving-view
+  name: kubeflow-kserve-view
 rules:
 - apiGroups:
   - serving.kserve.io
@@ -16565,8 +16565,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: leader-election-rolebinding
   namespace: kubeflow
 roleRef:
@@ -16582,13 +16582,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-  name: kfserving-manager-rolebinding
+    app: kserve
+    app.kubernetes.io/name: kserve
+  name: kserve-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfserving-manager-role
+  name: kserve-manager-role
 subjects:
 - kind: ServiceAccount
   name: default
@@ -16598,31 +16598,31 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app-binding
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfserving-models-web-app-cluster-role
+  name: kserve-models-web-app-cluster-role
 subjects:
 - kind: ServiceAccount
-  name: kfserving-models-web-app
+  name: kserve-models-web-app
   namespace: kubeflow
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-  name: kfserving-proxy-rolebinding
+    app: kserve
+    app.kubernetes.io/name: kserve
+  name: kserve-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kfserving-proxy-role
+  name: kserve-proxy-role
 subjects:
 - kind: ServiceAccount
   name: default
@@ -16710,7 +16710,7 @@ data:
         },
         "sklearn": {
           "v1": {
-            "image": "gcr.io/kfserving/sklearnserver",
+            "image": "kserve/sklearnserver",
             "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "sklearn"
@@ -16728,7 +16728,7 @@ data:
         },
         "xgboost": {
           "v1": {
-            "image": "gcr.io/kfserving/xgbserver",
+            "image": "kserve/xgbserver",
             "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "xgboost"
@@ -16746,7 +16746,7 @@ data:
         },
         "pytorch": {
           "v1" : {
-            "image": "gcr.io/kfserving/pytorchserver",
+            "image": "kserve/pytorchserver",
             "defaultImageVersion": "latest",
             "defaultGpuImageVersion": "latest-gpu",
             "supportedFrameworks": [
@@ -16756,8 +16756,8 @@ data:
           },
           "v2" : {
             "image": "pytorch/torchserve-kfs",
-            "defaultImageVersion": "0.4.0",
-            "defaultGpuImageVersion": "0.4.0-gpu",
+            "defaultImageVersion": "0.4.1",
+            "defaultGpuImageVersion": "0.4.1-gpu",
             "supportedFrameworks": [
               "pytorch"
             ],
@@ -16815,8 +16815,8 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: inferenceservice-config
   namespace: kubeflow
 ---
@@ -16826,9 +16826,9 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-  name: kfserving-config
+    app: kserve
+    app.kubernetes.io/name: kserve
+  name: kserve-config
   namespace: kubeflow
 ---
 apiVersion: v1
@@ -16837,20 +16837,20 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app-config-99hfgfg5f4
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app-config-99hfgfg5f4
   namespace: kubeflow
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-  name: kfserving-webhook-server-secret
+    app: kserve
+    app.kubernetes.io/name: kserve
+  name: kserve-webhook-server-secret
   namespace: kubeflow
 ---
 apiVersion: v1
@@ -16861,11 +16861,11 @@ metadata:
     prometheus.io/scheme: https
     prometheus.io/scrape: "true"
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-    control-plane: kfserving-controller-manager
+    app: kserve
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
-  name: kfserving-controller-manager-metrics-service
+  name: kserve-controller-manager-metrics-service
   namespace: kubeflow
 spec:
   ports:
@@ -16873,39 +16873,39 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-    control-plane: kfserving-controller-manager
+    app: kserve
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-    control-plane: kfserving-controller-manager
+    app: kserve
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
-  name: kfserving-controller-manager-service
+  name: kserve-controller-manager-service
   namespace: kubeflow
 spec:
   ports:
   - port: 443
   selector:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-    control-plane: kfserving-controller-manager
+    app: kserve
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kubeflow
 spec:
   ports:
@@ -16914,84 +16914,84 @@ spec:
     protocol: TCP
     targetPort: 5000
   selector:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
   type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-  name: kfserving-webhook-server-service
+    app: kserve
+    app.kubernetes.io/name: kserve
+  name: kserve-webhook-server-service
   namespace: kubeflow
 spec:
   ports:
   - port: 443
     targetPort: webhook-server
   selector:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-    control-plane: kfserving-controller-manager
+    app: kserve
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-controller-manager
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kubeflow
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kfserving
-      app.kubernetes.io/component: kfserving-models-web-app
-      app.kubernetes.io/name: kfserving
-      kustomize.component: kfserving-models-web-app
+      app: kserve
+      app.kubernetes.io/component: kserve-models-web-app
+      app.kubernetes.io/name: kserve
+      kustomize.component: kserve-models-web-app
   template:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
       labels:
-        app: kfserving
-        app.kubernetes.io/component: kfserving-models-web-app
-        app.kubernetes.io/name: kfserving
-        kustomize.component: kfserving-models-web-app
+        app: kserve
+        app.kubernetes.io/component: kserve-models-web-app
+        app.kubernetes.io/name: kserve
+        kustomize.component: kserve-models-web-app
     spec:
       containers:
       - envFrom:
         - configMapRef:
-            name: kfserving-models-web-app-config-99hfgfg5f4
-        image: kfserving/models-web-app:v0.7.0-rc0
+            name: kserve-models-web-app-config-99hfgfg5f4
+        image: andyarok/models-web-app:v0.7.0-rc0
         imagePullPolicy: Always
-        name: kfserving-models-web-app
+        name: kserve-models-web-app
         ports:
         - containerPort: 5000
-      serviceAccountName: kfserving-models-web-app
+      serviceAccountName: kserve-models-web-app
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
-    control-plane: kfserving-controller-manager
+    app: kserve
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-controller-manager
     controller-tools.k8s.io: "1.0"
-  name: kfserving-controller-manager
+  name: kserve-controller-manager
   namespace: kubeflow
 spec:
   selector:
     matchLabels:
-      app: kfserving
-      app.kubernetes.io/name: kfserving
-      control-plane: kfserving-controller-manager
+      app: kserve
+      app.kubernetes.io/name: kserve
+      control-plane: kserve-controller-manager
       controller-tools.k8s.io: "1.0"
   serviceName: controller-manager-service
   template:
@@ -16999,9 +16999,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
       labels:
-        app: kfserving
-        app.kubernetes.io/name: kfserving
-        control-plane: kfserving-controller-manager
+        app: kserve
+        app.kubernetes.io/name: kserve
+        control-plane: kserve-controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
@@ -17015,8 +17015,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: SECRET_NAME
-          value: kfserving-webhook-server-cert
-        image: gcr.io/kfserving/kfserving-controller:v0.7.0-rc0
+          value: kserve-webhook-server-cert
+        image: kserve/kserve-controller:v0.7.0-rc0
         imagePullPolicy: Always
         name: manager
         ports:
@@ -17049,31 +17049,31 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: kfserving-webhook-server-cert
+          secretName: kserve-webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: serving-cert
   namespace: kubeflow
 spec:
-  commonName: kfserving-webhook-server-service.kubeflow.svc
+  commonName: kserve-webhook-server-service.kubeflow.svc
   dnsNames:
-  - kfserving-webhook-server-service.kubeflow.svc
+  - kserve-webhook-server-service.kubeflow.svc
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: kfserving-webhook-server-cert
+  secretName: kserve-webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: selfsigned-issuer
   namespace: kubeflow
 spec:
@@ -17083,11 +17083,11 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kubeflow
 spec:
   gateways:
@@ -17102,7 +17102,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: kfserving-models-web-app.kubeflow.svc.cluster.local
+        host: kserve-models-web-app.kubeflow.svc.cluster.local
         port:
           number: 80
 ---
@@ -17110,11 +17110,11 @@ apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   labels:
-    app: kfserving
-    app.kubernetes.io/component: kfserving-models-web-app
-    app.kubernetes.io/name: kfserving
-    kustomize.component: kfserving-models-web-app
-  name: kfserving-models-web-app
+    app: kserve
+    app.kubernetes.io/component: kserve-models-web-app
+    app.kubernetes.io/name: kserve
+    kustomize.component: kserve-models-web-app
+  name: kserve-models-web-app
   namespace: kubeflow
 spec:
   action: ALLOW
@@ -17125,10 +17125,10 @@ spec:
         - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
   selector:
     matchLabels:
-      app: kfserving
-      app.kubernetes.io/component: kfserving-models-web-app
-      app.kubernetes.io/name: kfserving
-      kustomize.component: kfserving-models-web-app
+      app: kserve
+      app.kubernetes.io/component: kserve-models-web-app
+      app.kubernetes.io/name: kserve
+      kustomize.component: kserve-models-web-app
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
@@ -17136,18 +17136,18 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: kubeflow/serving-cert
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: inferenceservice.serving.kserve.io
 webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kubeflow
       path: /mutate-serving-kserve-io-v1alpha2-inferenceservice
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.defaulter
+  name: inferenceservice.kserve-webhook-server.defaulter
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -17161,11 +17161,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kubeflow
       path: /mutate-serving-kserve-io-v1beta1-inferenceservice
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.v1beta1.defaulter
+  name: inferenceservice.kserve-webhook-server.v1beta1.defaulter
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -17179,11 +17179,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kubeflow
       path: /mutate-pods
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.pod-mutator
+  name: inferenceservice.kserve-webhook-server.pod-mutator
   namespaceSelector:
     matchExpressions:
     - key: control-plane
@@ -17209,18 +17209,18 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: kubeflow/serving-cert
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: inferenceservice.serving.kserve.io
 webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kubeflow
       path: /validate-serving-kserve-io-v1alpha2-inferenceservice
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.validator
+  name: inferenceservice.kserve-webhook-server.validator
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -17234,11 +17234,11 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kubeflow
       path: /validate-serving-kserve-io-v1beta1-inferenceservice
   failurePolicy: Fail
-  name: inferenceservice.kfserving-webhook-server.v1beta1.validator
+  name: inferenceservice.kserve-webhook-server.v1beta1.validator
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -17256,18 +17256,18 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: kubeflow/serving-cert
   labels:
-    app: kfserving
-    app.kubernetes.io/name: kfserving
+    app: kserve
+    app.kubernetes.io/name: kserve
   name: trainedmodel.serving.kserve.io
 webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: kfserving-webhook-server-service
+      name: kserve-webhook-server-service
       namespace: kubeflow
       path: /validate-serving-kserve-io-v1alpha1-trainedmodel
   failurePolicy: Fail
-  name: trainedmodel.kfserving-webhook-server.validator
+  name: trainedmodel.kserve-webhook-server.validator
   rules:
   - apiGroups:
     - serving.kserve.io

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -24,7 +24,7 @@ from kserve import constants
 logging.basicConfig(level=logging.INFO)
 
 KSERVE_NAMESPACE = "kserve"
-KSERVE_TEST_NAMESPACE = "kfserving-ci-e2e-test"
+KSERVE_TEST_NAMESPACE = "kserve-ci-e2e-test"
 
 
 def predict(service_name, input_json, protocol_version="v1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes issue with e2e namespace.
Fixes issue with e2e test overlays.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 32, fixes #10 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
