### PR TITLE
Fix failure to create gRPC isvc when specifying multiple ContainerPorts

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -58,36 +58,38 @@ func NewServiceReconciler(client client.Client,
 
 func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec) *corev1.Service {
-	servicePorts := []corev1.ServicePort{}
-	if len(podSpec.Containers) != 0 && len(podSpec.Containers[0].Ports) != 0 {
-		for _, port := range podSpec.Containers[0].Ports {
-			var servicePort corev1.ServicePort
+	var servicePorts []corev1.ServicePort
+	if len(podSpec.Containers) != 0 {
+		if len(podSpec.Containers[0].Ports) > 0 {
+			for _, port := range podSpec.Containers[0].Ports {
+				var servicePort corev1.ServicePort
 
-			if port.Protocol == "" {
-				port.Protocol = corev1.ProtocolTCP
+				if port.Protocol == "" {
+					port.Protocol = corev1.ProtocolTCP
+				}
+				servicePort = corev1.ServicePort{
+					Name: port.Name,
+					Port: port.ContainerPort,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: port.ContainerPort,
+					},
+					Protocol: port.Protocol,
+				}
+				servicePorts = append(servicePorts, servicePort)
 			}
-			servicePort = corev1.ServicePort{
-				Name: port.Name,
-				Port: port.ContainerPort,
+		} else {
+			port, _ := strconv.Atoi(constants.InferenceServiceDefaultHttpPort)
+			servicePorts = append(servicePorts, corev1.ServicePort{
+				Name: componentMeta.Name,
+				Port: constants.CommonDefaultHttpPort,
 				TargetPort: intstr.IntOrString{
 					Type:   intstr.Int,
-					IntVal: port.ContainerPort,
+					IntVal: int32(port),
 				},
-				Protocol: port.Protocol,
-			}
-			servicePorts = append(servicePorts, servicePort)
+				Protocol: corev1.ProtocolTCP,
+			})
 		}
-	} else if len(podSpec.Containers) != 0 && len(podSpec.Containers[0].Ports) == 0 {
-		port, _ := strconv.Atoi(constants.InferenceServiceDefaultHttpPort)
-		servicePorts = append(servicePorts, corev1.ServicePort{
-			Name: componentMeta.Name,
-			Port: constants.CommonDefaultHttpPort,
-			TargetPort: intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: int32(port),
-			},
-			Protocol: corev1.ProtocolTCP,
-		})
 	}
 	if componentExt.Batcher != nil {
 		servicePorts[0].TargetPort = intstr.IntOrString{

--- a/test/e2e/predictor/test_raw_deployment.py
+++ b/test/e2e/predictor/test_raw_deployment.py
@@ -10,9 +10,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import base64
+import json
 import os
 from kubernetes import client
+from kubernetes.client import (
+    V1ResourceRequirements,
+    V1Container,
+    V1ContainerPort,
+)
 from kserve import (
     constants,
     KServeClient,
@@ -23,10 +29,9 @@ from kserve import (
     V1beta1ModelSpec,
     V1beta1ModelFormat,
 )
-from kubernetes.client import V1ResourceRequirements
 import pytest
 
-from ..common.utils import KSERVE_TEST_NAMESPACE
+from ..common.utils import KSERVE_TEST_NAMESPACE, predict_grpc
 from ..common.utils import predict
 
 api_version = constants.KSERVE_V1BETA1
@@ -102,4 +107,73 @@ def test_raw_deployment_runtime_kserve():
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
     res = predict(service_name, "./data/iris_input.json")
     assert res["predictions"] == [1, 1]
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+
+@pytest.mark.grpc
+def test_isvc_with_multiple_containerport():
+    service_name = "custom-model-grpc"
+    model_name = "custom-model"
+
+    predictor = V1beta1PredictorSpec(
+        containers=[
+            V1Container(
+                name="kserve-container",
+                image="kserve/custom-model-grpc:"
+                      + os.environ.get("GITHUB_SHA"),
+                resources=V1ResourceRequirements(
+                    requests={"cpu": "50m", "memory": "128Mi"},
+                    limits={"cpu": "100m", "memory": "1Gi"}),
+                ports=[
+                    V1ContainerPort(
+                        container_port=8081,
+                        name="grpc-port",
+                        protocol="TCP"
+                    ),
+                    V1ContainerPort(
+                        container_port=8080,
+                        name="http-port",
+                        protocol="TCP"
+                    )
+                ]
+            )
+
+        ]
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND,
+        metadata=client.V1ObjectMeta(
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE,
+            annotations={'serving.kserve.io/deploymentMode': 'RawDeployment'}
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
+    kserve_client.create(isvc)
+    kserve_client.wait_isvc_ready(
+        service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+    with open("./data/custom_model_input.json") as json_file:
+        data = json.load(json_file)
+    payload = [
+        {
+            "name": "input-0",
+            "shape": [],
+            "datatype": "BYTES",
+            "contents": {
+                "bytes_contents": [base64.b64decode(data["instances"][0]["image"]["b64"])]
+            }
+        }
+    ]
+    expected_output = ["14.976", "14.037", "13.966", "12.252", "12.086"]
+    grpc_response = predict_grpc(service_name=service_name,
+                                 payload=payload, model_name=model_name)
+    fields = grpc_response.outputs[0].contents.ListFields()
+    _, field_value = fields[0]
+    grpc_output = ['%.3f' % value for value in list(field_value)]
+    assert grpc_output == expected_output
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_raw_deployment.py
+++ b/test/e2e/predictor/test_raw_deployment.py
@@ -111,7 +111,7 @@ def test_raw_deployment_runtime_kserve():
 
 
 @pytest.mark.grpc
-def test_isvc_with_multiple_containerport():
+def test_isvc_with_multiple_container_port():
     service_name = "custom-model-grpc"
     model_name = "custom-model"
 
@@ -125,17 +125,17 @@ def test_isvc_with_multiple_containerport():
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"}),
                 ports=[
-                    V1ContainerPort(
-                        container_port=8081,
-                        name="grpc-port",
-                        protocol="TCP"
-                    ),
-                    V1ContainerPort(
-                        container_port=8080,
-                        name="http-port",
-                        protocol="TCP"
-                    )
-                ]
+                        V1ContainerPort(
+                            container_port=8081,
+                            name="grpc-port",
+                            protocol="TCP"
+                        ),
+                        V1ContainerPort(
+                            container_port=8080,
+                            name="http-port",
+                            protocol="TCP"
+                        )
+                      ]
             )
 
         ]


### PR DESCRIPTION

Signed-off-by: Andrews Arokiam <andrews.arokiam@ideas2it.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Made changes to copy ports in service reconciler to target service.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2376 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Feature/Issue validation/testing**:

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
