### PR TITLE
Enable explainers to work with ModelMesh

### DIFF
--- a/docs/samples/explanation/alibi/cifar10/cifar10-mm.yaml
+++ b/docs/samples/explanation/alibi/cifar10/cifar10-mm.yaml
@@ -1,0 +1,26 @@
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "cifar10-mm"
+  annotations:
+    serving.kserve.io/deploymentMode: ModelMesh
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: tensorflow
+      storageUri: gs://seldon-models/tfserving/cifar10/resnet32
+  explainer:
+    alibi:
+      type: AnchorImages
+      storageUri: "gs://seldon-models/tfserving/cifar10/explainer-py36-0.5.2"
+      config:
+        batch_size: "40"
+        stop_on_first: "True"
+      resources:
+        requests:
+          cpu: 0.1
+          memory: 5Gi            
+        limits:
+          memory: 10Gi
+        

--- a/docs/samples/explanation/alibi/cifar10/cifar10_explanations_modelmesh.ipynb
+++ b/docs/samples/explanation/alibi/cifar10/cifar10_explanations_modelmesh.ipynb
@@ -1,0 +1,215 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CIFAR10 Image Classifier Explanations\n",
+    "\n",
+    "\n",
+    "We will use a Tensorflow classifier built on [CIFAR10 image dataset](https://www.cs.toronto.edu/~kriz/cifar.html) which is a 10 class image dataset.\n",
+    "\n",
+    "The Kfserving resource describes:\n",
+    "   * A pretrained tensorflow model stored on a Google bucket\n",
+    "   * Am AnchorImage [Seldon Alibi](https://github.com/SeldonIO/alibi) Explainer. See the [Alibi Docs](https://docs.seldon.io/projects/alibi/en/stable/) for further details.\n",
+    "   \n",
+    "To download and get the pretrained image classifier locally you can run the following code:\n",
+    "\n",
+    "```python\n",
+    "url = \"https://storage.googleapis.com/seldon-models/alibi-detect/classifier/\"\n",
+    "path_model = os.path.join(url, \"cifar10\", \"resnet32\", \"model.h5\")\n",
+    "save_path = tf.keras.utils.get_file(\"resnet32\", path_model)\n",
+    "model = tf.keras.models.load_model(save_path)\n",
+    "```\n",
+    "\n",
+    "This example runs in the demo namespace. We expect you to complete these pre-requisites.\n",
+    "   * Create namespaces, \"modelmesh-serving\" and \"demo\"\n",
+    "   * Install KServe\n",
+    "   * Install ModelMesh using the quick start install command in the modelmesh-serving repo ```./script/install.sh -n modelmesh-serving -u demo --quickstart```\n",
+    "   * Edit the triton-2.x serving runtime ```kubectl edit servingruntime triton-2.x -n demo``` \n",
+    "       1. add \"--backend-config=default-max-batch-size=100\" to arguments \n",
+    "       2. change triton image tag to \"tritonserver:22.07-py3\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize cifar10-mm.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl apply -f cifar10-mm.yaml -n demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl wait --for condition=ready --timeout=600s pods --all -n demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CLUSTER_IPS=!(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')\n",
+    "CLUSTER_IP=CLUSTER_IPS[0]\n",
+    "print(CLUSTER_IP)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('../')\n",
+    "from alibi_helper import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "train, test = tf.keras.datasets.cifar10.load_data()\n",
+    "X_train, y_train = train\n",
+    "X_test, y_test = test\n",
+    "\n",
+    "X_train = X_train.astype(\"float32\") / 255\n",
+    "X_test = X_test.astype(\"float32\") / 255\n",
+    "print(X_train.shape, y_train.shape, X_test.shape, y_test.shape)\n",
+    "class_names = [\n",
+    "    \"airplane\",\n",
+    "    \"automobile\",\n",
+    "    \"bird\",\n",
+    "    \"cat\",\n",
+    "    \"deer\",\n",
+    "    \"dog\",\n",
+    "    \"frog\",\n",
+    "    \"horse\",\n",
+    "    \"ship\",\n",
+    "    \"truck\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the port forward command in a separate terminal: ```kubectl port-forward --address 0.0.0.0 service/modelmesh-serving 8008 -n demo```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from subprocess import PIPE, Popen, run\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "idx = 12\n",
+    "test_example = X_test[idx : idx + 1].tolist()\n",
+    "shape = list(np.shape(test_example)) \n",
+    "payload = '{\"inputs\": [ { \"name\": \"input_1\", \"shape\": ' + str(shape) + ', \"datatype\": \"FP32\", \"data\": ' + str(test_example) + ' } ] }'\n",
+    "\n",
+    "cmd = f\"\"\"curl -X POST -d '{payload}' \\\n",
+    "       -k http://localhost:8008/v2/models/cifar10-mm/infer \\\n",
+    "\"\"\"\n",
+    "\n",
+    "ret = Popen(cmd, shell=True, stdout=PIPE)\n",
+    "raw = ret.stdout.read().decode(\"utf-8\")\n",
+    "res = json.loads(raw)\n",
+    "print(res)\n",
+    "arr = np.array(res[\"outputs\"][0][\"data\"])\n",
+    "\n",
+    "X = X_test[idx].reshape(1, 32, 32, 3)\n",
+    "plt.imshow(X.reshape(32, 32, 3))\n",
+    "plt.axis(\"off\")\n",
+    "plt.show()\n",
+    "print(\"class:\", class_names[y_test[idx][0]])\n",
+    "print(\"prediction:\", class_names[arr[0].argmax()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_example = X_test[idx : idx + 1].tolist()\n",
+    "payload = '{\"instances\":' + f\"{test_example}\" + \" }\"\n",
+    "SERVICE_HOSTNAME=\"cifar10-mm.demo.example.com\"\n",
+    "cmd = f\"\"\"curl -s -d '{payload}' \\\n",
+    "   http://{CLUSTER_IP}/v1/models/cifar10-mm:explain \\\n",
+    "   -H \"Host: {SERVICE_HOSTNAME}\" \\\n",
+    "   -H \"Content-Type: application/json\"\n",
+    "\"\"\"\n",
+    "ret = Popen(cmd, shell=True, stdout=PIPE)\n",
+    "raw = ret.stdout.read().decode(\"utf-8\")\n",
+    "explanation = json.loads(raw)\n",
+    "arr = np.array(explanation[\"data\"][\"anchor\"])\n",
+    "plt.imshow(arr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Teardown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kubectl delete -f cifar10-mm.yaml -n demo"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pkg/apis/serving/v1beta1/explainer_alibi.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi.go
@@ -68,31 +68,24 @@ func (s *AlibiExplainerSpec) GetResourceRequirements() *v1.ResourceRequirements 
 }
 
 func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
