### PR TITLE
adding prometheus port configs for aggregating metrics in queue proxy

### DIFF
--- a/config/runtimes/kserve-lgbserver.yaml
+++ b/config/runtimes/kserve-lgbserver.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-lgbserver
 spec:
+  annotations:
+    prometheus.kserve.io/port: '8080'
   supportedModelFormats:
     - name: lightgbm
       version: "2"

--- a/config/runtimes/kserve-lgbserver.yaml
+++ b/config/runtimes/kserve-lgbserver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   annotations:
     prometheus.kserve.io/port: '8080'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: lightgbm
       version: "2"

--- a/config/runtimes/kserve-mlserver.yaml
+++ b/config/runtimes/kserve-mlserver.yaml
@@ -4,7 +4,9 @@ metadata:
   name: kserve-mlserver
 spec:
   annotations:
+    # mlserver version 1.1.0 uses port 8082 as default instead of 8080.
     prometheus.kserve.io/port: '8080'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: sklearn
       version: "0"

--- a/config/runtimes/kserve-mlserver.yaml
+++ b/config/runtimes/kserve-mlserver.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-mlserver
 spec:
+  annotations:
+    prometheus.kserve.io/port: '8080'
   supportedModelFormats:
     - name: sklearn
       version: "0"

--- a/config/runtimes/kserve-paddleserver.yaml
+++ b/config/runtimes/kserve-paddleserver.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-paddleserver
 spec:
+  annotations:
+    prometheus.kserve.io/port: '8080'
   supportedModelFormats:
     - name: paddle
       version: "2"

--- a/config/runtimes/kserve-paddleserver.yaml
+++ b/config/runtimes/kserve-paddleserver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   annotations:
     prometheus.kserve.io/port: '8080'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: paddle
       version: "2"

--- a/config/runtimes/kserve-pmmlserver.yaml
+++ b/config/runtimes/kserve-pmmlserver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   annotations:
     prometheus.kserve.io/port: '8080'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: pmml
       version: "3"

--- a/config/runtimes/kserve-pmmlserver.yaml
+++ b/config/runtimes/kserve-pmmlserver.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-pmmlserver
 spec:
+  annotations:
+    prometheus.kserve.io/port: '8080'
   supportedModelFormats:
     - name: pmml
       version: "3"

--- a/config/runtimes/kserve-sklearnserver.yaml
+++ b/config/runtimes/kserve-sklearnserver.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-sklearnserver
 spec:
+  annotations:
+    prometheus.kserve.io/port: '8080'
   supportedModelFormats:
     - name: sklearn
       version: "1"

--- a/config/runtimes/kserve-sklearnserver.yaml
+++ b/config/runtimes/kserve-sklearnserver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   annotations:
     prometheus.kserve.io/port: '8080'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: sklearn
       version: "1"

--- a/config/runtimes/kserve-tensorflow-serving.yaml
+++ b/config/runtimes/kserve-tensorflow-serving.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kserve-tensorflow-serving
 spec:
   annotations:
-    prometheus.kserve.io/port: '8501'
+    prometheus.kserve.io/port: '8080'
     prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: tensorflow

--- a/config/runtimes/kserve-tensorflow-serving.yaml
+++ b/config/runtimes/kserve-tensorflow-serving.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kserve-tensorflow-serving
 spec:
   annotations:
-    prometheus.kserve.io/port: '9153'
+    prometheus.kserve.io/port: '8080'
   supportedModelFormats:
     - name: tensorflow
       version: "1"

--- a/config/runtimes/kserve-tensorflow-serving.yaml
+++ b/config/runtimes/kserve-tensorflow-serving.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-tensorflow-serving
 spec:
+  annotations:
+    prometheus.kserve.io/port: '9153'
   supportedModelFormats:
     - name: tensorflow
       version: "1"

--- a/config/runtimes/kserve-tensorflow-serving.yaml
+++ b/config/runtimes/kserve-tensorflow-serving.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kserve-tensorflow-serving
 spec:
   annotations:
