### PR TITLE
Cherry-pick: Added a specific version for protobuf (#2201)

### DIFF
--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -28,3 +28,4 @@ idna==3.2
 certifi==2021.5.30
 azure_core==1.17.0
 tritonclient==2.14.2
+protobuf~=3.19.0

--- a/python/kserve/setup.py
+++ b/python/kserve/setup.py
@@ -28,7 +28,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kserve',
-    version='0.8.0.1',
+    version='0.8.0.2',
     author="The KServe Authors",
     author_email='ellisbigelow@google.com, hejinchi@cn.ibm.com, dsun20@bloomberg.net',
     license="Apache License Version 2.0",


### PR DESCRIPTION
Added a specific version for protobuf in requirements.txt

Signed-off-by: Andrews Arokiam <andrews.arokiam@ideas2it.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
publish kserve sdk 0.8.0.2 version
```
