### PR TITLE
Fixes Azure blob download as class is no longer hashable

### DIFF
--- a/python/kserve/kserve/storage.py
+++ b/python/kserve/kserve/storage.py
@@ -221,7 +221,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
                 else:
                     blobs += container_client.list_blobs(name_starts_with=item.name,
                                                          include=['snapshots'])
-        for blob in set(blobs):
+        for blob in blobs:
             dest_path = os.path.join(out_dir, blob.name.replace(prefix, "", 1).lstrip("/"))
             Path(os.path.dirname(dest_path)).mkdir(parents=True, exist_ok=True)
             logging.info("Downloading: %s to %s", blob.name, dest_path)


### PR DESCRIPTION
Signed-off-by: Zhongcheng Lao <Zhongcheng.Lao@microsoft.com>

**What this PR does / why we need it**:
This fixes an issue in storage-initializer v0.7.0 (azsdk-python-storage-blob/12.8.1)
which prevents Azure Blob to be downloaded as model files.

```code
Traceback (most recent call last):
  File "/storage-initializer/scripts/initializer-entrypoint", line 14, in <module>
    kserve.Storage.download(src_uri, dest_path)
  File "/usr/local/lib/python3.7/site-packages/kserve/storage.py", line 71, in download
    Storage._download_blob(uri, out_dir)
  File "/usr/local/lib/python3.7/site-packages/kserve/storage.py", line 208, in _download_blob
    for blob in set(blobs):
TypeError: unhashable type: 'BlobProperties'
```
