### PR TITLE
Adds support for ali-cloud oss in storage-uri

### DIFF
--- a/docs/samples/storage/oss/README.md
+++ b/docs/samples/storage/oss/README.md
@@ -1,0 +1,58 @@
+# Predict on a InferenceService with saved model on Ali-cloud OSS
+
+## Using OSS
+
+Kserve uses [aliyun-oss-python-sdk](https://github.com/aliyun/aliyun-oss-python-sdk) client to download artifacts.
+
+### Create a K8s Secret
+
+Store your OSS secrets as a k8s secret.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: osscreds
+type: Opaque
+data:
+  OSS_ACCESS_KEY_ID: xxxx
+  OSS_ACCESS_KEY_SECRET: xxxx
+  OSS_ENDPOINT: xxxx
+  OSS_REGION: xxxx
+```
+
+### Attach to Service Account
+
+`KServe` gets the secrets from your service account, you need to add the above created or existing secret to your service account's secret list.
+By default `Kserve` uses `default` service account, user can use own service account and overwrite on `InferenceService` CRD.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+secrets:
+  - name: osscreds
+```
+
+Save the YAMLs and apply them to your cluster:
+
+```bash
+kubectl apply -f osscreds.yaml
+```
+
+## Create the InferenceService
+
+Create the InferenceService with the oss `storageUri` and the service account with oss credential attached.
+
+```yaml
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "mnist-oss"
+spec:
+  predictor:
+    serviceAccountName: sa
+    tensorflow:
+      storageUri: "oss://<bucket_name>/mnist"
+```

--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -46,7 +46,7 @@ const (
 
 // Constants
 var (
-	SupportedStorageURIPrefixList     = []string{"gs://", "s3://", "pvc://", "file://", "https://", "http://"}
+	SupportedStorageURIPrefixList     = []string{"gs://", "s3://", "pvc://", "file://", "https://", "http://", "oss://"}
 	SupportedStorageSpecURIPrefixList = []string{"s3://"}
 	AzureBlobURL                      = "blob.core.windows.net"
 	AzureBlobURIRegEx                 = "https://(.+?).blob.core.windows.net/(.+)"

--- a/pkg/credentials/oss/oss_secret.go
+++ b/pkg/credentials/oss/oss_secret.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oss
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	OSSAccessKeyId     = "OSS_ACCESS_KEY_ID"
+	OSSAccessKeySecret = "OSS_ACCESS_KEY_SECRET"
+	OSSEndpointURL     = "OSS_ENDPOINT"
+	OSSRegion          = "OSS_REGION"
+)
+
+func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
+	envs := []v1.EnvVar{
+		{
+			Name: OSSAccessKeyId,
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: secret.Name,
+					},
+					Key: OSSAccessKeyId,
+				},
+			},
+		},
+		{
+			Name: OSSAccessKeySecret,
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: secret.Name,
+					},
+					Key: OSSAccessKeySecret,
+				},
+			},
+		},
+		{
+			Name: OSSEndpointURL,
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: secret.Name,
+					},
+					Key: OSSEndpointURL,
+				},
+			},
+		},
+		{
+			Name: OSSRegion,
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: secret.Name,
+					},
+					Key: OSSRegion,
+				},
+			},
+		},
+	}
+
+	return envs
+}

--- a/pkg/credentials/oss/oss_secret_test.go
+++ b/pkg/credentials/oss/oss_secret_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oss
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOssSecret(t *testing.T) {
+	scenarios := map[string]struct {
+		secret   *v1.Secret
+		expected []v1.EnvVar
+	}{
+		"OSSSecretEnvs": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "osscreds",
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name: OSSAccessKeyId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "osscreds",
+							},
+							Key: OSSAccessKeyId,
+						},
+					},
+				},
+				{
+					Name: OSSAccessKeySecret,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "osscreds",
+							},
+							Key: OSSAccessKeySecret,
+						},
+					},
+				},
+				{
+					Name: OSSEndpointURL,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "osscreds",
+							},
+							Key: OSSEndpointURL,
+						},
+					},
+				},
+				{
+					Name: OSSRegion,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "osscreds",
+							},
+							Key: OSSRegion,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		envs := BuildSecretEnvs(scenario.secret)
+
+		if diff := cmp.Diff(scenario.expected, envs); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}

--- a/pkg/credentials/service_account_credentials.go
+++ b/pkg/credentials/service_account_credentials.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/kserve/kserve/pkg/credentials/https"
+	"github.com/kserve/kserve/pkg/credentials/oss"
 
 	"github.com/kserve/kserve/pkg/credentials/azure"
 	"github.com/kserve/kserve/pkg/credentials/gcs"
