### PR TITLE
Add install script for KServe and ModelMesh

### DIFF
--- a/hack/install_kserve_mm.sh
+++ b/hack/install_kserve_mm.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+
+# Install KServe and ModelMesh into specified Kubernetes namespaces. KServe controller is
+# deployed in "kserve" namespace, ModelMesh controller is in "modelmesh-serving" namespace,
+# and ModelMesh is enabled for the optional user namespaces in the -u argument or the
+# current namespace when -u is not used. All namespaces will be created if not exist.
+# Expect cluster-admin authority and Kube cluster access to be configured, and git to be
+# installed prior to running.
+# This script can run anywhere and the repo branch variables can be changed to install
+# different versions of KServe and ModelMesh.
+
+set -e
+############################################################
+# Help                                                     #
+############################################################
+Help()
+{
+   # Display Help
+   echo "Quick install script to deploy KServe and ModelMesh"
+   echo
+   echo "Syntax: [-u user_namespaces]"
+   echo "options:"
+   echo "  -u: user namespaces, such as \"ns_a ns_b\", to enable for ModelMesh"
+   echo
+}
+
+export CTLR_NS="modelmesh-serving"
+export USER_NS=$(kubectl config  get-contexts $(kubectl config current-context) |tail -1|awk '{ print $5 }')
+export user_ns_array=()
+export C_DIR="$PWD"
+export KSERVE_BRANCH="release-0.8"
+export MMS_BRANCH="release-0.8"
+
+while (($# > 0)); do
+  case "$1" in
+  -h | --help)
+    Help
+    exit
+    ;;
+  -u | --user_namespaces)
+    shift
+    user_ns_array=($1)
+    ;;
+  -*)
+    echo "Unknown option: '${1}'"
+    exit 10
+    ;;
+  esac
+  shift
+done
+
+git clone -b $KSERVE_BRANCH --depth 1 --single-branch https://github.com/kserve/kserve.git
+git clone -b $MMS_BRANCH --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
+
+cd "${C_DIR}/kserve"
+./hack/quick_install.sh
+
+kubectl create ns ${CTLR_NS} || true
+cd "${C_DIR}/modelmesh-serving"
+./scripts/install.sh -n ${CTLR_NS} --quickstart
+
+if [[ ! -z $user_ns_array ]]; then
+  for USER_NS in "${user_ns_array[@]}"; do
+    kubectl create ns ${USER_NS} || true
+    echo "Enabling ModelMesh for namespace: ${USER_NS}..."
+    ./scripts/setup_user_namespaces.sh -u ${USER_NS} --create-storage-secret --deploy-serving-runtimes
+  done
+else
+  echo "Enabling ModelMesh for namespace: ${USER_NS}..."
+  ./scripts/setup_user_namespaces.sh -u ${USER_NS} --create-storage-secret --deploy-serving-runtimes
+fi
+
+cd "${C_DIR}"
+rm -rf kserve
+rm -rf modelmesh-serving


### PR DESCRIPTION
Add install script for KServe and ModelMesh so the user can
quickly experiment features provided by two repos.

The script will install all prerequisits knative, istio, cert
manager, etcd, and minio, and create namespaces when needed.
The repo branch variables can be changed to install different
versions of KServe and ModelMesh.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
