### PR TITLE
Add autoSelect labels to more ServingRuntime formats

### DIFF
--- a/config/runtimes/kserve-mlserver.yaml
+++ b/config/runtimes/kserve-mlserver.yaml
@@ -12,6 +12,7 @@ spec:
       version: "3"
     - name: mlflow
       version: "1"
+      autoSelect: true
   containers:
     - name: kserve-container
       image: mlserver:replace

--- a/config/runtimes/kserve-tritonserver.yaml
+++ b/config/runtimes/kserve-tritonserver.yaml
@@ -12,10 +12,12 @@ spec:
       version: "2"
     - name: onnx
       version: "1"
+      autoSelect: true
     - name: pytorch
       version: "1"
     - name: triton
       version: "2"
+      autoSelect: true
   containers:
     - name: kserve-container
       image: kserve-tritonserver:replace


### PR DESCRIPTION
Some formats like onnx did not have an autoSelect-able runtime assigned, so using an InferenceService with `modelFormat: onnx` would show `no runtime found to support predictor with model type...`. This enables `autoSelect` on formats I thought needed them.
