### PR TITLE
Change to fix sdk replace does not wait for new isvc to be ready

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -293,6 +293,7 @@ func (ss *InferenceServiceStatus) PropagateRawStatus(
 	readyCondition := conditionsMap[component]
 	ss.SetCondition(readyCondition, condition)
 	ss.Components[component] = statusSpec
+	ss.ObservedGeneration = deployment.Status.ObservedGeneration
 }
 
 func getDeploymentCondition(deployment *appsv1.Deployment, conditionType appsv1.DeploymentConditionType) *apis.Condition {
@@ -383,6 +384,7 @@ func (ss *InferenceServiceStatus) PropagateStatus(component ComponentType, servi
 	ss.ClearCondition(TransformerConfigurationeReady)
 
 	ss.Components[component] = statusSpec
+	ss.ObservedGeneration = serviceStatus.ObservedGeneration
 }
 
 func (ss *InferenceServiceStatus) SetCondition(conditionType apis.ConditionType, condition *apis.Condition) {

--- a/python/kserve/kserve/api/kserve_client.py
+++ b/python/kserve/kserve/api/kserve_client.py
@@ -251,7 +251,8 @@ class KServeClient(object):
             isvc_watch(
                 name=outputs['metadata']['name'],
                 namespace=namespace,
-                timeout_seconds=timeout_seconds)
+                timeout_seconds=timeout_seconds,
+                generation=outputs['metadata']['generation'])
         else:
             return outputs
 

--- a/python/kserve/kserve/api/watch.py
+++ b/python/kserve/kserve/api/watch.py
@@ -21,9 +21,10 @@ from ..constants import constants
 from ..utils import utils
 
 
-def isvc_watch(name=None, namespace=None, timeout_seconds=600):
+def isvc_watch(name=None, namespace=None, timeout_seconds=600, generation=0):
     """Watch the created or patched InferenceService in the specified namespace"""
 
+    print("isvc watch called")
     if namespace is None:
         namespace = utils.get_default_target_namespace()
 
@@ -51,10 +52,15 @@ def isvc_watch(name=None, namespace=None, timeout_seconds=600):
                 traffic = isvc['status'].get('components', {}).get(
                     'predictor', {}).get('traffic', [])
                 traffic_percent = 100
+                latest_ready_revision = isvc['status']['components']['predictor']['latestReadyRevision']
+                expected_revision = isvc_name+'-predictor-default-'+'{:05d}'.format(generation)
                 for t in traffic:
                     if t["latestRevision"]:
                         traffic_percent = t["percent"]
                 status = 'Unknown'
+                if generation!=0 and latest_ready_revision!=expected_revision:
+                    time.sleep(2)
+                    continue
                 for condition in isvc['status'].get('conditions', {}):
                     if condition.get('type', '') == 'Ready':
                         status = condition.get('status', 'Unknown')

--- a/python/kserve/kserve/api/watch.py
+++ b/python/kserve/kserve/api/watch.py
@@ -53,11 +53,12 @@ def isvc_watch(name=None, namespace=None, timeout_seconds=600, generation=0):
                 traffic_percent = 100
                 latest_ready_revision = isvc['status']['components']['predictor']['latestReadyRevision']
                 expected_revision = isvc_name+'-predictor-default-'+'{:05d}'.format(generation)
+                observed_generation = isvc['status']['observedGeneration']
                 for t in traffic:
                     if t["latestRevision"]:
                         traffic_percent = t["percent"]
                 status = 'Unknown'
-                if generation != 0 and latest_ready_revision != expected_revision:
+                if observed_generation != generation:
                     time.sleep(2)
                     continue
                 for condition in isvc['status'].get('conditions', {}):

--- a/python/kserve/kserve/api/watch.py
+++ b/python/kserve/kserve/api/watch.py
@@ -24,7 +24,6 @@ from ..utils import utils
 def isvc_watch(name=None, namespace=None, timeout_seconds=600, generation=0):
     """Watch the created or patched InferenceService in the specified namespace"""
 
-    print("isvc watch called")
     if namespace is None:
         namespace = utils.get_default_target_namespace()
 

--- a/python/kserve/kserve/api/watch.py
+++ b/python/kserve/kserve/api/watch.py
@@ -59,19 +59,16 @@ def isvc_watch(name=None, namespace=None, timeout_seconds=600, generation=0):
                             traffic_percent = t["percent"]
 
                     if generation != 0 and observed_generation != generation:
-                        time.sleep(2)
                         continue
                     for condition in isvc['status'].get('conditions', {}):
                         if condition.get('type', '') == 'Ready':
                             status = condition.get('status', 'Unknown')
                     tbl(isvc_name, status, 100-traffic_percent, traffic_percent, url)
+                    if status == 'True':
+                       break
 
             else:
                 tbl(isvc_name, status, '', '', '')
                 # Sleep 2 to avoid status section is not generated within a very short time.
                 time.sleep(2)
                 continue
-
-            if name == isvc_name and status == 'True':
-                time.sleep(2)
-                break

--- a/python/kserve/kserve/api/watch.py
+++ b/python/kserve/kserve/api/watch.py
@@ -46,30 +46,32 @@ def isvc_watch(name=None, namespace=None, timeout_seconds=600, generation=0):
         if name and name != isvc_name:
             continue
         else:
+            status = 'Unknown'
             if isvc.get('status', ''):
                 url = isvc['status'].get('url', '')
                 traffic = isvc['status'].get('components', {}).get(
                     'predictor', {}).get('traffic', [])
                 traffic_percent = 100
-                latest_ready_revision = isvc['status']['components']['predictor']['latestReadyRevision']
-                expected_revision = isvc_name+'-predictor-default-'+'{:05d}'.format(generation)
-                observed_generation = isvc['status']['observedGeneration']
-                for t in traffic:
-                    if t["latestRevision"]:
-                        traffic_percent = t["percent"]
-                status = 'Unknown'
-                if observed_generation != generation:
-                    time.sleep(2)
-                    continue
-                for condition in isvc['status'].get('conditions', {}):
-                    if condition.get('type', '') == 'Ready':
-                        status = condition.get('status', 'Unknown')
-                tbl(isvc_name, status, 100-traffic_percent, traffic_percent, url)
+                if constants.OBSERVED_GENERATION in isvc['status']:
+                    observed_generation = isvc['status'][constants.OBSERVED_GENERATION]
+                    for t in traffic:
+                        if t["latestRevision"]:
+                            traffic_percent = t["percent"]
+
+                    if generation != 0 and observed_generation != generation:
+                        time.sleep(2)
+                        continue
+                    for condition in isvc['status'].get('conditions', {}):
+                        if condition.get('type', '') == 'Ready':
+                            status = condition.get('status', 'Unknown')
+                    tbl(isvc_name, status, 100-traffic_percent, traffic_percent, url)
+
             else:
-                tbl(isvc_name, 'Unknown', '', '', '')
+                tbl(isvc_name, status, '', '', '')
                 # Sleep 2 to avoid status section is not generated within a very short time.
                 time.sleep(2)
                 continue
 
             if name == isvc_name and status == 'True':
+                time.sleep(2)
                 break

--- a/python/kserve/kserve/api/watch.py
+++ b/python/kserve/kserve/api/watch.py
@@ -65,7 +65,7 @@ def isvc_watch(name=None, namespace=None, timeout_seconds=600, generation=0):
                             status = condition.get('status', 'Unknown')
                     tbl(isvc_name, status, 100-traffic_percent, traffic_percent, url)
                     if status == 'True':
-                       break
+                        break
 
             else:
                 tbl(isvc_name, status, '', '', '')

--- a/python/kserve/kserve/api/watch.py
+++ b/python/kserve/kserve/api/watch.py
@@ -58,7 +58,7 @@ def isvc_watch(name=None, namespace=None, timeout_seconds=600, generation=0):
                     if t["latestRevision"]:
                         traffic_percent = t["percent"]
                 status = 'Unknown'
-                if generation!=0 and latest_ready_revision!=expected_revision:
+                if generation != 0 and latest_ready_revision != expected_revision:
                     time.sleep(2)
                     continue
                 for condition in isvc['status'].get('conditions', {}):

--- a/python/kserve/kserve/constants/constants.py
+++ b/python/kserve/kserve/constants/constants.py
@@ -66,3 +66,8 @@ GRPC_CONTENT_DATATYPE_MAPPINGS = {
     "FP64": "fp64_contents",
     "BYTES": "bytes_contents"
 }
+# K8S status key constants
+OBSERVED_GENERATION = 'observedGeneration'
+
+# K8S metadata key constants
+GENERATION = 'generation'


### PR DESCRIPTION
Made changes to wait for the new replaced version to be ready

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Made changes to  wait for isvc to be ready when watch true is set.
Implemented using generation of new isvc and comparing the `latestreadyrevision`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1739 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
