### PR TITLE
Check deployment mode in isvc webhook

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -74,7 +74,11 @@ func (isvc *InferenceService) Default() {
 }
 
 func (isvc *InferenceService) DefaultInferenceService(config *InferenceServicesConfig) {
-	isvc.setPredictorModelDefaults()
+	deploymentMode, ok := isvc.ObjectMeta.Annotations[constants.DeploymentMode]
+	if !ok || deploymentMode != string(constants.ModelMeshDeployment) {
+		// Only attempt to assign runtimes for non-modelmesh predictors
+		isvc.setPredictorModelDefaults()
+	}
 	for _, component := range []Component{
 		&isvc.Spec.Predictor,
 		isvc.Spec.Transformer,


### PR DESCRIPTION
InferenceServices with deployment mode of ModelMesh should not have the runtime assigning mutator run on it. This causes
an sms runtime to be assigned to the predictor when it shouldn't be if targeting deployment on modelmesh.

