### PR TITLE
updated istio download url

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -41,7 +41,7 @@ echo ${KUBE_VERSION:43:2}
 
 if [ ${KUBE_VERSION:43:2} -gt 20 ]; then export ISTIO_VERSION=1.10.3; export KNATIVE_VERSION=v0.23.2; fi
 
-curl -L https://git.io/getLatestIstio | sh -
+curl -L https://istio.io/downloadIstio | sh -
 cd istio-${ISTIO_VERSION}
 
 # Create istio-system namespace

--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -15,8 +15,7 @@ azure-storage-blob==12.8.1
 azure-identity>=1.6.0
 cloudevents>=1.2.0
 avro>=1.10.1
-boto3==1.18.18
-botocore==1.21.18
+boto3==1.20.24
 psutil>=5.0
 ray[serve]==1.9.0
 grpcio>=1.34.0

--- a/python/kserve/setup.py
+++ b/python/kserve/setup.py
@@ -16,6 +16,7 @@ import setuptools
 
 TESTS_REQUIRES = [
     'pytest',
+    'pytest-xdist',
     'pytest-cov',
     'pytest-asyncio',
     'pytest-tornasync',

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019 The Kubeflow Authors.
+# Copyright 2021 The KServe Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/relea
 echo "Waiting for cert manager started ..."
 kubectl wait --for=condition=ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager
 
-echo "Install KFServing ..."
+echo "Install KServe ..."
 export GOPATH="$HOME/go"
 export PATH="${PATH}:${GOPATH}/bin"
 
@@ -126,24 +126,19 @@ sed -i -e "s/latest/${PULL_BASE_SHA}/g" config/overlays/test/runtimes/kustomizat
 sed -i -e "s/latest/${PULL_BASE_SHA}/g" config/overlays/test/manager_image_patch.yaml
 make deploy-ci
 
-echo "Waiting for KFServing started ..."
+echo "Waiting for KServe started ..."
 kubectl wait --for=condition=Ready pods --all --timeout=180s -n kserve
 kubectl get events -A
 
 echo "Creating a namespace kserve-ci-test ..."
 kubectl create namespace kserve-ci-e2e-test
 
-echo "Istio, Knative and KFServing have been installed and started."
+echo "Istio, Knative and KServe have been installed and started."
 
-echo "Installing KFServing Python SDK ..."
+echo "Installing KServe Python SDK ..."
 python3 -m pip install --upgrade pip
-pip3 install pytest==6.0.2 pytest-xdist pytest-rerunfailures
-pip3 install --upgrade pytest-tornasync
-pip3 install urllib3==1.24.2
-pip3 install --upgrade setuptools
 pushd python/kserve >/dev/null
-    pip3 install -r requirements.txt
-    python3 setup.py install --force --user
+    pip3 install -e .[test] --user
 popd
 
 echo "Starting E2E functional tests ..."

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -45,7 +45,7 @@ curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack
 echo "Install istio ..."
 mkdir istio_tmp
 pushd istio_tmp >/dev/null
-  curl -L https://git.io/getLatestIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
+  curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
   cd istio-${ISTIO_VERSION}
   export PATH=$PWD/bin:$PATH
   istioctl operator init


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`git.io/getLatestIstio` is no longer reachable and fails to install Istio in e2e tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