-    prometheus.kserve.io/port: '8080'
+    prometheus.kserve.io/port: '8501'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: tensorflow
       version: "1"

--- a/config/runtimes/kserve-torchserve.yaml
+++ b/config/runtimes/kserve-torchserve.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-torchserve
 spec:
+  annotations:
+    prometheus.kserve.io/port: '8082'
   supportedModelFormats:
     - name: pytorch
       version: "1"

--- a/config/runtimes/kserve-torchserve.yaml
+++ b/config/runtimes/kserve-torchserve.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   annotations:
     prometheus.kserve.io/port: '8082'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: pytorch
       version: "1"

--- a/config/runtimes/kserve-tritonserver.yaml
+++ b/config/runtimes/kserve-tritonserver.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-tritonserver
 spec:
+  annotations:
+    prometheus.kserve.io/port: '8002'
   supportedModelFormats:
     - name: tensorrt
       version: "8"

--- a/config/runtimes/kserve-tritonserver.yaml
+++ b/config/runtimes/kserve-tritonserver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   annotations:
     prometheus.kserve.io/port: '8002'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: tensorrt
       version: "8"

--- a/config/runtimes/kserve-xgbserver.yaml
+++ b/config/runtimes/kserve-xgbserver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   annotations:
     prometheus.kserve.io/port: '8080'
+    prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: xgboost
       version: "1"

--- a/config/runtimes/kserve-xgbserver.yaml
+++ b/config/runtimes/kserve-xgbserver.yaml
@@ -3,6 +3,8 @@ kind: ClusterServingRuntime
 metadata:
   name: kserve-xgbserver
 spec:
+  annotations:
+    prometheus.kserve.io/port: '8080'
   supportedModelFormats:
     - name: xgboost
       version: "1"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -78,8 +78,13 @@ var (
 	MaxScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/maxScale"
 	RollOutDurationAnnotationKey                = KnativeServingAPIGroupName + "/rollout-duration"
 	EnableMetricAggregation                     = KServeAPIGroupName + "/enable-metric-aggregation"
-	KserveContainerPrometheusPort               = "prometheus.kserve.io/port"
-	SetPrometheusAggregateAnnotation            = KServeAPIGroupName + "/set-prometheus-aggregate-annotation"
+	SetPrometheusAggregateAnnotation            = KServeAPIGroupName + "/enable-prometheus-aggregate-scraping"
+	KserveContainerPrometheusPortKey            = "prometheus.kserve.io/port"
+	KServeContainerPrometheusPathKey            = "prometheus.kserve.io/path"
+	PrometheusPortAnnotationKey                 = "prometheus.io/port"
+	PrometheusPathAnnotationKey                 = "prometheus.io/path"
+	DefaultPrometheusPath                       = "/metrics"
+	QueueProxyAggregatePrometheusMetricsPort    = "9088"
 )
 
 // InferenceService Internal Annotations
