### PR TITLE
Make aix use default image only if no image is provided

### DIFF
--- a/pkg/apis/serving/v1beta1/explainer_aix360.go
+++ b/pkg/apis/serving/v1beta1/explainer_aix360.go
@@ -83,12 +83,13 @@ func (s *AIXExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *
 		args = append(args, s.Config[k])
 	}
 	args = append(args, s.Args...)
-	return &v1.Container{
-		Image:     config.Explainers.AIXExplainer.ContainerImage + ":" + *s.RuntimeVersion,
-		Name:      constants.InferenceServiceContainerName,
-		Resources: s.Resources,
-		Args:      args,
+
+	if s.Container.Image == "" {
+		s.Container.Image = config.Explainers.AIXExplainer.ContainerImage + ":" + *s.RuntimeVersion
 	}
+	s.Container.Name = constants.InferenceServiceContainerName
+	s.Container.Args = append(args, s.Container.Args...)
+	return &s.Container
 }
 
 func (s *AIXExplainerSpec) Default(config *InferenceServicesConfig) {

--- a/pkg/apis/serving/v1beta1/explainer_art.go
+++ b/pkg/apis/serving/v1beta1/explainer_art.go
@@ -81,12 +81,13 @@ func (s *ARTExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *
 		args = append(args, s.Config[k])
 	}
 	args = append(args, s.Args...)
-	return &v1.Container{
-		Image:     config.Explainers.ARTExplainer.ContainerImage + ":" + *s.RuntimeVersion,
-		Name:      constants.InferenceServiceContainerName,
-		Resources: s.Resources,
-		Args:      args,
+
+	if s.Container.Image == "" {
+		s.Container.Image = config.Explainers.ARTExplainer.ContainerImage + ":" + *s.RuntimeVersion
 	}
+	s.Container.Name = constants.InferenceServiceContainerName
+	s.Container.Args = append(args, s.Container.Args...)
+	return &s.Container
 }
 
 func (s *ARTExplainerSpec) Default(config *InferenceServicesConfig) {


### PR DESCRIPTION
Signed-off-by: Andrews Arokiam <andrews.arokiam@ideas2it.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR ensures AIX uses the provided image if specified and only uses default image only if none specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2281 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
