### PR TITLE
add wikimedia in the list of adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -19,4 +19,4 @@ This page contains a list of organizations who are using KFServing either in pro
 | [Seldon](https://www.seldon.io/) | [Clive Cox](https://github.com/cliveseldon) |
 | [Patterson Consulting](https://www.pattersonconsultingtn.com/) | [Josh Patterson](https://github.com/jpatanooga) |
 | [Samsung SDS](https://www.samsungsds.com/) | [Hanbae Seo](https://github.com/jazzsir) |
-
+| [Wikimedia Foundation](https://www.wikimedia.org/) | [Luca Toscano](https://github.com/elukey), [Andy Craze](https://github.com/accraze), [Kevin Bazira](https://github.com/kevinbazira) |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -19,4 +19,4 @@ This page contains a list of organizations who are using KFServing either in pro
 | [Seldon](https://www.seldon.io/) | [Clive Cox](https://github.com/cliveseldon) |
 | [Patterson Consulting](https://www.pattersonconsultingtn.com/) | [Josh Patterson](https://github.com/jpatanooga) |
 | [Samsung SDS](https://www.samsungsds.com/) | [Hanbae Seo](https://github.com/jazzsir) |
-| [Wikimedia Foundation](https://www.wikimedia.org/) | [Luca Toscano](https://github.com/elukey), [Andy Craze](https://github.com/accraze), [Kevin Bazira](https://github.com/kevinbazira) |
+| [Wikimedia Foundation](https://www.wikimedia.org/) | [Chris Albon](https://github.com/chrisalbon) |


### PR DESCRIPTION
Wikimedia is building the `liftwing` platform based on kfserving. There are already models in production that score wikipedia edits for quality/damage checks in some languages. More information about the inferenceservices in [wikimedia/machinelearning-liftwing-inference-services](https://github.com/wikimedia/machinelearning-liftwing-inference-services) and https://ores.wikimedia.org.

/cc @elukey @accraze @kevinbazira 