### PR TITLE
Add ingress class name configuration

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -158,7 +158,8 @@ data:
         "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
         "localGateway" : "knative-serving/knative-local-gateway",
         "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
-        "ingressDomain"  : "example.com"
+        "ingressDomain"  : "example.com",
+        "ingressClassName" : "istio"
     }
   logger: |-
     {

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -158,7 +158,8 @@ data:
         "ingressGateway" : "knative-serving/knative-ingress-gateway",
         "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
         "localGateway": "knative-serving/knative-local-gateway",
-        "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local"
+        "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
+        "ingressClassName" : "istio"
     }
   logger: |-
     {

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -114,11 +114,12 @@ type InferenceServicesConfig struct {
 
 // +kubebuilder:object:generate=false
 type IngressConfig struct {
-	IngressGateway          string `json:"ingressGateway,omitempty"`
-	IngressServiceName      string `json:"ingressService,omitempty"`
-	LocalGateway            string `json:"localGateway,omitempty"`
-	LocalGatewayServiceName string `json:"localGatewayService,omitempty"`
-	IngressDomain           string `json:"ingressDomain,omitempty"`
+	IngressGateway          string  `json:"ingressGateway,omitempty"`
+	IngressServiceName      string  `json:"ingressService,omitempty"`
+	LocalGateway            string  `json:"localGateway,omitempty"`
+	LocalGatewayServiceName string  `json:"localGatewayService,omitempty"`
+	IngressDomain           string  `json:"ingressDomain,omitempty"`
+	IngressClassName        *string `json:"ingressClassName,omitempty"`
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -526,7 +526,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}
 			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
 			defer k8sClient.Delete(context.TODO(), configMap)
-			serviceName := "raw-foo"
+			serviceName := "raw-foo-no-ingress-class"
 			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: "default"}}
 			var serviceKey = expectedRequest.NamespacedName
 			var storageUri = "s3://test/mnist/export"

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -94,7 +94,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
                "ingressService": "test-destination",
                "localGateway": "knative-serving/knative-local-gateway",
                "localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
-               "ingressDomain": "example.com"
+               "ingressDomain": "example.com",
+               "ingressClassName" : "istio"
             }`,
 		}
 	)
@@ -313,8 +314,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorIngressKey, actualIngress) }, timeout).
 				Should(Succeed())
+			ingressClassName := "istio"
 			expectedIngress := netv1.Ingress{
 				Spec: netv1.IngressSpec{
+					IngressClassName: &ingressClassName,
 					Rules: []netv1.IngressRule{
 						{
 							Host: "raw-foo-default.example.com",

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -98,6 +98,42 @@ var _ = Describe("v1beta1 inference service controller", func() {
                "ingressClassName" : "istio"
             }`,
 		}
