### PR TITLE
restore predictor images in isvc configmap

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -7,12 +7,18 @@ data:
   predictors: |-
     {
         "tensorflow": {
+            "image": "tensorflow/serving",
+            "defaultImageVersion": "2.6.2",
+            "defaultGpuImageVersion": "2.6.2-gpu",
+            "defaultTimeout": "60",
             "supportedFrameworks": [
               "tensorflow"
             ],
             "multiModelServer": false
         },
         "onnx": {
+            "image": "mcr.microsoft.com/onnxruntime/server",
+            "defaultImageVersion": "v1.0.0",
             "supportedFrameworks": [
               "onnx"
             ],
@@ -20,12 +26,16 @@ data:
         },
         "sklearn": {
           "v1": {
+            "image": "kserve/sklearnserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "sklearn"
             ],
             "multiModelServer": true
           },
           "v2": {
+            "image": "docker.io/seldonio/mlserver",
+            "defaultImageVersion": "0.5.3",
             "supportedFrameworks": [
               "sklearn"
             ],
@@ -34,12 +44,16 @@ data:
         },
         "xgboost": {
           "v1": {
+            "image": "kserve/xgbserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "xgboost"
             ],
             "multiModelServer": true
           },
           "v2": {
+            "image": "docker.io/seldonio/mlserver",
+            "defaultImageVersion": "0.5.3",
             "supportedFrameworks": [
               "xgboost"
             ],
@@ -47,12 +61,28 @@ data:
           }
         },
         "pytorch": {
-          "supportedFrameworks": [
-            "pytorch"
-          ],
-          "multiModelServer": false
+          "v1" : {
+            "image": "kserve/torchserve-kfs",
+            "defaultImageVersion": "0.5.3",
+            "defaultGpuImageVersion": "0.5.3-gpu",
+            "supportedFrameworks": [
+              "pytorch"
+            ],
+            "multiModelServer": false
+          },
+          "v2" : {
+            "image": "kserve/torchserve-kfs",
+            "defaultImageVersion": "0.5.3",
+            "defaultGpuImageVersion": "0.5.3-gpu",
+            "supportedFrameworks": [
+              "pytorch"
+            ],
+            "multiModelServer": false
+          }
         },
         "triton": {
+            "image": "nvcr.io/nvidia/tritonserver",
+            "defaultImageVersion": "21.09-py3",
             "supportedFrameworks": [
               "tensorrt",
               "tensorflow",
@@ -62,18 +92,24 @@ data:
             "multiModelServer": true
         },
         "pmml": {
+            "image": "kserve/pmmlserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "pmml"
             ],
             "multiModelServer": false
         },
         "lightgbm": {
+            "image": "kserve/lgbserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "lightgbm"
             ],
             "multiModelServer": false
         },
         "paddle": {
+            "image": "kserve/paddleserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "paddle"
             ],

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -7,12 +7,18 @@ data:
   predictors: |-
     {
         "tensorflow": {
+            "image": "tensorflow/serving",
+            "defaultImageVersion": "2.6.2",
+            "defaultGpuImageVersion": "2.6.2-gpu",
+            "defaultTimeout": "60",
             "supportedFrameworks": [
-             "tensorflow"
+              "tensorflow"
             ],
             "multiModelServer": false
         },
         "onnx": {
+            "image": "mcr.microsoft.com/onnxruntime/server",
+            "defaultImageVersion": "v1.0.0",
             "supportedFrameworks": [
               "onnx"
             ],
@@ -20,12 +26,16 @@ data:
         },
         "sklearn": {
           "v1": {
+            "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/sklearnserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "sklearn"
             ],
             "multiModelServer": true
           },
           "v2": {
+            "image": "docker.io/seldonio/mlserver",
+            "defaultImageVersion": "0.5.3",
             "supportedFrameworks": [
               "sklearn"
             ],
@@ -34,12 +44,16 @@ data:
         },
         "xgboost": {
           "v1": {
+            "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/xgbserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "xgboost"
             ],
             "multiModelServer": true
           },
           "v2": {
+            "image": "docker.io/seldonio/mlserver",
+            "defaultImageVersion": "0.5.3",
             "supportedFrameworks": [
               "xgboost"
             ],
@@ -47,18 +61,28 @@ data:
           }
         },
         "pytorch": {
-          "supportedFrameworks": [
-            "pytorch"
-          ],
-          "multiModelServer": false
-        },
-        "paddle": {
+          "v1" : {
+            "image": "kserve/torchserve-kfs",
+            "defaultImageVersion": "0.5.3",
+            "defaultGpuImageVersion": "0.5.3-gpu",
             "supportedFrameworks": [
-              "paddle"
+              "pytorch"
             ],
             "multiModelServer": false
+          },
+          "v2" : {
+            "image": "kserve/torchserve-kfs",
+            "defaultImageVersion": "0.5.3",
+            "defaultGpuImageVersion": "0.5.3-gpu",
+            "supportedFrameworks": [
+              "pytorch"
+            ],
+            "multiModelServer": false
+          }
         },
         "triton": {
+            "image": "nvcr.io/nvidia/tritonserver",
+            "defaultImageVersion": "21.09-py3",
             "supportedFrameworks": [
               "tensorrt",
               "tensorflow",
@@ -69,16 +93,28 @@ data:
             "multiModelServer": true
         },
         "pmml": {
+            "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/pmmlserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "pmml"
             ],
             "multiModelServer": false
         },
         "lightgbm": {
+            "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/lgbserver",
+            "defaultImageVersion": "latest",
             "supportedFrameworks": [
               "lightgbm"
             ],
-            "multiModelServer": true
+            "multiModelServer": false
+        },
+        "paddle": {
+            "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kserve/paddleserver",
+            "defaultImageVersion": "latest",
+            "supportedFrameworks": [
+              "paddle"
+            ],
+            "multiModelServer": false
         }
     }
   transformers: |-

