### PR TITLE
Refactor autoscaler functionality into an interface.

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -139,6 +139,8 @@ func validateInferenceServiceAutoscaler(isvc *InferenceService) error {
 					} else {
 						return nil
 					}
+				case constants.AutoscalerClassNone:
+					return nil
 				default:
 					return fmt.Errorf("unknown autoscaler class [%s]", class)
 				}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -137,7 +137,8 @@ var (
 
 // Autoscaler Class
 var (
-	AutoscalerClassHPA AutoscalerClassType = "hpa"
+	AutoscalerClassHPA  AutoscalerClassType = "hpa"
+	AutoscalerClassNone AutoscalerClassType = "none"
 )
 
 // Autoscaler Metrics
@@ -153,6 +154,7 @@ var (
 // Autoscaler Class Allowed List
 var AutoscalerAllowedClassList = []AutoscalerClassType{
 	AutoscalerClassHPA,
+	AutoscalerClassNone,
 }
 
 // Autoscaler Metrics Allowed List

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -110,10 +110,8 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 			return ctrl.Result{}, errors.Wrapf(err, "fails to set service owner reference for explainer")
 		}
 		//set autoscaler Controller
-		if r.Scaler.Autoscaler.AutoscalerClass == constants.AutoscalerClassHPA {
-			if err := controllerutil.SetControllerReference(isvc, r.Scaler.Autoscaler.HPA.HPA, e.scheme); err != nil {
-				return ctrl.Result{}, errors.Wrapf(err, "fails to set HPA owner reference for explainer")
-			}
+		if err := r.Scaler.Autoscaler.SetControllerReferences(isvc, e.scheme); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "fails to set autoscaler owner references for explainer")
 		}
 
 		deployment, err := r.Reconcile()

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -272,10 +272,8 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 			return ctrl.Result{}, errors.Wrapf(err, "fails to set service owner reference for predictor")
 		}
 		//set autoscaler Controller
-		if r.Scaler.Autoscaler.AutoscalerClass == constants.AutoscalerClassHPA {
-			if err := controllerutil.SetControllerReference(isvc, r.Scaler.Autoscaler.HPA.HPA, p.scheme); err != nil {
-				return ctrl.Result{}, errors.Wrapf(err, "fails to set HPA owner reference for predictor")
-			}
+		if err := r.Scaler.Autoscaler.SetControllerReferences(isvc, p.scheme); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "fails to set autoscaler owner references for predictor")
 		}
 
 		deployment, err := r.Reconcile()

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -141,10 +141,8 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, er
 			return ctrl.Result{}, errors.Wrapf(err, "fails to set service owner reference for transformer")
 		}
 		//set autoscaler Controller
