### PR TITLE
Update Triton to 21.09. Remove caffe2 from supported frameworks

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -82,13 +82,12 @@ data:
         },
         "triton": {
             "image": "nvcr.io/nvidia/tritonserver",
-            "defaultImageVersion": "20.08-py3",
+            "defaultImageVersion": "21.09-py3",
             "supportedFrameworks": [
               "tensorrt",
               "tensorflow",
               "onnx",
-              "pytorch",
-              "caffe2"
+              "pytorch"
             ],
             "multiModelServer": true
         },


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Triton to the latest stable version, 21.09.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Triton Inference Server updated to 21.09.
```
