### PR TITLE
Fix ServingRuntime kubebuilder annotations

### DIFF
--- a/config/crd/serving.kserve.io_clusterservingruntimes.yaml
+++ b/config/crd/serving.kserve.io_clusterservingruntimes.yaml
@@ -20,7 +20,7 @@ spec:
     - jsonPath: .spec.disabled
       name: Disabled
       type: boolean
-    - jsonPath: .spec.supportedModelTypes[*].name
+    - jsonPath: .spec.supportedModelFormats[*].name
       name: ModelType
       type: string
     - jsonPath: .spec.containers[*].name

--- a/config/crd/serving.kserve.io_servingruntimes.yaml
+++ b/config/crd/serving.kserve.io_servingruntimes.yaml
@@ -20,7 +20,7 @@ spec:
     - jsonPath: .spec.disabled
       name: Disabled
       type: boolean
-    - jsonPath: .spec.supportedModelTypes[*].name
+    - jsonPath: .spec.supportedModelFormats[*].name
       name: ModelType
       type: string
     - jsonPath: .spec.containers[*].name

--- a/pkg/apis/serving/v1alpha1/servingruntime_types.go
+++ b/pkg/apis/serving/v1alpha1/servingruntime_types.go
@@ -167,7 +167,7 @@ type BuiltInAdapter struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Disabled",type="boolean",JSONPath=".spec.disabled"
-// +kubebuilder:printcolumn:name="ModelType",type="string",JSONPath=".spec.supportedModelTypes[*].name"
+// +kubebuilder:printcolumn:name="ModelType",type="string",JSONPath=".spec.supportedModelFormats[*].name"
 // +kubebuilder:printcolumn:name="Containers",type="string",JSONPath=".spec.containers[*].name"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ServingRuntime struct {
@@ -192,7 +192,7 @@ type ServingRuntimeList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope="Cluster"
 // +kubebuilder:printcolumn:name="Disabled",type="boolean",JSONPath=".spec.disabled"
-// +kubebuilder:printcolumn:name="ModelType",type="string",JSONPath=".spec.supportedModelTypes[*].name"
+// +kubebuilder:printcolumn:name="ModelType",type="string",JSONPath=".spec.supportedModelFormats[*].name"
 // +kubebuilder:printcolumn:name="Containers",type="string",JSONPath=".spec.containers[*].name"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterServingRuntime struct {

--- a/test/crds/serving.kserve.io_inferenceservices.yaml
+++ b/test/crds/serving.kserve.io_inferenceservices.yaml
@@ -18,7 +18,7 @@ spec:
     - jsonPath: .spec.disabled
       name: Disabled
       type: boolean
-    - jsonPath: .spec.supportedModelTypes[*].name
+    - jsonPath: .spec.supportedModelFormats[*].name
       name: ModelType
       type: string
     - jsonPath: .spec.containers[*].name
@@ -13026,7 +13026,7 @@ spec:
     - jsonPath: .spec.disabled
       name: Disabled
       type: boolean
-    - jsonPath: .spec.supportedModelTypes[*].name
+    - jsonPath: .spec.supportedModelFormats[*].name
       name: ModelType
       type: string
     - jsonPath: .spec.containers[*].name


### PR DESCRIPTION
This adjusts the `printcolumn` annotations to use the correct key.

Signed-off-by: Paul Van Eck <pvaneck@us.ibm.com>
