### PR TITLE
storage-initializer: Let boto3 decide the endpoint for S3

### DIFF
--- a/python/kserve/kserve/storage.py
+++ b/python/kserve/kserve/storage.py
@@ -151,9 +151,13 @@ class Storage(object):  # pylint: disable=too-few-public-methods
         #    if awsAnonymousCredential env var true, passed in via config
         # 2. Environment variables
         # 3. ~/.aws/config file
-        s3 = boto3.resource('s3',
-                            endpoint_url=os.getenv("AWS_ENDPOINT_URL", "http://s3.amazonaws.com"),
-                            config=Storage.get_S3_config())
+        kwargs = {
+            "config": Storage.get_S3_config()
+        }
+        endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        if endpoint_url:
+            kwargs.update({"endpoint_url": endpoint_url})
+        s3 = boto3.resource("s3", **kwargs)
         parsed = urlparse(uri, scheme='s3')
         bucket_name = parsed.netloc
         bucket_path = parsed.path.lstrip('/')


### PR DESCRIPTION
Until now KServe was using the global HTTP endpoint for S3 by default
unless the user explicitly provides it with the corresponding
annotation. If one wants to use IAM roles for service accounts instead
of Secrets with HMAC credentials, storage-initializer will fail in case:

* the bucket is configured with SSE
* if the bucket allows HTTPS requests only
* of an airgapped environment

Specifically, if the bucket is configured with SSE it fails with:

  botocore.exceptions.ClientError: An error occurred (InvalidArgument) when calling the GetObject operation: Requests specifying Server Side Encryption with AWS KMS managed keys must be made over a secure connection.

If the bucket policy allows HTTPS requests only it fails with:

  botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the ListObjects operation: Access Denied

In case of an airgapped environment, S3 is only available via the
regional VPC endpoint so requests to the global endpoint will hang.

Handle the above cases by letting boto3 decide the S3 endpoint based
on the environment.

In case of IRSA, AWS will set AWS_REGION and AWS_DEFAULT_REGION and as
such boto3 will use the regional endpoint. boto3 will use HTTPS by
default which is inline with the default value of s3-usehttps
annotation. Finally, if the bucket is in different region boto3 will be
automatically redirected there.

This change should not break existing deployments that don't use IRSA
but don't set s3-endpoint either; boto3 will default using the global
HTTPS endpoint, https://s3.amazonaws.com.

Handle also the case where endpoint_url is unset or empty, where boto3
fails with:

  ValueError: Invalid endpoint:

With this commit, one can use service accounts with the
`eks.amazonaws.com/role-arn` and `eks.amazonaws.com/sts-regional-endpoints`
annotations directly without the need of an attached secret.

Refs #2003
Refs #2113

Signed-off-by: Dimitris Aragiorgis <dimara@arrikto.com>