### PR TITLE
AWS IRSA S3 Support

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -143,6 +143,14 @@ data:
         "cpuLimit": "1",
         "storageSpecSecretName": "storage-config"
     }
+  # ====================================== CREDENTIALS ======================================
+  # For a quick reference about AWS ENV variables:
+  # AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+  # Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables
+  #
+  # The `s3AccessKeyIDName` and `s3SecretAccessKeyName` fields are only used from this configmap when static credentials (IAM User Access Key Secret)
+  # are used as the authentication method for AWS S3. 
+  # The rest of the fields are used in both authentication methods (IAM Role for Service Account & IAM User Access Key Secret) if a non-empty value is provided.
   credentials: |-
     {
        "gcs": {
@@ -150,7 +158,14 @@ data:
        },
        "s3": {
            "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",
-           "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY"
+           "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY",
+           "s3Endpoint": "",
+           "s3UseHttps": "",
+           "s3Region": "",
+           "s3VerifySSL": "",
+           "s3UseVirtualBucket": "",
+           "s3UseAnonymousCredential": "",
+           "s3CABundle": ""
        }
     }
   ingress: |-

--- a/pkg/credentials/s3/s3_service_account.go
+++ b/pkg/credentials/s3/s3_service_account.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+/*
+For a quick reference about AWS ENV variables:
+AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables
+*/
+
+func BuildServiceAccountEnvs(serviceAccount *v1.ServiceAccount, s3Config *S3Config) []v1.EnvVar {
+	envs := []v1.EnvVar{}
+
+	envs = append(envs, BuildS3EnvVars(serviceAccount.Annotations, s3Config)...)
+
+	return envs
+}

--- a/pkg/credentials/s3/s3_service_account_test.go
+++ b/pkg/credentials/s3/s3_service_account_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2022 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestS3ServiceAccount(t *testing.T) {
+	scenarios := map[string]struct {
+		config         S3Config
+		serviceAccount *v1.ServiceAccount
+		expected       []v1.EnvVar
+	}{
+		"NoConfig": {
+			serviceAccount: &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-service-account",
+				},
+			},
+			expected: []v1.EnvVar{},
+		},
+
+		"S3Endpoint": {
+			serviceAccount: &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-service-account",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+					},
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+			},
+		},
+
+		"S3HttpsOverrideEnvs": {
+			serviceAccount: &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-service-account",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+						InferenceServiceS3SecretHttpsAnnotation:    "0",
+						InferenceServiceS3SecretSSLAnnotation:      "0",
+					},
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "0",
+				},
+			},
+		},
+
+		"S3EnvsWithAnonymousCredentials": {
+			serviceAccount: &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-service-account",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+						InferenceServiceS3UseAnonymousCredential:   "true",
+					},
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+				{
+					Name:  AWSAnonymousCredential,
+					Value: "true",
+				},
+			},
+		},
+
+		"S3Config": {
+			config: S3Config{
+				S3UseHttps:               "0",
+				S3Endpoint:               "s3.aws.com",
+				S3UseAnonymousCredential: "true",
+			},
+			serviceAccount: &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-service-account",
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://s3.aws.com",
+				},
+				{
+					Name:  AWSAnonymousCredential,
+					Value: "true",
+				},
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		envs := BuildServiceAccountEnvs(scenario.serviceAccount, &scenario.config)
+
+		if diff := cmp.Diff(scenario.expected, envs); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}

