### PR TITLE
Add aix-explainer deploy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PYTORCH_IMG ?= pytorchserver
 PMML_IMG ?= pmmlserver
 PADDLE_IMG ?= paddleserver
 ALIBI_IMG ?= alibi-explainer
-AIX_IMG ?= aix-explainer				# change this line
+AIX_IMG ?= aix-explainer				
 STORAGE_INIT_IMG ?= storage-initializer
 CRD_OPTIONS ?= "crd:maxDescLen=0"
 KSERVE_ENABLE_SELF_SIGNED_CA ?= false

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PYTORCH_IMG ?= pytorchserver
 PMML_IMG ?= pmmlserver
 PADDLE_IMG ?= paddleserver
 ALIBI_IMG ?= alibi-explainer
+AIX_IMG ?= aix-explainer				# change this line
 STORAGE_INIT_IMG ?= storage-initializer
 CRD_OPTIONS ?= "crd:maxDescLen=0"
 KSERVE_ENABLE_SELF_SIGNED_CA ?= false
@@ -87,6 +88,10 @@ deploy-dev-paddle: docker-push-paddle
 
 deploy-dev-alibi: docker-push-alibi
 	./hack/alibi_patch_dev.sh ${KO_DOCKER_REPO}/${ALIBI_IMG}
+	kustomize build config/overlays/dev-image-config | kubectl apply -f -
+
+deploy-dev-aix: docker-push-aix												
+	./hack/aix_patch_dev.sh ${KO_DOCKER_REPO}/${AIX_IMG}					
 	kustomize build config/overlays/dev-image-config | kubectl apply -f -
 
 deploy-dev-storageInitializer: docker-push-storageInitializer
@@ -227,6 +232,12 @@ docker-build-alibi:
 
 docker-push-alibi: docker-build-alibi
 	docker push ${KO_DOCKER_REPO}/${ALIBI_IMG}
+
+docker-build-aix:
+	cd python && docker build -t ${KO_DOCKER_REPO}/${AIX_IMG} -f aixexplainer.Dockerfile .
+
+docker-push-aix: docker-build-aix
+	docker push ${KO_DOCKER_REPO}/${AIX_IMG}
 
 docker-build-storageInitializer:
 	cd python && docker build -t ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG} -f storage-initializer.Dockerfile .

--- a/hack/aix_patch_dev.sh
+++ b/hack/aix_patch_dev.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Usage: image_patch_dev.sh [OVERLAY]
+set -u
+IMG=$1
+if [ -z ${IMG} ]; then exit; fi
+cat > config/overlays/dev-image-config/inferenceservice_patch.yaml << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inferenceservice-config
+  namespace: kserve
+data:
+  explainers: |-
+    {
+        "aix": {
+          "image" : "${IMG}",
+          "defaultImageVersion": "latest",
+          "allowedImageVersions": [
+               "latest"
+            ]
+        }
+    }
+EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
I added  some command in Makefile ,let users can easily deploy their own version of aix explainer.  Also added a file aix_patch_dev.sh in .hack directory 
When I try to deploy my own version of aix explainer in kserve, I noticed that there is no command to deploy aix explainer in Makefile.

**Type of changes**
Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

