### PR TITLE
Ensure e2e tests use correct runtime images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ deploy-ci: manifests
 	kustomize build config/overlays/test | kubectl apply -f -
 	# TODO: Add runtimes as part of default deployment
 	kubectl wait --for=condition=ready pod -l control-plane=kserve-controller-manager -n kserve --timeout=300s
-	kustomize build config/runtimes | kubectl apply --validate=false -f -
+	kustomize build config/overlays/test/runtimes | kubectl apply --validate=false -f -
 
 undeploy:
 	kustomize build config/default | kubectl delete -f -

--- a/config/overlays/test/runtimes/kustomization.yaml
+++ b/config/overlays/test/runtimes/kustomization.yaml
@@ -1,0 +1,24 @@
+bases:
+  - ../../../runtimes
+
+images:
+  - name: kserve/sklearnserver
+    newName: 809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/sklearnserver
+    newTag: latest
+
+  - name: kserve/xgbserver
+    newName: 809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/xgbserver
+    newTag: latest
+
+  - name: kserve/pmmlserver
+    newName: 809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/pmmlserver
+    newTag: latest
+
+  - name: kserve/paddleserver
+    newName: 809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/paddleserver
+    newTag: latest
+
+  - name: kserve/lgbserver
+    newName: 809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/lgbserver
+    newTag: latest
+

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -122,6 +122,7 @@ export PATH="${PATH}:${GOPATH}/bin"
 wget -O $GOPATH/bin/yq https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64
 chmod +x $GOPATH/bin/yq
 sed -i -e "s/latest/${PULL_BASE_SHA}/g" config/overlays/test/configmap/inferenceservice.yaml
+sed -i -e "s/latest/${PULL_BASE_SHA}/g" config/overlays/test/runtimes/kustomization.yaml
 sed -i -e "s/latest/${PULL_BASE_SHA}/g" config/overlays/test/manager_image_patch.yaml
 make deploy-ci
 

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -264,10 +264,10 @@
                     name: "build-pytorchserver-gpu",
                     template: "build-pytorchserver-gpu",
                   },
-                  //{
-                  //  name: "build-paddleserver",
-                  //  template: "build-paddleserver",
-                  //},
+                  {
+                    name: "build-paddleserver",
+                    template: "build-paddleserver",
+                  },
                   {
                     name: "build-sklearnserver",
                     template: "build-sklearnserver",


### PR DESCRIPTION
The e2e tests aren't using some of the ci-built images since we switched to use ServingRuntimes. This PR ensures that the runtime images are updated for testing.

