### PR TITLE
Fix cluster local label InferenceService

### DIFF
--- a/docs/samples/v1beta1/advanced/cluster_local.yaml
+++ b/docs/samples/v1beta1/advanced/cluster_local.yaml
@@ -3,7 +3,7 @@ kind: "InferenceService"
 metadata:
   name: "sklearn-iris-local"
   labels:
-    serving.knative.dev/visibility: cluster-local
+    networking.knative.dev/visibility: cluster-local
 spec:
   predictor:
     sklearn:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the advanced cluster local example for recent (recommended) Knative versions. The label to create a local InferenceService has changed to `networking.knative.dev/visibility: cluster-local`, see https://knative.dev/docs/serving/services/private-services/.

**Type of changes**

- [X] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

I created the cluster_local.yaml example with:
* KServe: 0.7.0, 
* Istio 1.12.2, 
* Knative 0.23.1

Using the label in this will create a private service, the original not.
