### PR TITLE
Update Feast transformer to support ModelMesh

### DIFF
--- a/docs/samples/v1beta1/transformer/feast/README.md
+++ b/docs/samples/v1beta1/transformer/feast/README.md
@@ -47,6 +47,8 @@ Expected Output
 $ inferenceservice.serving.kubeflow.org/driver-transformer created
 ```
 
+Note if you want to run the predictor in ModelMesh, update the [ModelMesh YAML file](./driver_transformer_modelmesh.yaml) instead, and adjust the kubectl apply command accordingly.
+
 ## Run a prediction
 The first step is to [determine the ingress IP and ports](../../../../../README.md#determine-the-ingress-ip-and-ports) and set `INGRESS_HOST` and `INGRESS_PORT`
 

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
@@ -13,17 +13,20 @@
 
 import argparse
 import kserve
+
 from .driver_transformer import DriverTransformer
 
-import logging
-logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
-
 DEFAULT_MODEL_NAME = "sklearn-driver-transformer"
+DEFAULT_PROTOCOL = "v1"
 
 parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument(
     "--predictor_host",
     help="The URL for the model predict function", required=True
+)
+parser.add_argument(
+    "--protocol", default=DEFAULT_PROTOCOL,
+    help="The protocol for the predictor"
 )
 parser.add_argument(
     "--model_name", default=DEFAULT_MODEL_NAME,
@@ -50,6 +53,7 @@ if __name__ == "__main__":
     transformer = DriverTransformer(
         name=args.model_name,
         predictor_host=args.predictor_host,
+        protocol=args.protocol,
         feast_serving_url=args.feast_serving_url,
         entity_ids=args.entity_ids,
         feature_refs=args.feature_refs)

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer_modelmesh.yaml
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer_modelmesh.yaml
@@ -1,0 +1,28 @@
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "sklearn-driver-transformer"
+  annotations:
+    serving.kserve.io/deploymentMode: ModelMesh
+spec:
+  transformer:
+    containers:
+    - image: chinhuang007/driver-transformer:latest
+      name: driver-container
+      command:
+      - "python"
+      - "-m"
+      - "driver_transformer"
+      args:
+      - --feast_serving_url
+      - x.x.x.x:x
+      - --entity_ids
+      - driver_id
+      - --feature_refs
+      - driver_hourly_stats:acc_rate
+      - driver_hourly_stats:avg_daily_trips
+      - driver_hourly_stats:conv_rate
+  predictor:
+    sklearn:
+      storageUri: "gs://kfserving-examples/models/feast/driver"
+          


### PR DESCRIPTION
Update Feast transformer to support ModelMesh
  - Add a new yaml file with ModelMesh annotation
  - Update the transformer code to check the predictor
    protocol and convert content types accordingly

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

**What this PR does / why we need it**:
The PR provides an example of a transformer working with ModelMesh predictor
