### PR TITLE
Added a specific version for protobuf

### DIFF
--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -26,3 +26,4 @@ cffi==1.15.0
 idna==3.3
 certifi==2021.10.8
 tritonclient==2.18.0
+protobuf~=3.19.0


### PR DESCRIPTION


Signed-off-by: Andrews Arokiam <andrews.arokiam@ideas2it.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Added a specific version for protobuf in requirements.txt
Since a new version of protobuf is incompatible with some of the generated code, using a specific version, thats lower than
3.20.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2200 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:


**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
