### PR TITLE
Added logic to update ModelStatus

### DIFF
--- a/config/crd/serving.kserve.io_inferenceservices.yaml
+++ b/config/crd/serving.kserve.io_inferenceservices.yaml
@@ -13019,6 +13019,13 @@ spec:
                       message:
                         type: string
                       reason:
+                        enum:
+                        - ModelLoadFailed
+                        - RuntimeUnhealthy
+                        - RuntimeDisabled
+                        - NoSupportingRuntime
+                        - RuntimeNotRecognized
+                        - InvalidPredictorSpec
                         type: string
                       severity:
                         type: string

--- a/config/crd/serving.kserve.io_inferenceservices.yaml
+++ b/config/crd/serving.kserve.io_inferenceservices.yaml
@@ -13019,13 +13019,6 @@ spec:
                       message:
                         type: string
                       reason:
-                        enum:
-                        - ModelLoadFailed
-                        - RuntimeUnhealthy
-                        - RuntimeDisabled
-                        - NoSupportingRuntime
-                        - RuntimeNotRecognized
-                        - InvalidPredictorSpec
                         type: string
                       severity:
                         type: string
@@ -13062,6 +13055,7 @@ spec:
                           enum:
                             - ModelLoadFailed
                             - RuntimeUnhealthy
+                            - RuntimeDisabled
                             - NoSupportingRuntime
                             - RuntimeNotRecognized
                             - InvalidPredictorSpec

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -76,6 +76,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -411,11 +411,10 @@ func (ss *InferenceServiceStatus) UpdateModelRevisionStates(modelState ModelStat
 		ss.ModelStatus.TransitionStatus = InProgress
 	} else if modelState == Loaded {
 		ss.ModelStatus.TransitionStatus = UpToDate
-	} else if modelState == FailedToLoad {
-		ss.ModelStatus.TransitionStatus = BlockedByFailedLoad
-	} else if modelState == Loaded {
 		ss.ModelStatus.ModelCopies = &ModelCopies{TotalCopies: totalCopies}
 		ss.ModelStatus.ModelRevisionStates.ActiveModelState = Loaded
+	} else if modelState == FailedToLoad {
+		ss.ModelStatus.TransitionStatus = BlockedByFailedLoad
 	}
 	if info != nil {
 		ss.SetModelFailureInfo(info)

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -188,7 +188,7 @@ const (
 )
 
 // FailureReason enum
-// +kubebuilder:validation:Enum=ModelLoadFailed;RuntimeUnhealthy;NoSupportingRuntime;RuntimeNotRecognized;InvalidPredictorSpec
+// +kubebuilder:validation:Enum=ModelLoadFailed;RuntimeUnhealthy;RuntimeDisabled;NoSupportingRuntime;RuntimeNotRecognized;InvalidPredictorSpec
 type FailureReason string
 
 // FailureReason enum values
@@ -423,7 +423,14 @@ func (ss *InferenceServiceStatus) UpdateModelTransitionStatus(status TransitionS
 	ss.ModelStatus.TransitionStatus = status
 	// Update model state to 'FailedToLoad' in case of invalid spec provided
 	if ss.ModelStatus.TransitionStatus == InvalidSpec {
-		ss.UpdateModelRevisionStates(FailedToLoad, info)
+		if ss.ModelStatus.ModelRevisionStates == nil {
+			ss.ModelStatus.ModelRevisionStates = &ModelRevisionStates{ActiveModelState: FailedToLoad}
+		} else {
+			ss.ModelStatus.ModelRevisionStates.ActiveModelState = FailedToLoad
+		}
+	}
+	if info != nil {
+		ss.SetModelFailureInfo(info)
 	}
 }
 

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"reflect"
+
+	"github.com/kserve/kserve/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,6 +197,8 @@ const (
 	ModelLoadFailed FailureReason = "ModelLoadFailed"
 	// Corresponding ServingRuntime containers failed to start or are unhealthy
 	RuntimeUnhealthy FailureReason = "RuntimeUnhealthy"
+	// The ServingRuntime is disabled
+	RuntimeDisabled FailureReason = "RuntimeDisabled"
 	// There are no ServingRuntime which support the specified model type
 	NoSupportingRuntime FailureReason = "NoSupportingRuntime"
 	// There is no ServingRuntime defined with the specified runtime name
@@ -392,5 +397,104 @@ func (ss *InferenceServiceStatus) SetCondition(conditionType apis.ConditionType,
 func (ss *InferenceServiceStatus) ClearCondition(conditionType apis.ConditionType) {
 	if conditionSet.Manage(ss).GetCondition(conditionType) != nil {
 		conditionSet.Manage(ss).ClearCondition(conditionType)
+	}
+}
+
+func (ss *InferenceServiceStatus) UpdateModelRevisionStates(modelState ModelState, info *FailureInfo) {
+	if ss.ModelStatus.ModelRevisionStates == nil {
+		ss.ModelStatus.ModelRevisionStates = &ModelRevisionStates{ActiveModelState: modelState}
+	} else {
+		ss.ModelStatus.ModelRevisionStates.ActiveModelState = modelState
+	}
+	// Update transition status, failure info based on new model state
+	if modelState == Pending || modelState == Loading {
+		ss.ModelStatus.TransitionStatus = InProgress
+	} else if modelState == Loaded {
+		ss.ModelStatus.TransitionStatus = UpToDate
+	} else if modelState == FailedToLoad {
+		ss.ModelStatus.TransitionStatus = BlockedByFailedLoad
+	}
+	if info != nil {
+		ss.SetModelFailureInfo(info)
+	}
+}
+
+func (ss *InferenceServiceStatus) UpdateModelTransitionStatus(status TransitionStatus, info *FailureInfo) {
+	ss.ModelStatus.TransitionStatus = status
+	// Update model state to 'FailedToLoad' in case of invalid spec provided
+	if ss.ModelStatus.TransitionStatus == InvalidSpec {
+		ss.UpdateModelRevisionStates(FailedToLoad, info)
+	}
+}
+
+func (ss *InferenceServiceStatus) SetModelFailureInfo(info *FailureInfo) bool {
+	if reflect.DeepEqual(info, ss.ModelStatus.LastFailureInfo) {
+		return false
+	}
+	ss.ModelStatus.LastFailureInfo = info
+	return true
+}
+
+func (ss *InferenceServiceStatus) PropagateModelStatus(statusSpec ComponentStatusSpec, podList *v1.PodList, rawDeplyment bool) {
+	// Check at least one pod is running for the latest revision of inferenceservice
+	if len(podList.Items) == 0 {
+		return
+	}
+	// Update model state to 'Loaded' if inferenceservice status is ready.
+	// For serverless deployment, the latest created revision and the latest ready revision should be equal
+	if ss.IsReady() {
+		if rawDeplyment {
+			ss.UpdateModelRevisionStates(Loaded, nil)
+			return
+		} else if statusSpec.LatestCreatedRevision == statusSpec.LatestReadyRevision {
+			ss.UpdateModelRevisionStates(Loaded, nil)
+			return
+		}
+	}
+	// Update model state to 'Loading' if storage initializer is running.
+	// If the storage initializer is terminated due to error or crashloopbackoff, update model
+	// state to 'ModelLoadFailed' with failure info.
+	for _, cs := range podList.Items[0].Status.InitContainerStatuses {
+		if cs.Name == constants.StorageInitializerContainerName {
+			if cs.State.Running != nil {
+				ss.UpdateModelRevisionStates(Loading, nil)
+				return
+			} else if cs.State.Terminated != nil &&
+				cs.State.Terminated.Reason == constants.StateReasonError {
+				ss.UpdateModelRevisionStates(FailedToLoad, &FailureInfo{
+					Reason:  ModelLoadFailed,
+					Message: cs.State.Terminated.Message,
+				})
+				return
+			} else if cs.State.Waiting != nil &&
+				cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff {
+				ss.UpdateModelRevisionStates(FailedToLoad, &FailureInfo{
+					Reason:  ModelLoadFailed,
+					Message: cs.LastTerminationState.Terminated.Message,
+				})
+				return
+			}
+		}
+	}
+	// If the kserve container is terminated due to error or crashloopbackoff, update model
+	// state to 'ModelLoadFailed' with failure info.
+	for _, cs := range podList.Items[0].Status.ContainerStatuses {
+		if cs.Name == constants.InferenceServiceContainerName {
+			if cs.State.Terminated != nil &&
+				cs.State.Terminated.Reason == constants.StateReasonError {
+				ss.UpdateModelRevisionStates(FailedToLoad, &FailureInfo{
+					Reason:  ModelLoadFailed,
+					Message: cs.State.Terminated.Message,
+				})
+			} else if cs.State.Waiting != nil &&
+				cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff {
+				ss.UpdateModelRevisionStates(FailedToLoad, &FailureInfo{
+					Reason:  ModelLoadFailed,
+					Message: cs.LastTerminationState.Terminated.Message,
+				})
+			} else {
+				ss.UpdateModelRevisionStates(Pending, nil)
+			}
+		}
 	}
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -237,7 +237,8 @@ const (
 
 // InferenceService container name
 const (
-	InferenceServiceContainerName = "kserve-container"
+	InferenceServiceContainerName   = "kserve-container"
+	StorageInitializerContainerName = "storage-initializer"
 )
 
 // DefaultModelLocalMountPath is where models will be mounted by the storage-initializer
@@ -337,6 +338,20 @@ const (
 	GRPCV1
 	GRPCV2
 	Unknown
+)
+
+// revision label
+const (
+	RevisionLabel         = "serving.knative.dev/revision"
+	RawDeploymentAppLabel = "app"
+)
+
+// container state reason
+const (
+	StateReasonRunning          = "Running"
+	StateReasonCompleted        = "Completed"
+	StateReasonError            = "Error"
+	StateReasonCrashLoopBackOff = "CrashLoopBackOff"
 )
 
 // GetRawServiceLabel generate native service label

--- a/pkg/controller/v1alpha1/trainedmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller_test.go
@@ -106,6 +106,12 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				},
 			},
 		}
+		modelStatus = v1beta1.ModelStatus{
+			TransitionStatus: v1beta1.UpToDate,
+			ModelRevisionStates: &v1beta1.ModelRevisionStates{
+				ActiveModelState: v1beta1.Loaded,
+			},
+		}
 	)
 
 	Context("When creating a new TrainedModel with an unready InferenceService", func() {
@@ -234,6 +240,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			inferenceService.Status.Status = readyConditions
+			inferenceService.Status.ModelStatus = modelStatus
 			Expect(k8sClient.Status().Update(context.TODO(), inferenceService)).To(BeNil())
 
 			// Create modelConfig
@@ -349,6 +356,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				URL: clusterURL,
 			}
 			inferenceService.Status.Status = readyConditions
+			inferenceService.Status.ModelStatus = modelStatus
 			Expect(k8sClient.Status().Update(context.TODO(), inferenceService)).To(BeNil())
 
 			tmInstance := &v1alpha1api.TrainedModel{
@@ -496,6 +504,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			inferenceService.Status.Status = readyConditions
+			inferenceService.Status.ModelStatus = modelStatus
 			Expect(k8sClient.Status().Update(context.TODO(), inferenceService)).To(BeNil())
 
 			tmInstance := &v1alpha1api.TrainedModel{
@@ -624,6 +633,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			inferenceService.Status.Status = readyConditions
+			inferenceService.Status.ModelStatus = modelStatus
 			Expect(k8sClient.Status().Update(context.TODO(), inferenceService)).To(BeNil())
 
 			// Create modelConfig
@@ -755,6 +765,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			inferenceService.Status.Status = readyConditions
+			inferenceService.Status.ModelStatus = modelStatus
 			Expect(k8sClient.Status().Update(context.TODO(), inferenceService)).To(BeNil())
 
 			// Create modelConfig
@@ -885,6 +896,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			inferenceService.Status.Status = readyConditions
+			inferenceService.Status.ModelStatus = modelStatus
 			Expect(k8sClient.Status().Update(context.TODO(), inferenceService)).To(BeNil())
 
 			// Create modelConfig

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -64,9 +64,6 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 	var container *v1.Container
 	var podSpec v1.PodSpec
 
-	// inferenceservice modelstatus set to 'Pending'
-	isvc.Status.UpdateModelRevisionStates(v1beta1.Pending, nil)
-
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
 	})

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -110,6 +110,10 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 
 			if isvc.Spec.Predictor.Model.ProtocolVersion != nil &&
 				!r.IsProtocolVersionSupported(*isvc.Spec.Predictor.Model.ProtocolVersion) {
+				isvc.Status.UpdateModelTransitionStatus(v1beta1.InvalidSpec, &v1beta1.FailureInfo{
+					Reason:  v1beta1.NoSupportingRuntime,
+					Message: "Specified runtime does not support specified protocol version",
+				})
 				return ctrl.Result{}, fmt.Errorf("specified runtime %s does not support specified protocol version", *isvc.Spec.Predictor.Model.Runtime)
 			}
 

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -180,6 +180,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err != nil {
 			r.Log.Error(err, "Failed to reconcile", "reconciler", reflect.ValueOf(reconciler), "Name", isvc.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "InternalError", err.Error())
+			r.updateStatus(isvc)
 			return reconcile.Result{}, errors.Wrapf(err, "fails to reconcile component")
 		}
 		if result.Requeue || result.RequeueAfter > 0 {

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -180,7 +180,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err != nil {
 			r.Log.Error(err, "Failed to reconcile", "reconciler", reflect.ValueOf(reconciler), "Name", isvc.Name)
 			r.Recorder.Eventf(isvc, v1.EventTypeWarning, "InternalError", err.Error())
-			r.updateStatus(isvc)
+			r.updateStatus(isvc, deploymentMode)
 			return reconcile.Result{}, errors.Wrapf(err, "fails to reconcile component")
 		}
 		if result.Requeue || result.RequeueAfter > 0 {

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -69,6 +69,7 @@ import (
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // InferenceState describes the Readiness of the InferenceService
 type InferenceServiceState string

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -142,6 +142,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
 			inferenceService := &v1beta1.InferenceService{}
 
 			Eventually(func() bool {
@@ -512,6 +513,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						URL:                   transformerUrl,
 					},
 				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus:    "InProgress",
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
+				},
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -731,6 +736,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						LatestCreatedRevision: "exp-revision-v1",
 						URL:                   explainerUrl,
 					},
+				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus:    "InProgress",
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
 			}
 			Eventually(func() string {
@@ -1221,6 +1230,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				if err != nil {
 					return false
 				}
+				if inferenceService.Status.ModelStatus.LastFailureInfo == nil {
+					return false
+				}
 				return true
 			}, timeout, interval).Should(BeTrue())
 
@@ -1229,7 +1241,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Message: "Waiting for runtime to become available",
 			}
 			Expect(inferenceService.Status.ModelStatus.TransitionStatus).To(Equal(v1beta1.InvalidSpec))
-			Expect(inferenceService.Status.ModelStatus.ModelRevisionStates.ActiveModelState).To(Equal(v1beta1.FailedToLoad))
+			Expect(inferenceService.Status.ModelStatus.ModelRevisionStates.TargetModelState).To(Equal(v1beta1.FailedToLoad))
 			Expect(cmp.Diff(&failureInfo, inferenceService.Status.ModelStatus.LastFailureInfo)).To(gomega.Equal(""))
 		})
 	})