@@ -179,11 +184,12 @@ const (
 
 // InferenceService Environment Variables
 const (
-	CustomSpecStorageUriEnvVarKey              = "STORAGE_URI"
-	CustomSpecProtocolEnvVarKey                = "PROTOCOL"
-	CustomSpecMultiModelServerEnvVarKey        = "MULTI_MODEL_SERVER"
-	KServeContainerPrometheusPortEnvVarKey     = "KSERVE_CONTAINER_PROMETHEUS_PORT"
-	QueueProxyAggregatePrometheusPortEnvVarKey = "AGGREGATE_PROMETHEUS_PORT"
+	CustomSpecStorageUriEnvVarKey                     = "STORAGE_URI"
+	CustomSpecProtocolEnvVarKey                       = "PROTOCOL"
+	CustomSpecMultiModelServerEnvVarKey               = "MULTI_MODEL_SERVER"
+	KServeContainerPrometheusMetricsPortEnvVarKey     = "KSERVE_CONTAINER_PROMETHEUS_METRICS_PORT"
+	KServeContainerPrometheusMetricsPathEnvVarKey     = "KSERVE_CONTAINER_PROMETHEUS_METRICS_PATH"
+	QueueProxyAggregatePrometheusMetricsPortEnvVarKey = "AGGREGATE_PROMETHEUS_METRICS_PORT"
 )
 
 type InferenceServiceComponent string

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -77,6 +77,9 @@ var (
 	MinScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/minScale"
 	MaxScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/maxScale"
 	RollOutDurationAnnotationKey                = KnativeServingAPIGroupName + "/rollout-duration"
+	EnableMetricAggregation                     = KServeAPIGroupName + "/enable-metric-aggregation"
+	KserveContainerPrometheusPort               = "prometheus.kserve.io/port"
+	SetPrometheusAggregateAnnotation            = KServeAPIGroupName + "/set-prometheus-aggregate-annotation"
 )
 
 // InferenceService Internal Annotations
@@ -176,9 +179,11 @@ const (
 
 // InferenceService Environment Variables
 const (
-	CustomSpecStorageUriEnvVarKey       = "STORAGE_URI"
-	CustomSpecProtocolEnvVarKey         = "PROTOCOL"
-	CustomSpecMultiModelServerEnvVarKey = "MULTI_MODEL_SERVER"
+	CustomSpecStorageUriEnvVarKey              = "STORAGE_URI"
+	CustomSpecProtocolEnvVarKey                = "PROTOCOL"
+	CustomSpecMultiModelServerEnvVarKey        = "MULTI_MODEL_SERVER"
+	KServeContainerPrometheusPortEnvVarKey     = "KSERVE_CONTAINER_PROMETHEUS_PORT"
+	QueueProxyAggregatePrometheusPortEnvVarKey = "AGGREGATE_PROMETHEUS_PORT"
 )
 
 type InferenceServiceComponent string

--- a/pkg/webhook/admission/pod/metrics_aggregate_injector.go
+++ b/pkg/webhook/admission/pod/metrics_aggregate_injector.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KServe Authors.
+Copyright 2022 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,13 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const (
-	defaultPrometheusPort          = "8080"
-	PrometheusPortAnnotationKey    = "prometheus.io/port"
-	PrometheusPathAnnotationKey    = "prometheus.io/path"
-	PrometheusPathAnnotationValue  = "/metrics"
-	QueueProxyAggregateMetricsPort = "9088"
-)
+const defaultPrometheusPort = "8080"
 
 // InjectMetricsAggregator looks for the annotations to enable aggregate kserve-container and queue-proxy metrics and
 // if specified, sets port-related EnvVars in queue-proxy and the aggregate prometheus annotation.
@@ -35,24 +29,31 @@ func InjectMetricsAggregator(pod *v1.Pod) error {
 	for i, container := range pod.Spec.Containers {
 		if container.Name == "queue-proxy" {
 			if enableMetricAgg, ok := pod.ObjectMeta.Annotations[constants.EnableMetricAggregation]; ok && enableMetricAgg == "true" {
-				// The kserve-container prometheus port is inherited from the ClusterServingRuntime YAML.
-				// If no port is defined (transformer using python SDK), use the default port for the kserve-container.
+				// The kserve-container prometheus port/path is inherited from the ClusterServingRuntime YAML.
+				// If no port is defined (transformer using python SDK), use the default port/path for the kserve-container.
 				kserveContainerPromPort := defaultPrometheusPort
-				if port, ok := pod.ObjectMeta.Annotations[constants.KserveContainerPrometheusPort]; ok {
+				if port, ok := pod.ObjectMeta.Annotations[constants.KserveContainerPrometheusPortKey]; ok {
 					kserveContainerPromPort = port
 				}
 
-				// The kserveContainerPort is set as an EnvVar in the queue-proxy container
-				// so that it knows which port to scrape from the kserve-container.
-				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.KServeContainerPrometheusPortEnvVarKey, Value: kserveContainerPromPort})
+				kserveContainerPromPath := constants.DefaultPrometheusPath
+				if path, ok := pod.ObjectMeta.Annotations[constants.KServeContainerPrometheusPathKey]; ok {
+					kserveContainerPromPath = path
+				}
+
+				// The kserve container port/path is set as an EnvVar in the queue-proxy container
+				// so that it knows which port/path to scrape from the kserve-container.
+				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.KServeContainerPrometheusMetricsPortEnvVarKey, Value: kserveContainerPromPort})
+				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.KServeContainerPrometheusMetricsPathEnvVarKey, Value: kserveContainerPromPath})
+
 				// Set the port that queue-proxy will use to expose the aggregate metrics.
-				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.QueueProxyAggregatePrometheusPortEnvVarKey, Value: QueueProxyAggregateMetricsPort})
+				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: constants.QueueProxyAggregatePrometheusMetricsPort})
 
 				// If SetPrometheusAggregateAnnotation is true, the pod annotations for prometheus port and path will be set. The scrape annotation is not set,
 				// that is left for the user to configure.
 				if setPromAnnotation, ok := pod.ObjectMeta.Annotations[constants.SetPrometheusAggregateAnnotation]; ok && setPromAnnotation == "true" {
-					pod.ObjectMeta.Annotations[PrometheusPortAnnotationKey] = QueueProxyAggregateMetricsPort
-					pod.ObjectMeta.Annotations[PrometheusPathAnnotationKey] = PrometheusPathAnnotationValue
+					pod.ObjectMeta.Annotations[constants.PrometheusPortAnnotationKey] = constants.QueueProxyAggregatePrometheusMetricsPort
+					pod.ObjectMeta.Annotations[constants.PrometheusPathAnnotationKey] = constants.DefaultPrometheusPath
 				}
 			}
 		}