-	alibiExplainerLogger.Info("=====hello 0 alibi=====", "metadata.Name", metadata.Name)
 	var args = []string{
 		constants.ArgumentModelName, metadata.Name,
 		constants.ArgumentHttpPort, constants.InferenceServiceDefaultHttpPort,
 	}
 
 	argumentPredictorHost := fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace)
-	//argumentPredictorPort := constants.InferenceServiceDefaultHttpPort
 	deploymentMode, ok := metadata.Annotations[constants.DeploymentMode]
-	alibiExplainerLogger.Info("=====hello 1.0 alibi=====", "argumentPredictorHost", argumentPredictorHost)
 
 	if ok && (deploymentMode == string(constants.ModelMeshDeployment)) {
 		// Get predictor host and protocol from annotations in modelmesh deployment mode
-		alibiExplainerLogger.Info("=====hello 1.1 alibi=====", "argumentPredictorHost", metadata.Annotations[constants.PredictorHostAnnotationKey])
 		argumentPredictorHost = metadata.Annotations[constants.PredictorHostAnnotationKey]
 		argumentPredictorProtocol := metadata.Annotations[constants.PredictorProtocolAnnotationKey]
-		alibiExplainerLogger.Info("=====hello 1.2 alibi=====", "argumentPredictorHost", argumentPredictorHost)
-		alibiExplainerLogger.Info("=====hello 2.1 alibi=====", "argumentPredictorProtocol", argumentPredictorProtocol)
 
 		// Set predictor protocol if not provided in container arguments
 		if !utils.IncludesArg(args, "--protocol") {
 			alibiExplainerLogger.Info("Set predictor protocol based on ModelMesh predictor URL", "protocol", argumentPredictorProtocol)
 			args = append(args, "--protocol", argumentPredictorProtocol)
 		}
-		//argumentPredictorPort = argumentPredictorProtocol
 	}
 
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentPredictorHost) {
@@ -125,7 +118,6 @@ func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions
 	}
 	s.Name = constants.InferenceServiceContainerName
 	s.Args = append(args, s.Args...)
-	alibiExplainerLogger.Info("=====hello 3.1 alibi=====", "s.Args", s.Args)
 	return &s.Container
 }
 

--- a/pkg/apis/serving/v1beta1/explainer_alibi.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi.go
@@ -85,13 +85,13 @@ func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions
 		argumentPredictorHost = metadata.Annotations[constants.PredictorHostAnnotationKey]
 		argumentPredictorProtocol := metadata.Annotations[constants.PredictorProtocolAnnotationKey]
 		alibiExplainerLogger.Info("=====hello 1.2 alibi=====", "argumentPredictorHost", argumentPredictorHost)
