### PR TITLE
Add rollout duration feature 

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -34,6 +34,7 @@ var (
 	KServeName                     = "kserve"
 	KServeAPIGroupName             = "serving.kserve.io"
 	KnativeAutoscalingAPIGroupName = "autoscaling.knative.dev"
+	KnativeServingAPIGroupName     = "serving.knative.dev"
 	KServeNamespace                = getEnvOrDefault("POD_NAMESPACE", "kserve")
 	KServeDefaultVersion           = "v0.5.0"
 )
@@ -75,6 +76,7 @@ var (
 	TargetUtilizationPercentage                 = KServeAPIGroupName + "/targetUtilizationPercentage"
 	MinScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/minScale"
 	MaxScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/maxScale"
+	RollOutDurationAnnotationKey                = KnativeServingAPIGroupName + "/rollout-duration"
 )
 
 // InferenceService Internal Annotations


### PR DESCRIPTION
* Add rollout duration feature for inferenceservice

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Allows Rollout duration annotation for a knative deployment, compared to other knative annotation the rollout annotation needs to be on the top level service annotation instead of template
https://knative.dev/docs/serving/rolling-out-latest-revision/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2009 

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**Feature/Issue validation/testing**:

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
