### PR TITLE
Update CloudEvent Handling in KFServer

### DIFF
--- a/python/kserve/kserve/handlers/http.py
+++ b/python/kserve/kserve/handlers/http.py
@@ -10,19 +10,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import Any
 
 import tornado.web
 import json
-import pytz
 import cloudevents.exceptions as ce
-from cloudevents.http import CloudEvent, from_http, is_binary, is_structured, to_binary, to_structured
+from cloudevents.http import from_http
 from cloudevents.sdk.converters.util import has_binary_headers
 from http import HTTPStatus
 from kserve.kfmodel_repository import KFModelRepository
 from kserve.kfmodel import ModelType
-from datetime import datetime
+from kserve.utils.utils import is_structured_cloudevent, create_response_cloudevent
 
 from ray.serve.api import RayServeHandle
 
@@ -65,20 +63,30 @@ class HTTPHandler(BaseHandler):
 
 
 class PredictHandler(HTTPHandler):
+    def get_binary_cloudevent(self) -> str:
+        try:
+            # Use default unmarshaller if contenttype is set in header
+            if "ce-contenttype" in self.request.headers:
+                event = from_http(self.request.headers, self.request.body)
+            else:
+                event = from_http(self.request.headers, self.request.body, lambda x: x)
+
+            return event
+        except (ce.MissingRequiredFields, ce.InvalidRequiredFields, ce.InvalidStructuredJSON,
+                ce.InvalidHeadersFormat, ce.DataMarshallerError, ce.DataUnmarshallerError) as e:
+            raise tornado.web.HTTPError(
+                status_code=HTTPStatus.BAD_REQUEST,
+                reason="Cloud Event Exceptions: %s" % e
+            )
+
     async def post(self, name: str):
+        is_cloudevent = False
+        is_binary_cloudevent = False
+
         if has_binary_headers(self.request.headers):
-            try:
-                # Use default unmarshaller if contenttype is set in header
-                if "ce-contenttype" in self.request.headers:
-                    body = from_http(self.request.headers, self.request.body)
-                else:
-                    body = from_http(self.request.headers, self.request.body, lambda x: x)
-            except (ce.MissingRequiredFields, ce.InvalidRequiredFields, ce.InvalidStructuredJSON,
-                    ce.InvalidHeadersFormat, ce.DataMarshallerError, ce.DataUnmarshallerError) as e:
-                raise tornado.web.HTTPError(
-                    status_code=HTTPStatus.BAD_REQUEST,
-                    reason="Cloud Event Exceptions: %s" % e
-                )
+            is_cloudevent = True
+            is_binary_cloudevent = True
+            body = self.get_binary_cloudevent()
         else:
             try:
                 body = json.loads(self.request.body)
@@ -87,6 +95,10 @@ class PredictHandler(HTTPHandler):
                     status_code=HTTPStatus.BAD_REQUEST,
                     reason="Unrecognized request format: %s" % e
                 )
+
+            if is_structured_cloudevent(body):
+                is_cloudevent = True
+
         # call model locally or remote model workers
         model = self.get_model(name)
         if not isinstance(model, RayServeHandle):
@@ -94,20 +106,18 @@ class PredictHandler(HTTPHandler):
         else:
             model_handle = model
             response = await model_handle.remote(body)
-        # process response from the model
-        if has_binary_headers(self.request.headers):
-            event = CloudEvent(body._attributes, response)
-            if is_binary(self.request.headers):
-                eventheader, eventbody = to_binary(event)
-            elif is_structured(self.request.headers):
-                eventheader, eventbody = to_structured(event)
-            for k, v in eventheader.items():
-                if k != "ce-time":
-                    self.set_header(k, v)
-                else:  # utc now() timestamp
-                    self.set_header('ce-time', datetime.utcnow().replace(tzinfo=pytz.utc).
-                                    strftime('%Y-%m-%dT%H:%M:%S.%f%z'))
-            response = eventbody
+
+        # if we received a cloudevent, then also return a cloudevent
+        if is_cloudevent:
+            headers, response = create_response_cloudevent(name, body, response, is_binary_cloudevent)
+
+            if is_binary_cloudevent:
+                self.set_header("Content-Type", "application/json")
+            else:
+                self.set_header("Content-Type", "application/cloudevents+json")
+
+            for k, v in headers.items():
+                self.set_header(k, v)
 
         self.write(response)
 

