### PR TITLE
Add content type for transformer to predictor HTTP call #1941

### DIFF
--- a/python/kserve/kserve/kfmodel.py
+++ b/python/kserve/kserve/kfmodel.py
@@ -161,10 +161,12 @@ class KFModel:
         predict_url = PREDICTOR_URL_FORMAT.format(self.predictor_host, self.name)
         if self.protocol == PredictorProtocol.REST_V2.value:
             predict_url = PREDICTOR_V2_URL_FORMAT.format(self.predictor_host, self.name)
+        json_header = {'Content-Type': 'application/json'}
         response = await self._http_client.fetch(
             predict_url,
             method='POST',
             request_timeout=self.timeout,
+            headers=json_header,
             body=json.dumps(request)
         )
         if response.code != 200:


### PR DESCRIPTION
**What this PR does / why we need it**:
When transformer sends http request, add ```content-type: application/json``` to header. In my experience, if that header doesn't exist, the triton predictor doesn't receive a large size message and ends with signal 11. Add that header to send the appropriate request to the predictor.

**Which issue(s) this PR fixes**:
Fixes #1941