### PR TITLE
chore: Update leader-election-role name

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: kserve-leader-election-role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: kserve-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: kserve-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: kserve-controller-manager


### PR DESCRIPTION
Made it be more specific to avoid potential conflicts when installing KServe with other components of Kubeflow.

fixes #2297 

```release-note
Appended 'kserve' prefix to leader-election Role and RoleBinding
```