--- a/pkg/webhook/admission/pod/metrics_aggregate_injector.go
+++ b/pkg/webhook/admission/pod/metrics_aggregate_injector.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"github.com/kserve/kserve/pkg/constants"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	defaultPrometheusPort          = "8080"
+	PrometheusPortAnnotationKey    = "prometheus.io/port"
+	PrometheusPathAnnotationKey    = "prometheus.io/path"
+	PrometheusPathAnnotationValue  = "/metrics"
+	QueueProxyAggregateMetricsPort = "9088"
+)
+
+// InjectMetricsAggregator looks for the annotations to enable aggregate kserve-container and queue-proxy metrics and
+// if specified, sets port-related EnvVars in queue-proxy and the aggregate prometheus annotation.
+func InjectMetricsAggregator(pod *v1.Pod) error {
+	for i, container := range pod.Spec.Containers {
+		if container.Name == "queue-proxy" {
+			if enableMetricAgg, ok := pod.ObjectMeta.Annotations[constants.EnableMetricAggregation]; ok && enableMetricAgg == "true" {
+				// The kserve-container prometheus port is inherited from the ClusterServingRuntime YAML.
+				// If no port is defined (transformer using python SDK), use the default port for the kserve-container.
+				kserveContainerPromPort := defaultPrometheusPort
+				if port, ok := pod.ObjectMeta.Annotations[constants.KserveContainerPrometheusPort]; ok {
+					kserveContainerPromPort = port
+				}
+
+				// The kserveContainerPort is set as an EnvVar in the queue-proxy container
+				// so that it knows which port to scrape from the kserve-container.
+				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.KServeContainerPrometheusPortEnvVarKey, Value: kserveContainerPromPort})
+				// Set the port that queue-proxy will use to expose the aggregate metrics.
+				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.QueueProxyAggregatePrometheusPortEnvVarKey, Value: QueueProxyAggregateMetricsPort})
+
+				// If SetPrometheusAggregateAnnotation is true, the pod annotations for prometheus port and path will be set. The scrape annotation is not set,
+				// that is left for the user to configure.
+				if setPromAnnotation, ok := pod.ObjectMeta.Annotations[constants.SetPrometheusAggregateAnnotation]; ok && setPromAnnotation == "true" {
+					pod.ObjectMeta.Annotations[PrometheusPortAnnotationKey] = QueueProxyAggregateMetricsPort
+					pod.ObjectMeta.Annotations[PrometheusPathAnnotationKey] = PrometheusPathAnnotationValue
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/webhook/admission/pod/metrics_aggregate_injector_test.go
+++ b/pkg/webhook/admission/pod/metrics_aggregate_injector_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pod
+
+import (
+	"github.com/kserve/kserve/pkg/constants"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmp"
+
+	"testing"
+)
+
+const sklearnPrometheusPort = "8080"
+
+func TestInjectMetricsAggregator(t *testing.T) {
+	scenarios := map[string]struct {
+		original *v1.Pod
+		expected *v1.Pod
+	}{
+		"EnableMetricAggTrue": {
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation: "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+						},
+					},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation: "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+							Env: []v1.EnvVar{
+								{Name: constants.KServeContainerPrometheusPortEnvVarKey, Value: sklearnPrometheusPort},
+								{Name: constants.QueueProxyAggregatePrometheusPortEnvVarKey, Value: QueueProxyAggregateMetricsPort},
+							},
+						},
+					},
+				},
+			},
+		},
+		"EnableMetricAggNotSet": {
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+						},
+					},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation: "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+						},
+					},
+				},
+			},
+		},
+		"EnableMetricAggFalse": {
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation: "false",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+						},
+					},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation: "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+						},
+					},
+				},
+			},
+		},
+		"setPromAnnotationTrue": {
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation:          "true",
+						constants.SetPrometheusAggregateAnnotation: "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+						},
+					},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation:          "true",
+						constants.SetPrometheusAggregateAnnotation: "true",
+						PrometheusPortAnnotationKey:                QueueProxyAggregateMetricsPort,
+						PrometheusPathAnnotationKey:                PrometheusPathAnnotationValue,
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+							Env: []v1.EnvVar{
+								{Name: constants.KServeContainerPrometheusPortEnvVarKey, Value: sklearnPrometheusPort},
+								{Name: constants.QueueProxyAggregatePrometheusPortEnvVarKey, Value: QueueProxyAggregateMetricsPort},
+							},
+						},
+					},
+				},
+			},
+		},
+		"SetPromAnnotationFalse": {
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation:          "true",
+						constants.SetPrometheusAggregateAnnotation: "false",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+						},
+					},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.EnableMetricAggregation:          "true",
+						constants.SetPrometheusAggregateAnnotation: "false",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name: "sklearn",
+					},
+						{
+							Name: "queue-proxy",
+							Env: []v1.EnvVar{
+								{Name: constants.KServeContainerPrometheusPortEnvVarKey, Value: sklearnPrometheusPort},
+								{Name: constants.QueueProxyAggregatePrometheusPortEnvVarKey, Value: QueueProxyAggregateMetricsPort},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		err := InjectMetricsAggregator(scenario.original)
+		if err != nil {
+			t.Errorf("Test %q unexpected error %e", name, err)
+		}
+		if diff, _ := kmp.SafeDiff(scenario.expected.Spec, scenario.original.Spec); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}

--- a/pkg/webhook/admission/pod/metrics_aggregate_injector_test.go
+++ b/pkg/webhook/admission/pod/metrics_aggregate_injector_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KServe Authors.
+Copyright 2022 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -65,8 +65,9 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						{
 							Name: "queue-proxy",
 							Env: []v1.EnvVar{
-								{Name: constants.KServeContainerPrometheusPortEnvVarKey, Value: sklearnPrometheusPort},
-								{Name: constants.QueueProxyAggregatePrometheusPortEnvVarKey, Value: QueueProxyAggregateMetricsPort},
+								{Name: constants.KServeContainerPrometheusMetricsPortEnvVarKey, Value: sklearnPrometheusPort},
+								{Name: constants.KServeContainerPrometheusMetricsPathEnvVarKey, Value: constants.DefaultPrometheusPath},
+								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: constants.QueueProxyAggregatePrometheusMetricsPort},
 							},
 						},
 					},
