### PR TITLE
Update versions for art-explainer to resolve several critical CVEs

### DIFF
--- a/python/artexplainer.Dockerfile
+++ b/python/artexplainer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-slim-bullseye
 
 COPY artexplainer artexplainer
 COPY kserve kserve

--- a/python/artexplainer.Dockerfile
+++ b/python/artexplainer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9-slim
 
 COPY artexplainer artexplainer
 COPY kserve kserve

--- a/python/artexplainer/setup.py
+++ b/python/artexplainer/setup.py
@@ -27,13 +27,13 @@ setup(
     url='https://github.com/kserve/kserve/python/artserver',
     description='Model Server implementation for AI Robustness Toolbox. \
                  Not intended for use outside KServe Frameworks Images',
-    python_requires='>3.7',
+    python_requires='>=3.9',
     packages=find_packages("artserver"),
     install_requires=[
         "kserve>=0.7.0",
         "argparse >= 1.4.0",
         "numpy >= 1.8.2",
-        "adversarial-robustness-toolbox[keras] == 1.4.1",
+        "adversarial-robustness-toolbox[keras] == 1.10.3",
         "nest_asyncio>=1.4.0"
     ],
     tests_require=tests_require,


### PR DESCRIPTION
Signed-off-by: MessKon <messiskon@gmail.com>

**What this PR does / why we need it**:
Fixing critical CVEs in latest kserve/art-explainer version
Comparing this to latest stable `kserve/art-explainer` image:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/35975404/175284905-f08f0214-4ec4-47e3-aac5-7fa11c9feaff.png">

<img width="602" alt="image" src="https://user-images.githubusercontent.com/35975404/175571236-32f50f16-db22-4e3b-8ff7-3d0eb5d2ee54.png">



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Not sure there's an open issue for this

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

`kserve/art-explainer` image builds ok with no issues

- Logs

**Special notes for your reviewer**:

1. This PR only changes image versions

**Release note**:
```release-note
fixing vulnerabilities (CVEs) in kserve/art-explainer

```
