### PR TITLE
Fix canary rollout falling back to prev rolledout version

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -335,7 +335,7 @@ func (ss *InferenceServiceStatus) PropagateStatus(component ComponentType, servi
 					if traffic.Percent != nil && *traffic.Percent < 100 {
 						// check the possibility that the traffic is split over the same revision
 						if val, ok := revisionTraffic[traffic.RevisionName]; ok {
-							if val == 100 {
+							if val == 100 && statusSpec.PreviousRolledoutRevision != "" {
 								statusSpec.LatestRolledoutRevision = statusSpec.PreviousRolledoutRevision
 							}
 						}

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -313,6 +313,12 @@ func (ss *InferenceServiceStatus) PropagateStatus(component ComponentType, servi
 		ss.Components[component] = ComponentStatusSpec{}
 	}
 	statusSpec.LatestCreatedRevision = serviceStatus.LatestCreatedRevisionName
+	revisionTraffic := map[string]int64{}
+	for _, traffic := range serviceStatus.Traffic {
+		if traffic.Percent != nil {
+			revisionTraffic[traffic.RevisionName] += *traffic.Percent
+		}
+	}
 	for _, traffic := range serviceStatus.Traffic {
 		if traffic.RevisionName == serviceStatus.LatestReadyRevisionName && traffic.LatestRevision != nil &&
 			*traffic.LatestRevision {
@@ -327,7 +333,12 @@ func (ss *InferenceServiceStatus) PropagateStatus(component ComponentType, servi
 				// so here we need to rollback the LatestRolledoutRevision to PreviousRolledoutRevision
 				if serviceStatus.LatestReadyRevisionName == serviceStatus.LatestCreatedRevisionName {
 					if traffic.Percent != nil && *traffic.Percent < 100 {
-						statusSpec.LatestRolledoutRevision = statusSpec.PreviousRolledoutRevision
+						// check the possibility that the traffic is split over the same revision
+						if val, ok := revisionTraffic[traffic.RevisionName]; ok {
+							if val == 100 {
+								statusSpec.LatestRolledoutRevision = statusSpec.PreviousRolledoutRevision
+							}
+						}
 					}
 				}
 			}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -19,8 +19,6 @@ package knative
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
@@ -88,17 +86,8 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 	}
 	lastRolledoutRevision := componentStatus.LatestRolledoutRevision
 
-	// This is to handle case when the first revision rolled out.
-	if strings.HasSuffix(componentStatus.LatestRolledoutRevision, "-00001") {
-		lastRolledoutRevision = componentStatus.PreviousRolledoutRevision
-	}
-
 	// Log component status and canary traffic percent
-	if componentExtension.CanaryTrafficPercent != nil {
-		log.Info("revision status:", "LatestRolledoutRevision", componentStatus.LatestRolledoutRevision, "LatestReadyRevision", componentStatus.LatestReadyRevision, "LatestCreatedRevision", componentStatus.LatestCreatedRevision, "PreviousRolledoutRevision", componentStatus.PreviousRolledoutRevision, "CanaryTrafficPercent", *componentExtension.CanaryTrafficPercent)
-	} else {
-		log.Info("revision status:", "LatestRolledoutRevision", componentStatus.LatestRolledoutRevision, "LatestReadyRevision", componentStatus.LatestReadyRevision, "LatestCreatedRevision", componentStatus.LatestCreatedRevision, "PreviousRolledoutRevision", componentStatus.PreviousRolledoutRevision, "CanaryTrafficPercent", "nil")
-	}
+        log.Info("revision status:", "LatestRolledoutRevision", componentStatus.LatestRolledoutRevision, "LatestReadyRevision", componentStatus.LatestReadyRevision, "LatestCreatedRevision", componentStatus.LatestCreatedRevision, "PreviousRolledoutRevision", componentStatus.PreviousRolledoutRevision, "CanaryTrafficPercent", componentExtension.CanaryTrafficPercent)
 
 	trafficTargets := []knservingv1.TrafficTarget{}
 	// Split traffic when canary traffic percent is specified


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1968

**Special notes for your reviewer**:

```
When canaryTrafficPercent is specified to roll out the new version from the current stable version, the previous rolled out version gets incorrectly spawn up for a brief time due to the condition of latestCreated == latestReady. We need additional check for "latestReady != latestCreated" so that the last rolled out stays on the current stable version. 
```
It seems that the problem has been solved. But the reality is that before the release of the new revision, the `createKnativeService` function would run serveral times wth the old configuration. We might as well think differently, `if else` here as the note says 

`This is to handle case when the latest ready revision is rolled out with 100% and then rolled back
	// so here we need to get the revision that is previously rolled out with 100%` . 

When the latest ready revision is rolled out with 100%, could we rolle out a new revision with the same as previous revision configuration instead of roll back?