@@ -1323,6 +1335,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				if err != nil {
 					return false
 				}
+				if inferenceService.Status.ModelStatus.LastFailureInfo == nil {
+					return false
+				}
 				return true
 			}, timeout, interval).Should(BeTrue())
 
@@ -1331,7 +1346,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Message: "Specified runtime is disabled",
 			}
 			Expect(inferenceService.Status.ModelStatus.TransitionStatus).To(Equal(v1beta1.InvalidSpec))
-			Expect(inferenceService.Status.ModelStatus.ModelRevisionStates.ActiveModelState).To(Equal(v1beta1.FailedToLoad))
+			Expect(inferenceService.Status.ModelStatus.ModelRevisionStates.TargetModelState).To(Equal(v1beta1.FailedToLoad))
 			Expect(cmp.Diff(&failureInfo, inferenceService.Status.ModelStatus.LastFailureInfo)).To(gomega.Equal(""))
 		})
 	})
@@ -1425,6 +1440,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				if err != nil {
 					return false
 				}
+				if inferenceService.Status.ModelStatus.LastFailureInfo == nil {
+					return false
+				}
 				return true
 			}, timeout, interval).Should(BeTrue())
 
@@ -1433,7 +1451,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Message: "Specified runtime does not support specified framework/version",
 			}
 			Expect(inferenceService.Status.ModelStatus.TransitionStatus).To(Equal(v1beta1.InvalidSpec))
