### PR TITLE
manifests: Upgrade cert manager API version from v1alpha2 to v1

### DIFF
--- a/manifests/charts/templates/certificate.yaml
+++ b/manifests/charts/templates/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert
@@ -12,10 +12,10 @@ spec:
     name: selfsigned-issuer
   secretName: kserve-webhook-server-cert
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
-  namespace: {{ .Release.Namespace }} 
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}


### PR DESCRIPTION
as: https://github.com/kserve/kserve/commit/df512fdf943303fb21d9fd8d3aaff818c5705851