### PR TITLE
Remove h5py installation step in python test workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -56,5 +56,4 @@ jobs:
         pip install -e ./paddleserver[test]
         pytest ./paddleserver
         pip install -e ./alibiexplainer
-        pip install h5py==2.9.0
         pytest ./alibiexplainer


### PR DESCRIPTION
**What this PR does / why we need it**:

h5py 2.9 is not compatible with the tensorflow version required by alibiexplainer. Should just use the version pulled in by alibiexplainer

https://github.com/kserve/kserve/pull/1951#issuecomment-997393658

