### PR TITLE
add hpa for raw deployment

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,6 +32,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -85,6 +85,29 @@ func TestInvalidAutoscalerClassType(t *testing.T) {
 	g.Expect(isvc.ValidateCreate()).ShouldNot(gomega.Succeed())
 }
 
+func TestValidTargetUtilizationPercentage(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	isvc := makeTestRawInferenceService()
+	isvc.ObjectMeta.Annotations["serving.kserve.io/targetUtilizationPercentage"] = "70"
+	g.Expect(isvc.ValidateCreate()).Should(gomega.Succeed())
+}
+
+func TestInvalidTargetUtilizationPercentage(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	isvc := makeTestRawInferenceService()
+	isvc.ObjectMeta.Annotations["serving.kserve.io/targetUtilizationPercentage"] = "101"
+	g.Expect(isvc.ValidateCreate()).ShouldNot(gomega.Succeed())
+
+	isvc.ObjectMeta.Annotations["serving.kserve.io/targetUtilizationPercentage"] = "abc"
+	g.Expect(isvc.ValidateCreate()).ShouldNot(gomega.Succeed())
+
+	isvc.ObjectMeta.Annotations["serving.kserve.io/targetUtilizationPercentage"] = "0"
+	g.Expect(isvc.ValidateCreate()).ShouldNot(gomega.Succeed())
+
+	isvc.ObjectMeta.Annotations["serving.kserve.io/targetUtilizationPercentage"] = "99.9"
+	g.Expect(isvc.ValidateCreate()).ShouldNot(gomega.Succeed())
+}
+
 func TestInvalidAutoscalerHPAMetrics(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	isvc := makeTestRawInferenceService()

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,6 +68,9 @@ var (
 	InferenceServiceGKEAcceleratorAnnotationKey = KServeAPIGroupName + "/gke-accelerator"
 	DeploymentMode                              = KServeAPIGroupName + "/deploymentMode"
 	EnableRoutingTagAnnotationKey               = KServeAPIGroupName + "/enable-tag-routing"
+	AutoscalerClass                             = KServeAPIGroupName + "/autoscalerClass"
+	AutoscalerMetrics                           = KServeAPIGroupName + "/metrics"
+	TargetUtilizationPercentage                 = KServeAPIGroupName + "/targetUtilizationPercentage"
 )
 
 // InferenceService Internal Annotations
@@ -96,6 +99,39 @@ var (
 	DefaultReadinessTimeout   int32 = 600
 	DefaultScalingTarget            = "1"
 	DefaultMinReplicas        int   = 1
+)
+
+type AutoscalerClassType string
+type AutoscalerMetricsType string
+
+// Autoscaler Default Class
+var (
+	DefaultAutoscalerClass = AutoscalerClassHPA
+)
+
+// Autoscaler Class
+var (
+	AutoscalerClassHPA AutoscalerClassType = "hpa"
+)
+
+// Autoscaler Metrics
+var (
+	AutoScalerMetricsCPU AutoscalerMetricsType = "cpu"
+)
+
+// Autoscaler Class Allowed List
+var AutoscalerAllowedClassList = []AutoscalerClassType{
+	AutoscalerClassHPA,
+}
+
+// Autoscaler Metrics Allowed List
+var AutoscalerAllowedMetricsList = []AutoscalerMetricsType{
+	AutoScalerMetricsCPU,
+}
+
+// Autoscaler Default Metrics Value
+var (
+	DefaultCPUUtilization int32 = 80
 )
 
 // Webhook Constants

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -122,7 +122,7 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) error {
 		//set autoscaler Controller
 		if r.Scaler.Autoscaler.AutoscalerClass == constants.AutoscalerClassHPA {
 			if err := controllerutil.SetControllerReference(isvc, r.Scaler.Autoscaler.HPA.HPA, p.scheme); err != nil {
-				return errors.Wrapf(err, "fails to set HPA owner reference for explainer")
+				return errors.Wrapf(err, "fails to set HPA owner reference for predictor")
 			}
 		}
 

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -114,7 +114,7 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) error {
 		//set autoscaler Controller
 		if r.Scaler.Autoscaler.AutoscalerClass == constants.AutoscalerClassHPA {
 			if err := controllerutil.SetControllerReference(isvc, r.Scaler.Autoscaler.HPA.HPA, p.scheme); err != nil {
-				return errors.Wrapf(err, "fails to set HPA owner reference for explainer")
+				return errors.Wrapf(err, "fails to set HPA owner reference for transformer")
 			}
 		}
 

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -98,8 +98,11 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) error {
 	}
 	// Here we allow switch between knative and vanilla deployment
 	if isvcutils.GetDeploymentMode(annotations, deployConfig) == constants.RawDeployment {
-		r := raw.NewRawKubeReconciler(p.client, p.scheme, objectMeta, &isvc.Spec.Transformer.ComponentExtensionSpec,
+		r, err := raw.NewRawKubeReconciler(p.client, p.scheme, objectMeta, &isvc.Spec.Transformer.ComponentExtensionSpec,
 			&podSpec)
+		if err != nil {
+			return errors.Wrapf(err, "fails to create NewRawKubeReconciler for transformer")
+		}
 		//set Deployment Controller
 		if err := controllerutil.SetControllerReference(isvc, r.Deployment.Deployment, p.scheme); err != nil {
 			return errors.Wrapf(err, "fails to set deployment owner reference for transformer")
@@ -107,6 +110,12 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) error {
 		//set Service Controller
 		if err := controllerutil.SetControllerReference(isvc, r.Service.Service, p.scheme); err != nil {
 			return errors.Wrapf(err, "fails to set service owner reference for transformer")
+		}
+		//set autoscaler Controller
+		if r.Scaler.Autoscaler.AutoscalerClass == constants.AutoscalerClassHPA {
+			if err := controllerutil.SetControllerReference(isvc, r.Scaler.Autoscaler.HPA.HPA, p.scheme); err != nil {
+				return errors.Wrapf(err, "fails to set HPA owner reference for explainer")
+			}
 		}
 
 		deployment, err := r.Reconcile()

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -53,6 +53,7 @@ import (
 // +kubebuilder:rbac:groups=serving.knative.dev,resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -404,6 +404,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			var minReplicas int32 = 1
 			var maxReplicas int32 = 3
 			var cpuUtilization int32 = 75
+			var stabilizationWindowSeconds int32 = 0
+			selectPolicy := v2beta2.MaxPolicySelect
 			actualHPA := &v2beta2.HorizontalPodAutoscaler{}
 			predictorHPAKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
@@ -426,6 +428,35 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								Target: v2beta2.MetricTarget{
 									Type:               "Utilization",
 									AverageUtilization: &cpuUtilization,
+								},
+							},
+						},
+					},
+					Behavior: &v2beta2.HorizontalPodAutoscalerBehavior{
+						ScaleUp: &v2beta2.HPAScalingRules{
+							StabilizationWindowSeconds: &stabilizationWindowSeconds,
+							SelectPolicy:               &selectPolicy,
+							Policies: []v2beta2.HPAScalingPolicy{
+								{
+									Type:          "Pods",
+									Value:         4,
+									PeriodSeconds: 15,
+								},
+								{
+									Type:          "Percent",
+									Value:         100,
+									PeriodSeconds: 15,
+								},
+							},
+						},
+						ScaleDown: &v2beta2.HPAScalingRules{
+							StabilizationWindowSeconds: nil,
+							SelectPolicy:               &selectPolicy,
+							Policies: []v2beta2.HPAScalingPolicy{
+								{
+									Type:          "Percent",
+									Value:         100,
+									PeriodSeconds: 15,
 								},
 							},
 						},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
@@ -17,7 +17,7 @@ limitations under the License.
 package autoscaler
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
@@ -59,26 +59,12 @@ func NewAutoscalerReconciler(client client.Client,
 	}, err
 }
 
-func autoscalerClassValidation(class constants.AutoscalerClassType) error {
-	for _, item := range constants.AutoscalerAllowedClassList {
-		if class == item {
-			return nil
-		}
-	}
-	var msg string = string(class) + " is not a supported autoscaler class."
-	return errors.New(msg)
-}
-
-func getAutoscalerClass(metadata metav1.ObjectMeta) (constants.AutoscalerClassType, error) {
+func getAutoscalerClass(metadata metav1.ObjectMeta) constants.AutoscalerClassType {
 	annotations := metadata.Annotations
 	if value, ok := annotations[constants.AutoscalerClass]; ok {
-		if err := autoscalerClassValidation(constants.AutoscalerClassType(value)); err != nil {
-			return "nil", err
-		} else {
-			return constants.AutoscalerClassType(value), nil
-		}
+		return constants.AutoscalerClassType(value)
 	} else {
-		return constants.DefaultAutoscalerClass, nil
+		return constants.DefaultAutoscalerClass
 	}
 }
 
@@ -86,10 +72,7 @@ func createAutoscaler(client client.Client,
 	scheme *runtime.Scheme, componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec) (*Autoscaler, error) {
 	as := &Autoscaler{}
-	ac, err := getAutoscalerClass(componentMeta)
-	if err != nil {
-		return nil, err
-	}
+	ac := getAutoscalerClass(componentMeta)
 	as.AutoscalerClass = ac
 	switch ac {
 	case constants.AutoscalerClassHPA:

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
@@ -76,11 +76,7 @@ func createAutoscaler(client client.Client,
 	as.AutoscalerClass = ac
 	switch ac {
 	case constants.AutoscalerClassHPA:
-		hpa, err := hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt)
-		if err != nil {
-			return nil, err
-		}
-		as.HPA = hpa
+		as.HPA = hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt)
 	default:
 		return nil, errors.New("unknown autoscaler class type.")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaler
+
+import (
+	"errors"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	hpa "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("AutoscalerReconciler")
+
+type Autoscaler struct {
+	AutoscalerClass constants.AutoscalerClassType
+	HPA             *hpa.HPAReconciler
+}
+
+//AutoscalerReconciler is the struct of Raw K8S Object
+type AutoscalerReconciler struct {
+	client       client.Client
+	scheme       *runtime.Scheme
+	Autoscaler   *Autoscaler
+	componentExt *v1beta1.ComponentExtensionSpec
+}
+
+func NewAutoscalerReconciler(client client.Client,
+	scheme *runtime.Scheme,
+	componentMeta metav1.ObjectMeta,
+	componentExt *v1beta1.ComponentExtensionSpec) (*AutoscalerReconciler, error) {
+	as, err := createAutoscaler(client, scheme, componentMeta, componentExt)
+	if err != nil {
+		return nil, err
+	}
+	return &AutoscalerReconciler{
+		client:       client,
+		scheme:       scheme,
+		Autoscaler:   as,
+		componentExt: componentExt,
+	}, err
+}
+
+func autoscalerClassValidation(class constants.AutoscalerClassType) error {
+	for _, item := range constants.AutoscalerAllowedClassList {
+		if class == item {
+			return nil
+		}
+	}
+	var msg string = string(class) + " is not a supported autoscaler class."
+	return errors.New(msg)
+}
+
+func getAutoscalerClass(metadata metav1.ObjectMeta) (constants.AutoscalerClassType, error) {
+	annotations := metadata.Annotations
+	if value, ok := annotations[constants.AutoscalerClass]; ok {
+		if err := autoscalerClassValidation(constants.AutoscalerClassType(value)); err != nil {
+			return "nil", err
+		} else {
+			return constants.AutoscalerClassType(value), nil
+		}
+	} else {
+		return constants.DefaultAutoscalerClass, nil
+	}
+}
+
+func createAutoscaler(client client.Client,
+	scheme *runtime.Scheme, componentMeta metav1.ObjectMeta,
+	componentExt *v1beta1.ComponentExtensionSpec) (*Autoscaler, error) {
+	as := &Autoscaler{}
+	ac, err := getAutoscalerClass(componentMeta)
+	if err != nil {
+		return nil, err
+	}
+	as.AutoscalerClass = ac
+	switch ac {
+	case constants.AutoscalerClassHPA:
+		hpa, err := hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt)
+		if err != nil {
+			return nil, err
+		}
+		as.HPA = hpa
+	default:
+		return nil, errors.New("unknown autoscaler class type.")
+	}
+	return as, nil
+}
+
+//Reconcile ...
+func (r *AutoscalerReconciler) Reconcile() (*Autoscaler, error) {
+	//reconcile Autoscaler
+	if r.Autoscaler.AutoscalerClass == constants.AutoscalerClassHPA {
+		_, err := r.Autoscaler.HPA.Reconcile()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return r.Autoscaler, nil
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -92,8 +92,8 @@ func (r *DeploymentReconciler) checkDeploymentExist(client client.Client) (const
 	//get deployment
 	existingDeployment := &appsv1.Deployment{}
 	err := client.Get(context.TODO(), types.NamespacedName{
-		Namespace: r.Deployment.Namespace,
-		Name:      r.Deployment.Name,
+		Namespace: r.Deployment.ObjectMeta.Namespace,
+		Name:      r.Deployment.ObjectMeta.Name,
 	}, existingDeployment)
 	if err != nil {
 		if apierr.IsNotFound(err) {
@@ -152,6 +152,10 @@ func setDefaultPodSpec(podSpec *corev1.PodSpec) {
 								},
 							},
 						},
+						TimeoutSeconds:   1,
+						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						FailureThreshold: 3,
 					}
 				} else {
 					container.ReadinessProbe = &corev1.Probe{
@@ -162,6 +166,10 @@ func setDefaultPodSpec(podSpec *corev1.PodSpec) {
 								},
 							},
 						},
+						TimeoutSeconds:   1,
+						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						FailureThreshold: 3,
 					}
 				}
 			}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -15,7 +15,6 @@ package hpa
 
 import (
 	"context"
-	"errors"
 	"strconv"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -57,36 +56,17 @@ func NewHPAReconciler(client client.Client,
 	}, err
 }
 
-func hpaMetricsValidation(metric string) error {
-	for _, item := range constants.AutoscalerAllowedMetricsList {
-		if item == constants.AutoscalerMetricsType(metric) {
-			return nil
-		}
-	}
-	var msg string = string(metric) + " is not a supported HPA metric."
-	return errors.New(msg)
-}
-
 func getHPAMetrics(metadata metav1.ObjectMeta) ([]v2beta2.MetricSpec, error) {
 	var metrics []v2beta2.MetricSpec
 	var cpuUtilization int32
 	annotations := metadata.Annotations
-	if metric, ok := annotations[constants.AutoscalerMetrics]; ok {
-		log.Info("getHPAMetrics", "metric", metric)
-		if err := hpaMetricsValidation(metric); err == nil {
-			log.Info("getHPAMetrics", "metricsValidationCheck", "OK")
-			if value, ok := annotations[constants.TargetUtilizationPercentage]; ok {
-				utilization, err := strconv.Atoi(value)
-				if err != nil {
-					return nil, err
-				}
-				cpuUtilization = int32(utilization)
-			} else {
-				cpuUtilization = constants.DefaultCPUUtilization
-			}
-		} else {
+
+	if value, ok := annotations[constants.TargetUtilizationPercentage]; ok {
+		utilization, err := strconv.Atoi(value)
+		if err != nil {
 			return nil, err
 		}
+		cpuUtilization = int32(utilization)
 	} else {
 		cpuUtilization = constants.DefaultCPUUtilization
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2021 The KServe Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hpa
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("HPAReconciler")
+
+//HPAReconciler is the struct of Raw K8S Object
+type HPAReconciler struct {
+	client       client.Client
+	scheme       *runtime.Scheme
+	HPA          *v2beta2.HorizontalPodAutoscaler
+	componentExt *v1beta1.ComponentExtensionSpec
+}
+
+func NewHPAReconciler(client client.Client,
+	scheme *runtime.Scheme,
+	componentMeta metav1.ObjectMeta,
+	componentExt *v1beta1.ComponentExtensionSpec) (*HPAReconciler, error) {
+	hpa, err := createHPA(componentMeta, componentExt)
+	if err != nil {
+		return nil, err
+	}
+	return &HPAReconciler{
+		client:       client,
+		scheme:       scheme,
+		HPA:          hpa,
+		componentExt: componentExt,
+	}, err
+}
+
+func hpaMetricsValidation(metric string) error {
+	for _, item := range constants.AutoscalerAllowedMetricsList {
+		if item == constants.AutoscalerMetricsType(metric) {
+			return nil
+		}
+	}
+	var msg string = string(metric) + " is not a supported HPA metric."
+	return errors.New(msg)
+}
+
+func getHPAMetrics(metadata metav1.ObjectMeta) ([]v2beta2.MetricSpec, error) {
+	var metrics []v2beta2.MetricSpec
+	var cpuUtilization int32
+	annotations := metadata.Annotations
+	if metric, ok := annotations[constants.AutoscalerMetrics]; ok {
+		log.Info("getHPAMetrics", "metric", metric)
+		if err := hpaMetricsValidation(metric); err == nil {
+			log.Info("getHPAMetrics", "metricsValidationCheck", "OK")
+			if value, ok := annotations[constants.TargetUtilizationPercentage]; ok {
+				utilization, err := strconv.Atoi(value)
+				if err != nil {
+					return nil, err
+				}
+				cpuUtilization = int32(utilization)
+			} else {
+				cpuUtilization = constants.DefaultCPUUtilization
+			}
+		} else {
+			return nil, err
+		}
+	} else {
+		cpuUtilization = constants.DefaultCPUUtilization
+	}
+
+	ms := v2beta2.MetricSpec{
+		Type: v2beta2.ResourceMetricSourceType,
+		Resource: &v2beta2.ResourceMetricSource{
+			Name: corev1.ResourceCPU,
+			Target: v2beta2.MetricTarget{
+				Type:               "Utilization",
+				AverageUtilization: &cpuUtilization,
+			},
+		},
+	}
+	metrics = append(metrics, ms)
+	return metrics, nil
+}
+
+func createHPA(componentMeta metav1.ObjectMeta,
+	componentExt *v1beta1.ComponentExtensionSpec) (*v2beta2.HorizontalPodAutoscaler, error) {
+	minReplicas := int32(*componentExt.MinReplicas)
+	if minReplicas < int32(constants.DefaultMinReplicas) {
+		minReplicas = int32(constants.DefaultMinReplicas)
+	}
+	maxReplicas := int32(componentExt.MaxReplicas)
+	if maxReplicas < minReplicas {
+		maxReplicas = minReplicas
+	}
+	metrics, err := getHPAMetrics(componentMeta)
+	if err != nil {
+		return nil, err
+	}
+	hpa := &v2beta2.HorizontalPodAutoscaler{
+		ObjectMeta: componentMeta,
+		Spec: v2beta2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: v2beta2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       componentMeta.Name,
+			},
+			MinReplicas: &minReplicas,
+			MaxReplicas: maxReplicas,
+			Metrics:     metrics,
+			Behavior:    &v2beta2.HorizontalPodAutoscalerBehavior{},
+		},
+	}
+	return hpa, nil
+}
+
+//checkHPAExist checks if the hpa exists?
+func (r *HPAReconciler) checkHPAExist(client client.Client) (constants.CheckResultType, *v2beta2.HorizontalPodAutoscaler, error) {
+	//get hpa
+	existingHPA := &v2beta2.HorizontalPodAutoscaler{}
+	err := client.Get(context.TODO(), types.NamespacedName{
+		Namespace: r.HPA.ObjectMeta.Namespace,
+		Name:      r.HPA.ObjectMeta.Name,
+	}, existingHPA)
+	if err != nil {
+		if apierr.IsNotFound(err) {
+			return constants.CheckResultCreate, nil, nil
+		}
+		return constants.CheckResultUnknown, nil, err
+	}
+
+	//existed, check equivalent
+	if semanticHPAEquals(r.HPA, existingHPA) {
+		return constants.CheckResultExisted, existingHPA, nil
+	}
+	return constants.CheckResultUpdate, existingHPA, nil
+}
+
+func semanticHPAEquals(desired, existing *v2beta2.HorizontalPodAutoscaler) bool {
+	return equality.Semantic.DeepEqual(desired.Spec.Metrics, existing.Spec.Metrics) &&
+		equality.Semantic.DeepEqual(desired.Spec.MaxReplicas, existing.Spec.MaxReplicas) &&
+		equality.Semantic.DeepEqual(*desired.Spec.MinReplicas, *existing.Spec.MinReplicas)
+}
+
+//Reconcile ...
+func (r *HPAReconciler) Reconcile() (*v2beta2.HorizontalPodAutoscaler, error) {
+	//reconcile Service
+	checkResult, existingHPA, err := r.checkHPAExist(r.client)
+	log.Info("service reconcile", "checkResult", checkResult, "err", err)
+	if err != nil {
+		return nil, err
+	}
+
+	if checkResult == constants.CheckResultCreate {
+		err = r.client.Create(context.TODO(), r.HPA)
+		if err != nil {
+			return nil, err
+		} else {
+			return r.HPA, nil
+		}
+	} else if checkResult == constants.CheckResultUpdate { //CheckResultUpdate
+		err = r.client.Update(context.TODO(), r.HPA)
+		if err != nil {
+			return nil, err
+		} else {
+			return r.HPA, nil
+		}
+	} else {
+		return existingHPA, nil
+	}
+}


### PR DESCRIPTION
# Raw Deployment autoscaler HPA Support
### Support autoscaler class
* HPA
> Note: HPA is default autoscaler

### Support Metrics
* CPU Utilization
> Note: default CPU Utilization is 80%

### Customized Utilization Value

change value by annotation , e.g.
```
annotations:
"serving.kserve.io/autoscalerClass": "hpa"
"serving.kserve.io/metrics": "cpu"
"serving.kserve.io/targetUtilizationPercentage": "80"
```
