### PR TITLE
add mlflow support

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -100,8 +100,9 @@ func (isvc *InferenceService) DefaultInferenceService(config *InferenceServicesC
 func (isvc *InferenceService) setPredictorModelDefaults() {
 	if isvc.Spec.Predictor.Model != nil {
 		// add mlserver specific default values
-		if isvc.Spec.Predictor.Model.Runtime != nil &&
-			*isvc.Spec.Predictor.Model.Runtime == constants.MLServer {
+		if isvc.Spec.Predictor.Model.ModelFormat.Name == constants.SupportedModelMLFlow ||
+			(isvc.Spec.Predictor.Model.Runtime != nil &&
+				*isvc.Spec.Predictor.Model.Runtime == constants.MLServer) {
 			isvc.setMlServerDefaults()
 		}
 		// add torchserve specific default values

--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -373,6 +373,8 @@ func (isvc *InferenceService) setMlServerDefaults() {
 		modelClass = constants.MLServerModelClassXGBoost
 	} else if isvc.Spec.Predictor.Model.ModelFormat.Name == constants.SupportedModelLightGBM {
 		modelClass = constants.MLServerModelClassLightGBM
+	} else if isvc.Spec.Predictor.Model.ModelFormat.Name == constants.SupportedModelMLFlow {
+		modelClass = constants.MLServerModelClassMLFlow
 	}
 	if isvc.ObjectMeta.Labels == nil {
 		isvc.ObjectMeta.Labels = map[string]string{constants.ModelClassLabel: modelClass}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -293,6 +293,7 @@ const (
 	MLServerModelClassSKLearn  = "mlserver_sklearn.SKLearnModel"
 	MLServerModelClassXGBoost  = "mlserver_xgboost.XGBoostModel"
 	MLServerModelClassLightGBM = "mlserver_lightgbm.LightGBMModel"
+	MLServerModelClassMLFlow   = "mlserver_mlflow.MLflowRuntime"
 )
 
 // torchserve service envelope label allowed values
@@ -312,6 +313,7 @@ const (
 	SupportedModelLightGBM   = "lightgbm"
 	SupportedModelPaddle     = "paddle"
 	SupportedModelTriton     = "triton"
+	SupportedModelMLFlow     = "mlflow"
 )
 
 // GetRawServiceLabel generate native service label

--- a/test/e2e/data/mlflow_input_v2.json
+++ b/test/e2e/data/mlflow_input_v2.json
@@ -1,0 +1,73 @@
+{
+    "parameters": {
+      "content_type": "pd"
+    },
+    "inputs": [
+        {
+          "name": "fixed acidity",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [7.4]
+        },
+        {
+          "name": "volatile acidity",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [0.7000]
+        },
+        {
+          "name": "citric acid",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [0]
+        },
+        {
+          "name": "residual sugar",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [1.9]
+        },
+        {
+          "name": "chlorides",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [0.076]
+        },
+        {
+          "name": "free sulfur dioxide",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [11]
+        },
+        {
+          "name": "total sulfur dioxide",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [34]
+        },
+        {
+          "name": "density",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [0.9978]
+        },
+        {
+          "name": "pH",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [3.51]
+        },
+        {
+          "name": "sulphates",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [0.56]
+        },
+        {
+          "name": "alcohol",
+          "shape": [1],
+          "datatype": "FP32",
+          "data": [9.4]
+        }
+    ]
+}

--- a/test/e2e/predictor/test_lightgbm.py
+++ b/test/e2e/predictor/test_lightgbm.py
@@ -91,3 +91,47 @@ def test_lightgbm_runtime_kserve():
     res = predict(service_name, "./data/iris_input_v3.json")
     assert res["predictions"][0][0] > 0.5
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+
+def test_lightgbm_v2_runtime_kserve():
+    service_name = "isvc-lightgbm-v2-runtime"
+
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        model=V1beta1ModelSpec(
+            model_format=V1beta1ModelFormat(
+                name="lightgbm",
+            ),
+            runtime="kserve-mlserver",
+            storage_uri="gs://kfserving-examples/models/lightgbm/v2/iris",
+            protocol_version="v2",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "100m", "memory": "256Mi"},
+                limits={"cpu": "1", "memory": "1Gi"},
+            ),
+        ),
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND,
+        metadata=client.V1ObjectMeta(
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
+    kserve_client.create(isvc)
+    kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+    res = predict(service_name, "./data/iris_input_v2.json", protocol_version="v2")
+    assert res["outputs"][0]["data"] == [
+        8.796664107010673e-06,
+        0.9992300031041593,
+        0.0007612002317336916,
+        4.974786820804187e-06,
+        0.9999919650711493,
+        3.0601420299625077e-06]
+
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_mlflow.py
+++ b/test/e2e/predictor/test_mlflow.py
@@ -1,0 +1,66 @@
+# Copyright 2022 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from kubernetes import client
+from kserve import (
+    constants,
+    KServeClient,
+    V1beta1InferenceService,
+    V1beta1InferenceServiceSpec,
+    V1beta1PredictorSpec,
+    V1beta1ModelSpec,
+    V1beta1ModelFormat,
+)
+from kubernetes.client import V1ResourceRequirements
+
+from ..common.utils import predict
+from ..common.utils import KSERVE_TEST_NAMESPACE
+
+
+def test_mlflow_v2_runtime_kserve():
+    service_name = "isvc-mlflow-v2-runtime"
+
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        model=V1beta1ModelSpec(
+            model_format=V1beta1ModelFormat(
+                name="mlflow",
+            ),
+            storage_uri="gs://kfserving-examples/models/mlflow/wine",
+            protocol_version="v2",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "100m", "memory": "256Mi"},
+                limits={"cpu": "1", "memory": "1Gi"},
+            ),
+        ),
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND,
+        metadata=client.V1ObjectMeta(
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
+    kserve_client.create(isvc)
+    kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+    res = predict(service_name, "./data/mlflow_input_v2.json", protocol_version="v2")
+    assert res["outputs"][0]["data"] == [5.576883936610762]
+
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)


### PR DESCRIPTION
Signed-off-by: Suresh Nakkeran <suresh.n@ideas2it.com>

fixes https://github.com/kserve/kserve/issues/2015

This PR is to add mlflow model format support in MlServer runtime. Also added E2E tests for lightgbm, mlflow models with MlServer.