### PR TITLE
Make webhook port number configurable

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -64,7 +64,9 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var webhookPort int
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "The port that the webhook server binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for kserve controller manager. "+
 			"Enabling this will ensure there is only one active kserve controller manager.")
@@ -84,7 +86,7 @@ func main() {
 	log.Info("Setting up manager")
 	mgr, err := manager.New(cfg, manager.Options{
 		MetricsBindAddress: metricsAddr,
-		Port:               9443,
+		Port:               webhookPort,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   LeaderLockName,
 	})

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,6 +55,34 @@ const (
 	LeaderLockName = "kserve-controller-manager-leader-lock"
 )
 
+// Options defines the program configurable options that may be passed on the command line.
+type Options struct {
+	metricsAddr          string
+	webhookPort          int
+	enableLeaderElection bool
+}
+
+// DefaultOptions returns the default values for the program options.
+func DefaultOptions() Options {
+	return Options{
+		metricsAddr:          ":8080",
+		webhookPort:          9443,
+		enableLeaderElection: false,
+	}
+}
+
+// GetOptions parses the program flags and returns them as Options.
+func GetOptions() Options {
+	opts := DefaultOptions()
+	flag.StringVar(&opts.metricsAddr, "metrics-addr", opts.metricsAddr, "The address the metric endpoint binds to.")
+	flag.IntVar(&opts.webhookPort, "webhook-port", opts.webhookPort, "The port that the webhook server binds to.")
+	flag.BoolVar(&opts.enableLeaderElection, "leader-elect", opts.enableLeaderElection,
+		"Enable leader election for kserve controller manager. "+
+			"Enabling this will ensure there is only one active kserve controller manager.")
+	flag.Parse()
+	return opts
+}
+
 func init() {
 	// Allow unknown fields in Istio API client for backwards compatibility if cluster has existing vs with deprecated fields.
 	istio_networking.VirtualServiceUnmarshaler.AllowUnknownFields = true
@@ -62,15 +90,6 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var webhookPort int
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "The port that the webhook server binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for kserve controller manager. "+
-			"Enabling this will ensure there is only one active kserve controller manager.")
-	flag.Parse()
 	logf.SetLogger(zap.New())
 	log := logf.Log.WithName("entrypoint")
 
@@ -84,10 +103,11 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	log.Info("Setting up manager")
+	options := GetOptions()
 	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: metricsAddr,
-		Port:               webhookPort,
-		LeaderElection:     enableLeaderElection,
+		MetricsBindAddress: options.metricsAddr,
+		Port:               options.webhookPort,
+		LeaderElection:     options.enableLeaderElection,
 		LeaderElectionID:   LeaderLockName,
 	})
 	if err != nil {

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOptions(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	defaults := DefaultOptions()
+	cases := []struct {
+		Name            string
+		Args            []string
+		ExpectedOptions Options
+	}{
+		{"defaults", []string{}, defaults},
+		{"withWebhookPort", []string{"-webhook-port=8000"},
+			Options{
+				metricsAddr:          defaults.metricsAddr,
+				webhookPort:          8000,
+				enableLeaderElection: defaults.enableLeaderElection,
+			}},
+		{"withMetricsAddr", []string{"-metrics-addr=:9090"},
+			Options{
+				metricsAddr:          ":9090",
+				webhookPort:          defaults.webhookPort,
+				enableLeaderElection: defaults.enableLeaderElection,
+			}},
+		{"withEnableLeaderElection", []string{"-leader-elect=true"},
+			Options{
+				metricsAddr:          defaults.metricsAddr,
+				webhookPort:          defaults.webhookPort,
+				enableLeaderElection: true,
+			}},
+		{"withSeveral", []string{"-webhook-port=8000", "-leader-elect=true"},
+			Options{
+				metricsAddr:          defaults.metricsAddr,
+				webhookPort:          8000,
+				enableLeaderElection: true,
+			}},
+		{"withAll", []string{"-metrics-addr=:9090", "-webhook-port=8000", "-leader-elect=true"},
+			Options{
+				metricsAddr:          ":9090",
+				webhookPort:          8000,
+				enableLeaderElection: true,
+			}},
+	}
+
+	for _, tc := range cases {
+		flag.CommandLine = flag.NewFlagSet(tc.Name, flag.ExitOnError)
+		os.Args = append([]string{tc.Name}, tc.Args...)
+		assert.Equal(t, tc.ExpectedOptions, GetOptions())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Previously the webhook listened on a fixed port, 9443, which can clash with other services when the webhook is run on the host network in Kubernetes, which is required when using some CNI implementations, notably Calico on EKS [1].

Enable configuration of the webhook listen port via the program flags.

[1] https://projectcalico.docs.tigera.io/getting-started/kubernetes/managed-public-cloud/eks#install-eks-with-calico-networking

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] `make test` was run to ensure that this causes no regression.


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The port on which the webhook server listens may be configured via the program flags.
```
