### PR TITLE
support custom lib for sklearn model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,6 @@ python/kserve/tox.ini
 
 # Ignore files for MacOS
 **/.DS_Store
-
+venv
 # Downloaded by hack install
 hack/istio-*

--- a/python/sklearnserver/sklearnserver/model.py
+++ b/python/sklearnserver/sklearnserver/model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-
+import sys
 import kserve
 import joblib
 import pathlib
@@ -40,6 +40,12 @@ class SKLearnModel(kserve.Model):  # pylint:disable=c-extension-no-member
         elif len(existing_paths) > 1:
             raise RuntimeError('More than one model file is detected, '
                                f'Only one is allowed within model_dir: {existing_paths}')
+        #support custom lib for the model
+        for filename in os.listdir(model_path):
+            if filename.endswith('.py'):
+                sys.path.append(model_path)
+                break
+
         self._model = joblib.load(existing_paths[0])
         self.ready = True
         return self.ready


### PR DESCRIPTION
in some scenarios,we need add custom logic like transformer when training a model,but joblib/pickle not support to persist the module ,which run into this 'No module named xxx '