### PR TITLE
Update kserve sdk examples with renamed classes

### DIFF
--- a/docs/samples/explanation/aif/germancredit/server/model.py
+++ b/docs/samples/explanation/aif/germancredit/server/model.py
@@ -6,7 +6,7 @@ from sklearn.linear_model import LogisticRegression
 from aif360.algorithms.preprocessing.optim_preproc_helpers.data_preproc_functions import load_preproc_data_german
 
 
-class KServeSampleModel(kserve.KFModel):
+class KServeSampleModel(kserve.Model):
     def __init__(self, name: str):
         super().__init__(name)
         self.name = name
@@ -39,4 +39,4 @@ class KServeSampleModel(kserve.KFModel):
 if __name__ == "__main__":
     model = KServeSampleModel("german-credit")
     model.load()
-    kserve.KFServer(workers=1).start([model])
+    kserve.ModelServer(workers=1).start([model])

--- a/docs/samples/explanation/aix/mnist/rfserver/rfserver/__main__.py
+++ b/docs/samples/explanation/aix/mnist/rfserver/rfserver/__main__.py
@@ -18,7 +18,7 @@ from .model import RFModel
 
 DEFAULT_MODEL_NAME = "rfserver"
 
-parser = argparse.ArgumentParser(parents=[kserve.kfserver.parser])
+parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument('--model_name', default=DEFAULT_MODEL_NAME,
                     help='The name that the model is served under.')
 args, _ = parser.parse_known_args()
@@ -26,4 +26,4 @@ args, _ = parser.parse_known_args()
 if __name__ == "__main__":
     model = RFModel(args.model_name)
     model.load()
-    kserve.KFServer().start([model])
+    kserve.ModelServer().start([model])

--- a/docs/samples/explanation/aix/mnist/rfserver/rfserver/model.py
+++ b/docs/samples/explanation/aix/mnist/rfserver/rfserver/model.py
@@ -33,7 +33,7 @@ class PipeStep(object):
         return self._step_func(X)
 
 
-class RFModel(kserve.KFModel):  # pylint:disable=c-extension-no-member
+class RFModel(kserve.Model):  # pylint:disable=c-extension-no-member
     def __init__(self, name: str):
         super().__init__(name)
         self.name = name

