### PR TITLE
Add deploymentMode annotation check in defaulter

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -80,9 +80,11 @@ func (isvc *InferenceService) Default() {
 }
 
 func (isvc *InferenceService) DefaultInferenceService(config *InferenceServicesConfig, deployConfig *DeployConfig) {
-	if deployConfig.DefaultDeploymentMode == string(constants.ModelMeshDeployment) ||
-		deployConfig.DefaultDeploymentMode == string(constants.RawDeployment) {
-		isvc.ObjectMeta.Annotations[constants.DeploymentMode] = deployConfig.DefaultDeploymentMode
+	if _, ok := isvc.ObjectMeta.Annotations[constants.DeploymentMode]; !ok {
+		if deployConfig.DefaultDeploymentMode == string(constants.ModelMeshDeployment) ||
+			deployConfig.DefaultDeploymentMode == string(constants.RawDeployment) {
+			isvc.ObjectMeta.Annotations[constants.DeploymentMode] = deployConfig.DefaultDeploymentMode
+		}
 	}
 	components := []Component{isvc.Spec.Transformer, isvc.Spec.Explainer}
 	deploymentMode, ok := isvc.ObjectMeta.Annotations[constants.DeploymentMode]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2337

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] Test the isvc with deploymentMode annotation, it should not be overridden by the setting from configmap  

1. Set deploymentMode to `RawDeployment`
```
    deploy: |-
      {
        "defaultDeploymentMode": "RawDeployment"
      }
```

2. Create an InferenceService with `defaultDeploymentMode` to `ModelMesh`, the annotation should not be overridden.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [X] Have you added unit/e2e tests that prove your fix is effective or that this feature works?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
