### PR TITLE
fix-1852: when minReplicas is nil, make the controller crash.

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -80,7 +80,6 @@ func getHPAMetrics(metadata metav1.ObjectMeta) []v2beta2.MetricSpec {
 
 func createHPA(componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec) *v2beta2.HorizontalPodAutoscaler {
-	var minReplicas int32 
 	if componentExt.MinReplicas == nil || (*componentExt.MinReplicas) < constants.DefaultMinReplicas {
 		minReplicas = int32(constants.DefaultMinReplicas)
 	} else {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -80,10 +80,13 @@ func getHPAMetrics(metadata metav1.ObjectMeta) []v2beta2.MetricSpec {
 
 func createHPA(componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec) *v2beta2.HorizontalPodAutoscaler {
-	minReplicas := int32(*componentExt.MinReplicas)
-	if minReplicas < int32(constants.DefaultMinReplicas) {
+	var minReplicas int32 
+	if(componentExt.MinReplicas == nil || (*componentExt.MinReplicas) < constants.DefaultMinReplicas) {
 		minReplicas = int32(constants.DefaultMinReplicas)
+	} else {
+		minReplicas = int32(*componentExt.MinReplicas)
 	}
+	
 	maxReplicas := int32(componentExt.MaxReplicas)
 	if maxReplicas < minReplicas {
 		maxReplicas = minReplicas

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -81,7 +81,7 @@ func getHPAMetrics(metadata metav1.ObjectMeta) []v2beta2.MetricSpec {
 func createHPA(componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec) *v2beta2.HorizontalPodAutoscaler {
 	var minReplicas int32 
-	if(componentExt.MinReplicas == nil || (*componentExt.MinReplicas) < constants.DefaultMinReplicas) {
+	if componentExt.MinReplicas == nil || (*componentExt.MinReplicas) < constants.DefaultMinReplicas {
 		minReplicas = int32(constants.DefaultMinReplicas)
 	} else {
 		minReplicas = int32(*componentExt.MinReplicas)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -80,6 +80,7 @@ func getHPAMetrics(metadata metav1.ObjectMeta) []v2beta2.MetricSpec {
 
 func createHPA(componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec) *v2beta2.HorizontalPodAutoscaler {
+	var minReplicas int32
 	if componentExt.MinReplicas == nil || (*componentExt.MinReplicas) < constants.DefaultMinReplicas {
 		minReplicas = int32(constants.DefaultMinReplicas)
 	} else {


### PR DESCRIPTION

**What this PR does / why we need it**:
When minReplicas is nil, make the kserver controller crash.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1852

This is a hot fix. After this fix, we should test the "why the webhook has already checked the `minReplicas` and defaulted, but not passed to controller".