-			Expect(inferenceService.Status.ModelStatus.ModelRevisionStates.ActiveModelState).To(Equal(v1beta1.FailedToLoad))
+			Expect(inferenceService.Status.ModelStatus.ModelRevisionStates.TargetModelState).To(Equal(v1beta1.FailedToLoad))
 			Expect(cmp.Diff(&failureInfo, inferenceService.Status.ModelStatus.LastFailureInfo)).To(gomega.Equal(""))
 		})
 	})

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -512,6 +512,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						URL:                   transformerUrl,
 					},
 				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus: v1beta1.InProgress,
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Pending,
+					},
+				},
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -730,6 +736,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						LatestReadyRevision:   "exp-revision-v1",
 						LatestCreatedRevision: "exp-revision-v1",
 						URL:                   explainerUrl,
+					},
+				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus: v1beta1.InProgress,
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Pending,
 					},
 				},
 			}

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -402,6 +402,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						},
 					},
 				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus: v1beta1.InProgress,
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Pending,
+					},
+				},
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -813,6 +819,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Scheme: "http",
 							Host:   fmt.Sprintf("%s-predictor-default-default.example.com", serviceName),
 						},
+					},
+				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus: v1beta1.InProgress,
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Pending,
 					},
 				},
 			}
@@ -1227,6 +1239,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Scheme: "http",
 							Host:   fmt.Sprintf("%s-predictor-default.%s.%s", serviceName, serviceKey.Namespace, domain),
 						},