@@ -195,6 +196,10 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(namespace string, serviceAc
 		} else if _, ok := secret.Data[azure.AzureClientSecret]; ok {
 			log.Info("Setting secret envs for azure", "AzureSecret", secret.Name)
 			envs := azure.BuildSecretEnvs(secret)
+			container.Env = append(container.Env, envs...)
+		} else if _, ok := secret.Data[oss.OSSAccessKeySecret]; ok {
+			log.Info("Setting secret envs for oss", "OSSSecret", secret.Name)
+			envs := oss.BuildSecretEnvs(secret)
 			container.Env = append(container.Env, envs...)
 		} else if _, ok := secret.Data[https.HTTPSHost]; ok {
 			log.Info("Setting secret volume from uri", "HTTP(S)Secret", secret.Name)

--- a/python/kserve/kserve/storage.py
+++ b/python/kserve/kserve/storage.py
@@ -23,6 +23,7 @@ import shutil
 import tarfile
 import tempfile
 import zipfile
+import oss2
 from urllib.parse import urlparse
 import requests
 from pathlib import Path
@@ -39,6 +40,7 @@ from kserve.model_repository import MODEL_MOUNT_DIRS
 
 _GCS_PREFIX = "gs://"
 _S3_PREFIX = "s3://"
+_OSS_PREFIX = "oss://"
 _BLOB_RE = "https://(.+?).blob.core.windows.net/(.+)"
 _ACCOUNT_RE = "https://(.+?).blob.core.windows.net"
 _LOCAL_PREFIX = "file://"
@@ -73,6 +75,8 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             Storage._download_gcs(uri, out_dir)
         elif uri.startswith(_S3_PREFIX):
             Storage._download_s3(uri, out_dir)
+        elif uri.startswith(_OSS_PREFIX):
+            Storage._download_oss(uri, out_dir)
         elif re.search(_BLOB_RE, uri):
             Storage._download_blob(uri, out_dir)
         elif is_local:
@@ -168,6 +172,50 @@ class Storage(object):  # pylint: disable=too-few-public-methods
                 "Failed to fetch model. No model found in %s." % bucket_path)
 
         # Unpack compressed file, supports .tgz, tar.gz and zip file formats.
+        if count == 1:
+            mimetype, _ = mimetypes.guess_type(target)
+            if mimetype in ["application/x-tar", "application/zip"]:
+                Storage._unpack_archive_file(target, mimetype, temp_dir)
+
+    @staticmethod
+    def _download_oss(uri, temp_dir: str):
+        access_key_id = os.getenv("OSS_ACCESS_KEY_ID", "")
+        access_key_secret = os.getenv("OSS_ACCESS_KEY_SECRET", "")
+        endpoint = os.getenv("OSS_ENDPOINT", "")
+        
+        if access_key_id == "" or access_key_secret == "" or endpoint == "":
+            logging.error("Couldn't find OSS Env variables")
+            return None
+        
+        parsed = urlparse(uri, scheme='oss')
+        bucket_name = parsed.netloc
+        bucket_path = parsed.path.lstrip('/')
+
+        count = 0
+        bucket = oss2.Bucket(oss2.Auth(access_key_id, access_key_secret), endpoint, bucket_name)
+
+        for obj in oss2.ObjectIterator(bucket):
+            if obj.key.endswith("/"):
+                continue
+
+            target_key = (
+                obj.key.rsplit("/", 1)[-1]
+                if bucket_path == obj.key
+                else obj.key.replace(bucket_path, "", 1).lstrip("/")
+            )
+
+            target = f"{temp_dir}/{target_key}"
+
+            if not os.path.exists(os.path.dirname(target)):
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+            
+            bucket.get_object_to_file(obj.key, target)
+            logging.info('Downloaded object %s to %s' % (obj.key, target))
+            count = count + 1
+        if count == 0:
+            raise RuntimeError("Failed to fetch model. No model found in %s." % bucket_path)
+
+        # Unpack if a file is compressed.
         if count == 1:
             mimetype, _ = mimetypes.guess_type(target)
             if mimetype in ["application/x-tar", "application/zip"]:

--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -25,3 +25,4 @@ cffi==1.15.0
 idna==3.3
 certifi==2021.10.8
 tritonclient==2.18.0
+oss2==2.15.0


### PR DESCRIPTION
Signed-off-by: Vikash Sharma <vika.sharma@live.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adds support for Alicloud's `oss://` in storageUri

**Type of changes**
- [x] New feature (non-breaking change which adds functionality)
 
**Feature/Issue validation/testing**:

- [x] Tested locally using storageUri:
1. Create oss_secret.yaml

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: osscreds
type: Opaque
# credentials for oss
data:
  OSS_ACCESS_KEY_ID: "<>"
  OSS_ACCESS_KEY_SECRET: "<>"
  OSS_ENDPOINT: "<>"
  OSS_REGION: "<>"
```

2. Create oss_sa.yaml

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: sa
secrets:
  - name: osscreds
```

3. Create inference_service.yaml

```yaml
apiVersion: "serving.kserve.io/v1beta1"
kind: InferenceService
metadata:
  name: "mnist-oss"
spec:
  predictor:
    serviceAccountName: sa
    tensorflow:
      storageUri: "oss://<bucket_name>"
```

- Logs - init storage-container
```sh
# have replaced the actual bucket_name with <bucket_name>
[I 220401 06:28:17 initializer-entrypoint:13] Initializing, args: src_uri [oss://<bucket_name>] dest_path[ [/mnt/models]
[I 220401 06:28:17 storage:57] Copying contents of oss://<bucket_name> to local
[I 220401 06:28:18 storage:213] Downloaded object folder1/churn.csv to /mnt/models/folder1/churn.csv
[I 220401 06:28:18 storage:213] Downloaded object folder1/churn2.csv to /mnt/models/folder1/churn2.csv
[I 220401 06:28:19 storage:213] Downloaded object test/gender/gender.pkl to /mnt/models/test/gender/gender.pkl
[I 220401 06:28:19 storage:213] Downloaded object test/gender/model.py to /mnt/models/test/gender/model.py
[I 220401 06:28:19 storage:213] Downloaded object test/tfmodel/1/saved_model.pb to /mnt/models/test/tfmodel/1/saved_model.pb
[I 220401 06:28:19 storage:95] Successfully copied oss://<bucket_name> to /mnt/models
```

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds support for Ali-cloud's oss in storageUri
```
