### PR TITLE
chore: Disable storage spec type validation

### DIFF
--- a/pkg/apis/serving/v1beta1/predictor.go
+++ b/pkg/apis/serving/v1beta1/predictor.go
@@ -139,7 +139,9 @@ func (s *PredictorSpec) GetExtensions() *ComponentExtensionSpec {
 func (p *PredictorExtensionSpec) Validate() error {
 	return utils.FirstNonNilError([]error{
 		validateStorageURI(p.GetStorageUri()),
-		validateStorageSpec(p.GetStorageSpec(), p.GetStorageUri()),
+		// TODO: Re-enable storage spec validation once azure/gcs are supported.
+		// Enabling this currently prevents those storage types from working with ModelMesh.
+		// validateStorageSpec(p.GetStorageSpec(), p.GetStorageUri()),
 	})
 }
 


### PR DESCRIPTION
Due to differences in storage provider support between the KServe storage initializer and ModelMesh puller, this commit
disables the storage spec type validation. With this enabled, Isvcs on ModelMesh trying to use the new storage spec with azure or gcs providers will be blocked by KServe's validation webhook. This check could potentially be re-enabled once gs/azure storage spec support is provided in the storage initializer.

Overall, I think we should be fine without this validation.