--- a/pkg/credentials/s3/utils.go
+++ b/pkg/credentials/s3/utils.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2022 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import v1 "k8s.io/api/core/v1"
+
+func BuildS3EnvVars(annotations map[string]string, s3Config *S3Config) []v1.EnvVar {
+	envs := []v1.EnvVar{}
+
+	if s3Endpoint, ok := annotations[InferenceServiceS3SecretEndpointAnnotation]; ok {
+		s3EndpointUrl := "https://" + s3Endpoint
+		if s3UseHttps, ok := annotations[InferenceServiceS3SecretHttpsAnnotation]; ok {
+			if s3UseHttps == "0" {
+				s3EndpointUrl = "http://" + annotations[InferenceServiceS3SecretEndpointAnnotation]
+			}
+			envs = append(envs, v1.EnvVar{
+				Name:  S3UseHttps,
+				Value: s3UseHttps,
+			})
+		}
+		envs = append(envs, v1.EnvVar{
+			Name:  S3Endpoint,
+			Value: s3Endpoint,
+		})
+		envs = append(envs, v1.EnvVar{
+			Name:  AWSEndpointUrl,
+			Value: s3EndpointUrl,
+		})
+
+	} else if s3Config.S3Endpoint != "" {
+		s3EndpointUrl := "https://" + s3Config.S3Endpoint
+		if s3Config.S3UseHttps == "0" {
+			s3EndpointUrl = "http://" + s3Config.S3Endpoint
+			envs = append(envs, v1.EnvVar{
+				Name:  S3UseHttps,
+				Value: s3Config.S3UseHttps,
+			})
+		}
+		envs = append(envs, v1.EnvVar{
+			Name:  S3Endpoint,
+			Value: s3Config.S3Endpoint,
+		})
+		envs = append(envs, v1.EnvVar{
+			Name:  AWSEndpointUrl,
+			Value: s3EndpointUrl,
+		})
+
+	}
+
+	// For each variable, prefer the value from the annotation, otherwise default to the value from the inferenceservice configmap if set.
+	verifySsl, ok := annotations[InferenceServiceS3SecretSSLAnnotation]
+	if !ok {
+		verifySsl = s3Config.S3VerifySSL
+	}
+	if verifySsl != "" {
+		envs = append(envs, v1.EnvVar{
+			Name:  S3VerifySSL,
+			Value: verifySsl,
+		})
+	}
+
+	useAnonymousCredential, ok := annotations[InferenceServiceS3UseAnonymousCredential]
+	if !ok {
+		useAnonymousCredential = s3Config.S3UseAnonymousCredential
+	}
+	if useAnonymousCredential != "" {
+		envs = append(envs, v1.EnvVar{
+			Name:  AWSAnonymousCredential,
+			Value: useAnonymousCredential,
+		})
+	}
+
+	s3Region, ok := annotations[InferenceServiceS3SecretRegionAnnotation]
+	if !ok {
+		s3Region = s3Config.S3Region
+	}
+	if s3Region != "" {
+		envs = append(envs, v1.EnvVar{
+			Name:  AWSRegion,
+			Value: s3Region,
+		})
+	}
+
+	useVirtualBucket, ok := annotations[InferenceServiceS3UseVirtualBucketAnnotation]
+	if !ok {
+		useVirtualBucket = s3Config.S3UseVirtualBucket
+	}
+	if useVirtualBucket != "" {
+		envs = append(envs, v1.EnvVar{
+			Name:  S3UseVirtualBucket,
+			Value: useVirtualBucket,
+		})
+	}
+
+	customCABundle, ok := annotations[InferenceServiceS3CABundleAnnotation]
+	if !ok {
+		customCABundle = s3Config.S3CABundle
+	}
+	if customCABundle != "" {
+		envs = append(envs, v1.EnvVar{
+			Name:  AWSCABundle,
+			Value: customCABundle,
+		})
+	}
+
+	return envs
+}

