### PR TITLE
fix: hpa scale up failed, when using rawdeployment

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -96,24 +96,13 @@ func (r *DeploymentReconciler) checkDeploymentExist(client client.Client) (const
 		return constants.CheckResultUnknown, nil, err
 	}
 	//existed, check equivalence
-	if semanticDeploymentEquals(r.Deployment.Spec, existingDeployment.Spec) {
-		return constants.CheckResultExisted, existingDeployment, nil
-	}
-
-	diff, err := kmp.SafeDiff(r.Deployment.Spec, existingDeployment.Spec)
-	log.Info("Deployment Updated", "Diff", diff, "err", err)
-
-	return constants.CheckResultUpdate, existingDeployment, nil
-}
-
-func semanticDeploymentEquals(desired, existing appsv1.DeploymentSpec) bool {
 	//for HPA scaling, we should ignore Replicas of Deployment
 	ignoreFields := cmpopts.IgnoreFields(appsv1.DeploymentSpec{}, "Replicas")
-	if diff, err := kmp.SafeDiff(desired, existing, ignoreFields); err != nil || diff != "" {
+	if diff, err := kmp.SafeDiff(r.Deployment.Spec, existingDeployment.Spec, ignoreFields); err != nil || diff != "" {
 		log.Info("Deployment Updated", "Diff", diff, "err", err)
-		return false
+		return constants.CheckResultUpdate, existingDeployment, nil
 	}
-	return true
+	return constants.CheckResultExisted, existingDeployment, nil
 }
 
 func setDefaultPodSpec(podSpec *corev1.PodSpec) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -98,8 +98,10 @@ func (r *DeploymentReconciler) checkDeploymentExist(client client.Client) (const
 	//existed, check equivalence
 	//for HPA scaling, we should ignore Replicas of Deployment
 	ignoreFields := cmpopts.IgnoreFields(appsv1.DeploymentSpec{}, "Replicas")
-	if diff, err := kmp.SafeDiff(r.Deployment.Spec, existingDeployment.Spec, ignoreFields); err != nil || diff != "" {
-		log.Info("Deployment Updated", "Diff", diff, "err", err)
+	if diff, err := kmp.SafeDiff(r.Deployment.Spec, existingDeployment.Spec, ignoreFields); err != nil {
+		return constants.CheckResultUnknown, nil, err
+	} else if diff != "" {
+		log.Info("Deployment Updated", "Diff", diff)
 		return constants.CheckResultUpdate, existingDeployment, nil
 	}
 	return constants.CheckResultExisted, existingDeployment, nil


### PR DESCRIPTION
Signed-off-by: iamlovingit <bitfrog@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes #2278 #2269 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Test result:
* **Create a `isvc` service**
```yaml
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "custom-simple"
  namespace: "cqs"
  annotations:
    serving.kserve.io/deploymentMode: "RawDeployment"
    serving.kserve.io/autoscalerClass: "hpa"
    serving.kserve.io/metrics: "cpu"
    serving.kserve.io/targetUtilizationPercentage: "30"
spec:
  predictor:
    minReplicas: 1
    maxReplicas: 10
    containers:
    - image: iamlovingit/bgtest:latest
      name: custom
      ports:
      - containerPort: 8080
        protocol: TCP
```
```
kubectl get all -n cqs                                                                                                                                                                              Tue Jun 28 20:15:40 2022

NAME                                                   READY   STATUS    RESTARTS   AGE
pod/custom-simple-predictor-default-776cb967f4-8897f   1/1     Running   0          18s

NAME                                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
service/custom-simple-predictor-default   ClusterIP   10.103.124.101   <none>        80/TCP    19s

NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/custom-simple-predictor-default   1/1     1            1           19s

NAME                                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/custom-simple-predictor-default-776cb967f4   1         1         1       19s

NAME                                                                  REFERENCE                                    TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/custom-simple-predictor-default   Deployment/custom-simple-predictor-default   <unknown>/30%   1         10        1          19s
```
* **Starting load test**
```
hey -m POST -c 10 -z 5m http://10.103.124.101/single
```

* **Watch the behavior of scaling**
```shell
kubectl get all -n cqs                                                                                                                                                                              Tue Jun 28 20:23:17 2022

NAME                                                   READY   STATUS     RESTARTS   AGE
pod/custom-simple-predictor-default-776cb967f4-7bf6b   1/1     Running    0          17s
pod/custom-simple-predictor-default-776cb967f4-8897f   1/1     Running    0          7m56s
pod/custom-simple-predictor-default-776cb967f4-wj6wt   0/1     Init:0/1   0          2s

NAME                                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
service/custom-simple-predictor-default   ClusterIP   10.103.124.101   <none>        80/TCP    7m57s

NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/custom-simple-predictor-default   2/3     3            2           7m57s

NAME                                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/custom-simple-predictor-default-776cb967f4   3         3         2       7m57s

NAME                                                                  REFERENCE                                    TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/custom-simple-predictor-default   Deployment/custom-simple-predictor-default   87%/30%   1         10        2          7m57s
```
The description of `HPA` after scaled up
```
kubectl describe hpa -n cqs
Name:                                                  custom-simple-predictor-default
Namespace:                                             cqs
Labels:                                                app=isvc.custom-simple-predictor-default
                                                       component=predictor
                                                       serving.kserve.io/inferenceservice=custom-simple
Annotations:                                           serving.kserve.io/autoscalerClass: hpa
                                                       serving.kserve.io/deploymentMode: RawDeployment
                                                       serving.kserve.io/metrics: cpu
                                                       serving.kserve.io/targetUtilizationPercentage: 30
CreationTimestamp:                                     Tue, 28 Jun 2022 20:15:21 +0800
Reference:                                             Deployment/custom-simple-predictor-default
Metrics:                                               ( current / target )
  resource cpu on pods  (as a percentage of request):  28% (280m) / 30%
Min replicas:                                          1
Max replicas:                                          10
Behavior:
  Scale Up:
    Stabilization Window: 0 seconds
    Select Policy: Max
    Policies:
      - Type: Pods     Value: 4    Period: 15 seconds
      - Type: Percent  Value: 100  Period: 15 seconds
  Scale Down:
    Select Policy: Max
    Policies:
      - Type: Percent  Value: 100  Period: 15 seconds
Deployment pods:       3 current / 3 desired
Conditions:
  Type            Status  Reason              Message
  ----            ------  ------              -------
  AbleToScale     True    ReadyForNewScale    recommended size matches current size
  ScalingActive   True    ValidMetricFound    the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)
  ScalingLimited  False   DesiredWithinRange  the desired count is within the acceptable range
Events:
  Type     Reason                        Age                   From                       Message
  ----     ------                        ----                  ----                       -------
  Warning  FailedGetResourceMetric       8m20s (x4 over 9m7s)  horizontal-pod-autoscaler  failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API
  Warning  FailedComputeMetricsReplicas  8m20s (x4 over 9m7s)  horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API
  Normal   SuccessfulRescale             105s                  horizontal-pod-autoscaler  New size: 2; reason: cpu resource utilization (percentage of request) above target
  Normal   SuccessfulRescale             89s                   horizontal-pod-autoscaler  New size: 3; reason: cpu resource utilization (percentage of request) above target
```
* **Stop load test and watching the behavior of scaling down**
```
kubectl get all -n cqs                                                                                                                                                                              Tue Jun 28 20:31:31 2022

NAME                                                   READY   STATUS        RESTARTS   AGE
pod/custom-simple-predictor-default-776cb967f4-7bf6b   0/1     Terminating   0          8m30s
pod/custom-simple-predictor-default-776cb967f4-8897f   1/1     Running       0          16m

NAME                                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
service/custom-simple-predictor-default   ClusterIP   10.103.124.101   <none>        80/TCP    16m

NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/custom-simple-predictor-default   1/1     1            1           16m

NAME                                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/custom-simple-predictor-default-776cb967f4   1         1         1       16m

NAME                                                                  REFERENCE                                    TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/custom-simple-predictor-default   Deployment/custom-simple-predictor-default   0%/30%    1         10        2          16m
```
The description of `HPA` after scaled down
```
kubectl describe hpa -n cqs
Name:                                                  custom-simple-predictor-default
Namespace:                                             cqs
Labels:                                                app=isvc.custom-simple-predictor-default
                                                       component=predictor
                                                       serving.kserve.io/inferenceservice=custom-simple
Annotations:                                           serving.kserve.io/autoscalerClass: hpa
                                                       serving.kserve.io/deploymentMode: RawDeployment
                                                       serving.kserve.io/metrics: cpu
                                                       serving.kserve.io/targetUtilizationPercentage: 30
CreationTimestamp:                                     Tue, 28 Jun 2022 20:15:21 +0800
Reference:                                             Deployment/custom-simple-predictor-default
Metrics:                                               ( current / target )
  resource cpu on pods  (as a percentage of request):  0% (1m) / 30%
Min replicas:                                          1
Max replicas:                                          10
Behavior:
  Scale Up:
    Stabilization Window: 0 seconds
    Select Policy: Max
    Policies:
      - Type: Pods     Value: 4    Period: 15 seconds
      - Type: Percent  Value: 100  Period: 15 seconds
  Scale Down:
    Select Policy: Max
    Policies:
      - Type: Percent  Value: 100  Period: 15 seconds
Deployment pods:       1 current / 1 desired
Conditions:
  Type            Status  Reason            Message
  ----            ------  ------            -------
  AbleToScale     True    ReadyForNewScale  recommended size matches current size
  ScalingActive   True    ValidMetricFound  the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)
  ScalingLimited  True    TooFewReplicas    the desired replica count is less than the minimum replica count
Events:
  Type     Reason                        Age                From                       Message
  ----     ------                        ----               ----                       -------
  Warning  FailedGetResourceMetric       16m (x4 over 17m)  horizontal-pod-autoscaler  failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API
  Warning  FailedComputeMetricsReplicas  16m (x4 over 17m)  horizontal-pod-autoscaler  invalid metrics (1 invalid out of 1), first error is: failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API
  Normal   SuccessfulRescale             10m                horizontal-pod-autoscaler  New size: 2; reason: cpu resource utilization (percentage of request) above target
  Normal   SuccessfulRescale             9m47s              horizontal-pod-autoscaler  New size: 3; reason: cpu resource utilization (percentage of request) above target
  Normal   SuccessfulRescale             108s               horizontal-pod-autoscaler  New size: 2; reason: All metrics below target
  Normal   SuccessfulRescale             93s                horizontal-pod-autoscaler  New size: 1; reason: All metrics below target
```

* **Update the `minReplicas` and `maxReplicas` of `isvc` by user**
```yaml
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "custom-simple"
  namespace: "cqs"
  annotations:
    serving.kserve.io/deploymentMode: "RawDeployment"
    serving.kserve.io/autoscalerClass: "hpa"
    serving.kserve.io/metrics: "cpu"
    serving.kserve.io/targetUtilizationPercentage: "30"
spec:
  predictor:
    minReplicas: 3
    maxReplicas: 15
    containers:
    - image: iamlovingit/bgtest:latest
      name: custom
      ports:
      - containerPort: 8080
        protocol: TCP
``` 
**Result after updated:**
```
kubectl get all -n cqs                                                                                                                                                                              Tue Jun 28 20:38:14 2022

NAME                                                   READY   STATUS    RESTARTS   AGE
pod/custom-simple-predictor-default-776cb967f4-5blkz   1/1     Running   0          15s
pod/custom-simple-predictor-default-776cb967f4-8897f   1/1     Running   0          22m
pod/custom-simple-predictor-default-776cb967f4-x77fr   1/1     Running   0          15s

NAME                                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
service/custom-simple-predictor-default   ClusterIP   10.103.124.101   <none>        80/TCP    22m

NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/custom-simple-predictor-default   3/3     3            3           22m

NAME                                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/custom-simple-predictor-default-776cb967f4   3         3         3       22m

NAME                                                                  REFERENCE                                    TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/custom-simple-predictor-default   Deployment/custom-simple-predictor-default   <unknown>/30%   3         15        1          22m
```