### PR TITLE
Update deprecated gcs bucket

### DIFF
--- a/docs/samples/v1beta1/triton/bert/README.md
+++ b/docs/samples/v1beta1/triton/bert/README.md
@@ -110,7 +110,7 @@ spec:
           - "bert_transformer_v2"
         env:
           - name: STORAGE_URI
-            value: "gs://kfserving-samples/models/triton/bert-transformer"
+            value: "gs://kfserving-examples/models/triton/bert-transformer"
   predictor:
     triton:
       runtimeVersion: 20.10-py3

--- a/docs/samples/v1beta1/triton/bert/bert_v1beta1.yaml
+++ b/docs/samples/v1beta1/triton/bert/bert_v1beta1.yaml
@@ -13,7 +13,7 @@ spec:
           - "bert_transformer_v2"
         env:
           - name: STORAGE_URI
-            value: "gs://kfserving-samples/models/triton/bert-transformer"
+            value: "gs://kfserving-examples/models/triton/bert-transformer"
   predictor:
     triton:
       runtimeVersion: 20.10-py3

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -121,7 +121,7 @@ metadata:
 spec:
   predictor:
     tensorflow:
-      storageUri: "gs://kfserving-samples/models/tensorflow/flowers
+      storageUri: "gs://kfserving-examples/models/tensorflow/flowers
       resources:
         requests:
           cpu: "4"
@@ -154,7 +154,7 @@ spec:
   predictor:
     containerConcurrency: 1 #CC=1
     tensorflow:
-      storageUri: "gs://kfserving-samples/models/tensorflow/flowers
+      storageUri: "gs://kfserving-examples/models/tensorflow/flowers
       resources:
         requests:
           cpu: "4"
@@ -189,7 +189,7 @@ metadata:
 spec:
   predictor:
     tensorflow:
-      storageUri: "gs://kfserving-samples/models/tensorflow/flowers
+      storageUri: "gs://kfserving-examples/models/tensorflow/flowers
       resources:
         requests:
           cpu: "4"

--- a/test/benchmark/tf_flowers.yaml
+++ b/test/benchmark/tf_flowers.yaml
@@ -7,7 +7,7 @@ spec:
     predictor:
       parallelism: 1 #CC=1
       tensorflow:
-        storageUri: "gs://kfserving-samples/models/tensorflow/flowers"
+        storageUri: "gs://kfserving-examples/models/tensorflow/flowers"
         resources:
           requests:
             cpu: "4"

--- a/test/benchmark/tf_flowers_hpa.yaml
+++ b/test/benchmark/tf_flowers_hpa.yaml
@@ -10,7 +10,7 @@ spec:
   default:
     predictor:
       tensorflow:
-        storageUri: "gs://kfserving-samples/models/tensorflow/flowers"
+        storageUri: "gs://kfserving-examples/models/tensorflow/flowers"
         resources:
           requests:
             cpu: "4"

--- a/test/e2e/predictor/test_canary.py
+++ b/test/e2e/predictor/test_canary.py
@@ -35,7 +35,7 @@ def test_canary_rollout():
         predictor=V1beta1PredictorSpec(
             min_replicas=1,
             tensorflow=V1beta1TFServingSpec(
-                storage_uri='gs://kfserving-samples/models/tensorflow/flowers',
+                storage_uri='gs://kfserving-examples/models/tensorflow/flowers',
                 resources=V1ResourceRequirements(
                     requests={'cpu': '10m', 'memory': '128Mi'},
                     limits={'cpu': '100m', 'memory': '256Mi'}))))
@@ -54,7 +54,7 @@ def test_canary_rollout():
         predictor=V1beta1PredictorSpec(
             canary_traffic_percent=10,
             tensorflow=V1beta1TFServingSpec(
-                storage_uri='gs://kfserving-samples/models/tensorflow/flowers-2',
+                storage_uri='gs://kfserving-examples/models/tensorflow/flowers-2',
                 resources=V1ResourceRequirements(
                     requests={'cpu': '10m', 'memory': '128Mi'},
                     limits={'cpu': '100m', 'memory': '256Mi'}))))
@@ -85,7 +85,7 @@ def test_canary_rollout_runtime():
                 model_format=V1beta1ModelFormat(
                     name="tensorflow",
                 ),
-                storage_uri='gs://kfserving-samples/models/tensorflow/flowers',
+                storage_uri='gs://kfserving-examples/models/tensorflow/flowers',
                 resources=V1ResourceRequirements(
                     requests={'cpu': '10m', 'memory': '128Mi'},
                     limits={'cpu': '100m', 'memory': '256Mi'}))))
@@ -107,7 +107,7 @@ def test_canary_rollout_runtime():
                 model_format=V1beta1ModelFormat(
                     name="tensorflow",
                 ),
-                storage_uri='gs://kfserving-samples/models/tensorflow/flowers-2',
+                storage_uri='gs://kfserving-examples/models/tensorflow/flowers-2',
                 resources=V1ResourceRequirements(
                     requests={'cpu': '10m', 'memory': '128Mi'},
                     limits={'cpu': '100m', 'memory': '256Mi'}))))

--- a/test/e2e/predictor/test_pytorch.py
+++ b/test/e2e/predictor/test_pytorch.py
@@ -33,7 +33,7 @@ def test_pytorch():
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         pytorch=V1beta1TorchServeSpec(
-            storage_uri='gs://kfserving-samples/models/pytorch/cifar10',
+            storage_uri='gs://kfserving-examples/models/pytorch/cifar10',
             model_class_name="Net",
             resources=V1ResourceRequirements(
                 requests={'cpu': '10m', 'memory': '128Mi'},

--- a/test/e2e/predictor/test_xgboost.py
+++ b/test/e2e/predictor/test_xgboost.py
@@ -135,7 +135,7 @@ def test_xgboost_v2_runtime_kserve():
                 name="xgboost",
             ),
             runtime="kserve-mlserver",
-            storage_uri="gs://kfserving-samples/models/xgboost/iris",
+            storage_uri="gs://kfserving-examples/models/xgboost/iris",
             protocol_version="v2",
             resources=V1ResourceRequirements(
                 requests={"cpu": "50m", "memory": "128Mi"},

--- a/tools/tf2openapi/generator/generate_test.go
+++ b/tools/tf2openapi/generator/generate_test.go
@@ -145,7 +145,7 @@ func TestGenerateOpenAPISpecGenerationErr(t *testing.T) {
 }
 
 func TestGenerateOpenAPIForRowFmtMultipleTensors(t *testing.T) {
-	// model src: gs://kfserving-samples/models/tensorflow/flowers
+	// model src: gs://kfserving-examples/models/tensorflow/flowers
 	g := gomega.NewGomegaWithT(t)
 	model := model(t, "TestRowFmtMultipleTensors")
 	generator := defaultGenerator()


### PR DESCRIPTION
Signed-off-by: Dan Sun <dsun20@bloomberg.net>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. kfserving gcp project is now deprecated, so need to update the gcs bucket we are still using from that project.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
