### PR TITLE
Fix path to kserve.yaml in quick_install.sh script

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -103,6 +103,6 @@ KSERVE_CONFIG=kfserving.yaml
 if [ ${KSERVE_VERSION:3:1} -gt 6 ]; then KSERVE_CONFIG=kserve.yaml; fi
 
 # Retry inorder to handle that it may take a minute or so for the TLS assets required for the webhook to function to be provisioned
-for i in 1 2 3 4 5 ; do kubectl apply -f install/${KSERVE_VERSION}/${KSERVE_CONFIG} && break || sleep 15; done
+for i in 1 2 3 4 5 ; do kubectl apply -f https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/${KSERVE_CONFIG} && break || sleep 15; done
 # Clean up
 rm -rf istio-${ISTIO_VERSION}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The current quick install script is broken. It will install Istio, KNative, and Cert Manager, but the KServe install itself will fix.

The script is attempting to install KServe from a local filesystem location (`install/${KSERVE_VERSION}/${KSERVE_CONFIG}`). This path does not exist. It appears to want to refer to the release GH release file (`https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/${KSERVE_CONFIG}`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

I could not find an existing issue.

**Special notes for your reviewer**:

To validate/reproduce:

1. Create a new  / empty Kind / Minikube install (on MacOS 4GB / 4CPU seems to do the trick).
2. `cd` into an empty directory.
3. (To reproduce) Run the quick install instructions: https://kserve.github.io/website/get_started/#install-the-kserve-quickstart-environment
4. (To validate) Run the patched script in the PR.

ALSO - the existing quick start needs to be patched to get new users up and running once the fix is confirmed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
