### PR TITLE
Fix canary rollout falling back to prev rolledout version

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -290,8 +290,8 @@ const (
 
 // allowed model class implementation in mlserver
 const (
-	MLServerModelClassSKLearn = "mlserver_sklearn.SKLearnModel"
-	MLServerModelClassXGBoost = "mlserver_xgboost.XGBoostModel"
+	MLServerModelClassSKLearn  = "mlserver_sklearn.SKLearnModel"
+	MLServerModelClassXGBoost  = "mlserver_xgboost.XGBoostModel"
 	MLServerModelClassLightGBM = "mlserver_lightgbm.LightGBMModel"
 )
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -89,6 +89,7 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 	// This is to handle case when the latest ready revision is rolled out with 100% and then rolled back
 	// so here we need to get the revision that is previously rolled out with 100%
 	if componentStatus.LatestRolledoutRevision == componentStatus.LatestReadyRevision &&
+		componentStatus.LatestReadyRevision == componentStatus.LatestCreatedRevision &&
 		componentExtension.CanaryTrafficPercent != nil && *componentExtension.CanaryTrafficPercent < 100 {
 		lastRolledoutRevision = componentStatus.PreviousRolledoutRevision
 	}

--- a/test/e2e/predictor/test_lightgbm.py
+++ b/test/e2e/predictor/test_lightgbm.py
@@ -33,7 +33,7 @@ def test_lightgbm_kserve():
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         lightgbm=V1beta1LightGBMSpec(
-            storage_uri="gs://kfserving-examples/models/lightgbm",
+            storage_uri="gs://kfserving-examples/models/lightgbm/iris",
             resources=V1ResourceRequirements(
                 requests={"cpu": "100m", "memory": "256Mi"},
                 limits={"cpu": "100m", "memory": "256Mi"},
@@ -67,7 +67,7 @@ def test_lightgbm_runtime_kserve():
             model_format=V1beta1ModelFormat(
                 name="lightgbm",
             ),
-            storage_uri="gs://kfserving-examples/models/lightgbm",
+            storage_uri="gs://kfserving-examples/models/lightgbm/iris",
             resources=V1ResourceRequirements(
                 requests={"cpu": "100m", "memory": "256Mi"},
                 limits={"cpu": "100m", "memory": "256Mi"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1968 

**Special notes for your reviewer**:

When `canaryTrafficPercent` is specified to roll out the new version from the current stable version, the previous rolled out version gets incorrectly spawn up for a brief time due to the condition of `latestCreated == latestReady`. We need additional check for "latestReady != latestCreated" so that the last rolled out stays on the current stable version. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