+					},
+				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus: v1beta1.InProgress,
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{
+						ActiveModelState: v1beta1.Pending,
 					},
 				},
 			}

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -402,12 +402,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						},
 					},
 				},
-				ModelStatus: v1beta1.ModelStatus{
-					TransitionStatus: v1beta1.InProgress,
-					ModelRevisionStates: &v1beta1.ModelRevisionStates{
-						ActiveModelState: v1beta1.Pending,
-					},
-				},
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -819,12 +813,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Scheme: "http",
 							Host:   fmt.Sprintf("%s-predictor-default-default.example.com", serviceName),
 						},
-					},
-				},
-				ModelStatus: v1beta1.ModelStatus{
-					TransitionStatus: v1beta1.InProgress,
-					ModelRevisionStates: &v1beta1.ModelRevisionStates{
-						ActiveModelState: v1beta1.Pending,
 					},
 				},
 			}
@@ -1239,12 +1227,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Scheme: "http",
 							Host:   fmt.Sprintf("%s-predictor-default.%s.%s", serviceName, serviceKey.Namespace, domain),
 						},
-					},
-				},
-				ModelStatus: v1beta1.ModelStatus{
-					TransitionStatus: v1beta1.InProgress,
-					ModelRevisionStates: &v1beta1.ModelRevisionStates{
-						ActiveModelState: v1beta1.Pending,
 					},
 				},
 			}

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -402,6 +402,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						},
 					},
 				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus:    "InProgress",
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
+				},
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -814,6 +818,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Host:   fmt.Sprintf("%s-predictor-default-default.example.com", serviceName),
 						},
 					},