--- a/python/kserve/kserve/handlers/http.py
+++ b/python/kserve/kserve/handlers/http.py
@@ -15,7 +15,7 @@ from typing import Any
 import tornado.web
 import json
 import cloudevents.exceptions as ce
-from cloudevents.http import from_http
+from cloudevents.http import CloudEvent, from_http
 from cloudevents.sdk.converters.util import has_binary_headers
 from http import HTTPStatus
 from kserve.kfmodel_repository import KFModelRepository
@@ -63,7 +63,7 @@ class HTTPHandler(BaseHandler):
 
 
 class PredictHandler(HTTPHandler):
-    def get_binary_cloudevent(self) -> str:
+    def get_binary_cloudevent(self) -> CloudEvent:
         try:
             # Use default unmarshaller if contenttype is set in header
             if "ce-contenttype" in self.request.headers:

--- a/python/kserve/kserve/kfmodel.py
+++ b/python/kserve/kserve/kfmodel.py
@@ -174,11 +174,11 @@ class KFModel:
         async_result = await self._grpc_client.ModelInfer(request=request, timeout=self.timeout)
         return async_result
 
-    async def predict(self, request: Union[Dict, CloudEvent, ModelInferRequest]) -> Union[Dict, ModelInferResponse]:
+    async def predict(self, request: Union[Dict, ModelInferRequest]) -> Union[Dict, ModelInferResponse]:
         """
         The predict handler can be overridden to implement the model inference.
         The default implementation makes a call to the predictor if predictor_host is specified
-        :param request: Dict|CloudEvent|ModelInferRequest passed from preprocess handler
+        :param request: Dict|ModelInferRequest passed from preprocess handler
         :return: Dict|ModelInferResponse
         """
         if not self.predictor_host:

--- a/python/kserve/kserve/kfmodel.py
+++ b/python/kserve/kserve/kfmodel.py
@@ -110,20 +110,23 @@ class KFModel:
         self.ready = True
         return self.ready
 
-    async def preprocess(self, request: Dict) -> Union[Dict, CloudEvent, ModelInferRequest]:
+    async def preprocess(self, request: Union[Dict, CloudEvent]) -> Union[Dict, ModelInferRequest]:
         """
-        The preprocess handler can be overridden for data or feature transformation
-        the default implementation decodes to Dict if it is a binary CloudEvent
-        or gets the data field from a structured CloudEvent
+        The preprocess handler can be overridden for data or feature transformation.
+        The default implementation decodes to Dict if it is a binary CloudEvent
+        or gets the data field from a structured CloudEvent.
         :param request: Dict|CloudEvent|ModelInferRequest
         :return: Transformed Dict|ModelInferRequest which passes to predict handler
         """
+        response = request
+
         if isinstance(request, CloudEvent):
-            # Try to decode JSON UTF-8 if possible, otherwise leave the CloudEvent alone
-            # and just pass the CloudEvent on to the predict function.
+            response = request.data
+            # Try to decode and parse JSON UTF-8 if possible, otherwise
+            # just pass the CloudEvent data on to the predict function.
             # This is for the cases that CloudEvent encoding is protobuf, avro etc.
             try:
-                request = json.loads(request.data.decode('UTF-8'))
+                response = json.loads(response.decode('UTF-8'))
             except (json.decoder.JSONDecodeError, UnicodeDecodeError) as e:
                 # If decoding or parsing failed, check if it was supposed to be JSON UTF-8
                 if "content-type" in request._attributes and \
@@ -136,9 +139,9 @@ class KFModel:
 
         elif isinstance(request, dict):
             if is_structured_cloudevent(request):
-                request = request["data"]
+                response = request["data"]
 
