### PR TITLE
fix: predict address url on status object

### DIFF
--- a/pkg/apis/serving/v1beta1/predictor_model.go
+++ b/pkg/apis/serving/v1beta1/predictor_model.go
@@ -67,7 +67,7 @@ func (m *ModelSpec) GetProtocol() constants.InferenceServiceProtocol {
 	if m.ProtocolVersion != nil {
 		return *m.ProtocolVersion
 	}
-	return constants.ProtocolV2
+	return constants.ProtocolV1
 }
 
 func (m *ModelSpec) IsMMS(config *InferenceServicesConfig) bool {
@@ -213,12 +213,12 @@ func (m *ModelSpec) getPredictorConfig(config *InferenceServicesConfig) *Predict
 
 func sortServingRuntimeList(runtimes *v1alpha1.ServingRuntimeList) {
 	sort.Slice(runtimes.Items, func(i, j int) bool {
-		if getProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) <
-			getProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
+		if GetProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) <
+			GetProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
 			return true
 		}
-		if getProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) >
-			getProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
+		if GetProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) >
+			GetProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
 			return false
 		}
 		if runtimes.Items[i].CreationTimestamp.Before(&runtimes.Items[j].CreationTimestamp) {
@@ -233,12 +233,12 @@ func sortServingRuntimeList(runtimes *v1alpha1.ServingRuntimeList) {
 
 func sortClusterServingRuntimeList(runtimes *v1alpha1.ClusterServingRuntimeList) {
 	sort.Slice(runtimes.Items, func(i, j int) bool {
-		if getProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) <
-			getProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
+		if GetProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) <
+			GetProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
 			return true
 		}
-		if getProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) >
-			getProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
+		if GetProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) >
+			GetProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
 			return false
 		}
 		if runtimes.Items[i].CreationTimestamp.Before(&runtimes.Items[j].CreationTimestamp) {
@@ -251,7 +251,7 @@ func sortClusterServingRuntimeList(runtimes *v1alpha1.ClusterServingRuntimeList)
 	})
 }
 
-func getProtocolVersionPriority(protocols []constants.InferenceServiceProtocol) int {
+func GetProtocolVersionPriority(protocols []constants.InferenceServiceProtocol) int {
 	if protocols == nil || len(protocols) == 0 {
 		return int(constants.Unknown)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -191,10 +191,11 @@ const (
 
 // InferenceService protocol enums
 const (
-	ProtocolV1     InferenceServiceProtocol = "v1"
-	ProtocolV2     InferenceServiceProtocol = "v2"
-	ProtocolGRPCV1 InferenceServiceProtocol = "grpc-v1"
-	ProtocolGRPCV2 InferenceServiceProtocol = "grpc-v2"
+	ProtocolV1      InferenceServiceProtocol = "v1"
+	ProtocolV2      InferenceServiceProtocol = "v2"
+	ProtocolGRPCV1  InferenceServiceProtocol = "grpc-v1"
+	ProtocolGRPCV2  InferenceServiceProtocol = "grpc-v2"
+	ProtocolUnknown InferenceServiceProtocol = ""
 )
 
 // InferenceService Endpoint Ports
@@ -330,7 +331,7 @@ const (
 type ProtocolVersion int
 
 const (
-	_ = iota
+	_ ProtocolVersion = iota
 	V1
 	V2
 	GRPCV1
@@ -411,11 +412,13 @@ func InferenceServicePrefix(name string) string {
 }
 
 func PredictPath(name string, protocol InferenceServiceProtocol) string {
-	if protocol == ProtocolV2 {
-		return fmt.Sprintf("/v2/models/%s/infer", name)
-	} else {
-		return fmt.Sprintf("/v1/models/%s:predict", name)
+	path := ""
+	if protocol == ProtocolV1 {
+		path = fmt.Sprintf("/v1/models/%s:predict", name)
+	} else if protocol == ProtocolV2 {
+		path = fmt.Sprintf("/v2/models/%s/infer", name)
 	}
+	return path
 }
 
 func ExplainPath(name string) string {
@@ -487,5 +490,20 @@ func GetProtocolVersionInt(protocol InferenceServiceProtocol) ProtocolVersion {
 		return GRPCV2
 	default:
 		return Unknown
+	}
+}
+
+func GetProtocolVersionString(protocol ProtocolVersion) InferenceServiceProtocol {
+	switch protocol {
+	case V1:
+		return ProtocolV1
+	case V2:
+		return ProtocolV2
+	case GRPCV1:
+		return ProtocolGRPCV1
+	case GRPCV2:
+		return ProtocolGRPCV2
+	default:
+		return ProtocolUnknown
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -126,6 +126,16 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) error {
 			// set runtime defaults
 			isvc.SetRuntimeDefaults()
 		}
+		// assign protocol version to inferenceservice based on runtime selected
+		if isvc.Spec.Predictor.Model.ProtocolVersion == nil {
+			protocolVersion := constants.GetProtocolVersionString(
+				constants.ProtocolVersion(
+					v1beta1.GetProtocolVersionPriority(sRuntime.ProtocolVersions),
+				),
+			)
+			isvc.Spec.Predictor.Model.ProtocolVersion = &protocolVersion
+		}
+
 		if len(sRuntime.Containers) == 0 {
 			return errors.New("no container configuration found in selected serving runtime")
 		}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -368,10 +368,11 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 			return err
 		}
 		if !isvcutils.IsMMSPredictor(&isvc.Spec.Predictor, isvcConfig) {
-			if isvc.Spec.Predictor.GetImplementation().GetProtocol() == constants.ProtocolV2 {
-				path = constants.PredictPath(isvc.Name, constants.ProtocolV2)
-			} else {
+			protocol := isvc.Spec.Predictor.GetImplementation().GetProtocol()
+			if protocol == constants.ProtocolV1 {
 				path = constants.PredictPath(isvc.Name, constants.ProtocolV1)
+			} else if protocol == constants.ProtocolV2 {
+				path = constants.PredictPath(isvc.Name, constants.ProtocolV2)
 			}
 		}
 		isvc.Status.Address = &duckv1.Addressable{


### PR DESCRIPTION
Signed-off-by: Suresh Nakkeran <suresh.n@ideas2it.com>

The inference service address url is updated V2 predict url since ModelSpec GetProtocol function returns protocolV2 by default. This PR is to assign protocol version to inference service based on selected runtime if it is not provided.