### PR TITLE
user defined model name overwrite issue fix

### DIFF
--- a/docs/samples/v1beta1/custom/simple.yaml
+++ b/docs/samples/v1beta1/custom/simple.yaml
@@ -7,6 +7,7 @@ spec:
     minReplicas: 1
     containers:
     - image: codait/max-object-detector
+      name: kserve-container
       ports:
         - containerPort: 5000
           protocol: TCP

--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/transformer.yaml
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/transformer.yaml
@@ -6,7 +6,7 @@ spec:
   transformer:
     containers:
     - image: kserve/torchserve-image-transformer:latest
-      name: kfserving-container
+      name: kserve-container
       env:
         - name: STORAGE_URI
           value: gs://kfserving-examples/models/torchserve/image_classifier/v1

--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -257,14 +258,14 @@ func (isvc *InferenceService) SetMlServerDefaults() {
 	}
 	// set environment variables based on storage uri
 	if isvc.Spec.Predictor.Model.StorageURI == nil && isvc.Spec.Predictor.Model.Storage == nil {
-		isvc.Spec.Predictor.Model.Env = append(isvc.Spec.Predictor.Model.Env,
+		isvc.Spec.Predictor.Model.Env = utils.AppendEnvVarIfNotExists(isvc.Spec.Predictor.Model.Env,
 			v1.EnvVar{
 				Name:  constants.MLServerLoadModelsStartupEnv,
 				Value: strconv.FormatBool(false),
 			},
 		)
 	} else {
-		isvc.Spec.Predictor.Model.Env = append(isvc.Spec.Predictor.Model.Env,
+		isvc.Spec.Predictor.Model.Env = utils.AppendEnvVarIfNotExists(isvc.Spec.Predictor.Model.Env,
 			v1.EnvVar{
 				Name:  constants.MLServerModelNameEnv,
 				Value: isvc.Name,

--- a/pkg/apis/serving/v1beta1/openapi_generated.go
+++ b/pkg/apis/serving/v1beta1/openapi_generated.go
@@ -1140,7 +1140,6 @@ func schema_pkg_apis_serving_v1alpha1_SupportedModelFormat(ref common.ReferenceC
 						},
 					},
 				},
-				
 			},
 		},
 	}
@@ -3848,7 +3847,6 @@ func schema_pkg_apis_serving_v1beta1_ExplainerExtensionSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -4998,7 +4996,6 @@ func schema_pkg_apis_serving_v1beta1_LightGBMSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5083,7 +5080,6 @@ func schema_pkg_apis_serving_v1beta1_ModelFormat(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 	}
@@ -5708,7 +5704,6 @@ func schema_pkg_apis_serving_v1beta1_ONNXRuntimeSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5981,7 +5976,6 @@ func schema_pkg_apis_serving_v1beta1_PMMLSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -6253,7 +6247,6 @@ func schema_pkg_apis_serving_v1beta1_PaddleServerSpec(ref common.ReferenceCallba
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -6921,7 +6914,6 @@ func schema_pkg_apis_serving_v1beta1_PredictorExtensionSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -7710,7 +7702,6 @@ func schema_pkg_apis_serving_v1beta1_SKLearnSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -8032,7 +8023,6 @@ func schema_pkg_apis_serving_v1beta1_TFServingSpec(ref common.ReferenceCallback)
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -8305,7 +8295,6 @@ func schema_pkg_apis_serving_v1beta1_TorchServeSpec(ref common.ReferenceCallback
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -9034,7 +9023,6 @@ func schema_pkg_apis_serving_v1beta1_TritonSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -9307,7 +9295,6 @@ func schema_pkg_apis_serving_v1beta1_XGBoostSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/serving/v1beta1/predictor.go
+++ b/pkg/apis/serving/v1beta1/predictor.go
@@ -27,7 +27,6 @@ import (
 // PredictorImplementation defines common functions for all predictors e.g Tensorflow, Triton, etc
 // +kubebuilder:object:generate=false
 type PredictorImplementation interface {
-	IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool
 }
 
 // PredictorSpec defines the configuration for a predictor,

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -84,7 +84,7 @@ func (c *CustomPredictor) GetStorageSpec() *StorageSpec {
 	return nil
 }
 
-// GetContainers transforms the resource into a container spec
+// GetContainer transforms the resource into a container spec
 func (c *CustomPredictor) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
 	return &c.Containers[0]
 }
@@ -107,9 +107,4 @@ func (c *CustomPredictor) IsMMS(config *InferenceServicesConfig) bool {
 		}
 	}
 	return false
-}
-
-func (c *CustomPredictor) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
-	//TODO: Figure out how to check if custom predictor is supports framework
-	return true
 }

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -97,14 +97,3 @@ func (c *CustomPredictor) GetProtocol() constants.InferenceServiceProtocol {
 	}
 	return constants.ProtocolV1
 }
