### PR TITLE
chore: Update e2e k8s version to 1.22

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -20,11 +20,11 @@ jobs:
           go-version: '1.17.3'
       - name: Setup Minikube
         run: |
-          wget --no-verbose https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-linux-amd64
+          wget --no-verbose https://github.com/kubernetes/minikube/releases/download/v1.25.1/minikube-linux-amd64
           sudo cp minikube-linux-amd64 /usr/local/bin/minikube
           sudo chmod 755 /usr/local/bin/minikube
           sudo apt-get install -y conntrack socat
-          minikube start --driver=none --kubernetes-version v1.21.0
+          minikube start --driver=none --kubernetes-version v1.22.10
       - name: Check Kubernetes pods
         run: |
           sleep 40
@@ -59,6 +59,7 @@ jobs:
         run: |
           sleep 10
           df -T
+          kubectl get pods -n knative-serving
           docker image ls
           kubectl get pods -n kserve
           kubectl get pods -n kserve-ci-e2e-test

--- a/test/scripts/gh-actions/setup-deps.sh
+++ b/test/scripts/gh-actions/setup-deps.sh
@@ -24,8 +24,8 @@ set -o pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 
 ISTIO_VERSION="1.12.0"
-KNATIVE_VERSION="knative-v1.0.0"
-CERT_MANAGER_VERSION="v1.2.0"
+KNATIVE_VERSION="knative-v1.4.0"
+CERT_MANAGER_VERSION="v1.5.0"
 KUSTOMIZE_VERSION="4.2.0"
 YQ_VERSION="3.3.2"
 


### PR DESCRIPTION
The targeted K8s version for the next Kubeflow release is 1.22. And with K8s 1.21 being EOL [later this month](https://kubernetes.io/releases/#release-v1-21), let's go ahead and bump our e2e tests to test against 1.22.

* Cert-manager and knative-serving were also bumped.