-		alibiExplainerLogger.Info("=====hello 2 alibi=====", "argumentPredictorProtocol", argumentPredictorProtocol)
+		alibiExplainerLogger.Info("=====hello 2.1 alibi=====", "argumentPredictorProtocol", argumentPredictorProtocol)
 
 		// Set predictor protocol if not provided in container arguments
-		//if !utils.IncludesArg(args, "--protocol") {
-		//	customExplainerLogger.Info("Set predictor protocol based on ModelMesh predictor URL", "protocol", argumentPredictorProtocol)
-		//	args = append(args, "--protocol", argumentPredictorProtocol)
-		//}
+		if !utils.IncludesArg(args, "--protocol") {
+			alibiExplainerLogger.Info("Set predictor protocol based on ModelMesh predictor URL", "protocol", argumentPredictorProtocol)
+			args = append(args, "--protocol", argumentPredictorProtocol)
+		}
 		//argumentPredictorPort = argumentPredictorProtocol
 	}
 
@@ -125,6 +125,7 @@ func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions
 	}
 	s.Name = constants.InferenceServiceContainerName
 	s.Args = append(args, s.Args...)
+	alibiExplainerLogger.Info("=====hello 3.1 alibi=====", "s.Args", s.Args)
 	return &s.Container
 }
 

--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -256,7 +256,7 @@ func (isvc *InferenceService) SetMlServerDefaults() {
 		isvc.Spec.Predictor.Model.ProtocolVersion = &protocolV2
 	}
 	// set environment variables based on storage uri