+				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus:    "InProgress",
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
 			}
 			Eventually(func() string {
@@ -1228,6 +1236,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Host:   fmt.Sprintf("%s-predictor-default.%s.%s", serviceName, serviceKey.Namespace, domain),
 						},
 					},
+				},
+				ModelStatus: v1beta1.ModelStatus{
+					TransitionStatus:    "InProgress",
+					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
 			}
 			Eventually(func() string {

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -202,3 +202,17 @@ func UpdateImageTag(container *v1.Container, runtimeVersion *string, isvcConfig 
 		}
 	}
 }
+
+// ListPodsByLabel Get a PodList by label.
+func ListPodsByLabel(cl client.Client, namespace string, labelKey string, labelVal string) (*v1.PodList, error) {
+	podList := &v1.PodList{}
+	opts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{labelKey: labelVal},
+	}
+	err := cl.List(context.TODO(), podList, opts...)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	return podList, nil
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"html/template"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -214,5 +215,12 @@ func ListPodsByLabel(cl client.Client, namespace string, labelKey string, labelV
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}
+	sortPodsByCreatedTimestampDesc(podList)
 	return podList, nil
+}
+
+func sortPodsByCreatedTimestampDesc(pods *v1.PodList) {
+	sort.Slice(pods.Items, func(i, j int) bool {
+		return pods.Items[j].ObjectMeta.CreationTimestamp.Before(&pods.Items[i].ObjectMeta.CreationTimestamp)
+	})
 }

--- a/test/crds/serving.kserve.io_inferenceservices.yaml
+++ b/test/crds/serving.kserve.io_inferenceservices.yaml
@@ -14828,6 +14828,7 @@ spec:
                         enum:
                         - ModelLoadFailed
                         - RuntimeUnhealthy
+                        - RuntimeDisabled
                         - NoSupportingRuntime
                         - RuntimeNotRecognized
                         - InvalidPredictorSpec


### PR DESCRIPTION
Signed-off-by: Suresh Nakkeran <suresh.n@ideas2it.com>

As part of this PR, ModelStatus field is added in InferenceServiceStatus struct which will be used for updating single model deployment status and ModelMesh predictor status.