### PR TITLE
Allows to make Istio and VirtualServices optional

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -177,7 +177,8 @@ data:
         "ingressDomain"  : "example.com",
         "ingressClassName" : "istio",
         "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-        "urlScheme": "http"
+        "urlScheme": "http",
+        "disableIstioVirtualHost": false
     }
   logger: |-
     {

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -127,6 +127,7 @@ type IngressConfig struct {
 	IngressClassName        *string `json:"ingressClassName,omitempty"`
 	DomainTemplate          string  `json:"domainTemplate,omitempty"`
 	UrlScheme               string  `json:"urlScheme,omitempty"`
+	DisableIstioVirtualHost bool    `json:"disableIstioVirtualHost,omitempty"`
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/controller/v1beta1/inferenceservice/suite_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/suite_test.go
@@ -100,7 +100,7 @@ var _ = BeforeSuite(func() {
 		Scheme:   k8sClient.Scheme(),
 		Log:      ctrl.Log.WithName("V1beta1InferenceServiceController"),
 		Recorder: k8sManager.GetEventRecorderFor("V1beta1InferenceServiceController"),
-	}).SetupWithManager(k8sManager, deployConfig)
+	}).SetupWithManager(k8sManager, deployConfig, false)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
Signed-off-by: Suresh-Nakkeran <suresh.n@ideas2it.com>

**What this PR does / why we need it**:
This PR allows followining:
- Istio is optional for Serverless mode and other [networking layer Knative supported](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/#install-a-networking-layer) can be integrated with KServe such as Contour. 
- KServe Serverless installation can fully run in mesh mode without knative local gateway.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1336 

**Type of changes**
Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] When `DisableIstioVirtualHost` is true, KServe does not create the top level virtual service thus Istio is no longer required for serverless mode.
- [X] When `DisableIstioVirtualHost` is true, KServe works with [Contour](https://projectcontour.io).
- [X] When `DisableIstioVirtualHost` is false, KServe works like before.

**Special notes for your reviewer**:

1. The Service url in status returns the InferenceService component ksvc url instead of the url with virtual host(isvc name) as top level vs is now disabled, e.g when transformer is added to the InferenceService, the url returns the transformer ksvc url otherwise it returns the predictor ksvc url.

**Checklist**:

- [X] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`DisableIstioVirtualHost` is introduced in the configmap to disable top level Istio virtual service, Istio is no longer required for serverless mode.
```
 