@@ -173,8 +174,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 					Annotations: map[string]string{
 						constants.EnableMetricAggregation:          "true",
 						constants.SetPrometheusAggregateAnnotation: "true",
-						PrometheusPortAnnotationKey:                QueueProxyAggregateMetricsPort,
-						PrometheusPathAnnotationKey:                PrometheusPathAnnotationValue,
+						constants.PrometheusPortAnnotationKey:      constants.QueueProxyAggregatePrometheusMetricsPort,
+						constants.PrometheusPathAnnotationKey:      constants.DefaultPrometheusPath,
 					},
 				},
 				Spec: v1.PodSpec{
@@ -184,8 +185,9 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						{
 							Name: "queue-proxy",
 							Env: []v1.EnvVar{
-								{Name: constants.KServeContainerPrometheusPortEnvVarKey, Value: sklearnPrometheusPort},
-								{Name: constants.QueueProxyAggregatePrometheusPortEnvVarKey, Value: QueueProxyAggregateMetricsPort},
+								{Name: constants.KServeContainerPrometheusMetricsPortEnvVarKey, Value: sklearnPrometheusPort},
+								{Name: constants.KServeContainerPrometheusMetricsPathEnvVarKey, Value: constants.DefaultPrometheusPath},
+								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: constants.QueueProxyAggregatePrometheusMetricsPort},
 							},
 						},
 					},
