### PR TITLE
Move annotation keys to constants

### DIFF
--- a/pkg/apis/serving/v1beta1/transformer_custom.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom.go
@@ -82,8 +82,8 @@ func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions 
 
 	if ok && (deploymentMode == string(constants.ModelMeshDeployment)) {
 		// Get predictor host and protocol from annotations in modelmesh deployment mode
-		argumentPredictorHost = metadata.Annotations["predictor-host"]
-		argumentPredictorProtocol := metadata.Annotations["predictor-protocol"]
+		argumentPredictorHost = metadata.Annotations[constants.PredictorHostAnnotationKey]
+		argumentPredictorProtocol := metadata.Annotations[constants.PredictorProtocolAnnotationKey]
 
 		// Set predictor protocol if not provided in container arguments
 		if !utils.IncludesArg(container.Args, "--protocol") {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -95,6 +95,8 @@ var (
 	AgentModelConfigVolumeNameAnnotationKey          = InferenceServiceInternalAnnotationsPrefix + "/configVolumeName"
 	AgentModelConfigMountPathAnnotationKey           = InferenceServiceInternalAnnotationsPrefix + "/configMountPath"
 	AgentModelDirAnnotationKey                       = InferenceServiceInternalAnnotationsPrefix + "/modelDir"
+	PredictorHostAnnotationKey                       = InferenceServiceInternalAnnotationsPrefix + "/predictor-host"
+	PredictorProtocolAnnotationKey                   = InferenceServiceInternalAnnotationsPrefix + "/predictor-protocol"
 )
 
 // StorageSpec Constants

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -100,12 +100,12 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, er
 		}
 
 		// add predictor host and protocol to metadata
-		isvc.ObjectMeta.Annotations["predictor-host"] = predictorURL.Host
+		isvc.ObjectMeta.Annotations[constants.PredictorHostAnnotationKey] = predictorURL.Host
 		if predictorURL.Scheme == "grpc" {
-			isvc.ObjectMeta.Annotations["predictor-protocol"] = string(constants.ProtocolGRPCV2)
+			isvc.ObjectMeta.Annotations[constants.PredictorProtocolAnnotationKey] = string(constants.ProtocolGRPCV2)
 		} else if predictorURL.Scheme == "http" || predictorURL.Scheme == "https" {
 			// modelmesh supports v2 only
-			isvc.ObjectMeta.Annotations["predictor-protocol"] = string(constants.ProtocolV2)
+			isvc.ObjectMeta.Annotations[constants.PredictorProtocolAnnotationKey] = string(constants.ProtocolV2)
 		} else {
 			return ctrl.Result{}, fmt.Errorf("Predictor URL Scheme not supported: %v", predictorURL.Scheme)
 		}


### PR DESCRIPTION
Move annotation keys to constants so that we don't have
strings in different code segments. Just a tiny cosmetic
change, no impact to functionality.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>