--- a/pkg/credentials/s3/utils_test.go
+++ b/pkg/credentials/s3/utils_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2022 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestBuildS3EnvVars(t *testing.T) {
+	scenarios := map[string]struct {
+		config      S3Config
+		annotations map[string]string
+		expected    []v1.EnvVar
+	}{
+		"S3Endpoint": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+			},
+			expected: []v1.EnvVar{
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+			},
+		},
+		"AllAnnotations": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation:   "s3.aws.com",
+				InferenceServiceS3SecretRegionAnnotation:     "us-east-2",
+				InferenceServiceS3SecretSSLAnnotation:        "0",
+				InferenceServiceS3SecretHttpsAnnotation:      "0",
+				InferenceServiceS3UseVirtualBucketAnnotation: "true",
+				InferenceServiceS3UseAnonymousCredential:     "true",
+				InferenceServiceS3CABundleAnnotation:         "value",
+			},
+			expected: []v1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "0",
+				},
+				{
+					Name:  AWSAnonymousCredential,
+					Value: "true",
+				},
+				{
+					Name:  AWSRegion,
+					Value: "us-east-2",
+				},
+				{
+					Name:  S3UseVirtualBucket,
+					Value: "true",
+				},
+				{
+					Name:  AWSCABundle,
+					Value: "value",
+				},
+			},
+		},
+	}
+	for name, scenario := range scenarios {
+		envs := BuildS3EnvVars(scenario.annotations, &scenario.config)
+
+		if diff := cmp.Diff(scenario.expected, envs); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -111,3 +111,29 @@ func IsPrefixSupported(input string, prefixes []string) bool {
 	}
 	return false
 }
+
+// Merge a slice of EnvVars (`O`) into another slice of EnvVars (`B`), which does the following:
+// 1. If an EnvVar is present in B but not in O, value remains unchanged in the result
+// 2. If an EnvVar is present in `O` but not in `B`, appends to the result
+// 3. If an EnvVar is present in both O and B, uses the value from O in the result
+func MergeEnvs(baseEnvs []v1.EnvVar, overrideEnvs []v1.EnvVar) []v1.EnvVar {
+	var extra []v1.EnvVar
+
+	for _, override := range overrideEnvs {
+		inBase := false
+
+		for i, base := range baseEnvs {
+			if override.Name == base.Name {
+				inBase = true
+				baseEnvs[i].Value = override.Value
+				break
+			}
+		}
+
+		if !inBase {
+			extra = append(extra, override)
+		}
+	}
+
+	return append(baseEnvs, extra...)
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -239,3 +239,143 @@ func TestAppendVolumeIfNotExists(t *testing.T) {
 		}
 	}
 }