-
-func (c *CustomPredictor) IsMMS(config *InferenceServicesConfig) bool {
-	// Check container env if MULTI_MODEL_SERVER env var is set to true
-	container := c.Containers[0]
-	for _, envVar := range container.Env {
-		if envVar.Name == constants.CustomSpecMultiModelServerEnvVarKey && envVar.Value == "true" {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -286,50 +286,6 @@ func TestCreateCustomPredictorContainer(t *testing.T) {
 	}
 }
 
-func TestCustomPredictorIsMMS(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-	config := InferenceServicesConfig{}
-
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
-
-	mmsCase := false
-	scenarios := map[string]struct {
-		spec     PredictorSpec
-		expected bool
-	}{
-		"DefaultResources": {
-			spec: PredictorSpec{
-				PodSpec: PodSpec{
-					Containers: []v1.Container{
-						{
-							Env: []v1.EnvVar{
-								{
-									Name:  "STORAGE_URI",
-									Value: "hdfs://modelzoo",
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: mmsCase,
-		},
-	}
-
-	for name, scenario := range scenarios {
-		t.Run(name, func(t *testing.T) {
-			customPredictor := NewCustomPredictor(&scenario.spec.PodSpec)
-			res := customPredictor.IsMMS(&config)
-			if !g.Expect(res).To(gomega.Equal(scenario.expected)) {
-				t.Errorf("got %t, want %t", res, scenario.expected)
-			}
-		})
-	}
-}
-
 func TestCustomPredictorGetProtocol(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	scenarios := map[string]struct {

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -330,50 +330,6 @@ func TestCustomPredictorIsMMS(t *testing.T) {
 	}
 }
 
-func TestCustomPredictorIsFrameworkSupported(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-	framework := "framework"
-	config := InferenceServicesConfig{}
-
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
-
-	scenarios := map[string]struct {
-		spec     PredictorSpec
-		expected bool
-	}{
-		"DefaultResources": {
-			spec: PredictorSpec{
-				PodSpec: PodSpec{
-					Containers: []v1.Container{
-						{
-							Env: []v1.EnvVar{
-								{
-									Name:  "STORAGE_URI",
-									Value: "hdfs://modelzoo",
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: true,
-		},
-	}
-
-	for name, scenario := range scenarios {
-		t.Run(name, func(t *testing.T) {
-			customPredictor := NewCustomPredictor(&scenario.spec.PodSpec)
-			res := customPredictor.IsFrameworkSupported(framework, &config)
-			if !g.Expect(res).To(gomega.Equal(scenario.expected)) {
-				t.Errorf("got %t, want %t", res, scenario.expected)
-			}
-		})
-	}
-}
-
 func TestCustomPredictorGetProtocol(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	scenarios := map[string]struct {

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -201,8 +201,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								},
 								Annotations: map[string]string{
 									constants.StorageInitializerSourceUriInternalAnnotationKey: *isvc.Spec.Predictor.Model.StorageURI,
-									"autoscaling.knative.dev/max-scale":                         "3",
-									"autoscaling.knative.dev/min-scale":                         "1",
+									"autoscaling.knative.dev/max-scale":                        "3",
+									"autoscaling.knative.dev/min-scale":                        "1",
 									"autoscaling.knative.dev/class":                            "kpa.autoscaling.knative.dev",
 									"key1":                                                     "val1FromSR",
 								},
@@ -467,7 +467,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									constants.KServiceComponentLabel: constants.Transformer.String(),
 								},
 								Annotations: map[string]string{
-									"autoscaling.knative.dev/class":    "kpa.autoscaling.knative.dev",
+									"autoscaling.knative.dev/class":     "kpa.autoscaling.knative.dev",
 									"autoscaling.knative.dev/max-scale": "3",
 									"autoscaling.knative.dev/min-scale": "1",
 								},
@@ -688,8 +688,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								},
 								Annotations: map[string]string{
 									"autoscaling.knative.dev/class":                            "kpa.autoscaling.knative.dev",
-									"autoscaling.knative.dev/max-scale":                         "3",
-									"autoscaling.knative.dev/min-scale":                         "1",
+									"autoscaling.knative.dev/max-scale":                        "3",
+									"autoscaling.knative.dev/min-scale":                        "1",
 									"internal.serving.kserve.io/storage-initializer-sourceuri": "s3://test/mnist/explainer",
 								},
 							},
@@ -1261,8 +1261,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								Annotations: map[string]string{
 									constants.StorageInitializerSourceUriInternalAnnotationKey: "s3://test/mnist/export",
 									"autoscaling.knative.dev/class":                            "kpa.autoscaling.knative.dev",
-									"autoscaling.knative.dev/max-scale":                         "3",
-									"autoscaling.knative.dev/min-scale":                         "1",
+									"autoscaling.knative.dev/max-scale":                        "3",
+									"autoscaling.knative.dev/min-scale":                        "1",
 									"key1":                                                     "val1FromSR",
 									"key2":                                                     "val2FromISVC",
 								},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -378,21 +378,14 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService, disableIs
 	if url, err := apis.ParseURL(serviceUrl); err == nil {
 		isvc.Status.URL = url
 		path := ""
+		modelName := isvcutils.GetModelName(isvc)
 		if isvc.Spec.Transformer != nil {
 			// As of now transformer only supports protocol V1
-			path = constants.PredictPath(isvc.Name, constants.ProtocolV1)
+			path = constants.PredictPath(modelName, constants.ProtocolV1)
 		} else if !isvcutils.IsMMSPredictor(&isvc.Spec.Predictor) {
 
 			protocol := isvc.Spec.Predictor.GetImplementation().GetProtocol()
-			modelName := isvc.Name
-			// Set model name from env variable for mlserver
-			if isvc.Spec.Predictor.Model != nil {
-				for _, env := range isvc.Spec.Predictor.Model.Env {
-					if env.Name == constants.MLServerModelNameEnv {
-						modelName = env.Value
-					}
-				}
-			}
+
 			if protocol == constants.ProtocolV1 {
 				path = constants.PredictPath(modelName, constants.ProtocolV1)
 			} else if protocol == constants.ProtocolV2 {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -384,10 +384,19 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService, disableIs
 		} else if !isvcutils.IsMMSPredictor(&isvc.Spec.Predictor) {
 
 			protocol := isvc.Spec.Predictor.GetImplementation().GetProtocol()
+			modelName := isvc.Name
+			// Set model name from env variable for mlserver
+			if isvc.Spec.Predictor.Model != nil {
+				for _, env := range isvc.Spec.Predictor.Model.Env {
+					if env.Name == constants.MLServerModelNameEnv {
+						modelName = env.Value
+					}
+				}
+			}
 			if protocol == constants.ProtocolV1 {
-				path = constants.PredictPath(isvc.Name, constants.ProtocolV1)
+				path = constants.PredictPath(modelName, constants.ProtocolV1)
 			} else if protocol == constants.ProtocolV2 {
-				path = constants.PredictPath(isvc.Name, constants.ProtocolV2)
+				path = constants.PredictPath(modelName, constants.ProtocolV2)
 			}
 
 		}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -42,7 +42,17 @@ import (
 // IsMMSPredictor Only enable MMS predictor when predictor config sets MMS to true and neither
 // storage uri nor storage spec is set
 func IsMMSPredictor(predictor *v1beta1api.PredictorSpec) bool {
-	return predictor.GetImplementation().GetStorageUri() == nil && predictor.GetImplementation().GetStorageSpec() == nil
+	if len(predictor.Containers) > 0 {
+		container := predictor.Containers[0]
+		for _, envVar := range container.Env {
+			if envVar.Name == constants.CustomSpecMultiModelServerEnvVarKey && envVar.Value == "true" {
+				return true
+			}
+		}
+		return false
+	} else {
+		return predictor.GetImplementation().GetStorageUri() == nil && predictor.GetImplementation().GetStorageSpec() == nil
+	}
 }
 
 func IsMemoryResourceAvailable(isvc *v1beta1api.InferenceService, totalReqMemory resource.Quantity) bool {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -137,3 +137,19 @@ func MergeEnvs(baseEnvs []v1.EnvVar, overrideEnvs []v1.EnvVar) []v1.EnvVar {
 
 	return append(baseEnvs, extra...)
 }
+
+func AppendEnvVarIfNotExists(slice []v1.EnvVar, elems ...v1.EnvVar) []v1.EnvVar {
+	for _, elem := range elems {
+		isElemExists := false
+		for _, item := range slice {
+			if item.Name == elem.Name {
+				isElemExists = true
+				break
+			}
+		}
+		if isElemExists == false {
+			slice = append(slice, elem)
+		}
+	}
+	return slice
+}

--- a/python/custom_transformer/model_grpc.py
+++ b/python/custom_transformer/model_grpc.py
@@ -18,7 +18,6 @@ from typing import Dict, Union
 
 from kserve import Model, ModelServer, model_server
 from kserve.grpc.grpc_predict_v2_pb2 import ModelInferRequest
-from kserve.handlers.v2_datamodels import InferenceRequest
 
 
 class ImageTransformer(Model):
@@ -28,7 +27,7 @@ class ImageTransformer(Model):
         self.protocol = protocol
         self.model_name = name
 
-    def preprocess(self, request: Union[Dict, ModelInferRequest, InferenceRequest], headers=None) -> ModelInferRequest:
+    def preprocess(self, request: Union[Dict, ModelInferRequest], headers=None) -> ModelInferRequest:
         if isinstance(request, ModelInferRequest):
             return request
         else:


### PR DESCRIPTION
Signed-off-by: Suresh Nakkeran <suresh.n@ideas2it.com>

**What this PR does / why we need it**:

- This PR is to address the user defined envs were overwritten by the default model server env issue. If the user provided custom model name as env variable that would also reflected in the inference service url.
- Fix IsMMSPredictor function as it incorrectly marks custom model server as MMS

**Which issue(s) this PR fixes**
fixes #2332 #2568 

**Type of changes**
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
