### PR TITLE
Fix model agent settings when deployed as raw deployment

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -90,7 +90,6 @@ type batcherArgs struct {
 func main() {
 	flag.Parse()
 	// Parse the environment.
-	//TODO agent config debug
 	var env config
 	if err := envconfig.Process("", &env); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -58,14 +58,15 @@ var (
 )
 
 type config struct {
-	ContainerConcurrency   int    `split_words:"true" required:"true"`
-	QueueServingPort       int    `split_words:"true" required:"true"`
-	UserPort               int    `split_words:"true" required:"true"`
-	RevisionTimeoutSeconds int    `split_words:"true" required:"true"`
+	//Making the below fields optional since raw deployment wont have them
+	ContainerConcurrency   int    `split_words:"true"`
+	QueueServingPort       int    `split_words:"true"`
+	UserPort               int    `split_words:"true"`
+	RevisionTimeoutSeconds int    `split_words:"true"`
 	ServingReadinessProbe  string `split_words:"true" required:"true"`
 	// Logging configuration
-	ServingLoggingConfig         string `split_words:"true" required:"true"`
-	ServingLoggingLevel          string `split_words:"true" required:"true"`
+	ServingLoggingConfig         string `split_words:"true"`
+	ServingLoggingLevel          string `split_words:"true"`
 	ServingRequestLogTemplate    string `split_words:"true"` // optional
 	ServingEnableRequestLog      bool   `split_words:"true"` // optional
 	ServingEnableProbeRequestLog bool   `split_words:"true"` // optional
@@ -89,6 +90,7 @@ type batcherArgs struct {
 func main() {
 	flag.Parse()
 	// Parse the environment.
+	//TODO agent config debug
 	var env config
 	if err := envconfig.Process("", &env); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/docs/samples/multimodelserving/triton/trained_model.yaml
+++ b/docs/samples/multimodelserving/triton/trained_model.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kserve.io/v1alpha1"
 kind: "TrainedModel"
 metadata:
   name: "cifar10"

--- a/docs/samples/multimodelserving/triton/trained_model2.yaml
+++ b/docs/samples/multimodelserving/triton/trained_model2.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kserve.io/v1alpha1"
 kind: "TrainedModel"
 metadata:
   name: "simple-string"

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -103,8 +103,9 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	deploymentMode := isvcutils.GetDeploymentMode(annotations, deployConfig)
+	r.Log.Info("Inference service deployment mode ", "deployment mode ", deploymentMode)
 
-	if  deploymentMode == constants.ModelMeshDeployment {
+	if deploymentMode == constants.ModelMeshDeployment {
 		r.Log.Info("Skipping reconciliation for InferenceService", constants.DeploymentMode, deploymentMode,
 			"apiVersion", isvc.APIVersion, "isvc", isvc.Name)
 		return ctrl.Result{}, nil

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -71,7 +71,6 @@ func getAgentConfigs(configMap *v1.ConfigMap) (*AgentConfig, error) {
 			panic(fmt.Errorf("Unable to unmarshall agent json string due to %v ", err))
 		}
 	}
-	log.Info("Initializing agent info ", "agent info ", agentConfig)
 	//Ensure that we set proper values for CPU/Memory Limit/Request
 	resourceDefaults := []string{agentConfig.MemoryRequest,
 		agentConfig.MemoryLimit,

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -62,8 +62,8 @@ type AgentInjector struct {
 	batcherConfig     *BatcherConfig
 }
 
+//TODO agent config
 func getAgentConfigs(configMap *v1.ConfigMap) (*AgentConfig, error) {
-
 	agentConfig := &AgentConfig{}
 	if agentConfigValue, ok := configMap.Data[constants.AgentConfigMapKeyName]; ok {
 		err := json.Unmarshal([]byte(agentConfigValue), &agentConfig)
@@ -71,7 +71,7 @@ func getAgentConfigs(configMap *v1.ConfigMap) (*AgentConfig, error) {
 			panic(fmt.Errorf("Unable to unmarshall agent json string due to %v ", err))
 		}
 	}
-
+	log.Info("Initializing agent info ", "agent info ", agentConfig)
 	//Ensure that we set proper values for CPU/Memory Limit/Request
 	resourceDefaults := []string{agentConfig.MemoryRequest,
 		agentConfig.MemoryLimit,
@@ -202,6 +202,12 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 			queueProxyEnvs = container.Env
 		}
 	}
+	readinessProbeJson, err := json.Marshal(pod.Spec.Containers[0].ReadinessProbe)
+	if err != nil {
+		return err
+	}
+
+	queueProxyEnvs = append(queueProxyEnvs, v1.EnvVar{Name: "SERVING_READINESS_PROBE", Value: string(readinessProbeJson)})
 
 	// Make sure securityContext is initialized and valid
 	securityContext := pod.Spec.Containers[0].SecurityContext.DeepCopy()

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -122,7 +122,7 @@ func TestAgentInjector(t *testing.T) {
 								},
 							},
 							Args: []string{"--enable-puller", "--config-dir", "/mnt/configs", "--model-dir", "/mnt/models"},
-							Env:  []v1.EnvVar{},
+							Env:  []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "null"}},
 							ReadinessProbe: &v1.Probe{
 								Handler: v1.Handler{
 									Exec: &v1.ExecAction{
@@ -235,7 +235,7 @@ func TestAgentInjector(t *testing.T) {
 								LoggerArgumentComponent,
 								"predictor",
 							},
-							Env:       []v1.EnvVar{},
+							Env:       []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "null"}},
 							Resources: agentResourceRequirement,
 							ReadinessProbe: &v1.Probe{
 								Handler: v1.Handler{

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/credentials"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"knative.dev/pkg/kmp"
 
 	"github.com/kserve/kserve/pkg/constants"
@@ -89,6 +91,20 @@ func TestAgentInjector(t *testing.T) {
 					ServiceAccountName: "sa",
 					Containers: []v1.Container{{
 						Name: "sklearn",
+						ReadinessProbe: &v1.Probe{
+							Handler: v1.Handler{
+								TCPSocket: &v1.TCPSocketAction{
+									Port: intstr.IntOrString{
+										IntVal: 8080,
+									},
+								},
+							},
+							InitialDelaySeconds: 0,
+							TimeoutSeconds:      1,
+							PeriodSeconds:       10,
+							SuccessThreshold:    1,
+							FailureThreshold:    3,
+						},
 					}},
 				},
 			},
@@ -104,6 +120,20 @@ func TestAgentInjector(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name: "sklearn",
+							ReadinessProbe: &v1.Probe{
+								Handler: v1.Handler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.IntOrString{
+											IntVal: 8080,
+										},
+									},
+								},
+								InitialDelaySeconds: 0,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
 						},
 						{
 							Name:      constants.AgentContainerName,
@@ -122,7 +152,7 @@ func TestAgentInjector(t *testing.T) {
 								},
 							},
 							Args: []string{"--enable-puller", "--config-dir", "/mnt/configs", "--model-dir", "/mnt/models"},
-							Env:  []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "null"}},
+							Env:  []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 							ReadinessProbe: &v1.Probe{
 								Handler: v1.Handler{
 									Exec: &v1.ExecAction{
@@ -200,6 +230,20 @@ func TestAgentInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
 						Name: "sklearn",
+						ReadinessProbe: &v1.Probe{
+							Handler: v1.Handler{
+								TCPSocket: &v1.TCPSocketAction{
+									Port: intstr.IntOrString{
+										IntVal: 8080,
+									},
+								},
+							},
+							InitialDelaySeconds: 0,
+							TimeoutSeconds:      1,
+							PeriodSeconds:       10,
+							SuccessThreshold:    1,
+							FailureThreshold:    3,
+						},
 					}},
 				},
 			},
@@ -215,6 +259,20 @@ func TestAgentInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
 						Name: "sklearn",
+						ReadinessProbe: &v1.Probe{
+							Handler: v1.Handler{
+								TCPSocket: &v1.TCPSocketAction{
+									Port: intstr.IntOrString{
+										IntVal: 8080,
+									},
+								},
+							},
+							InitialDelaySeconds: 0,
+							TimeoutSeconds:      1,
+							PeriodSeconds:       10,
+							SuccessThreshold:    1,
+							FailureThreshold:    3,
+						},
 					},
 						{
 							Name:  constants.AgentContainerName,
@@ -235,7 +293,7 @@ func TestAgentInjector(t *testing.T) {
 								LoggerArgumentComponent,
 								"predictor",
 							},
-							Env:       []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "null"}},
+							Env:       []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 							Resources: agentResourceRequirement,
 							ReadinessProbe: &v1.Probe{
 								Handler: v1.Handler{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Raw deployment mode in kserve does not require knative to be installed. However, the environment variables are set from queue proxy. Since  knative is not present, mms agent throws error for missing fields.
Made changes to get readiness probe from pod spec and use it as env to agent

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1857 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
