### PR TITLE
Allow unknown fields in InferenceService status

### DIFF
--- a/config/crd/serving.kserve.io_inferenceservices.yaml
+++ b/config/crd/serving.kserve.io_inferenceservices.yaml
@@ -15972,6 +15972,7 @@ spec:
                 url:
                   type: string
               type: object
+              x-kubernetes-preserve-unknown-fields: true
           type: object
       served: true
       storage: true

--- a/pkg/apis/serving/v1beta1/inference_service.go
+++ b/pkg/apis/serving/v1beta1/inference_service.go
@@ -92,7 +92,9 @@ type InferenceService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   InferenceServiceSpec   `json:"spec,omitempty"`
+	Spec InferenceServiceSpec `json:"spec,omitempty"`
+
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status InferenceServiceStatus `json:"status,omitempty"`
 }
 

--- a/test/crds/serving.kserve.io_inferenceservices.yaml
+++ b/test/crds/serving.kserve.io_inferenceservices.yaml
@@ -15993,6 +15993,7 @@ spec:
               url:
                 type: string
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true


### PR DESCRIPTION
This will allow various status fields populated by ModelMesh Serving to appear under the InferenceService status section. For now, this is useful to allow some ModelMesh specific status info to be conveyed when a user deploys using the InferenceService CR.