--- a/docs/samples/explanation/aix/mnist/rfserver/setup.py
+++ b/docs/samples/explanation/aix/mnist/rfserver/setup.py
@@ -25,7 +25,7 @@ setup(
     license='https://github.com/kserve/kserve/LICENSE',
     url='https://github.com/kserve/kserve/python/rfserver',
     description='Model Server implementation for AI eXplainability using LIME. \
-                 Not intended for use outside KFServing Frameworks Images',
+                 Not intended for use outside KServe Frameworks Images',
     long_description=open('README.md').read(),
     python_requires='>3.4',
     packages=find_packages("rfserver"),

--- a/docs/samples/explanation/art/mnist/sklearnserver/setup.py
+++ b/docs/samples/explanation/art/mnist/sklearnserver/setup.py
@@ -26,7 +26,7 @@ setup(
     license='https://github.com/kserve/kserve/LICENSE',
     url='https://github.com/kserve/kserve/python/sklearnserver',
     description='Model Server implementation for scikit-learn. \
-                 Not intended for use outside KFServing Frameworks Images',
+                 Not intended for use outside KServe Frameworks Images',
     long_description=open('README.md').read(),
     python_requires='>3.4',
     packages=find_packages("sklearnserver"),

--- a/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/__main__.py
+++ b/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/__main__.py
@@ -16,13 +16,13 @@ import logging
 import sys
 
 import kserve
-from .kfserver import KFServer
+from .kfserver import ModelServer
 from sklearnserver import SKLearnModel, SKLearnModelRepository
 
 DEFAULT_MODEL_NAME = "model"
 DEFAULT_LOCAL_MODEL_DIR = "/tmp/model"
 
-parser = argparse.ArgumentParser(parents=[kserve.kfserver.parser])
+parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument('--model_dir', required=True,
                     help='A URI pointer to the model binary')
 parser.add_argument('--model_name', default=DEFAULT_MODEL_NAME,
@@ -38,4 +38,4 @@ if __name__ == "__main__":
         logging.error(f"fail to load model {args.model_name} from dir {args.model_dir}. "
                       f"exception type {ex_type}, exception msg: {ex_value}")
         model.ready = False
-    KFServer(registered_models=SKLearnModelRepository(args.model_dir)).start([model] if model.ready else [])
+    ModelServer(registered_models=SKLearnModelRepository(args.model_dir)).start([model] if model.ready else [])

--- a/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/http.py
+++ b/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/http.py
@@ -15,11 +15,11 @@ import inspect
 import tornado.web
 import json
 from http import HTTPStatus
-from .kfmodel_repository import KFModelRepository
+from .model_repository import ModelRepository
 
 
 class HTTPHandler(tornado.web.RequestHandler):
-    def initialize(self, models: KFModelRepository):
+    def initialize(self, models: ModelRepository):
         self.models = models  # pylint:disable=attribute-defined-outside-init
 
     def get_model(self, name: str):

--- a/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/kfmodel_repository.py
+++ b/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/kfmodel_repository.py
@@ -12,12 +12,12 @@
 # limitations under the License.
 
 from typing import List, Optional
-from kserve import KFModel
+from kserve import Model
 
 MODEL_MOUNT_DIRS = "/mnt/models"
 
 
-class KFModelRepository:
+class ModelRepository:
     """
     Model repository interface, follows NVIDIA Triton's `model-repository`
     extension.
@@ -30,17 +30,17 @@ class KFModelRepository:
     def set_models_dir(self, models_dir):  # used for unit tests
         self.models_dir = models_dir
 
-    def get_model(self, name: str) -> Optional[KFModel]:
+    def get_model(self, name: str) -> Optional[Model]:
         return self.models.get(name, None)
 
-    def get_models(self) -> List[KFModel]:
+    def get_models(self) -> List[Model]:
         return list(self.models.values())
 
     def is_model_ready(self, name: str):
         model = self.get_model(name)
         return False if model is None else model.ready
 
-    def update(self, model: KFModel):
+    def update(self, model: Model):
         self.models[model.name] = model
 
     def load(self, name: str) -> bool:

--- a/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/kfserver.py
+++ b/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/kfserver.py
@@ -23,8 +23,8 @@ import tornado.httpserver
 import tornado.log
 
 from .http import PredictHandler, ExplainHandler
-from kserve import KFModel
-from .kfmodel_repository import KFModelRepository
+from kserve import Model
+from .model_repository import ModelRepository
 
 DEFAULT_HTTP_PORT = 8080
 DEFAULT_GRPC_PORT = 8081
@@ -44,12 +44,12 @@ args, _ = parser.parse_known_args()
 tornado.log.enable_pretty_logging()
 
 
-class KFServer:
+class ModelServer:
     def __init__(self, http_port: int = args.http_port,
                  grpc_port: int = args.grpc_port,
                  max_buffer_size: int = args.max_buffer_size,
                  workers: int = args.workers,
-                 registered_models: KFModelRepository = KFModelRepository()):
+                 registered_models: ModelRepository = ModelRepository()):
         self.registered_models = registered_models
         self.http_port = http_port
         self.grpc_port = grpc_port
@@ -85,7 +85,7 @@ class KFServer:
              UnloadHandler, dict(models=self.registered_models)),
         ])
 
-    def start(self, models: List[KFModel], nest_asyncio: bool = False):
+    def start(self, models: List[Model], nest_asyncio: bool = False):
         for model in models:
             self.register_model(model)
 
@@ -106,7 +106,7 @@ class KFServer:
 
         tornado.ioloop.IOLoop.current().start()
 
-    def register_model(self, model: KFModel):
+    def register_model(self, model: Model):
         if not model.name:
             raise Exception(
                 "Failed to register model, model.name must be provided.")
@@ -120,7 +120,7 @@ class LivenessHandler(tornado.web.RequestHandler):  # pylint:disable=too-few-pub
 
 
 class HealthHandler(tornado.web.RequestHandler):
-    def initialize(self, models: KFModelRepository):
+    def initialize(self, models: ModelRepository):
         self.models = models  # pylint:disable=attribute-defined-outside-init
 
     def get(self, name: str):
@@ -144,7 +144,7 @@ class HealthHandler(tornado.web.RequestHandler):
 
 
 class ListHandler(tornado.web.RequestHandler):
-    def initialize(self, models: KFModelRepository):
+    def initialize(self, models: ModelRepository):
         self.models = models  # pylint:disable=attribute-defined-outside-init
 
     def get(self):
@@ -152,7 +152,7 @@ class ListHandler(tornado.web.RequestHandler):
 
 
 class LoadHandler(tornado.web.RequestHandler):
-    def initialize(self, models: KFModelRepository):  # pylint:disable=attribute-defined-outside-init
+    def initialize(self, models: ModelRepository):  # pylint:disable=attribute-defined-outside-init
         self.models = models
 
     async def post(self, name: str):
@@ -178,7 +178,7 @@ class LoadHandler(tornado.web.RequestHandler):
 
 
 class UnloadHandler(tornado.web.RequestHandler):
-    def initialize(self, models: KFModelRepository):  # pylint:disable=attribute-defined-outside-init
+    def initialize(self, models: ModelRepository):  # pylint:disable=attribute-defined-outside-init
         self.models = models
 
     def post(self, name: str):

--- a/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/model.py
+++ b/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/model.py
@@ -21,7 +21,7 @@ MODEL_BASENAME = "model"
 MODEL_EXTENSIONS = [".joblib", ".pkl", ".pickle"]
 
 
-class SKLearnModel(kserve.KFModel):  # pylint:disable=c-extension-no-member
+class SKLearnModel(kserve.Model):  # pylint:disable=c-extension-no-member
     def __init__(self, name: str, model_dir: str):
         super().__init__(name)
         self.name = name

--- a/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/sklearn_model_repository.py
+++ b/docs/samples/explanation/art/mnist/sklearnserver/sklearnserver/sklearn_model_repository.py
@@ -12,11 +12,11 @@
 # limitations under the License.
 
 import os
-from .kfmodel_repository import KFModelRepository, MODEL_MOUNT_DIRS
+from .model_repository import ModelRepository, MODEL_MOUNT_DIRS
 from sklearnserver import SKLearnModel
 
 
-class SKLearnModelRepository(KFModelRepository):
+class SKLearnModelRepository(ModelRepository):
 
     def __init__(self, model_dir: str = MODEL_MOUNT_DIRS):
         super().__init__(model_dir)

--- a/docs/samples/kafka/image_transformer/__main__.py
+++ b/docs/samples/kafka/image_transformer/__main__.py
@@ -17,7 +17,7 @@ from .image_transformer import ImageTransformer
 
 DEFAULT_MODEL_NAME = "model"
 
-parser = argparse.ArgumentParser(parents=[kserve.kfserver.parser])
+parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument('--model_name', default=DEFAULT_MODEL_NAME,
                     help='The name that the model is served under.')
 parser.add_argument('--predictor_host', help='The URL for the model predict function', required=True)
@@ -26,5 +26,5 @@ args, _ = parser.parse_known_args()
 
 if __name__ == "__main__":
     transformer = ImageTransformer(args.model_name, predictor_host=args.predictor_host)
-    kfserver = kserve.KFServer()
-    kfserver.start(models=[transformer])
+    server = kserve.ModelServer()
+    server.start(models=[transformer])

--- a/docs/samples/kafka/image_transformer/image_transformer.py
+++ b/docs/samples/kafka/image_transformer/image_transformer.py
@@ -31,7 +31,7 @@ def image_transform(image):
     return g.tolist()
 
 
-class ImageTransformer(kserve.KFModel):
+class ImageTransformer(kserve.Model):
     def __init__(self, name: str, predictor_host: str):
         super().__init__(name)
         self.predictor_host = predictor_host

--- a/docs/samples/v1beta1/custom/torchserve/README.md
+++ b/docs/samples/v1beta1/custom/torchserve/README.md
@@ -4,14 +4,14 @@ In this example we use torchserve as custom server to serve an mnist model. The 
 
 ## Setup
 
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ### This example requires v1beta1/KFS 0.5
 
 ## Build and push the sample Docker Image
 
-The custom torchserve image is wrapped with model inside the container and serves it with KFServing.
+The custom torchserve image is wrapped with model inside the container and serves it with KServe.
 
 In this example we build a torchserve image with marfile and config.properties into a container. To build and push with Docker Hub, run these commands replacing {username} with your Docker Hub username:
 

--- a/docs/samples/v1beta1/custom/torchserve/bert-sample/hugging-face-bert-sample.md
+++ b/docs/samples/v1beta1/custom/torchserve/bert-sample/hugging-face-bert-sample.md
@@ -41,7 +41,7 @@ torch-model-archiver --model-name BERTSeqClassification --version 1.0 --serializ
 
 ## Build and push the sample Docker Image
 
-The custom torchserve image is wrapped with model inside the container and serves it with KFServing.
+The custom torchserve image is wrapped with model inside the container and serves it with KServe.
 
 In this example we use Docker to build the torchserve image with marfile and config.properties into a container.
 

--- a/docs/samples/v1beta1/custom/torchserve/docs/metrics.md
+++ b/docs/samples/v1beta1/custom/torchserve/docs/metrics.md
@@ -4,7 +4,7 @@ This adds prometheus and granfana to the cluster with some default metrics.
 
 ## Setup
 
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ## Enable request metrics

--- a/docs/samples/v1beta1/lightgbm/README.md
+++ b/docs/samples/v1beta1/lightgbm/README.md
@@ -48,7 +48,7 @@ print(res.text)
 ## Predict on a InferenceService using LightGBM Server
 
 ## Setup
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ## Create the InferenceService
@@ -99,11 +99,11 @@ Expected Output
 ```
 
 ## Run LightGBM InferenceService with your own image
-Since the KFServing LightGBM image is built from a specific version of `lightgbm` pip package, sometimes it might not be compatible with the pickled model
+Since the KServe LightGBM image is built from a specific version of `lightgbm` pip package, sometimes it might not be compatible with the pickled model
 you saved from your training environment, however you can build your own lgbserver image following [this instruction](../../../python/lgbserver/README.md#building-your-own-ligthgbm-server-docker-image).
 
 To use your lgbserver image:
-- Add the image to the KFServing [configmap](../../../../config/configmap/inferenceservice.yaml)
+- Add the image to the KServe [configmap](../../../../config/configmap/inferenceservice.yaml)
 ```yaml
         "lightgbm": {
             "image": "<your-dockerhub-id>/kfserving/lgbserver",

--- a/docs/samples/v1beta1/paddle/README.md
+++ b/docs/samples/v1beta1/paddle/README.md
@@ -3,7 +3,7 @@ In this example, we use a trained paddle resnet50 model to classify images by ru
 
 ## Setup
 
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ## Create the InferenceService

--- a/docs/samples/v1beta1/pmml/README.md
+++ b/docs/samples/v1beta1/pmml/README.md
@@ -12,7 +12,7 @@ If you want to scale the PMMLServer to improve predict performance, you should t
 
 
 ## Setup
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ## Create the InferenceService

--- a/docs/samples/v1beta1/rollout/README.md
+++ b/docs/samples/v1beta1/rollout/README.md
@@ -1,13 +1,13 @@
 # Rollout InferenceService with Canary Strategy
 
 ## Setup
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ## Create the InferenceService
 In v1beta1 you no longer need to specify both default and canary spec on `InferenceService` to rollout the `InferenceService` with canary strategy, 
-KFServing automatically tracks the last good revision that was rolled out with 100% traffic, you only need to set the `canaryTrafficPercent` field on the component
-and KFServing automatically splits the traffic between the revision that is currently rolling out and the last known good revision that had 100% traffic rolled out.
+KServe automatically tracks the last good revision that was rolled out with 100% traffic, you only need to set the `canaryTrafficPercent` field on the component
+and KServe automatically splits the traffic between the revision that is currently rolling out and the last known good revision that had 100% traffic rolled out.
 
 ![Canary Rollout](./canary.png)
 

--- a/docs/samples/v1beta1/sklearn/v1/README.md
+++ b/docs/samples/v1beta1/sklearn/v1/README.md
@@ -38,7 +38,7 @@ print(res.text)
 # Predict on an InferenceService using SKLearnServer
 
 ## Setup
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ## Create the InferenceService
@@ -88,12 +88,12 @@ Expected Output
 ```
 
 ## Run SKLearn InferenceService with your own image
-Since the KFServing SKLearnServer image is built from a specific version of `scikit-learn` pip package, sometimes it might not be compatible with the pickled model
+Since the KServe SKLearnServer image is built from a specific version of `scikit-learn` pip package, sometimes it might not be compatible with the pickled model
 you saved from your training environment, however you can build your own SKLearnServer image following [these instructions](../../../../../python/sklearnserver/README.md#building-your-own-scikit-learn-server-docker-image
 ).
 
 To use your SKLearnServer image:
-- Add the image to the KFServing [configmap](../../../config/configmap/inferenceservice.yaml)
+- Add the image to the KServe [configmap](../../../config/configmap/inferenceservice.yaml)
 ```yaml
         "sklearn": {
             "image": "<your-dockerhub-id>/kfserving/sklearnserver",

--- a/docs/samples/v1beta1/sklearn/v2/README.md
+++ b/docs/samples/v1beta1/sklearn/v2/README.md
@@ -65,7 +65,7 @@ These can be specified through environment variables or by creating a local
 }
 ```
 
-Note that, when we [deploy our model](#deployment), **KFServing will already
+Note that, when we [deploy our model](#deployment), **KServe will already
 inject some sensible defaults** so that it runs out-of-the-box without any
 further configuration.
 However, you can still override these defaults by providing a
@@ -84,7 +84,7 @@ mlserver start .
 
 ## Deployment
 
-Lastly, we will use KFServing to deploy our trained model.
+Lastly, we will use KServe to deploy our trained model.
 For this, we will just need to use **version `v1beta1`** of the
 `InferenceService` CRD and set the the **`protocolVersion` field to `v2`**.
 
@@ -106,10 +106,10 @@ Note that this makes the following assumptions:
   to a "model repository" (GCS in this example) and can be accessed as
   `gs://seldon-models/sklearn/iris`.
 - There is a K8s cluster available, accessible through `kubectl`.
-- KFServing has already been [installed in your
-  cluster](https://github.com/kubeflow/kfserving/#install-kfserving).
+- KServe has already been [installed in your
+  cluster](https://github.com/kserve/kserve#installation).
 
-Assuming that we've got a cluster accessible through `kubectl` with KFServing
+Assuming that we've got a cluster accessible through `kubectl` with KServe
 already installed, we can deploy our model as:
 
 ```

--- a/docs/samples/v1beta1/spark/README.md
+++ b/docs/samples/v1beta1/spark/README.md
@@ -2,7 +2,7 @@
 spark.mllib supports model export to Predictive Model Markup Language [PMML](https://en.wikipedia.org/wiki/Predictive_Model_Markup_Language).
 
 ## Setup
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 3. Install `pyspark` 3.0.x and `pyspark2pmml`
 ```bash

--- a/docs/samples/v1beta1/tensorflow/README.md
+++ b/docs/samples/v1beta1/tensorflow/README.md
@@ -1,6 +1,6 @@
 # Predict on an InferenceService with Tensorflow model
 ## Setup
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md#deploy-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md#deploy-kfserving).
 2. Your cluster's Istio Ingress gateway must be network accessible.
 
 
@@ -104,7 +104,7 @@ NAME            URL                                        READY   PREV   LATEST
 flower-sample   http://flower-sample.default.example.com   True    80     20       flower-sample-predictor-default-n9zs6   flower-sample-predictor-default-2kwtr   7m15s
 ```
 
-As you can see the traffic is split between the last rolled out revision and the current latest ready revision, KFServing automatically tracks the last rolled out(stable) revision for you so you
+As you can see the traffic is split between the last rolled out revision and the current latest ready revision, KServe automatically tracks the last rolled out(stable) revision for you so you
 do not need to maintain both default and canary on the `InferenceService` as in v1alpha2.
 
 

--- a/docs/samples/v1beta1/torchserve/README.md
+++ b/docs/samples/v1beta1/torchserve/README.md
@@ -24,7 +24,7 @@ The KServe/TorchServe integration expects following model store layout.
 │   ├── mnist.mar
 ```
 
-- For remote storage you can choose to start the example using the prebuilt mnist MAR file stored on KFServing example GCS bucket
+- For remote storage you can choose to start the example using the prebuilt mnist MAR file stored on KServe example GCS bucket
 `gs://kfserving-examples/models/torchserve/image_classifier`,
 you can also generate the MAR file with `torch-model-archiver` and create the model store on remote storage according to the above layout.
 
@@ -39,14 +39,14 @@ torch-model-archiver --model-name mnist --version 1.0 \
 - For PVC user please refer to [model archive file generation](./model-archiver/README.md) for auto generation of MAR files from
 the model and dependent files.
 
-- The [config.properties](./v1/config.properties) file includes the flag `service_envelope=kfserving` to enable the KFServing inference protocol.
-The requests are converted from KFServing inference request format to torchserve request format and sent to the `inference_address` configured
+- The [config.properties](./v1/config.properties) file includes the flag `service_envelope=kfserving` to enable the KServe inference protocol.
+The requests are converted from KServe inference request format to torchserve request format and sent to the `inference_address` configured
 via local socket.
 
 
 ## TorchServe with KFS envelope inference endpoints
 
-The KServe/TorchServe integration supports both KFServing v1 and v2 protocols.
+The KServe/TorchServe integration supports both KServe v1 and v2 protocols.
 
 V1 Protocol
 

--- a/docs/samples/v1beta1/torchserve/autoscaling/README.md
+++ b/docs/samples/v1beta1/torchserve/autoscaling/README.md
@@ -1,5 +1,5 @@
 # Autoscaling
-KFServing supports the implementation of Knative Pod Autoscaler (KPA) and Kubernetes’ Horizontal Pod Autoscaler (HPA).
+KServe supports the implementation of Knative Pod Autoscaler (KPA) and Kubernetes’ Horizontal Pod Autoscaler (HPA).
 The features and limitations of each of these Autoscalers are listed below.
 
 IMPORTANT: If you want to use Kubernetes Horizontal Pod Autoscaler (HPA), you must install [HPA extension](https://knative.dev/docs/install/any-kubernetes-cluster/#optional-serving-extensions)

--- a/docs/samples/v1beta1/torchserve/metrics/README.md
+++ b/docs/samples/v1beta1/torchserve/metrics/README.md
@@ -4,7 +4,7 @@ This adds prometheus and granfana to the cluster with some default metrics.
 
 ## Setup
 
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ##  Open the Istio Dashboard via the Grafana UI and Prometheus UI

--- a/docs/samples/v1beta1/torchserve/model-archiver/README.md
+++ b/docs/samples/v1beta1/torchserve/model-archiver/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ## 1. Create PV and PVC

--- a/docs/samples/v1beta1/torchserve/v2/tensor_conv/utils.py
+++ b/docs/samples/v1beta1/torchserve/v2/tensor_conv/utils.py
@@ -25,7 +25,7 @@ _NumpyToDatatype["object"] = "BYTES"
 
 def _to_datatype(dtype: np.dtype) -> str:
     """
-    Converts numpy datatype to KFServing datatype
+    Converts numpy datatype to KServe datatype
     """
     as_str = str(dtype)
     datatype = _NumpyToDatatype[as_str]

--- a/docs/samples/v1beta1/transformer/feast/README.md
+++ b/docs/samples/v1beta1/transformer/feast/README.md
@@ -8,16 +8,16 @@ Transformer is an `InferenceService` component which does pre/post processing al
 3. Your Feast online store is populated with driver [data](https://github.com/tedhtchang/populate_feast_online_store/blob/main/driver_stats.parquet), instructions available [here](https://github.com/tedhtchang/populate_feast_online_store), and network accessible.
 
 ## Build Transformer image
-`KServe.KFModel` base class mainly defines three handlers `preprocess`, `predict` and `postprocess`, these handlers are executed
+`KServe.Model` base class mainly defines three handlers `preprocess`, `predict` and `postprocess`, these handlers are executed
 in sequence, the output of the `preprocess` is passed to `predict` as the input, when `predictor_host` is passed the `predict` handler by default makes a HTTP call to the predictor url 
 and gets back a response which then passes to `postproces` handler. KServe automatically fills in the `predictor_host` for `Transformer` and handle the call to the `Predictor`, for gRPC
 predictor currently you would need to overwrite the `predict` handler to make the gRPC call.
 
-To implement a `Transformer` you can derive from the base `KFModel` class and then overwrite the `preprocess` and `postprocess` handler to have your own
+To implement a `Transformer` you can derive from the base `Model` class and then overwrite the `preprocess` and `postprocess` handler to have your own
 customized transformation logic.
 
-### Extend KFModel and implement pre/post processing functions
-We created a class, DriverTransformer, which extends KFModel for this driver ranking example. It takes additional arguments for the transformer to interact with Feast:
+### Extend Model and implement pre/post processing functions
+We created a class, DriverTransformer, which extends Model for this driver ranking example. It takes additional arguments for the transformer to interact with Feast:
 * feast_serving_url: The Feast serving URL, in the form of `<host_name_or_ip:port>`
 * entity_ids: The entity IDs for which to retrieve features from the Feast feature store
 * feature_refs: The feature references for the features to be retrieved

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
 
 DEFAULT_MODEL_NAME = "sklearn-driver-transformer"
 
-parser = argparse.ArgumentParser(parents=[kserve.kfserver.parser])
+parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument(
     "--predictor_host",
     help="The URL for the model predict function", required=True
@@ -53,5 +53,5 @@ if __name__ == "__main__":
         feast_serving_url=args.feast_serving_url,
         entity_ids=args.entity_ids,
         feature_refs=args.feature_refs)
-    kfserver = kserve.KFServer()
+    kfserver = kserve.ModelServer()
     kfserver.start(models=[transformer])

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
@@ -53,5 +53,5 @@ if __name__ == "__main__":
         feast_serving_url=args.feast_serving_url,
         entity_ids=args.entity_ids,
         feature_refs=args.feature_refs)
-    kfserver = kserve.ModelServer()
-    kfserver.start(models=[transformer])
+    server = kserve.ModelServer()
+    server.start(models=[transformer])

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer/driver_transformer.py
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer/driver_transformer.py
@@ -20,12 +20,12 @@ import json
 logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
 
 
-class DriverTransformer(kserve.KFModel):
+class DriverTransformer(kserve.Model):
     """ A class object for the data handling activities of driver ranking
     Task and returns a KServe compatible response.
 
     Args:
-        kserve (class object): The KFModel class from the KServe
+        kserve (class object): The Model class from the KServe
         modeule is passed here.
     """
     def __init__(self, name: str,

--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -4,22 +4,22 @@ input tensors model server expects. In this example we demonstrate an example of
 
 ## Setup
 
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 
 ## Build Transformer image
-`KFServing.KFModel` base class mainly defines three handlers `preprocess`, `predict` and `postprocess`, these handlers are executed
+`KServe.Model` base class mainly defines three handlers `preprocess`, `predict` and `postprocess`, these handlers are executed
 in sequence, the output of the `preprocess` is passed to `predict` as the input, when `predictor_host` is passed the `predict` handler by default makes a HTTP call to the predictor url 
-and gets back a response which then passes to `postproces` handler. KFServing automatically fills in the `predictor_host` for `Transformer` and handle the call to the `Predictor`, for gRPC
+and gets back a response which then passes to `postproces` handler. KServe automatically fills in the `predictor_host` for `Transformer` and handle the call to the `Predictor`, for gRPC
 predictor currently you would need to overwrite the `predict` handler to make the gRPC call.
 
-To implement a `Transformer` you can derive from the base `KFModel` class and then overwrite the `preprocess` and `postprocess` handler to have your own
+To implement a `Transformer` you can derive from the base `Model` class and then overwrite the `preprocess` and `postprocess` handler to have your own
 customized transformation logic.
 
-### Extend KFModel and implement pre/post processing functions
+### Extend Model and implement pre/post processing functions
 
 ```python
-import kfserving
+import kserve
 from typing import List, Dict
 from PIL import Image
 import torchvision.transforms as transforms
@@ -45,7 +45,7 @@ def image_transform(instance):
     return res.tolist()
 
 
-class ImageTransformer(kfserving.KFModel):
+class ImageTransformer(kserve.Model):
     def __init__(self, name: str, predictor_host: str):
         super().__init__(name)
         self.predictor_host = predictor_host
@@ -70,9 +70,9 @@ docker push {username}/image-transformer:latest
 ## Create the InferenceService
 Please use the [YAML file](./transformer.yaml) to create the `InferenceService`, which includes a Transformer and a PyTorch Predictor.
 
-By default `InferenceService` uses `TorchServe` to serve the PyTorch models and the models are loaded from a model repository in KFServing example gcs bucket according to `TorchServe` model repository layout.
+By default `InferenceService` uses `TorchServe` to serve the PyTorch models and the models are loaded from a model repository in KServe example gcs bucket according to `TorchServe` model repository layout.
 The model repository contains a mnist model but you can store more than one models there. In the `Transformer` image you can create a tranformer class for all the models in the repository if they can share the same transformer 
-or maintain a map from model name to transformer classes so KFServing knows to use the transformer for the corresponding model.  
+or maintain a map from model name to transformer classes so KServe knows to use the transformer for the corresponding model.  
 
 ```yaml
 apiVersion: serving.kserve.io/v1beta1

--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/image_transformer/__main__.py
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/image_transformer/__main__.py
@@ -19,7 +19,7 @@ from .transformer_model_repository import TransformerModelRepository
 
 DEFAULT_MODEL_NAME = "model"
 
-parser = argparse.ArgumentParser(parents=[kserve.kfserver.parser])
+parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument(
     "--predictor_host", help="The URL for the model predict function", required=True
 )
@@ -65,6 +65,6 @@ if __name__ == "__main__":
     for model_name in model_names:
         transformer = ImageTransformer(model_name, predictor_host=args.predictor_host)
         models.append(transformer)
-    kserve.KFServer(
+    kserve.ModelServer(
         registered_models=TransformerModelRepository(args.predictor_host)
     ).start(models=models)

--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/image_transformer/image_transformer.py
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/image_transformer/image_transformer.py
@@ -50,12 +50,12 @@ def image_transform(instance):
     return instance
 
 
-class ImageTransformer(kserve.KFModel):
+class ImageTransformer(kserve.Model):
     """ A class object for the data handling activities of Image Classification
     Task and returns a KServe compatible response.
 
     Args:
-        kserve (class object): The KFModel class from the KServe
+        kserve (class object): The Model class from the KServe
         modeule is passed here.
     """
     def __init__(self, name: str, predictor_host: str):

--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/image_transformer/transformer_model_repository.py
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/image_transformer/transformer_model_repository.py
@@ -1,18 +1,18 @@
 import logging
 
 
-from kserve.kfmodel_repository import KFModelRepository
+from kserve.model_repository import ModelRepository
 import kserve
 
 
 logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
 
 
-class TransformerModelRepository(KFModelRepository):
+class TransformerModelRepository(ModelRepository):
     """The class object for the Image Transformer.
 
     Args:
-        KFModelRepository (class): KFModel Repository class object of
+        ModelRepository (class): Model Repository class object of
         kfserving is passed here.
     """
 

--- a/docs/samples/v1beta1/triton/bert/README.md
+++ b/docs/samples/v1beta1/triton/bert/README.md
@@ -7,14 +7,14 @@ This example demonstrates
 - The use of fine-tuned NVIDIA BERT models
 - Deploy Transformer for preprocess using BERT tokenizer
 - Deploy BERT model on Triton Inference Server
-- Inference with V2 KFServing protocol
+- Inference with V2 KServe protocol
 
 We can run inference on a fine-tuned BERT model for tasks like Question Answering.
 
 Here we use a BERT model fine-tuned on a SQuaD 2.0 Dataset which contains 100,000+ question-answer pairs on 500+ articles combined with over 50,000 new, unanswerable questions.
 
 ## Setup
-1. Your ~/.kube/config should point to a cluster with [KFServing 0.5 installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe 0.5 installed](https://github.com/kserve/kserve#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 3. Skip [tag resolution](https://knative.dev/docs/serving/tag-resolution/) for `nvcr.io` which requires auth to resolve triton inference server image digest
 ```bash
@@ -30,7 +30,7 @@ kubectl patch cm config-deployment --patch '{"data":{"progressDeadline": "600s"}
 - The `predict` handler calls `Triton Inference Server` using PYTHON REST API  
 - The `postprocess` handler converts raw prediction to the answer with the probability
 ```python
-class BertTransformer(kfserving.KFModel):
+class BertTransformer(kserve.Model):
     def __init__(self, name: str, predictor_host: str):
         super().__init__(name)
         self.short_paragraph_text = "The Apollo program was the third United States human spaceflight program. First conceived as a three-man spacecraft to follow the one-man Project Mercury which put the first Americans in space, Apollo was dedicated to President John F. Kennedy's national goal of landing a man on the Moon. The first manned flight of Apollo was in 1968. Apollo ran from 1961 to 1972 followed by the Apollo-Soyuz Test Project a joint Earth orbit mission with the Soviet Union in 1975."
@@ -85,7 +85,7 @@ class BertTransformer(kfserving.KFModel):
         return {"predictions": prediction, "prob": nbest_json[0]['probability'] * 100.0}
 ```
 
-Build the KFServing Transformer image with above code
+Build the KServe Transformer image with above code
 ```bash
 cd bert_tokenizer_v2
 docker build -t $USER/bert_transformer-v2:latest . --rm
@@ -93,7 +93,7 @@ docker build -t $USER/bert_transformer-v2:latest . --rm
 Or you can use the prebuild image `kfserving/bert-transformer-v2:latest`
 
 ## Create the InferenceService
-Add above custom KFServing Transformer image and Triton Predictor to the `InferenceService` spec
+Add above custom KServe Transformer image and Triton Predictor to the `InferenceService` spec
 ```yaml
 apiVersion: "serving.kserve.io/v1beta1"
 kind: "InferenceService"

--- a/docs/samples/v1beta1/triton/bert/bert_tokenizer_v2/bert_transformer_v2/__main__.py
+++ b/docs/samples/v1beta1/triton/bert/bert_tokenizer_v2/bert_transformer_v2/__main__.py
@@ -26,5 +26,5 @@ args, _ = parser.parse_known_args()
 
 if __name__ == "__main__":
     transformer = BertTransformer(args.model_name, predictor_host=args.predictor_host)
-    kfserver = kserve.ModelServer()
-    kfserver.start(models=[transformer])
+    server = kserve.ModelServer()
+    server.start(models=[transformer])

--- a/docs/samples/v1beta1/triton/bert/bert_tokenizer_v2/bert_transformer_v2/__main__.py
+++ b/docs/samples/v1beta1/triton/bert/bert_tokenizer_v2/bert_transformer_v2/__main__.py
@@ -17,7 +17,7 @@ from .bert_transformer import BertTransformer
 
 DEFAULT_MODEL_NAME = "model"
 
-parser = argparse.ArgumentParser(parents=[kserve.kfserver.parser])
+parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument('--model_name', default=DEFAULT_MODEL_NAME,
                     help='The name that the model is served under.')
 parser.add_argument('--predictor_host', help='The URL for the model predict function', required=True)
@@ -26,5 +26,5 @@ args, _ = parser.parse_known_args()
 
 if __name__ == "__main__":
     transformer = BertTransformer(args.model_name, predictor_host=args.predictor_host)
-    kfserver = kserve.KFServer()
+    kfserver = kserve.ModelServer()
     kfserver.start(models=[transformer])

--- a/docs/samples/v1beta1/triton/bert/bert_tokenizer_v2/bert_transformer_v2/bert_transformer.py
+++ b/docs/samples/v1beta1/triton/bert/bert_tokenizer_v2/bert_transformer_v2/bert_transformer.py
@@ -22,7 +22,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-class BertTransformer(kserve.KFModel):
+class BertTransformer(kserve.Model):
     def __init__(self, name: str, predictor_host: str):
         super().__init__(name)
         self.short_paragraph_text = "The Apollo program was the third United States human spaceflight program. " \

--- a/docs/samples/v1beta1/triton/torchscript/README.md
+++ b/docs/samples/v1beta1/triton/torchscript/README.md
@@ -147,7 +147,7 @@ kubectl get inferenceservices torchscript-demo
 ### Run a prediction with curl
 The first step is to [determine the ingress IP and ports](../../../../../README.md#determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 
-The latest Triton Inference Server already switched to use KFServing [prediction V2 protocol](https://github.com/kserve/kserve/tree/master/docs/predict-api/v2), so 
+The latest Triton Inference Server already switched to use KServe [prediction V2 protocol](https://github.com/kserve/kserve/tree/master/docs/predict-api/v2), so 
 the input request needs to follow the V2 schema with the specified data type, shape.
 ```bash
 MODEL_NAME=cifar10
@@ -229,7 +229,7 @@ Error Set:
 
 `Triton Inference Server` expects tensors as input data, often times a pre-processing step is required before making the prediction call
 when the user is sending in request with raw input format. Transformer component can be specified on InferenceService spec for user implemented pre/post processing code.
-User is responsible to create a python class which extends from KFServing `KFModel` base class which implements `preprocess` handler to transform raw input
+User is responsible to create a python class which extends from KServe `Model` base class which implements `preprocess` handler to transform raw input
 format to tensor format according to V2 prediction protocol, `postprocess` handle is to convert raw prediction response to a more user friendly response.
 
 ### Implement pre/post processing functions
@@ -259,7 +259,7 @@ def image_transform(instance):
     return res.tolist()
 
 
-class ImageTransformer(kserve.KFModel):
+class ImageTransformer(kserve.Model):
     def __init__(self, name: str, predictor_host: str):
         super().__init__(name)
         self.predictor_host = predictor_host

--- a/docs/samples/v1beta1/triton/torchscript/image_transformer_v2/__main__.py
+++ b/docs/samples/v1beta1/triton/torchscript/image_transformer_v2/__main__.py
@@ -17,7 +17,7 @@ from .image_transformer_v2 import ImageTransformerV2
 
 DEFAULT_MODEL_NAME = "model"
 
-parser = argparse.ArgumentParser(parents=[kserve.kfserver.parser])
+parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument('--model_name', default=DEFAULT_MODEL_NAME,
                     help='The name that the model is served under.')
 parser.add_argument('--predictor_host', help='The URL for the model predict function', required=True)
@@ -27,5 +27,5 @@ args, _ = parser.parse_known_args()
 
 if __name__ == "__main__":
     transformer = ImageTransformerV2(args.model_name, predictor_host=args.predictor_host, protocol=args.protocol)
-    kfserver = kserve.KFServer()
+    kfserver = kserve.ModelServer()
     kfserver.start(models=[transformer])

--- a/docs/samples/v1beta1/triton/torchscript/image_transformer_v2/__main__.py
+++ b/docs/samples/v1beta1/triton/torchscript/image_transformer_v2/__main__.py
@@ -27,5 +27,5 @@ args, _ = parser.parse_known_args()
 
 if __name__ == "__main__":
     transformer = ImageTransformerV2(args.model_name, predictor_host=args.predictor_host, protocol=args.protocol)
-    kfserver = kserve.ModelServer()
-    kfserver.start(models=[transformer])
+    server = kserve.ModelServer()
+    server.start(models=[transformer])

--- a/docs/samples/v1beta1/triton/torchscript/image_transformer_v2/image_transformer_v2.py
+++ b/docs/samples/v1beta1/triton/torchscript/image_transformer_v2/image_transformer_v2.py
@@ -37,7 +37,7 @@ def image_transform(instance):
     return res.tolist()
 
 
-class ImageTransformerV2(kserve.KFModel):
+class ImageTransformerV2(kserve.Model):
     def __init__(self, name: str, predictor_host: str, protocol: str):
         super().__init__(name)
         self.predictor_host = predictor_host

--- a/docs/samples/v1beta1/xgboost/README.md
+++ b/docs/samples/v1beta1/xgboost/README.md
@@ -75,7 +75,7 @@ These can be specified through environment variables or by creating a local
 }
 ```
 
-Note that, when we [deploy our model](#deployment), **KFServing will already
+Note that, when we [deploy our model](#deployment), **KServe will already
 inject some sensible defaults** so that it runs out-of-the-box without any
 further configuration.
 However, you can still override these defaults by providing a
@@ -94,7 +94,7 @@ mlserver start .
 
 ## Deployment
 
-Lastly, we will use KFServing to deploy our trained model.
+Lastly, we will use KServe to deploy our trained model.
 For this, we will just need to use **version `v1beta1`** of the
 `InferenceService` CRD and set the the **`protocolVersion` field to `v2`**.
 
@@ -116,10 +116,10 @@ Note that this makes the following assumptions:
   to a "model repository" (GCS in this example) and can be accessed as
   `gs://kfserving-samples/models/xgboost/iris`.
 - There is a K8s cluster available, accessible through `kubectl`.
-- KFServing has already been [installed in your
-  cluster](https://github.com/kubeflow/kfserving/#install-kfserving).
+- KServe has already been [installed in your
+  cluster](https://github.com/kserve/kserve#installation).
 
-Assuming that we've got a cluster accessible through `kubectl` with KFServing
+Assuming that we've got a cluster accessible through `kubectl` with KServe
 already installed, we can deploy our model as:
 
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

I have updated usage of kserve sdk in `docs/` following this PR renaming classes https://github.com/kserve/kserve/pull/1951

Will make a PR for website repo later