-		if r.Scaler.Autoscaler.AutoscalerClass == constants.AutoscalerClassHPA {
-			if err := controllerutil.SetControllerReference(isvc, r.Scaler.Autoscaler.HPA.HPA, p.scheme); err != nil {
-				return ctrl.Result{}, errors.Wrapf(err, "fails to set HPA owner reference for transformer")
-			}
+		if err := r.Scaler.Autoscaler.SetControllerReferences(isvc, p.scheme); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "fails to set autoscaler owner references for transformer")
 		}
 
 		deployment, err := r.Reconcile()

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
@@ -17,8 +17,7 @@ limitations under the License.
 package autoscaler
 
 import (
-	"github.com/pkg/errors"
-
+	"fmt"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	hpa "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa"
@@ -30,16 +29,28 @@ import (
 
 var log = logf.Log.WithName("AutoscalerReconciler")
 
-type Autoscaler struct {
-	AutoscalerClass constants.AutoscalerClassType
-	HPA             *hpa.HPAReconciler
+// Interface implemented by all autoscalers
+type Autoscaler interface {
+	Reconcile() error
+	SetControllerReferences(owner metav1.Object, scheme *runtime.Scheme) error
+}
+
+// Autoscaler that does nothing. Can be used to disable creation of autoscaler resources.
+type NoOpAutoscaler struct{}
+
+func (*NoOpAutoscaler) Reconcile() error {
+	return nil
+}
+
+func (a *NoOpAutoscaler) SetControllerReferences(owner metav1.Object, scheme *runtime.Scheme) error {
+	return nil
 }
 
 // AutoscalerReconciler is the struct of Raw K8S Object
 type AutoscalerReconciler struct {
 	client       client.Client
 	scheme       *runtime.Scheme
-	Autoscaler   *Autoscaler
+	Autoscaler   Autoscaler
 	componentExt *v1beta1.ComponentExtensionSpec
 }
 
@@ -70,27 +81,21 @@ func getAutoscalerClass(metadata metav1.ObjectMeta) constants.AutoscalerClassTyp
 
 func createAutoscaler(client client.Client,
 	scheme *runtime.Scheme, componentMeta metav1.ObjectMeta,
-	componentExt *v1beta1.ComponentExtensionSpec) (*Autoscaler, error) {
-	as := &Autoscaler{}
+	componentExt *v1beta1.ComponentExtensionSpec) (Autoscaler, error) {
 	ac := getAutoscalerClass(componentMeta)
-	as.AutoscalerClass = ac
 	switch ac {
 	case constants.AutoscalerClassHPA:
-		as.HPA = hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt)
+		return hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt), nil
+	case constants.AutoscalerClassNone:
+		return &NoOpAutoscaler{}, nil
 	default:
-		return nil, errors.New("unknown autoscaler class type.")
+		return nil, fmt.Errorf("Unknown autoscaler class type: %v", ac)
 	}
-	return as, nil
 }
 
 // Reconcile ...
-func (r *AutoscalerReconciler) Reconcile() (*Autoscaler, error) {
+func (r *AutoscalerReconciler) Reconcile() error {
 	//reconcile Autoscaler
-	if r.Autoscaler.AutoscalerClass == constants.AutoscalerClassHPA {
-		_, err := r.Autoscaler.HPA.Reconcile()
-		if err != nil {
-			return nil, err
-		}
-	}
-	return r.Autoscaler, nil
+	r.Autoscaler.Reconcile()
+	return nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -52,41 +53,28 @@ func NewHPAReconciler(client client.Client,
 	}
 }
 
-func getHPAMetrics(metadata metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec) []v2beta2.MetricSpec {
+func getHPAMetrics(metadata metav1.ObjectMeta) []v2beta2.MetricSpec {
 	var metrics []v2beta2.MetricSpec
-	var utilization int32
+	var cpuUtilization int32
 	annotations := metadata.Annotations
 
-	resourceName := corev1.ResourceCPU
-
 	if value, ok := annotations[constants.TargetUtilizationPercentage]; ok {
-		utilizationInt, _ := strconv.Atoi(value)
-		utilization = int32(utilizationInt)
+		utilization, _ := strconv.Atoi(value)
+		cpuUtilization = int32(utilization)
 	} else {
-		utilization = constants.DefaultCPUUtilization
-	}
-
-	if componentExt.ScaleTarget != nil {
-		utilization = int32(*componentExt.ScaleTarget)
-	}
-
-	if componentExt.ScaleMetric != nil {
-		resourceName = corev1.ResourceName(*componentExt.ScaleMetric)
-	}
-
-	metricTarget := v2beta2.MetricTarget{
-		Type:               "Utilization",
-		AverageUtilization: &utilization,
+		cpuUtilization = constants.DefaultCPUUtilization
 	}
 
 	ms := v2beta2.MetricSpec{
 		Type: v2beta2.ResourceMetricSourceType,
 		Resource: &v2beta2.ResourceMetricSource{
-			Name:   resourceName,
-			Target: metricTarget,
+			Name: corev1.ResourceCPU,
+			Target: v2beta2.MetricTarget{
+				Type:               "Utilization",
+				AverageUtilization: &cpuUtilization,
+			},
 		},
 	}
-
 	metrics = append(metrics, ms)
 	return metrics
 }
@@ -104,7 +92,7 @@ func createHPA(componentMeta metav1.ObjectMeta,
 	if maxReplicas < minReplicas {
 		maxReplicas = minReplicas
 	}
-	metrics := getHPAMetrics(componentMeta, componentExt)
+	metrics := getHPAMetrics(componentMeta)
 	hpa := &v2beta2.HorizontalPodAutoscaler{
 		ObjectMeta: componentMeta,
 		Spec: v2beta2.HorizontalPodAutoscalerSpec{
@@ -115,9 +103,8 @@ func createHPA(componentMeta metav1.ObjectMeta,
 			},
 			MinReplicas: &minReplicas,
 			MaxReplicas: maxReplicas,
-
-			Metrics:  metrics,
-			Behavior: &v2beta2.HorizontalPodAutoscalerBehavior{},
+			Metrics:     metrics,
+			Behavior:    &v2beta2.HorizontalPodAutoscalerBehavior{},
 		},
 	}
 	return hpa
@@ -152,29 +139,23 @@ func semanticHPAEquals(desired, existing *v2beta2.HorizontalPodAutoscaler) bool 
 }
 
 // Reconcile ...
-func (r *HPAReconciler) Reconcile() (*v2beta2.HorizontalPodAutoscaler, error) {
+func (r *HPAReconciler) Reconcile() error {
 	//reconcile Service
-	checkResult, existingHPA, err := r.checkHPAExist(r.client)
+	checkResult, _, err := r.checkHPAExist(r.client)
 	log.Info("service reconcile", "checkResult", checkResult, "err", err)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if checkResult == constants.CheckResultCreate {
-		err = r.client.Create(context.TODO(), r.HPA)
-		if err != nil {
-			return nil, err
-		} else {
-			return r.HPA, nil
-		}
+		return r.client.Create(context.TODO(), r.HPA)
 	} else if checkResult == constants.CheckResultUpdate { //CheckResultUpdate
-		err = r.client.Update(context.TODO(), r.HPA)
-		if err != nil {
-			return nil, err
-		} else {
-			return r.HPA, nil
-		}
+		return r.client.Update(context.TODO(), r.HPA)
 	} else {
-		return existingHPA, nil
+		return nil
 	}
+}
+
+func (r *HPAReconciler) SetControllerReferences(owner metav1.Object, scheme *runtime.Scheme) error {
+	return controllerutil.SetControllerReference(owner, r.HPA, scheme)
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -97,7 +97,7 @@ func (r *RawKubeReconciler) Reconcile() (*appsv1.Deployment, error) {
 		return nil, err
 	}
 	//reconcile HPA
-	_, err = r.Scaler.Reconcile()
+	err = r.Scaler.Reconcile()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add no-op autoscaler so users disable creation of autoscaler resources.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
 This PR makes it possible to disable the creation of an HPA on raw deployments by adding an annotation:

``` yaml
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "my-model"
  annotations:
    "serving.kserve.io/autoscalerClass": "none"
```
It also refactors the autoscaler reconciler, making it easier to add different autoscaler strategies in the future.

**Which issue(s) this PR fixes**:
Fixes #2131

**Type of changes**

-  New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

- Tested on local KServe cluster
