### PR TITLE
update kserve manager kind as deployment in helm chart

### DIFF
--- a/manifests/charts/templates/deployment.yaml
+++ b/manifests/charts/templates/deployment.yaml
@@ -14,6 +14,78 @@ spec:
       control-plane: kserve-controller-manager
       controller-tools.k8s.io: "1.0"
   serviceName: controller-manager-service
+  replicas: 0
+  template:
+    metadata:
+      labels:
+        control-plane: kserve-controller-manager
+        controller-tools.k8s.io: "1.0"
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      serviceAccountName: kserve-controller-manager
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - command:
+        - /manager
+        image: "{{ .Values.kserve.controller.image }}"
+        imagePullPolicy: Always
+        name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SECRET_NAME
+            value: kserve-webhook-server-cert
+        resources:
+{{- if .Values.kserve.controller.resources }}
+{{ toYaml .Values.kserve.controller.resources | trim | indent 12 }}
+{{- end }}
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: kserve-webhook-server-cert
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    control-plane: kserve-controller-manager
+    controller-tools.k8s.io: "1.0"
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  selector:
+    matchLabels:
+      control-plane: kserve-controller-manager
+      controller-tools.k8s.io: "1.0"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Suresh Nakkeran <suresh.n@ideas2it.com>

This is a follow-up PR to update the Kserve manager kind as Deployment in helm chart to support leader election and make HA.

-->
```release-note
Update Kserve manager kind as Deployment in helm chart to support leader election and make HA.
```
