### PR TITLE
Convert kserve manager from statefulset to deployment to make HA

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -23,3 +23,27 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-controller-manager
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -10,3 +10,16 @@ spec:
       # Change the value of image field below to your controller image URL
       - image: kserve/kserve-controller:latest
         name: manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-controller-manager
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      # Change the value of image field below to your controller image URL
+      - image: kserve/kserve-controller:latest
+        name: manager

--- a/config/default/manager_prometheus_metrics_patch.yaml
+++ b/config/default/manager_prometheus_metrics_patch.yaml
@@ -17,3 +17,22 @@ spec:
         - containerPort: 8080
           name: metrics
           protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-controller-manager
+  namespace: kserve
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      # Expose the prometheus metrics on default port
+      - name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP

--- a/config/default/manager_resources_patch.yaml
+++ b/config/default/manager_resources_patch.yaml
@@ -12,4 +12,19 @@ spec:
           limits:
             cpu: 100m
             memory: 300Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-controller-manager
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
             

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -12,6 +12,7 @@ spec:
       control-plane: kserve-controller-manager
       controller-tools.k8s.io: "1.0"
   serviceName: controller-manager-service
+  replicas: 0
   template:
     metadata:
       labels:
@@ -38,6 +39,69 @@ spec:
                 fieldPath: metadata.namespace
           - name: SECRET_NAME
             value: kserve-webhook-server-cert
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: kserve-webhook-server-cert
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-controller-manager
+  namespace: kserve
+  labels:
+    control-plane: kserve-controller-manager
+    controller-tools.k8s.io: "1.0"
+spec:
+  selector:
+    matchLabels:
+      control-plane: kserve-controller-manager
+      controller-tools.k8s.io: "1.0"
+  template:
+    metadata:
+      labels:
+        control-plane: kserve-controller-manager
+        controller-tools.k8s.io: "1.0"
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      serviceAccountName: kserve-controller-manager
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+        - /manager
+        image: ko://github.com/kserve/kserve/cmd/manager
+        imagePullPolicy: Always
+        name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SECRET_NAME
+            value: kserve-webhook-server-cert
+        args:
+          - --leader-elect=true
         resources:
           limits:
             cpu: 100m

--- a/hack/image_patch_dev.sh
+++ b/hack/image_patch_dev.sh
@@ -3,11 +3,24 @@
 set -u
 set -e
 OVERLAY=$1
-IMG=$(ko resolve -f config/manager/manager.yaml | grep 'image:' | awk '{print $2}')
+IMG=$(ko resolve -f config/manager/manager.yaml | grep 'image:' | head -1 | awk '{print $2}')
 if [ -z ${IMG} ]; then exit; fi
 cat > config/overlays/${OVERLAY}/manager_image_patch.yaml << EOF
 apiVersion: apps/v1
 kind: StatefulSet 
+metadata:
+  name: kserve-controller-manager
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          command:
+          image: ${IMG}
+---
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: kserve-controller-manager
   namespace: kserve

--- a/python/pytorch-gpu.Dockerfile
+++ b/python/pytorch-gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS BUILD
+FROM nvidia/cuda:11.4.3-cudnn8-devel-ubuntu18.04 AS BUILD
 
 ARG PYTHON_VERSION=3.7
 ARG CONDA_PYTHON_VERSION=3
@@ -27,7 +27,7 @@ RUN conda install -y python=$PYTHON_VERSION && \
     conda clean -tipsy
 
 # Runtime image
-FROM nvidia/cuda:10.0-base
+FROM nvidia/cuda:11.4.3-base-ubuntu18.04
 
 ARG CONDA_DIR=/opt/conda
 

--- a/test/scripts/post-e2e-tests.sh
+++ b/test/scripts/post-e2e-tests.sh
@@ -29,5 +29,4 @@ kubectl describe pods -n kserve-ci-e2e-test
 kubectl get events -n kserve-ci-e2e-test
 
 # Print controller logs
-kubectl logs kserve-controller-manager-0 -n kserve manager
-
+kubectl logs -l control-plane=kserve-controller-manager -n kserve -c manager


### PR DESCRIPTION
Signed-off-by: Suresh Nakkeran <suresh.n@ideas2it.com>

This PR converts KServe Manager from StatefulSet to Deployment to create more replicas and to enable leader election. This helps to achieve High Availability.

Fixes #2010 

```release-note
KServe controller statefulset replica is set to 0 and will be removed in the next release.
```