@@ -228,8 +230,9 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						{
 							Name: "queue-proxy",
 							Env: []v1.EnvVar{
-								{Name: constants.KServeContainerPrometheusPortEnvVarKey, Value: sklearnPrometheusPort},
-								{Name: constants.QueueProxyAggregatePrometheusPortEnvVarKey, Value: QueueProxyAggregateMetricsPort},
+								{Name: constants.KServeContainerPrometheusMetricsPortEnvVarKey, Value: sklearnPrometheusPort},
+								{Name: constants.KServeContainerPrometheusMetricsPathEnvVarKey, Value: constants.DefaultPrometheusPath},
+								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: constants.QueueProxyAggregatePrometheusMetricsPort},
 							},
 						},
 					},

--- a/pkg/webhook/admission/pod/mutator.go
+++ b/pkg/webhook/admission/pod/mutator.go
@@ -115,6 +115,7 @@ func (mutator *Mutator) mutate(pod *v1.Pod, configMap *v1.ConfigMap) error {
 		InjectGKEAcceleratorSelector,
 		storageInitializer.InjectStorageInitializer,
 		agentInjector.InjectAgent,
+		InjectMetricsAggregator,
 	}
 
 	for _, mutator := range mutators {


### PR DESCRIPTION
Signed-off-by: alexagriffith <agriffith50@bloomberg.net>

**What this PR does / why we need it**:

This PR follows https://github.com/kserve/kserve/pull/2425 where prometheus metrics were added in python sdk. 
This PR is the first of two that will allow the queue proxy to scrape metrics from the kserve-container. The reason this is needed is because of the limitations of knative only being able to scrape one port per pod. The end goal is to extend queue-proxy so that it scrapes metrics from kserve-container and aggregates them/exposes them on one port. A PoC for this already exists and. I am using it to test (this will be next PR). 

This PR's goal is to pass the kserve-container prometheus port into the queue-proxy so that queue-proxy can use it to scrape metrics and aggregate them. To do this, a new mutator is added. 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Unit test
- [x] Deployed each model and checked pod yaml and configs 

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