+
+func TestMergeEnvs(t *testing.T) {
+
+	scenarios := map[string]struct {
+		baseEnvs     []v1.EnvVar
+		overrideEnvs []v1.EnvVar
+		expectedEnvs []v1.EnvVar
+	}{
+		"EmptyOverrides": {
+			baseEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value1",
+				},
+			},
+			overrideEnvs: []v1.EnvVar{},
+			expectedEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value1",
+				},
+			},
+		},
+		"EmptyBase": {
+			baseEnvs: []v1.EnvVar{},
+			overrideEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value1",
+				},
+			},
+			expectedEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value1",
+				},
+			},
+		},
+		"NoOverlap": {
+			baseEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value1",
+				},
+			},
+			overrideEnvs: []v1.EnvVar{
+				{
+					Name:  "name2",
+					Value: "value2",
+				},
+			},
+			expectedEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value1",
+				},
+				{
+					Name:  "name2",
+					Value: "value2",
+				},
+			},
+		},
+		"SingleOverlap": {
+			baseEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value1",
+				},
+			},
+			overrideEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value2",
+				},
+			},
+			expectedEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value2",
+				},
+			},
+		},
+		"MultiOverlap": {
+			baseEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value1",
+				},
+				{
+					Name:  "name2",
+					Value: "value2",
+				},
+				{
+					Name:  "name3",
+					Value: "value3",
+				},
+			},
+			overrideEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value3",
+				},
+				{
+					Name:  "name3",
+					Value: "value1",
+				},
+				{
+					Name:  "name4",
+					Value: "value4",
+				},
+			},
+			expectedEnvs: []v1.EnvVar{
+				{
+					Name:  "name1",
+					Value: "value3",
+				},
+				{
+					Name:  "name2",
+					Value: "value2",
+				},
+				{
+					Name:  "name3",
+					Value: "value1",
+				},
+				{
+					Name:  "name4",
+					Value: "value4",
+				},
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		envs := MergeEnvs(scenario.baseEnvs, scenario.overrideEnvs)
+
+		if diff := cmp.Diff(scenario.expectedEnvs, envs); diff != "" {
+			t.Errorf("Test %q unexpected envs (-want +got): %v", name, diff)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
At the moment to use AWS IRSA functionality for storage initializer, dummy kubernetes secrets need to be created to get kserve to correctly parse s3 annotations and configure storage init container correctly with environment variables (see https://github.com/kserve/kserve/issues/2003#issuecomment-1053530385) 

This PR allows configuration of S3 storage init three ways now:
1. Configure S3 options in global `inferenceservice` configmap so multiple k8s service accounts/IRSA can be configured without needing to repeat annotations
2. Configure S3 options on individual k8s service accounts/IRSA (which will be used instead of global options where specified)
3. Configure S3 options on k8s secret attached to k8s service account to preserve static credential functionality (AWS access key + secret key)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2113 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

For both tests I followed the [developer guide](https://kserve.github.io/website/master/developer/developer/), using `istioctl` 1.14.3 to deploy Istio, deploying Knative serving 1.6, and then running the `make deploy-dev` command on this branch.

- [x] Test A: Deploy S3 Example using only service account (no secret) and with all possible s3 annotations configured
```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: s3
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/s3access
    serving.kserve.io/s3-endpoint: s3.amazonaws.com # replace with your s3 endpoint e.g minio-service.kubeflow:9000
    serving.kserve.io/s3-usehttps: "1" # by default 1, if testing with minio you can set to 0
    serving.kserve.io/s3-region: "us-east-2"
    serving.kserve.io/s3-useanoncredential: "false" # omitting this is the same as false, if true will ignore provided credential and use anonymous credentials
    serving.kserve.io/s3-verifyssl: "0"
    serving.kserve.io/s3-usevirtualbucket: "false"
    serving.kserve.io/s3-cabundle: "test"
---
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "mnist-s3"
spec:
  predictor:
    serviceAccountName: s3
    model:
      modelFormat:
        name: tensorflow
      storageUri: "s3://kserve-examples/mnist"
```
Describing pod with `kubectl describe pod -n default -l serving.kserve.io/inferenceservice=mnist-s3` gives the following configuration on storage-init container
<img width="874" alt="image" src="https://user-images.githubusercontent.com/40691156/184264968-903e89fe-3449-4553-ab92-21b6db1ba5b0.png">


- [x] Test B: Deploy S3 Example using only service account (no secret) configuring all values inside `inferenceservice` configmap
```yaml
  credentials: |-
    {
       "gcs": {
           "gcsCredentialFileName": "gcloud-application-credentials.json"
       },
       "s3": {
           "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",
           "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY",
           "s3Endpoint": "s3.ap-southeast-2.amazonaws.com",
           "s3UseHttps": "0",
           "s3Region": "ap-southeast-2",
           "s3VerifySSL": "0",
           "s3UseVirtualBucket": "true",
           "s3UseAnonymousCredential": "true",
           "s3CABundle": "test"
       }
    }
```

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: s3-configmap
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/s3access
---
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "mnist-s3-configmap"
spec:
  predictor:
    serviceAccountName: s3-configmap
    model:
      modelFormat:
        name: tensorflow
      storageUri: "s3://kserve-examples/mnist"
```
Describing pod with `kubectl describe pod -n default -l serving.kserve.io/inferenceservice=mnist-s3-configmap` gives following configuration on storage init container
<img width="906" alt="image" src="https://user-images.githubusercontent.com/40691156/184265311-d6b02621-6300-4722-b829-a05b95993d2c.png">

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?: I will make a separate PR to the kserve website repo updating documentation


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
Adds AWS S3 configuration + IRSA support to inferenceservice configmap and k8s svcaccount
```