-	if isvc.Spec.Predictor.Model.StorageURI == nil && isvc.Spec.Predictor.Model.Storage == nil {
+	if isvc.Spec.Predictor.Model.StorageURI == nil {
 		isvc.Spec.Predictor.Model.Env = append(isvc.Spec.Predictor.Model.Env,
 			v1.EnvVar{
 				Name:  constants.MLServerLoadModelsStartupEnv,
@@ -315,7 +315,7 @@ func (isvc *InferenceService) SetTritonDefaults() {
 		isvc.Spec.Predictor.Model.ProtocolVersion = &protocolV2
 	}
 	// set model-control-model arg to 'explicit' if storage uri is nil
-	if isvc.Spec.Predictor.Model.StorageURI == nil && isvc.Spec.Predictor.Model.Storage == nil {
+	if isvc.Spec.Predictor.Model.StorageURI == nil {
 		isvc.Spec.Predictor.Model.Args = append(isvc.Spec.Predictor.Model.Args,
 			fmt.Sprintf("%s=%s", "--model-control-mode", "explicit"))
 	}

--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -256,7 +256,7 @@ func (isvc *InferenceService) SetMlServerDefaults() {
 		isvc.Spec.Predictor.Model.ProtocolVersion = &protocolV2
 	}
 	// set environment variables based on storage uri
-	if isvc.Spec.Predictor.Model.StorageURI == nil {
+	if isvc.Spec.Predictor.Model.StorageURI == nil && isvc.Spec.Predictor.Model.Storage == nil {
 		isvc.Spec.Predictor.Model.Env = append(isvc.Spec.Predictor.Model.Env,
 			v1.EnvVar{
 				Name:  constants.MLServerLoadModelsStartupEnv,
@@ -315,7 +315,7 @@ func (isvc *InferenceService) SetTritonDefaults() {
 		isvc.Spec.Predictor.Model.ProtocolVersion = &protocolV2
 	}
 	// set model-control-model arg to 'explicit' if storage uri is nil
-	if isvc.Spec.Predictor.Model.StorageURI == nil {
+	if isvc.Spec.Predictor.Model.StorageURI == nil && isvc.Spec.Predictor.Model.Storage == nil {
 		isvc.Spec.Predictor.Model.Args = append(isvc.Spec.Predictor.Model.Args,
 			fmt.Sprintf("%s=%s", "--model-control-mode", "explicit"))
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -105,6 +105,10 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 
 		// add predictor host and protocol to metadata
 		isvc.ObjectMeta.Annotations[constants.PredictorHostAnnotationKey] = predictorURL.Host
+		e.Log.Info("=====hello4 Explainer=====", "predictorURL.Scheme", predictorURL.Scheme)
+		e.Log.Info("=====hello5 Explainer=====", "predictorURL.Host", predictorURL.Host)
+		e.Log.Info("=====hello6 Explainer=====", "predictorURL", predictorURL)
+
 		if predictorURL.Scheme == "grpc" {
 			isvc.ObjectMeta.Annotations[constants.PredictorProtocolAnnotationKey] = string(constants.ProtocolGRPCV2)
 		} else if predictorURL.Scheme == "http" || predictorURL.Scheme == "https" {
@@ -125,6 +129,7 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 		//e.Log.Info("=====hello6 Explainer=====", "port", port)
 
 	}
+	e.Log.Info("=====hello7 Explainer=====", "protocol key", isvc.ObjectMeta.Annotations[constants.PredictorProtocolAnnotationKey])
 	container := explainer.GetContainer(isvc.ObjectMeta, isvc.Spec.Explainer.GetExtensions(), e.inferenceServiceConfig)
 	if len(isvc.Spec.Explainer.PodSpec.Containers) == 0 {
 		isvc.Spec.Explainer.PodSpec.Containers = []v1.Container{

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -62,7 +62,6 @@ func NewExplainer(client client.Client, scheme *runtime.Scheme, inferenceService
 // Reconcile observes the explainer and attempts to drive the status towards the desired state.
 func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, error) {
 	e.Log.Info("Reconciling Explainer", "ExplainerSpec", isvc.Spec.Explainer)
-	e.Log.Info("=====hello0 Explainer=====")
 	explainer := isvc.Spec.Explainer.GetImplementation()
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
@@ -75,13 +74,10 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 	addLoggerAnnotations(isvc.Spec.Explainer.Logger, annotations)
 	// Add StorageSpec annotations so mutator will mount storage credentials to InferenceService's explainer
 	addStorageSpecAnnotations(explainer.GetStorageSpec(), annotations)
-	e.Log.Info("=====hello1 Explainer=====")
-
 	deployConfig, err := v1beta1.NewDeployConfig(e.client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-
 	objectMeta := metav1.ObjectMeta{
 		Name:      constants.DefaultExplainerServiceName(isvc.Name),
 		Namespace: isvc.Namespace,
@@ -92,10 +88,9 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 		Annotations: annotations,
 	}
 
-	// Need to wait for predictor URL in modelmesh deployment mode
+	// Need to wait for predictor URL in ModelMesh deployment mode
 	if isvcutils.GetDeploymentMode(annotations, deployConfig) == constants.ModelMeshDeployment {
 		// check if predictor URL is populated
-		e.Log.Info("=====hello3 Explainer=====")
 		predictorURL := (*url.URL)(isvc.Status.Components["predictor"].URL)
 		if predictorURL == nil {
 			// explainer reconcile will retry every 3 second until predictor URL is populated
@@ -103,33 +98,18 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 			return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
 		}
 
-		// add predictor host and protocol to metadata
+		// Add predictor host and protocol to metadata
 		isvc.ObjectMeta.Annotations[constants.PredictorHostAnnotationKey] = predictorURL.Host
-		e.Log.Info("=====hello4 Explainer=====", "predictorURL.Scheme", predictorURL.Scheme)
-		e.Log.Info("=====hello5 Explainer=====", "predictorURL.Host", predictorURL.Host)
-		e.Log.Info("=====hello6 Explainer=====", "predictorURL", predictorURL)
-
 		if predictorURL.Scheme == "grpc" {
 			isvc.ObjectMeta.Annotations[constants.PredictorProtocolAnnotationKey] = string(constants.ProtocolGRPCV2)
 		} else if predictorURL.Scheme == "http" || predictorURL.Scheme == "https" {
-			// modelmesh supports v2 only
+			// ModelMesh supports v2 only
 			isvc.ObjectMeta.Annotations[constants.PredictorProtocolAnnotationKey] = string(constants.ProtocolV2)
 		} else {
 			return ctrl.Result{}, fmt.Errorf("Predictor URL Scheme not supported: %v", predictorURL.Scheme)
 		}
-		//predictorURL = (*url.URL)(isvc.Status.Components["predictor"].RestURL)
-		//e.Log.Info("=====hello4 Explainer=====", "predictorURL.Host", predictorURL.Host)
-		//host, port, err := net.SplitHostPort(predictorURL.Host)
-		//if err != nil {
-		//		return ctrl.Result{}, err
-		//}
-		//isvc.ObjectMeta.Annotations[constants.PredictorHostAnnotationKey] = host
-		//isvc.ObjectMeta.Annotations[constants.PredictorProtocolAnnotationKey] = port
-		//e.Log.Info("=====hello5 Explainer=====", "host", host)
-		//e.Log.Info("=====hello6 Explainer=====", "port", port)
-
 	}
-	e.Log.Info("=====hello7 Explainer=====", "protocol key", isvc.ObjectMeta.Annotations[constants.PredictorProtocolAnnotationKey])
+
 	container := explainer.GetContainer(isvc.ObjectMeta, isvc.Spec.Explainer.GetExtensions(), e.inferenceServiceConfig)
 	if len(isvc.Spec.Explainer.PodSpec.Containers) == 0 {
 		isvc.Spec.Explainer.PodSpec.Containers = []v1.Container{

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -18,7 +18,6 @@ package components
 
 import (
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -91,7 +90,7 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 	// Need to wait for predictor URL in ModelMesh deployment mode
 	if isvcutils.GetDeploymentMode(annotations, deployConfig) == constants.ModelMeshDeployment {
 		// check if predictor URL is populated
-		predictorURL := (*url.URL)(isvc.Status.Components["predictor"].URL)
+		predictorURL := isvc.Status.Components["predictor"].URL
 		if predictorURL == nil {
 			// explainer reconcile will retry every 3 second until predictor URL is populated
 			e.Log.Info("Explainer reconciliation is waiting for predictor URL to be populated")

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -188,7 +188,6 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 	//Reconcile ingress
-	//Skip if deployment mode is modelmesh and explainer exists
 	ingressConfig, err := v1beta1api.NewIngressConfig(r.Client)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "fails to create IngressConfig")

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -204,8 +204,6 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return reconcile.Result{}, errors.Wrapf(err, "fails to reconcile ingress")
 		}
 	} else {
-		// }
-		// if deploymentMode == constants.Serverless || (deploymentMode == constants.ModelMeshDeployment && isvc.Spec.Explainer == nil) {
 		reconciler := ingress.NewIngressReconciler(r.Client, r.Scheme, ingressConfig)
 		r.Log.Info("Reconciling ingress for inference service", "isvc", isvc.Name)
 		if err := reconciler.Reconcile(isvc, ingressConfig.DisableIstioVirtualHost); err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -116,13 +116,13 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if deploymentMode == constants.ModelMeshDeployment {
 		if isvc.Spec.Transformer == nil && isvc.Spec.Explainer == nil {
-			// Skip if no transformers
-			r.Log.Info("=====hello 0 Skipping reconciliation for InferenceService", constants.DeploymentMode, deploymentMode,
+			// Skip when there is no transformer and explainer
+			r.Log.Info("Skipping reconciliation for InferenceService", constants.DeploymentMode, deploymentMode,
 				"apiVersion", isvc.APIVersion, "isvc", isvc.Name)
 			return ctrl.Result{}, nil
 		}
-		// Continue to reconcile when there is a transformer
-		r.Log.Info("=====hello 1 Continue reconciliation for InferenceService", constants.DeploymentMode, deploymentMode,
+		// Continue to reconcile when there is a transformer or explainer
+		r.Log.Info("Continue reconciliation for InferenceService", constants.DeploymentMode, deploymentMode,
 			"apiVersion", isvc.APIVersion, "isvc", isvc.Name)
 	}
 	// name of our custom finalizer
@@ -218,7 +218,6 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := configMapReconciler.Reconcile(isvc); err != nil {
 		return reconcile.Result{}, err
 	}
-	r.Log.Info("=====hello 2 update status next =======", "deploymentMode", deploymentMode)
 
 	if err = r.updateStatus(isvc, deploymentMode); err != nil {
 		r.Recorder.Eventf(isvc, v1.EventTypeWarning, "InternalError", err.Error())
@@ -235,26 +234,19 @@ func (r *InferenceServiceReconciler) updateStatus(desiredService *v1beta1api.Inf
 		return err
 	}
 	wasReady := inferenceServiceReadiness(existingService.Status)
-	r.Log.Info("=====hello 3 update status here =======", "wasReady", wasReady)
-
 	if inferenceServiceStatusEqual(existingService.Status, desiredService.Status, deploymentMode) {
-		r.Log.Info("=====hello 4.0 update status here =======", "status equal", desiredService.Status)
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
 	} else if err := r.Status().Update(context.TODO(), desiredService); err != nil {
-		r.Log.Info("=====hello 4.1 update status here =======", "failed to update", desiredService.Status)
 		r.Log.Error(err, "Failed to update InferenceService status", "InferenceService", desiredService.Name)
 		r.Recorder.Eventf(desiredService, v1.EventTypeWarning, "UpdateFailed",
 			"Failed to update status for InferenceService %q: %v", desiredService.Name, err)
 		return errors.Wrapf(err, "fails to update InferenceService status")
 	} else {
 		// If there was a difference and there was no error.
-		r.Log.Info("=====hello 4 update status here =======", "desiredService.Status", desiredService.Status)
-
 		isReady := inferenceServiceReadiness(desiredService.Status)
-		r.Log.Info("=====hello 5 update status here =======", "isReady", isReady)
 		if wasReady && !isReady { // Moved to NotReady State
 			r.Recorder.Eventf(desiredService, v1.EventTypeWarning, string(InferenceServiceNotReadyState),
 				fmt.Sprintf("InferenceService [%v] is no longer Ready", desiredService.GetName()))

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
-	v1beta1api "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	isvcutils "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/utils"
 	utils "github.com/kserve/kserve/pkg/utils"
@@ -100,7 +99,7 @@ func getServiceHost(isvc *v1beta1.InferenceService, deploymentMode constants.Dep
 	}
 }
 
-func getServiceUrl(isvc *v1beta1.InferenceService, urlScheme string) string {
+func getServiceUrl(isvc *v1beta1.InferenceService, urlScheme string, disableIstioVirtualHost bool) string {
 	if isvc.Status.Components == nil {
 		return ""
 	}
@@ -113,7 +112,11 @@ func getServiceUrl(isvc *v1beta1.InferenceService, urlScheme string) string {
 		} else {
 			url := transformerStatus.URL
 			url.Scheme = urlScheme
-			return strings.Replace(url.String(), fmt.Sprintf("-%s-default", string(constants.Transformer)), "", 1)
+			if disableIstioVirtualHost == false {
+				return strings.Replace(url.String(), fmt.Sprintf("-%s-default", string(constants.Transformer)), "", 1)
+			} else {
+				return url.String()
+			}
 		}
 	}
 
@@ -127,7 +130,11 @@ func getServiceUrl(isvc *v1beta1.InferenceService, urlScheme string) string {
 			return url.String()
 		}
 		url.Scheme = urlScheme
-		return strings.Replace(url.String(), fmt.Sprintf("-%s-default", string(constants.Predictor)), "", 1)
+		if disableIstioVirtualHost == false {
+			return strings.Replace(url.String(), fmt.Sprintf("-%s-default", string(constants.Predictor)), "", 1)
+		} else {
+			return url.String()
+		}
 	}
 }
 
@@ -339,55 +346,58 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 	return desiredIngress
 }
 
-func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
+func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService, disableIstioVirtualHost bool) error {
 	//get annotations from isvc
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
 	})
-	deployConfig, err := v1beta1api.NewDeployConfig(ir.client)
+	deployConfig, err := v1beta1.NewDeployConfig(ir.client)
 	if err != nil {
 		return errors.Wrapf(err, "fails to create DeployConfig")
 	}
 	deploymentMode := isvcutils.GetDeploymentMode(annotations, deployConfig)
 
 	serviceHost := getServiceHost(isvc, deploymentMode)
-	serviceUrl := getServiceUrl(isvc, ir.ingressConfig.UrlScheme)
+	serviceUrl := getServiceUrl(isvc, ir.ingressConfig.UrlScheme, disableIstioVirtualHost)
 	if serviceHost == "" || serviceUrl == "" {
 		return nil
 	}
-	//Create ingress
-	desiredIngress := createIngress(isvc, ir.ingressConfig, deploymentMode)
-	if desiredIngress == nil {
-		return nil
-	}
-
-	//Create external service which points to local gateway
-	if err := ir.reconcileExternalService(isvc, ir.ingressConfig); err != nil {
-		return errors.Wrapf(err, "fails to reconcile external name service")
-	}
-
-	if err := controllerutil.SetControllerReference(isvc, desiredIngress, ir.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set owner reference for ingress")
-	}
-
-	existing := &v1alpha3.VirtualService{}
-	err = ir.client.Get(context.TODO(), types.NamespacedName{Name: desiredIngress.Name, Namespace: desiredIngress.Namespace}, existing)
-	if err != nil {
-		if apierr.IsNotFound(err) {
-			log.Info("Creating Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
-			err = ir.client.Create(context.TODO(), desiredIngress)
+	// When Istio virtual host is disabled, we return the underlying component url.
+	// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
+	if disableIstioVirtualHost == false {
+		desiredIngress := createIngress(isvc, ir.ingressConfig, deploymentMode)
+		if desiredIngress == nil {
+			return nil
 		}
-	} else {
-		if !routeSemanticEquals(desiredIngress, existing) {
-			existing.Spec = desiredIngress.Spec
-			existing.Annotations = desiredIngress.Annotations
-			existing.Labels = desiredIngress.Labels
-			log.Info("Update Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
-			err = ir.client.Update(context.TODO(), existing)
+
+		//Create external service which points to local gateway
+		if err := ir.reconcileExternalService(isvc, ir.ingressConfig); err != nil {
+			return errors.Wrapf(err, "fails to reconcile external name service")
 		}
-	}
-	if err != nil {
-		return errors.Wrapf(err, "fails to create or update ingress")
+
+		if err := controllerutil.SetControllerReference(isvc, desiredIngress, ir.scheme); err != nil {
+			return errors.Wrapf(err, "fails to set owner reference for ingress")
+		}
+
+		existing := &v1alpha3.VirtualService{}
+		err = ir.client.Get(context.TODO(), types.NamespacedName{Name: desiredIngress.Name, Namespace: desiredIngress.Namespace}, existing)
+		if err != nil {
+			if apierr.IsNotFound(err) {
+				log.Info("Creating Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
+				err = ir.client.Create(context.TODO(), desiredIngress)
+			}
+		} else {
+			if !routeSemanticEquals(desiredIngress, existing) {
+				existing.Spec = desiredIngress.Spec
+				existing.Annotations = desiredIngress.Annotations
+				existing.Labels = desiredIngress.Labels
+				log.Info("Update Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
+				err = ir.client.Update(context.TODO(), existing)
+			}
+		}
+		if err != nil {
+			return errors.Wrapf(err, "fails to create or update ingress")
+		}
 	}
 
 	if url, err := apis.ParseURL(serviceUrl); err == nil {
@@ -406,10 +416,11 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 			}
 
 		}
+		hostPrefix := getHostPrefix(isvc, disableIstioVirtualHost)
 		if deploymentMode != constants.ModelMeshDeployment || isvc.Spec.Transformer != nil {
 			isvc.Status.Address = &duckv1.Addressable{
 				URL: &apis.URL{
-					Host:   network.GetServiceHostname(isvc.Name, isvc.Namespace),
+					Host:   network.GetServiceHostname(hostPrefix, isvc.Namespace),
 					Scheme: "http",
 					Path:   path,
 				},
@@ -429,4 +440,14 @@ func routeSemanticEquals(desired, existing *v1alpha3.VirtualService) bool {
 	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec) &&
 		equality.Semantic.DeepEqual(desired.ObjectMeta.Labels, existing.ObjectMeta.Labels) &&
 		equality.Semantic.DeepEqual(desired.ObjectMeta.Annotations, existing.ObjectMeta.Annotations)
+}
+
+func getHostPrefix(isvc *v1beta1.InferenceService, disableIstioVirtualHost bool) string {
+	if disableIstioVirtualHost == true {
+		if isvc.Spec.Transformer != nil {
+			return constants.DefaultTransformerServiceName(isvc.Name)
+		}
+		return constants.DefaultPredictorServiceName(isvc.Name)
+	}
+	return isvc.Name
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -523,7 +523,7 @@ func TestGetServiceHostname(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			testIsvc := createInferenceServiceWithHostname(tt.predictorHostName)
-			result := getServiceHost(testIsvc)
+			result := getServiceHost(testIsvc, constants.Serverless)
 			if diff := cmp.Diff(tt.expectedHostName, result); diff != "" {
 				t.Errorf("Test %q unexpected result (-want +got): %v", t.Name(), diff)
 			}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -493,7 +493,7 @@ func TestCreateVirtualService(t *testing.T) {
 				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
 			}
 
-			actualService := createIngress(testIsvc, ingressConfig)
+			actualService := createIngress(testIsvc, ingressConfig, constants.Serverless)
 			if diff := cmp.Diff(tc.expectedService, actualService); diff != "" {
 				t.Errorf("Test %q unexpected status (-want +got): %v", tc.name, diff)
 			}

--- a/python/alibiexplainer/alibiexplainer/__main__.py
+++ b/python/alibiexplainer/alibiexplainer/__main__.py
@@ -43,6 +43,7 @@ def main():
 
     explainer = AlibiExplainer(
         args.model_name,
+        args.protocol,
         args.predictor_host,
         ExplainerMethod(args.command),
         extra,

--- a/python/alibiexplainer/alibiexplainer/explainer.py
+++ b/python/alibiexplainer/alibiexplainer/explainer.py
@@ -19,16 +19,27 @@ from typing import List, Any, Mapping, Union, Dict
 
 import kserve
 import numpy as np
+import struct
 from alibiexplainer.anchor_images import AnchorImages
 from alibiexplainer.anchor_tabular import AnchorTabular
 from alibiexplainer.anchor_text import AnchorText
 from alibiexplainer.explainer_wrapper import ExplainerWrapper
+from kserve.model import PredictorProtocol
+from tritonclient.grpc import service_pb2 as pb
 
 import nest_asyncio
 nest_asyncio.apply()
 
 logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
 
+def deserialize_bytes_tensor(encoded_tensor):
+    strs = list()
+    offset = 0
+    while offset < len(encoded_tensor):
+        val = struct.unpack_from("<f", encoded_tensor, offset)[0]
+        offset += 4
+        strs.append(val)
+    return np.array(strs, dtype=np.float32)
 
 class ExplainerMethod(Enum):
     anchor_tabular = "AnchorTabular"
@@ -41,14 +52,16 @@ class ExplainerMethod(Enum):
 
 class AlibiExplainer(kserve.Model):
     def __init__(  # pylint:disable=too-many-arguments
-            self,
-            name: str,
-            predictor_host: str,
-            method: ExplainerMethod,
-            config: Mapping,
-            explainer: object = None,
+        self,
+        name: str,
+        protocol: str,
+        predictor_host: str,
+        method: ExplainerMethod,
+        config: Mapping,
+        explainer: object = None,
     ):
         super().__init__(name)
+        self.protocol = protocol
         self.predictor_host = predictor_host
         logging.info("Predict URL set to %s", self.predictor_host)
         self.method = method
@@ -74,9 +87,50 @@ class AlibiExplainer(kserve.Model):
                 instances.append(req_data.tolist())
             else:
                 instances.append(req_data)
+        shape = np.shape(instances)
         loop = asyncio.get_running_loop()  # type: ignore
-        resp = loop.run_until_complete(self.predict({"instances": instances}))
-        return np.array(resp["predictions"])
+        
+        # Prepare the request beased on the predictor protocol
+        if self.protocol == PredictorProtocol.GRPC_V2.value:
+            data = np.array(instances, dtype=np.float32).flatten()
+            tensor_contents = pb.InferTensorContents(fp32_contents=data)
+            inputs = pb.ModelInferRequest().InferInputTensor(
+                    name="input_1",
+                    shape=list(shape),
+                    datatype="FP32",
+                    contents=tensor_contents
+            )
+            predict_req = pb.ModelInferRequest(model_name=self.name, inputs=[inputs])
+        elif self.protocol == PredictorProtocol.REST_V2.value:
+            predict_req = { 
+                "inputs": [
+                    {
+                        "name": "input_1",
+                        "shape": list(shape),
+                        "datatype": "FP32",
+                        "data": instances
+                    }
+                ]
+            }
+        else:
+            predict_req = {"instances": instances}
+
+        resp = loop.run_until_complete(self.predict(predict_req))
+ 
+        # Process the request beased on the predictor protocol
+        if self.protocol == PredictorProtocol.GRPC_V2.value:
+            shape = []
+            for value in resp.outputs[0].shape:
+                shape.append(value)
+            rst = deserialize_bytes_tensor(resp.raw_output_contents[0])
+            outputs=np.resize(rst, shape)
+        elif self.protocol == PredictorProtocol.REST_V2.value:
+            outputs_shape = resp["outputs"][0]["shape"]
+            outputs = np.reshape(np.array(resp["outputs"][0]["data"]), outputs_shape)
+        else:
+            outputs = np.array(resp["predictions"])
+
+        return outputs
 
     def explain(self, payload: Dict, headers: Dict[str, str] = None) -> Any:
         if (
@@ -90,3 +144,4 @@ class AlibiExplainer(kserve.Model):
             return json.loads(explanationAsJsonStr)
 
         raise NotImplementedError
+

--- a/python/alibiexplainer/alibiexplainer/parser.py
+++ b/python/alibiexplainer/alibiexplainer/parser.py
@@ -155,7 +155,7 @@ def parse_args(sys_args):
         "--predictor_host", help="The host for the predictor", required=True
     )
     parser.add_argument(
-        "--protocol", default=DEFAULT_PREDICTOR_PROTOCOL, help="The protocol for the predictor", required=False 
+        "--protocol", default=DEFAULT_PREDICTOR_PROTOCOL, help="The protocol for the predictor", required=False
     )
     parser.add_argument(
         "--storage_uri",

--- a/python/alibiexplainer/alibiexplainer/parser.py
+++ b/python/alibiexplainer/alibiexplainer/parser.py
@@ -22,6 +22,7 @@ logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
 
 DEFAULT_EXPLAINER_NAME = "explainer"
 ENV_STORAGE_URI = "STORAGE_URI"
+DEFAULT_PREDICTOR_PROTOCOL = "v1"
 
 
 class GroupedAction(argparse.Action):  # pylint:disable=too-few-public-methods
@@ -152,6 +153,9 @@ def parse_args(sys_args):
     )
     parser.add_argument(
         "--predictor_host", help="The host for the predictor", required=True
+    )
+    parser.add_argument(
+        "--protocol", default=DEFAULT_PREDICTOR_PROTOCOL, help="The protocol for the predictor", required=False 
     )
     parser.add_argument(
         "--storage_uri",


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently explainers don't work when the inference service deploymentMode is ModelMesh. This PR enables KServe explainers to work with ModelMesh.

**Which issue(s) this PR fixes**:
Fixes #2388

**Type of changes**
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**Feature/Issue validation/testing**:
The alibi cifar10 explainer example is updated with ModelMesh annotation and used to validate the changes.

**Special notes for your reviewer**:
1. The controllers are changed to wait for predictor status and provide predictor protocol for explainers to adjust payloads and innovation
2. Ingress reconciler is updated to bypass predictor route when deploymentMode is ModelMesh
3. Alibi explainer is enhanced with logic to handle additional predictor protocols, REST v2 and gRPC
4. AIX, AIF, ART are unchanged since these don't use framework based servingtimes for predictors, not suitable for ModelMesh
5. The default triton server in ModelMesh is not configured to support batch size > 1. Manual configuration (max-batch-size>=100) is needed to make the alibi cifar10 explainer to work. 

**Release note**:
```
KServe explainers are now enabled to work with ModelMesh. Please note the Triton server in ModelMesh has to be configured with max-batch-size=100 or more for the Alibi cifar10 explainer to work.
```