-        return request
+        return response
 
     def postprocess(self, response: Union[Dict, ModelInferResponse]) -> Dict:
         """

--- a/python/kserve/test/test_server.py
+++ b/python/kserve/test/test_server.py
@@ -11,7 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import os
 import re
+from unittest import mock
 
 import avro.io
 import avro.schema
@@ -39,7 +41,7 @@ test_avsc_schema = '''
         '''
 
 
-def dummy_cloud_event(data, set_contenttype=False):
+def dummy_cloud_event(data, set_contenttype=False, add_extension=False):
     # This data defines a binary cloudevent
     attributes = {
         "type": "com.example.sampletype1",
@@ -50,6 +52,8 @@ def dummy_cloud_event(data, set_contenttype=False):
     }
     if set_contenttype:
         attributes["content-type"] = "application/json"
+    if add_extension:
+        attributes["custom-extension"] = "custom-value"
 
     event = CloudEvent(attributes, data)
     return event
@@ -189,19 +193,6 @@ class TestTFHttpServer:
         assert resp.body == b'{"predictions": [[1, 2]]}'
         assert resp.headers['content-type'] == "application/json; charset=UTF-8"
 
-    async def test_predict_ce_structured(self, http_server_client):
-
-        event = dummy_cloud_event({"instances": [[1, 2]]})
-        headers, body = to_structured(event)
-        resp = await http_server_client.fetch('/v1/models/TestModel:predict',
-                                              method="POST",
-                                              headers=headers,
-                                              body=body)
-
-        assert resp.code == 200
-        assert resp.body == b'{"predictions": [[1, 2]]}'
-        assert resp.headers['content-type'] == "application/json; charset=UTF-8"
-
     async def test_explain(self, http_server_client):
         resp = await http_server_client.fetch('/v1/models/TestModel:explain',
                                               method="POST",
@@ -322,13 +313,94 @@ class TestTFHttpServerModelNotLoaded:
 
 
 class TestTFHttpServerCloudEvent:
-
     @pytest.fixture(scope="class")
     def app(self):  # pylint: disable=no-self-use
         model = DummyCEModel("TestModel")
         server = kfserver.KFServer()
         server.register_model(model)
         return server.create_application()
+
+    async def test_predict_ce_structured(self, http_server_client):
+        event = dummy_cloud_event({"instances": [[1, 2]]})
+        headers, body = to_structured(event)
+
+        resp = await http_server_client.fetch('/v1/models/TestModel:predict',
+                                              method="POST",
+                                              headers=headers,
+                                              body=body)
+        body = json.loads(resp.body)
+
+        assert resp.code == 200
+        assert resp.headers['content-type'] == "application/cloudevents+json"
+
+        assert body["id"] != "36077800-0c23-4f38-a0b4-01f4369f670a"
+        assert body["data"] == {"predictions": [[1, 2]]}
+        assert body['specversion'] == "1.0"
+        assert body['source'] == "io.kserve.kfserver.TestModel"
+        assert body['type'] == "io.kserve.inference.response"
+        assert body['time'] > "2021-01-28T21:04:43.144141+00:00"
+
+    async def test_predict_custom_ce_attributes(self, http_server_client):
+        with mock.patch.dict(os.environ,
+                             {"CE_SOURCE": "io.kserve.kfserver.CustomSource", "CE_TYPE": "io.kserve.custom_type"}):
+            event = dummy_cloud_event({"instances": [[1, 2]]})
+            headers, body = to_structured(event)
+
+            resp = await http_server_client.fetch('/v1/models/TestModel:predict',
+                                                  method="POST",
+                                                  headers=headers,
+                                                  body=body)
+            body = json.loads(resp.body)
+
+            assert resp.code == 200
+            assert resp.headers['content-type'] == "application/cloudevents+json"
+
+            assert body["id"] != "36077800-0c23-4f38-a0b4-01f4369f670a"
+            assert body["data"] == {"predictions": [[1, 2]]}
+            assert body['source'] == "io.kserve.kfserver.CustomSource"
+            assert body['type'] == "io.kserve.custom_type"
+
+    async def test_predict_merge_structured_ce_attributes(self, http_server_client):
+        with mock.patch.dict(os.environ, {"CE_MERGE": "true"}):
+            event = dummy_cloud_event({"instances": [[1, 2]]}, add_extension=True)
+            headers, body = to_structured(event)
+
+            resp = await http_server_client.fetch('/v1/models/TestModel:predict',
+                                                  method="POST",
+                                                  headers=headers,
+                                                  body=body)
+            body = json.loads(resp.body)
+
+            assert resp.code == 200
+            assert resp.headers['content-type'] == "application/cloudevents+json"
+
+            assert body["id"] != "36077800-0c23-4f38-a0b4-01f4369f670a"
+            assert body["data"] == {"predictions": [[1, 2]]}
+            assert body['source'] == "io.kserve.kfserver.TestModel"
+            assert body['type'] == "io.kserve.inference.response"
+            assert body["custom-extension"] == "custom-value"  # Added by add_extension=True in dummy_cloud_event
+            assert body['time'] > "2021-01-28T21:04:43.144141+00:00"
+
+    async def test_predict_merge_binary_ce_attributes(self, http_server_client):
+        with mock.patch.dict(os.environ, {"CE_MERGE": "true"}):
+            event = dummy_cloud_event({"instances": [[1, 2]]}, set_contenttype=True, add_extension=True)
+            headers, body = to_binary(event)
+
+            resp = await http_server_client.fetch('/v1/models/TestModel:predict',
+                                                  method="POST",
+                                                  headers=headers,
+                                                  body=body)
+
+            assert resp.code == 200
+            assert resp.headers['content-type'] == "application/json"
+            assert resp.headers['ce-specversion'] == "1.0"
+            assert resp.headers["ce-id"] != "36077800-0c23-4f38-a0b4-01f4369f670a"
+            # Added by add_extension=True in dummy_cloud_event
+            assert resp.headers['ce-custom-extension'] == 'custom-value'
+            assert resp.headers['ce-source'] == "io.kserve.kfserver.TestModel"
+            assert resp.headers['ce-type'] == "io.kserve.inference.response"
+            assert resp.headers['ce-time'] > "2021-01-28T21:04:43.144141+00:00"
+            assert resp.body == b'{"predictions": [[1, 2]]}'
 
     async def test_predict_ce_binary_dict(self, http_server_client):
         event = dummy_cloud_event({"instances": [[1, 2]]}, set_contenttype=True)
@@ -339,14 +411,13 @@ class TestTFHttpServerCloudEvent:
                                               body=body)
 
         assert resp.code == 200
-        assert resp.body == b'{"predictions": [[1, 2]]}'
-        assert resp.headers['content-type'] == "application/x-www-form-urlencoded"
+        assert resp.headers['content-type'] == "application/json"
         assert resp.headers['ce-specversion'] == "1.0"
-        assert resp.headers['ce-id'] == "36077800-0c23-4f38-a0b4-01f4369f670a"
-        assert resp.headers['ce-source'] == "https://example.com/event-producer"
-        assert resp.headers['ce-type'] == "com.example.sampletype1"
-        assert resp.headers['ce-datacontenttype'] == "application/x-www-form-urlencoded"
+        assert resp.headers["ce-id"] != "36077800-0c23-4f38-a0b4-01f4369f670a"
+        assert resp.headers['ce-source'] == "io.kserve.kfserver.TestModel"
+        assert resp.headers['ce-type'] == "io.kserve.inference.response"
         assert resp.headers['ce-time'] > "2021-01-28T21:04:43.144141+00:00"
+        assert resp.body == b'{"predictions": [[1, 2]]}'
 
     async def test_predict_ce_binary_bytes(self, http_server_client):
         event = dummy_cloud_event(b'{"instances":[[1,2]]}', set_contenttype=True)
@@ -357,14 +428,13 @@ class TestTFHttpServerCloudEvent:
                                               body=body)
 
         assert resp.code == 200
-        assert resp.body == b'{"predictions": [[1, 2]]}'
-        assert resp.headers['content-type'] == "application/x-www-form-urlencoded"
+        assert resp.headers['content-type'] == "application/json"
         assert resp.headers['ce-specversion'] == "1.0"
-        assert resp.headers['ce-id'] == "36077800-0c23-4f38-a0b4-01f4369f670a"
-        assert resp.headers['ce-source'] == "https://example.com/event-producer"
-        assert resp.headers['ce-type'] == "com.example.sampletype1"
-        assert resp.headers['ce-datacontenttype'] == "application/x-www-form-urlencoded"
+        assert resp.headers["ce-id"] != "36077800-0c23-4f38-a0b4-01f4369f670a"
+        assert resp.headers['ce-source'] == "io.kserve.kfserver.TestModel"
+        assert resp.headers['ce-type'] == "io.kserve.inference.response"
         assert resp.headers['ce-time'] > "2021-01-28T21:04:43.144141+00:00"
+        assert resp.body == b'{"predictions": [[1, 2]]}'
 
     async def test_predict_ce_bytes_bad_format_exception(self, http_server_client):
         event = dummy_cloud_event(b'{', set_contenttype=True)
@@ -376,8 +446,8 @@ class TestTFHttpServerCloudEvent:
                                                headers=headers,
                                                body=body)
         assert err.value.code == 400
-
-        error_regex = re.compile("Unrecognized request format: Expecting property name enclosed in double quotes.*")
+        error_regex = re.compile("Failed to decode or parse binary json cloudevent: "
+                                 "Expecting property name enclosed in double quotes.*")
         response = json.loads(err.value.response.body)
         assert error_regex.match(response["error"]) is not None
 
@@ -391,9 +461,8 @@ class TestTFHttpServerCloudEvent:
                                                headers=headers,
                                                body=body)
         assert err.value.code == 400
-
-        error_regex = re.compile("Unrecognized request format: 'utf-8' codec can't decode byte 0x80 in position 1: "
-                                 "invalid start byte.*")
+        error_regex = re.compile("Failed to decode or parse binary json cloudevent: "
+                                 "'utf-8' codec can't decode byte 0x80 in position 1: invalid start byte.*")
         response = json.loads(err.value.response.body)
         assert error_regex.match(response["error"]) is not None
 
@@ -418,7 +487,6 @@ class TestTFHttpServerAvroCloudEvent:
         data = bytes_writer.getvalue()
 
         event = dummy_cloud_event(data, set_contenttype=True)
-
         # Creates the HTTP request representation of the CloudEvent in binary content mode
         headers, body = to_binary(event)
         resp = await http_server_client.fetch('/v1/models/TestModel:predict',
@@ -427,11 +495,10 @@ class TestTFHttpServerAvroCloudEvent:
                                               body=body)
 
         assert resp.code == 200
-        assert resp.body == b'{"predictions": [["foo", 1, "pink"]]}'
-        assert resp.headers['content-type'] == "application/x-www-form-urlencoded"
+        assert resp.headers['content-type'] == "application/json"
         assert resp.headers['ce-specversion'] == "1.0"
-        assert resp.headers['ce-id'] == "36077800-0c23-4f38-a0b4-01f4369f670a"
-        assert resp.headers['ce-source'] == "https://example.com/event-producer"
-        assert resp.headers['ce-type'] == "com.example.sampletype1"
-        assert resp.headers['ce-datacontenttype'] == "application/x-www-form-urlencoded"
+        assert resp.headers["ce-id"] != "36077800-0c23-4f38-a0b4-01f4369f670a"
+        assert resp.headers['ce-source'] == "io.kserve.kfserver.TestModel"
+        assert resp.headers['ce-type'] == "io.kserve.inference.response"
         assert resp.headers['ce-time'] > "2021-01-28T21:04:43.144141+00:00"
+        assert resp.body == b'{"predictions": [["foo", 1, "pink"]]}'

--- a/python/kserve/test/test_server.py
+++ b/python/kserve/test/test_server.py
@@ -134,15 +134,13 @@ class DummyAvroCEModel(kfmodel.KFModel):
             assert attributes["type"] == "com.example.sampletype1"
             assert attributes["datacontenttype"] == "application/x-www-form-urlencoded"
             assert attributes["content-type"] == "application/json"
-            return request.data
+            return self._parserequest(request.data)
 
     async def predict(self, request):
-        record1 = self._parserequest(request)
-        return {"predictions": [[record1['name'], record1['favorite_number'], record1['favorite_color']]]}
+        return {"predictions": [[request['name'], request['favorite_number'], request['favorite_color']]]}
 
     async def explain(self, request):
-        record1 = self._parserequest(request)
-        return {"predictions": [[record1['name'], record1['favorite_number'], record1['favorite_color']]]}
+        return {"predictions": [[request['name'], request['favorite_number'], request['favorite_color']]]}
 
 
 class DummyKFModelRepository(KFModelRepository):


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the handling of CloudEvent requests to the KFServer.

There were two main issues:
- The response CE attributes were just a copy of the request CE attributes. This is incorrect for a couple of reasons:
  - Each event should have a unique ID
  - The source and type fields are inherently incorrect
  - Not usable with Knative Eventing `Trigger` as the response will match the request filter in the `Trigger`
- A CloudEvent was only returned as a response if the request was a binary CE. If you sent a structured CE then the server would respond with normal a KFServer JSON response.
  - Now a structured CE request will get a structured CE response

I've also made it so that the CE `source` and `type` fields can be changed using environment variables `CE_SOURCE` `CE_TYPE`

Users can also optionally merge CE fields if they set the environment variable `CE_MERGE` to `"true"`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1923
Fixed #1671

**Release note**:

```release-note
Update CloudEvent handling
  - Structured CloudEvent requests now get a structured CloudEvent as a response
  - Correctly set CloudEvent id, time, source, type fields
  - Source and type fields can be overwritten by env variables `CE_SOURCE` `CE_TYPE`
  - Optionally merge original CloudEvent request attributes with response attributes with env variable `CE_MERGE`
```