+		configsWithEmptyIngressClassName = map[string]string{
+			"predictors": `{
+               "tensorflow": {
+                  "image": "tensorflow/serving",
+				  "defaultTimeout": "60",
+ 				  "multiModelServer": false
+               },
+               "sklearn": {
+                 "v1": {
+                  	"image": "kfserving/sklearnserver",
+					"multiModelServer": true
+                 },
+                 "v2": {
+                  	"image": "kfserving/sklearnserver",
+					"multiModelServer": true
+                 }
+               },
+               "xgboost": {
+				  	"image": "kfserving/xgbserver",
+				  	"multiModelServer": true
+               }
+	         }`,
+			"explainers": `{
+               "alibi": {
+                  "image": "kfserving/alibi-explainer",
+			      "defaultImageVersion": "latest"
+               }
+            }`,
+			"ingress": `{
+               "ingressGateway": "knative-serving/knative-ingress-gateway",
+               "ingressService": "test-destination",
+               "localGateway": "knative-serving/knative-local-gateway",
+               "localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
+               "ingressDomain": "example.com"
+            }`,
+		}
 	)
 	Context("When creating inference service with raw kube predictor", func() {
 		It("Should have ingress/service/deployment/hpa created", func() {
@@ -318,6 +354,382 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			expectedIngress := netv1.Ingress{
 				Spec: netv1.IngressSpec{
 					IngressClassName: &ingressClassName,
+					Rules: []netv1.IngressRule{
+						{
+							Host: "raw-foo-default.example.com",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &pathType,
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
+													Name: "raw-foo-predictor-default",
+													Port: netv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Host: "raw-foo-predictor-default-default.example.com",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &pathType,
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
+													Name: "raw-foo-predictor-default",
+													Port: netv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(actualIngress.Spec).To(gomega.Equal(expectedIngress.Spec))
+			// verify if InferenceService status is updated
+			expectedIsvcStatus := v1beta1.InferenceServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   v1beta1.IngressReady,
+							Status: "True",
+						},
+						{
+							Type:   v1beta1.PredictorReady,
+							Status: "True",
+						},
+						{
+							Type:   apis.ConditionReady,
+							Status: "True",
+						},
+					},
+				},
+				URL: &apis.URL{
+					Scheme: "http",
+					Host:   "raw-foo-default.example.com",
+				},
+				Address: &duckv1.Addressable{
+					URL: &apis.URL{
+						Scheme: "http",
+						Host:   network.GetServiceHostname(serviceKey.Name, serviceKey.Namespace),
+					},
+				},
+				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+					v1beta1.PredictorComponent: {
+						LatestCreatedRevision: "",
+						URL: &apis.URL{
+							Scheme: "http",
+							Host:   "raw-foo-predictor-default-default.example.com",
+						},
+					},
+				},
+			}
+			Eventually(func() string {
+				isvc := &v1beta1.InferenceService{}
+				if err := k8sClient.Get(context.TODO(), serviceKey, isvc); err != nil {
+					return err.Error()
+				}
+				return cmp.Diff(&expectedIsvcStatus, &isvc.Status, cmpopts.IgnoreTypes(apis.VolatileTime{}))
+			}, timeout).Should(gomega.BeEmpty())
+
+			//check HPA
+			var minReplicas int32 = 1
+			var maxReplicas int32 = 3
+			var cpuUtilization int32 = 75
+			var stabilizationWindowSeconds int32 = 0
+			selectPolicy := v2beta2.MaxPolicySelect
+			actualHPA := &v2beta2.HorizontalPodAutoscaler{}
+			predictorHPAKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace}
+			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorHPAKey, actualHPA) }, timeout).
+				Should(Succeed())
+			expectedHPA := &v2beta2.HorizontalPodAutoscaler{
+				Spec: v2beta2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: v2beta2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       constants.DefaultPredictorServiceName(serviceKey.Name),
+					},
+					MinReplicas: &minReplicas,
+					MaxReplicas: maxReplicas,
+					Metrics: []v2beta2.MetricSpec{
+						{
+							Type: v2beta2.ResourceMetricSourceType,
+							Resource: &v2beta2.ResourceMetricSource{
+								Name: v1.ResourceCPU,
+								Target: v2beta2.MetricTarget{
+									Type:               "Utilization",
+									AverageUtilization: &cpuUtilization,
+								},
+							},
+						},
+					},
+					Behavior: &v2beta2.HorizontalPodAutoscalerBehavior{
+						ScaleUp: &v2beta2.HPAScalingRules{
+							StabilizationWindowSeconds: &stabilizationWindowSeconds,
+							SelectPolicy:               &selectPolicy,
+							Policies: []v2beta2.HPAScalingPolicy{
+								{
+									Type:          "Pods",
+									Value:         4,
+									PeriodSeconds: 15,
+								},
+								{
+									Type:          "Percent",
+									Value:         100,
+									PeriodSeconds: 15,
+								},
+							},
+						},
+						ScaleDown: &v2beta2.HPAScalingRules{
+							StabilizationWindowSeconds: nil,
+							SelectPolicy:               &selectPolicy,
+							Policies: []v2beta2.HPAScalingPolicy{
+								{
+									Type:          "Percent",
+									Value:         100,
+									PeriodSeconds: 15,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(actualHPA.Spec).To(gomega.Equal(expectedHPA.Spec))
+		})
+	})
+	Context("When creating inference service with raw kube predictor and empty ingressClassName", func() {
+		It("Should have ingress/service/deployment/hpa created", func() {
+			By("By creating a new InferenceService")
+			// Create configmap
+			var configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configsWithEmptyIngressClassName,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+			serviceName := "raw-foo"
+			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: "default"}}
+			var serviceKey = expectedRequest.NamespacedName
+			var storageUri = "s3://test/mnist/export"
+			ctx := context.Background()
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":              "RawDeployment",
+						"serving.kserve.io/autoscalerClass":             "hpa",
+						"serving.kserve.io/metrics":                     "cpu",
+						"serving.kserve.io/targetUtilizationPercentage": "75",
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: v1beta1.GetIntReference(1),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     &storageUri,
+								RuntimeVersion: proto.String("1.14.0"),
+								Container: v1.Container{
+									Name:      "kfs",
+									Resources: defaultResource,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+
+			inferenceService := &v1beta1.InferenceService{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, inferenceService)
+				if err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			actualDeployment := &appsv1.Deployment{}
+			predictorDeploymentKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace}
+			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment) }, timeout).
+				Should(Succeed())
+			var replicas int32 = 1
+			var revisionHistory int32 = 10
+			var progressDeadlineSeconds int32 = 600
+			var gracePeriod int64 = 30
+			expectedDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      predictorDeploymentKey.Name,
+					Namespace: predictorDeploymentKey.Namespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "isvc." + predictorDeploymentKey.Name,
+						},
+					},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      predictorDeploymentKey.Name,
+							Namespace: "default",
+							Labels: map[string]string{
+								"app":                                 "isvc." + predictorDeploymentKey.Name,
+								constants.KServiceComponentLabel:      constants.Predictor.String(),
+								constants.InferenceServicePodLabelKey: serviceName,
+							},
+							Annotations: map[string]string{
+								constants.StorageInitializerSourceUriInternalAnnotationKey: *isvc.Spec.Predictor.Tensorflow.StorageURI,
+								"serving.kserve.io/deploymentMode":                         "RawDeployment",
+								"serving.kserve.io/autoscalerClass":                        "hpa",
+								"serving.kserve.io/metrics":                                "cpu",
+								"serving.kserve.io/targetUtilizationPercentage":            "75",
+							},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Image: "tensorflow/serving:" +
+										*isvc.Spec.Predictor.Tensorflow.RuntimeVersion,
+									Name:    constants.InferenceServiceContainerName,
+									Command: []string{v1beta1.TensorflowEntrypointCommand},
+									Args: []string{
+										"--port=" + v1beta1.TensorflowServingGRPCPort,
+										"--rest_api_port=" + v1beta1.TensorflowServingRestPort,
+										"--model_name=" + isvc.Name,
+										"--model_base_path=" + constants.DefaultModelLocalMountPath,
+										"--rest_api_timeout_in_ms=60000",
+									},
+									Resources: defaultResource,
+									ReadinessProbe: &v1.Probe{
+										Handler: v1.Handler{
+											TCPSocket: &v1.TCPSocketAction{
+												Port: intstr.IntOrString{
+													IntVal: 8080,
+												},
+											},
+										},
+										InitialDelaySeconds: 0,
+										TimeoutSeconds:      1,
+										PeriodSeconds:       10,
+										SuccessThreshold:    1,
+										FailureThreshold:    3,
+									},
+									TerminationMessagePath:   "/dev/termination-log",
+									TerminationMessagePolicy: "File",
+									ImagePullPolicy:          "IfNotPresent",
+								},
+							},
+							SchedulerName:                 "default-scheduler",
+							RestartPolicy:                 "Always",
+							TerminationGracePeriodSeconds: &gracePeriod,
+							DNSPolicy:                     "ClusterFirst",
+							SecurityContext: &v1.PodSecurityContext{
+								SELinuxOptions:      nil,
+								WindowsOptions:      nil,
+								RunAsUser:           nil,
+								RunAsGroup:          nil,
+								RunAsNonRoot:        nil,
+								SupplementalGroups:  nil,
+								FSGroup:             nil,
+								Sysctls:             nil,
+								FSGroupChangePolicy: nil,
+								SeccompProfile:      nil,
+							},
+						},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type: "RollingUpdate",
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxUnavailable: &intstr.IntOrString{Type: 1, IntVal: 0, StrVal: "25%"},
+							MaxSurge:       &intstr.IntOrString{Type: 1, IntVal: 0, StrVal: "25%"},
+						},
+					},
+					RevisionHistoryLimit:    &revisionHistory,
+					ProgressDeadlineSeconds: &progressDeadlineSeconds,
+				},
+			}
+			Expect(actualDeployment.Spec).To(gomega.Equal(expectedDeployment.Spec))
+
+			//check service
+			actualService := &v1.Service{}
+			predictorServiceKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace}
+			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
+				Should(Succeed())
+
+			expectedService := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      predictorServiceKey.Name,
+					Namespace: predictorServiceKey.Namespace,
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:       "raw-foo-predictor-default",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.IntOrString{Type: 0, IntVal: 8080, StrVal: ""},
+						},
+					},
+					Type:            "ClusterIP",
+					SessionAffinity: "None",
+					Selector: map[string]string{
+						"app": "isvc.raw-foo-predictor-default",
+					},
+				},
+			}
+			actualService.Spec.ClusterIP = ""
+			actualService.Spec.ClusterIPs = nil
+			actualService.Spec.IPFamilies = nil
+			actualService.Spec.IPFamilyPolicy = nil
+			actualService.Spec.InternalTrafficPolicy = nil
+			Expect(actualService.Spec).To(gomega.Equal(expectedService.Spec))
+
+			//check isvc status
+			updatedDeployment := actualDeployment.DeepCopy()
+			updatedDeployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: v1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(context.TODO(), updatedDeployment)).NotTo(gomega.HaveOccurred())
+
+			//check ingress
+			pathType := netv1.PathTypePrefix
+			actualIngress := &netv1.Ingress{}
+			predictorIngressKey := types.NamespacedName{Name: serviceKey.Name,
+				Namespace: serviceKey.Namespace}
+			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorIngressKey, actualIngress) }, timeout).
+				Should(Succeed())
+			expectedIngress := netv1.Ingress{
+				Spec: netv1.IngressSpec{
 					Rules: []netv1.IngressRule{
 						{
 							Host: "raw-foo-default.example.com",

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -18,6 +18,7 @@ package inferenceservice
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -691,7 +692,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: v1.ServiceSpec{
 					Ports: []v1.ServicePort{
 						{
-							Name:       "raw-foo-predictor-default",
+							Name:       fmt.Sprintf("%s-predictor-default", serviceName),
 							Protocol:   "TCP",
 							Port:       80,
 							TargetPort: intstr.IntOrString{Type: 0, IntVal: 8080, StrVal: ""},
@@ -700,7 +701,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					Type:            "ClusterIP",
 					SessionAffinity: "None",
 					Selector: map[string]string{
-						"app": "isvc.raw-foo-predictor-default",
+						"app": fmt.Sprintf("isvc.%s-predictor-default", serviceName),
 					},
 				},
 			}
@@ -732,7 +733,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: netv1.IngressSpec{
 					Rules: []netv1.IngressRule{
 						{
-							Host: "raw-foo-default.example.com",
+							Host: fmt.Sprintf("%s-default.example.com", serviceName),
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -741,7 +742,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 											PathType: &pathType,
 											Backend: netv1.IngressBackend{
 												Service: &netv1.IngressServiceBackend{
-													Name: "raw-foo-predictor-default",
+													Name: fmt.Sprintf("%s-predictor-default", serviceName),
 													Port: netv1.ServiceBackendPort{
 														Number: 80,
 													},
@@ -753,7 +754,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							},
 						},
 						{
-							Host: "raw-foo-predictor-default-default.example.com",
+							Host: fmt.Sprintf("%s-predictor-default-default.example.com", serviceName),
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -762,7 +763,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 											PathType: &pathType,
 											Backend: netv1.IngressBackend{
 												Service: &netv1.IngressServiceBackend{
-													Name: "raw-foo-predictor-default",
+													Name: fmt.Sprintf("%s-predictor-default", serviceName),
 													Port: netv1.ServiceBackendPort{
 														Number: 80,
 													},
@@ -797,7 +798,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				},
 				URL: &apis.URL{
 					Scheme: "http",
-					Host:   "raw-foo-default.example.com",
+					Host:   fmt.Sprintf("%s-default.example.com", serviceName),
 				},
 				Address: &duckv1.Addressable{
 					URL: &apis.URL{
@@ -810,7 +811,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						LatestCreatedRevision: "",
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   "raw-foo-predictor-default-default.example.com",
+							Host:   fmt.Sprintf("%s-predictor-default-default.example.com", serviceName),
 						},
 					},
 				},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -190,7 +190,8 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1api.InferenceService,
 			Annotations: isvc.Annotations,
 		},
 		Spec: netv1.IngressSpec{
-			Rules: rules,
+			IngressClassName: ingressConfig.IngressClassName,
+			Rules:            rules,
 		},
 	}
 	if err := controllerutil.SetControllerReference(isvc, ingress, scheme); err != nil {

--- a/test/e2e/predictor/test_raw_deployment.py
+++ b/test/e2e/predictor/test_raw_deployment.py
@@ -35,7 +35,6 @@ def test_raw_deployment_kserve():
     service_name = "raw-sklearn"
     annotations = dict()
     annotations['serving.kserve.io/deploymentMode'] = 'RawDeployment'
-    annotations['kubernetes.io/ingress.class'] = 'istio'
 
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -70,7 +69,6 @@ def test_raw_deployment_runtime_kserve():
     service_name = "raw-sklearn-runtime"
     annotations = dict()
     annotations['serving.kserve.io/deploymentMode'] = 'RawDeployment'
-    annotations['kubernetes.io/ingress.class'] = 'istio'
 
     predictor = V1beta1PredictorSpec(
         min_replicas=1,

--- a/test/e2e/transformer/test_raw_transformer.py
+++ b/test/e2e/transformer/test_raw_transformer.py
@@ -57,7 +57,6 @@ def test_transformer():
 
     annotations = dict()
     annotations['serving.kserve.io/deploymentMode'] = 'RawDeployment'
-    annotations['kubernetes.io/ingress.class'] = 'istio'
     isvc = V1beta1InferenceService(api_version=constants.KSERVE_V1BETA1,
                                    kind=constants.KSERVE_KIND,
                                    metadata=client.V1ObjectMeta(

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -54,6 +54,17 @@ popd
 echo "Waiting for istio started ..."
 kubectl wait --for=condition=Ready pods --all --timeout=180s -n istio-system
 
+# Necessary since istio is the default ingressClassName in kserve.yaml
+echo "Creating istio ingress class"
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: istio
+spec:
+  controller: istio.io/ingress-controller
+EOF
+
 echo "Installing knative serving ..."
 kubectl apply -f https://github.com/knative/operator/releases/download/${KNATIVE_VERSION}/operator.yaml
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
To allow selecting specific ingress controller when using RawDeployment


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2048

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

- [x] Run the controller with and without ingress class name in cluster and create inference service

- Logs
Ingress generated when ingress class name is set to "istio"
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
    queue.sidecar.serving.knative.dev/resourcePercentage: "20"
  creationTimestamp: "2022-02-18T09:48:52Z"
  generation: 1
  name: xgboost-sample-413
  namespace: test
  resourceVersion: "10446008"
  uid: 79862c9c-e97f-4da9-9d58-e39a0b5481b5
spec:
  ingressClassName: istio
  rules:
  - host: xgboost-sample-413-test.example.com
    http:
      paths:
      - backend:
          service:
            name: xgboost-sample-413-predictor-default
            port:
              number: 80
        path: /
        pathType: Prefix
  - host: xgboost-sample-413-predictor-default-test.example.com
    http:
      paths:
      - backend:
          service:
            name: xgboost-sample-413-predictor-default
            port:
              number: 80
        path: /
        pathType: Prefix
```


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `ingressClassName` configuration to allow selecting specific ingress controller for RawDeployment
```
