### PR TITLE
Cherrypick: upgrade kserve dependencies (#2103)

### DIFF
--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -18,7 +18,6 @@ boto3==1.20.24
 psutil>=5.0
 ray[serve]==1.9.0
 grpcio>=1.34.0
-google_api_core==1.29.0
 jmespath==0.10.0
 googleapis_common_protos==1.53.0
 cachetools==4.2.2

--- a/python/kserve/setup.py
+++ b/python/kserve/setup.py
@@ -28,7 +28,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kserve',
-    version='0.8.0',
+    version='0.8.0.1',
     author="The KServe Authors",
     author_email='ellisbigelow@google.com, hejinchi@cn.ibm.com, dsun20@bloomberg.net',
     license="Apache License Version 2.0",


### PR DESCRIPTION
Signed-off-by: Suresh Nakkeran <suresh.n@ideas2it.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Cherrypick PR #2103 to release-0.8 branch to fix the pinned `google_api_core` dependency issue


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
