### PR TITLE
Readiness Probe issue

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	network "knative.dev/networking/pkg"
 	pkglogging "knative.dev/pkg/logging"
@@ -295,11 +294,7 @@ func buildProbe(logger *zap.SugaredLogger, probeJSON string, port string) *readi
 	if err != nil {
 		logger.Fatalw("Agent failed to parse readiness probe", zap.Error(err))
 	}
-	if coreProbe.TCPSocket != nil {
-		coreProbe.TCPSocket.Port = intstr.FromString(port)
-	} else if coreProbe.HTTPGet != nil {
-		coreProbe.HTTPGet.Port = intstr.FromString(port)
-	}
+
 	return readiness.NewProbe(coreProbe)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Removed http get port and tcp socket port being set from componentPort for readiness probe.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1536 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