--- a/install/v0.8.0/kserve.yaml
+++ b/install/v0.8.0/kserve.yaml
@@ -14865,12 +14865,18 @@ data:
   predictors: |-
     {
         "tensorflow": {
+            "image": "tensorflow/serving",
+            "defaultImageVersion": "2.6.2",
+            "defaultGpuImageVersion": "2.6.2-gpu",
+            "defaultTimeout": "60",
             "supportedFrameworks": [
               "tensorflow"
             ],
             "multiModelServer": false
         },
         "onnx": {
+            "image": "mcr.microsoft.com/onnxruntime/server",
+            "defaultImageVersion": "v1.0.0",
             "supportedFrameworks": [
               "onnx"
             ],
@@ -14878,12 +14884,16 @@ data:
         },
         "sklearn": {
           "v1": {
+            "image": "kserve/sklearnserver",
+            "defaultImageVersion": "v0.8.0",
             "supportedFrameworks": [
               "sklearn"
             ],
             "multiModelServer": true
           },
           "v2": {
+            "image": "docker.io/seldonio/mlserver",
+            "defaultImageVersion": "0.5.3",
             "supportedFrameworks": [
               "sklearn"
             ],
@@ -14892,12 +14902,16 @@ data:
         },
         "xgboost": {
           "v1": {
+            "image": "kserve/xgbserver",
+            "defaultImageVersion": "v0.8.0",
             "supportedFrameworks": [
               "xgboost"
             ],
             "multiModelServer": true
           },
           "v2": {
+            "image": "docker.io/seldonio/mlserver",
+            "defaultImageVersion": "0.5.3",
             "supportedFrameworks": [
               "xgboost"
             ],
@@ -14905,12 +14919,28 @@ data:
           }
         },
         "pytorch": {
-          "supportedFrameworks": [
-            "pytorch"
-          ],
-          "multiModelServer": false
+          "v1" : {
+            "image": "kserve/torchserve-kfs",
+            "defaultImageVersion": "0.5.3",
+            "defaultGpuImageVersion": "0.5.3-gpu",
+            "supportedFrameworks": [
+              "pytorch"
+            ],
+            "multiModelServer": false
+          },
+          "v2" : {
+            "image": "kserve/torchserve-kfs",
+            "defaultImageVersion": "0.5.3",
+            "defaultGpuImageVersion": "0.5.3-gpu",
+            "supportedFrameworks": [
+              "pytorch"
+            ],
+            "multiModelServer": false
+          }
         },
         "triton": {
+            "image": "nvcr.io/nvidia/tritonserver",
+            "defaultImageVersion": "21.09-py3",
             "supportedFrameworks": [
               "tensorrt",
               "tensorflow",
@@ -14920,18 +14950,24 @@ data:
             "multiModelServer": true
         },
         "pmml": {
+            "image": "kserve/pmmlserver",
+            "defaultImageVersion": "v0.8.0",
             "supportedFrameworks": [
               "pmml"
             ],
             "multiModelServer": false
         },
         "lightgbm": {
+            "image": "kserve/lgbserver",
+            "defaultImageVersion": "v0.8.0",
             "supportedFrameworks": [
               "lightgbm"
             ],
             "multiModelServer": false
         },
         "paddle": {
+            "image": "kserve/paddleserver",
+            "defaultImageVersion": "v0.8.0",
             "supportedFrameworks": [
               "paddle"
             ],


### PR DESCRIPTION
fixes #2045 

This PR is to fix the issue that container image becomes empty for old inferenceservices if the Kserve is upgraded from v0.7.0 to v0.8.0.

Solution:
The predictor images are restored in inferenceservice configmap.