### PR TITLE
Remove "default" suffix from generated component name - updated

### DIFF
--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -57,7 +57,7 @@ var (
 type ComponentImplementation interface {
 	Default(config *InferenceServicesConfig)
 	Validate() error
-	GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container
+	GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container
 	GetStorageUri() *string
 	GetStorageSpec() *StorageSpec
 	GetProtocol() constants.InferenceServiceProtocol

--- a/pkg/apis/serving/v1beta1/explainer_aix360.go
+++ b/pkg/apis/serving/v1beta1/explainer_aix360.go
@@ -49,7 +49,8 @@ func (s *AIXExplainerSpec) GetResourceRequirements() *v1.ResourceRequirements {
 	return &s.Resources
 }
 
-func (s *AIXExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (s *AIXExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	var args = []string{
 		constants.ArgumentModelName,
 		metadata.Name,
@@ -58,8 +59,7 @@ func (s *AIXExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentPredictorHost) {
 		args = append(args, constants.ArgumentPredictorHost,
-			fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace))
-
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace))
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentWorkers) {
 		if extensions.ContainerConcurrency != nil {

--- a/pkg/apis/serving/v1beta1/explainer_aix360_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_aix360_test.go
@@ -119,7 +119,8 @@ func TestCreateAIXExplainerContainer(t *testing.T) {
 	}
 
 	// Test Create with config
-	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config)
+	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config,
+		"someName-predictor-default")
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
 
@@ -190,7 +191,8 @@ func TestCreateAIXExplainerContainerWithConfig(t *testing.T) {
 	}
 
 	// Test Create with config
-	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config)
+	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config,
+		"someName-predictor-default")
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
 

--- a/pkg/apis/serving/v1beta1/explainer_alibi.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi.go
@@ -61,14 +61,15 @@ func (s *AlibiExplainerSpec) GetResourceRequirements() *v1.ResourceRequirements 
 	return &s.Resources
 }
 
-func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (s *AlibiExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	var args = []string{
 		constants.ArgumentModelName, metadata.Name,
 		constants.ArgumentHttpPort, constants.InferenceServiceDefaultHttpPort,
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentPredictorHost) {
 		args = append(args, constants.ArgumentPredictorHost,
-			fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace))
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace))
 
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentWorkers) {

--- a/pkg/apis/serving/v1beta1/explainer_alibi_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi_test.go
@@ -348,7 +348,8 @@ func TestCreateAlibiModelServingContainer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			explainer := scenario.isvc.Spec.Explainer.GetImplementation()
 			explainer.Default(&config)
-			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec, &config)
+			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec,
+				&config, constants.DefaultPredictorServiceName("someName"))
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/explainer_art.go
+++ b/pkg/apis/serving/v1beta1/explainer_art.go
@@ -49,14 +49,15 @@ func (s *ARTExplainerSpec) GetResourceRequirements() *v1.ResourceRequirements {
 	return &s.Resources
 }
 
-func (s *ARTExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (s *ARTExplainerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	var args = []string{
 		constants.ArgumentModelName, metadata.Name,
 		constants.ArgumentHttpPort, constants.InferenceServiceDefaultHttpPort,
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentPredictorHost) {
 		args = append(args, constants.ArgumentPredictorHost,
-			fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace))
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace))
 
 	}
 	if !utils.IncludesArg(s.Container.Args, constants.ArgumentWorkers) {

--- a/pkg/apis/serving/v1beta1/explainer_art_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_art_test.go
@@ -119,7 +119,8 @@ func TestCreateARTExplainerContainer(t *testing.T) {
 	}
 
 	// Test Create with config
-	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config)
+	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config,
+		"someName-predictor-default")
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
 
@@ -190,7 +191,8 @@ func TestCreateARTExplainerContainerWithConfig(t *testing.T) {
 	}
 
 	// Test Create with config
-	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec, config)
+	container := spec.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &ComponentExtensionSpec,
+		config, "someName-predictor-default")
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
 

--- a/pkg/apis/serving/v1beta1/explainer_custom.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/kserve/kserve/pkg/constants"
@@ -67,7 +68,8 @@ func (c *CustomExplainer) GetStorageSpec() *StorageSpec {
 }
 
 // GetContainer transforms the resource into a container spec
-func (c *CustomExplainer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (c *CustomExplainer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	container := &c.Containers[0]
 	if !utils.IncludesArg(container.Args, constants.ArgumentModelName) {
 		container.Args = append(container.Args, []string{
@@ -78,7 +80,7 @@ func (c *CustomExplainer) GetContainer(metadata metav1.ObjectMeta, extensions *C
 	if !utils.IncludesArg(container.Args, constants.ArgumentPredictorHost) {
 		container.Args = append(container.Args, []string{
 			constants.ArgumentPredictorHost,
-			constants.PredictorURL(metadata, false),
+			fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace),
 		}...)
 	}
 	container.Args = append(container.Args, []string{

--- a/pkg/apis/serving/v1beta1/explainer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom_test.go
@@ -291,7 +291,8 @@ func TestCreateCustomExplainerContainer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			explainer := scenario.isvc.Spec.Explainer.GetImplementation()
 			explainer.Default(&config)
-			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec, &config)
+			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec,
+				&config, constants.DefaultPredictorServiceName("someName"))
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -84,8 +84,9 @@ func (c *CustomPredictor) GetStorageSpec() *StorageSpec {
 	return nil
 }
 
-// GetContainer transforms the resource into a container spec
-func (c *CustomPredictor) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+// GetContainers transforms the resource into a container spec
+func (c *CustomPredictor) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	return &c.Containers[0]
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm.go
@@ -39,7 +39,7 @@ func (x *LightGBMSpec) Default(config *InferenceServicesConfig) {
 
 }
 
-func (x *LightGBMSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (x *LightGBMSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &x.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_model.go
+++ b/pkg/apis/serving/v1beta1/predictor_model.go
@@ -59,7 +59,7 @@ var (
 
 func (m *ModelSpec) Default(config *InferenceServicesConfig) {}
 
-func (m *ModelSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (m *ModelSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &m.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -61,7 +61,7 @@ func (o *ONNXRuntimeSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainers transforms the resource into a container spec
-func (o *ONNXRuntimeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (o *ONNXRuntimeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &o.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_paddle.go
+++ b/pkg/apis/serving/v1beta1/predictor_paddle.go
@@ -32,7 +32,7 @@ func (p *PaddleServerSpec) Default(config *InferenceServicesConfig) {
 	setResourceRequirementDefaults(&p.Resources)
 }
 
-func (p *PaddleServerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (p *PaddleServerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &p.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_pmml.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml.go
@@ -48,7 +48,7 @@ func (p *PMMLSpec) Default(config *InferenceServicesConfig) {
 	setResourceRequirementDefaults(&p.Resources)
 }
 
-func (p *PMMLSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (p *PMMLSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &p.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_sklearn.go
+++ b/pkg/apis/serving/v1beta1/predictor_sklearn.go
@@ -105,7 +105,7 @@ func (k *SKLearnSpec) getDefaultsV2(metadata metav1.ObjectMeta) []v1.EnvVar {
 	return vars
 }
 
-func (k *SKLearnSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (k *SKLearnSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &k.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_tfserving.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving.go
@@ -18,9 +18,10 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/utils"
@@ -75,7 +76,7 @@ func (t *TFServingSpec) Default(config *InferenceServicesConfig) {
 	setResourceRequirementDefaults(&t.Resources)
 }
 
-func (t *TFServingSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (t *TFServingSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &t.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_torchserve.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve.go
@@ -18,9 +18,10 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/utils"
@@ -77,7 +78,7 @@ func (t *TorchServeSpec) Default(config *InferenceServicesConfig) {
 	setResourceRequirementDefaults(&t.Resources)
 }
 
-func (t *TorchServeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (t *TorchServeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &t.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_triton.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton.go
@@ -38,7 +38,7 @@ func (t *TritonSpec) Default(config *InferenceServicesConfig) {
 	setResourceRequirementDefaults(&t.Resources)
 }
 
-func (t *TritonSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (t *TritonSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &t.Container
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_xgboost.go
+++ b/pkg/apis/serving/v1beta1/predictor_xgboost.go
@@ -106,7 +106,7 @@ func (x *XGBoostSpec) getDefaultsV2(metadata metav1.ObjectMeta) []v1.EnvVar {
 	return vars
 }
 
-func (x *XGBoostSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (x *XGBoostSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig, predictorHost ...string) *v1.Container {
 	return &x.Container
 }
 

--- a/pkg/apis/serving/v1beta1/transformer_custom.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom.go
@@ -74,10 +74,10 @@ func (c *CustomTransformer) GetStorageSpec() *StorageSpec {
 }
 
 // GetContainers transforms the resource into a container spec
-func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
+	predictorHost ...string) *v1.Container {
 	container := &c.Containers[0]
-	argumentPredictorHost := fmt.Sprintf("%s.%s", constants.DefaultPredictorServiceName(metadata.Name), metadata.Namespace)
-
+	argumentPredictorHost := fmt.Sprintf("%s.%s", predictorHost[0], metadata.Namespace)
 	deploymentMode, ok := metadata.Annotations[constants.DeploymentMode]
 
 	if ok && (deploymentMode == string(constants.ModelMeshDeployment)) {

--- a/pkg/apis/serving/v1beta1/transformer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom_test.go
@@ -360,8 +360,8 @@ func TestCreateTransformerContainer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			transformer := scenario.isvc.Spec.Transformer.GetImplementation()
 			transformer.Default(nil)
-			res := transformer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"},
-				&scenario.isvc.Spec.Transformer.ComponentExtensionSpec, nil)
+			res := transformer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Transformer.ComponentExtensionSpec,
+				nil, constants.DefaultPredictorServiceName("someName"))
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -430,6 +430,10 @@ func DefaultPredictorServiceName(name string) string {
 	return name + "-" + string(Predictor) + "-" + InferenceServiceDefault
 }
 
+func PredictorServiceName(name string) string {
+	return name + "-" + string(Predictor)
+}
+
 func CanaryPredictorServiceName(name string) string {
 	return name + "-" + string(Predictor) + "-" + InferenceServiceCanary
 }
@@ -438,12 +442,20 @@ func DefaultExplainerServiceName(name string) string {
 	return name + "-" + string(Explainer) + "-" + InferenceServiceDefault
 }
 
+func ExplainerServiceName(name string) string {
+	return name + "-" + string(Explainer)
+}
+
 func CanaryExplainerServiceName(name string) string {
 	return name + "-" + string(Explainer) + "-" + InferenceServiceCanary
 }
 
 func DefaultTransformerServiceName(name string) string {
 	return name + "-" + string(Transformer) + "-" + InferenceServiceDefault
+}
+
+func TransformerServiceName(name string) string {
+	return name + "-" + string(Transformer)
 }
 
 func CanaryTransformerServiceName(name string) string {

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -74,23 +74,25 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = *sourceURI
 	}
 	addLoggerAnnotations(isvc.Spec.Explainer.Logger, annotations)
-	existing := &knservingv1.Service{}
+
 	explainerName := constants.ExplainerServiceName(isvc.Name)
 	predictorName := constants.PredictorServiceName(isvc.Name)
-	err := e.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultExplainerServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
-	if err == nil {
-		explainerName = constants.DefaultExplainerServiceName(isvc.Name)
-		predictorName = constants.DefaultPredictorServiceName(isvc.Name)
-	}
-
 	if e.deploymentMode == constants.RawDeployment {
 		existing := &v1.Service{}
-		err = e.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultExplainerServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
+		err := e.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultExplainerServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
+		if err == nil {
+			explainerName = constants.DefaultExplainerServiceName(isvc.Name)
+			predictorName = constants.DefaultPredictorServiceName(isvc.Name)
+		}
+	} else {
+		existing := &knservingv1.Service{}
+		err := e.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultExplainerServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
 		if err == nil {
 			explainerName = constants.DefaultExplainerServiceName(isvc.Name)
 			predictorName = constants.DefaultPredictorServiceName(isvc.Name)
 		}
 	}
+
 	objectMeta := metav1.ObjectMeta{
 		Name:      explainerName,
 		Namespace: isvc.Namespace,

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -249,16 +249,16 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = *sourceURI
 	}
 
-	existing := &knservingv1.Service{}
 	predictorName := constants.PredictorServiceName(isvc.Name)
-	err := p.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
-	if err == nil {
-		predictorName = constants.DefaultPredictorServiceName(isvc.Name)
-	}
-
 	if p.deploymentMode == constants.RawDeployment {
 		existing := &v1.Service{}
-		err = p.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
+		err := p.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
+		if err == nil {
+			predictorName = constants.DefaultPredictorServiceName(isvc.Name)
+		}
+	} else {
+		existing := &knservingv1.Service{}
+		err := p.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
 		if err == nil {
 			predictorName = constants.DefaultPredictorServiceName(isvc.Name)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -323,7 +323,7 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 	}
 	statusSpec, _ := isvc.Status.Components[v1beta1.PredictorComponent]
 	if rawDeployment {
-		podLabelValue = constants.GetRawServiceLabel(constants.PredictorServiceName(isvc.ObjectMeta.Name))
+		podLabelValue = constants.GetRawServiceLabel(predictorName)
 	} else {
 		podLabelValue = statusSpec.LatestCreatedRevision
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -80,18 +80,18 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, er
 	addLoggerAnnotations(isvc.Spec.Transformer.Logger, annotations)
 	addBatcherAnnotations(isvc.Spec.Transformer.Batcher, annotations)
 
-	existing := &knservingv1.Service{}
 	transformerName := constants.TransformerServiceName(isvc.Name)
 	predictorName := constants.PredictorServiceName(isvc.Name)
-	err := p.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultTransformerServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
-	if err == nil {
-		transformerName = constants.DefaultTransformerServiceName(isvc.Name)
-		predictorName = constants.DefaultPredictorServiceName(isvc.Name)
-	}
-
 	if p.deploymentMode == constants.RawDeployment {
 		existing := &corev1.Service{}
-		err = p.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultTransformerServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
+		err := p.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultTransformerServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
+		if err == nil {
+			transformerName = constants.DefaultTransformerServiceName(isvc.Name)
+			predictorName = constants.DefaultPredictorServiceName(isvc.Name)
+		}
+	} else {
+		existing := &knservingv1.Service{}
+		err := p.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultTransformerServiceName(isvc.Name), Namespace: isvc.Namespace}, existing)
 		if err == nil {
 			transformerName = constants.DefaultTransformerServiceName(isvc.Name)
 			predictorName = constants.DefaultPredictorServiceName(isvc.Name)

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -167,13 +167,13 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	reconcilers := []components.Component{}
 	if deploymentMode != constants.ModelMeshDeployment {
-		reconcilers = append(reconcilers, components.NewPredictor(r.Client, r.Scheme, isvcConfig))
+		reconcilers = append(reconcilers, components.NewPredictor(r.Client, r.Scheme, isvcConfig, deploymentMode))
 	}
 	if isvc.Spec.Transformer != nil {
-		reconcilers = append(reconcilers, components.NewTransformer(r.Client, r.Scheme, isvcConfig))
+		reconcilers = append(reconcilers, components.NewTransformer(r.Client, r.Scheme, isvcConfig, deploymentMode))
 	}
 	if isvc.Spec.Explainer != nil {
-		reconcilers = append(reconcilers, components.NewExplainer(r.Client, r.Scheme, isvcConfig))
+		reconcilers = append(reconcilers, components.NewExplainer(r.Client, r.Scheme, isvcConfig, deploymentMode))
 	}
 	for _, reconciler := range reconcilers {
 		result, err := reconciler.Reconcile(isvc)

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -180,7 +180,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			actualService := &knservingv1.Service{}
-			predictorServiceKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorServiceKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
 				Should(Succeed())
@@ -301,7 +301,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{
 									Set: map[string]string{
-										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace),
+										"Host": network.GetServiceHostname(constants.PredictorServiceName(serviceKey.Name), serviceKey.Namespace),
 									},
 								},
 							},
@@ -349,9 +349,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: namespace}}
 			var serviceKey = expectedRequest.NamespacedName
 
-			var predictorServiceKey = types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceName),
+			var predictorServiceKey = types.NamespacedName{Name: constants.PredictorServiceName(serviceName),
 				Namespace: namespace}
-			var transformerServiceKey = types.NamespacedName{Name: constants.DefaultTransformerServiceName(serviceName),
+			var transformerServiceKey = types.NamespacedName{Name: constants.TransformerServiceName(serviceName),
 				Namespace: namespace}
 			var transformer = &v1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
@@ -453,10 +453,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			transformerService := &knservingv1.Service{}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), transformerServiceKey, transformerService) }, timeout).
 				Should(gomega.Succeed())
-
 			expectedTransformerService := &knservingv1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      constants.DefaultTransformerServiceName(instance.Name),
+					Name:      constants.TransformerServiceName(instance.Name),
 					Namespace: instance.Namespace,
 				},
 				Spec: knservingv1.ServiceSpec{
@@ -483,7 +482,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 												"--model_name",
 												serviceName,
 												"--predictor_host",
-												constants.DefaultPredictorServiceName(instance.Name) + "." + instance.Namespace,
+												constants.PredictorServiceName(instance.Name) + "." + instance.Namespace,
 												constants.ArgumentHttpPort,
 												constants.InferenceServiceDefaultHttpPort,
 											},
@@ -504,8 +503,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			Expect(cmp.Diff(transformerService.Spec, expectedTransformerService.Spec)).To(gomega.Equal(""))
 
 			// mock update knative service status since knative serving controller is not running in test
-			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
-			transformerUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultTransformerServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.PredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			transformerUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.TransformerServiceName(serviceKey.Name), serviceKey.Namespace, domain))
 
 			// update predictor
 			updatedPredictorService := predictorService.DeepCopy()
@@ -601,9 +600,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: namespace}}
 			var serviceKey = expectedRequest.NamespacedName
 
-			var predictorServiceKey = types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceName),
+			var predictorServiceKey = types.NamespacedName{Name: constants.PredictorServiceName(serviceName),
 				Namespace: namespace}
-			var explainerServiceKey = types.NamespacedName{Name: constants.DefaultExplainerServiceName(serviceName),
+			var explainerServiceKey = types.NamespacedName{Name: constants.ExplainerServiceName(serviceName),
 				Namespace: namespace}
 			var explainer = &v1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
@@ -707,7 +706,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 												constants.ArgumentHttpPort,
 												constants.InferenceServiceDefaultHttpPort,
 												"--predictor_host",
-												constants.DefaultPredictorServiceName(instance.Name) + "." + instance.Namespace,
+												constants.PredictorServiceName(instance.Name) + "." + instance.Namespace,
 												"--storage_uri",
 												"/mnt/models",
 												"AnchorTabular",
@@ -728,8 +727,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			Expect(cmp.Diff(explainerService.Spec, expectedExplainerService.Spec)).To(gomega.Equal(""))
 
 			// mock update knative service status since knative serving controller is not running in test
-			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
-			explainerUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultExplainerServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.PredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			explainerUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.ExplainerServiceName(serviceKey.Name), serviceKey.Namespace, domain))
 
 			// update predictor
 			updatedPredictorService := predictorService.DeepCopy()
@@ -910,12 +909,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			updatedService := &knservingv1.Service{}
-			predictorServiceKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorServiceKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, updatedService) }, timeout).
 				Should(Succeed())
 
-			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.PredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
 			// update predictor status
 			updatedService.Status.LatestCreatedRevisionName = "revision-v1"
 			updatedService.Status.LatestReadyRevisionName = "revision-v1"
@@ -1135,7 +1134,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			serviceName := "svc-with-servingruntime"
 			namespace := "default"
 
-			var predictorServiceKey = types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceName),
+			var predictorServiceKey = types.NamespacedName{Name: constants.PredictorServiceName(serviceName),
 				Namespace: namespace}
 			servingRuntime := &v1alpha1.ServingRuntime{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1739,12 +1738,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout).Should(BeTrue())
 
 			actualService := &knservingv1.Service{}
-			predictorServiceKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceName),
+			predictorServiceKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceName),
 				Namespace: namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
 				Should(Succeed())
 
-			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceName), namespace, domain))
+			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.PredictorServiceName(serviceName), namespace, domain))
 			// update predictor status
 			updatedService := actualService.DeepCopy()
 			updatedService.Status.LatestCreatedRevisionName = serviceName + "-predictor-" + namespace + "-00001"
@@ -1848,12 +1847,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			actualService := &knservingv1.Service{}
-			predictorServiceKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorServiceKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error {
 				return k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
 			}, timeout).Should(Succeed())
-			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.PredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
 			// update predictor
 			updatedService := actualService.DeepCopy()
 			updatedService.Status.LatestCreatedRevisionName = "revision-v1"
@@ -1879,7 +1878,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 			Expect(actualIsvc.Status.URL).To(gomega.Equal(&apis.URL{
 				Scheme: "http",
-				Host:   constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain),
+				Host:   constants.InferenceServiceHostName(constants.PredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain),
 			}))
 			Expect(actualIsvc.Status.Address.URL).To(gomega.Equal(&apis.URL{
 				Scheme: "http",

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -345,7 +345,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 											PathType: &pathType,
 											Backend: netv1.IngressBackend{
 												Service: &netv1.IngressServiceBackend{
-													Name: "raw-foo-predictor-default",
+													Name: "raw-foo-predictor",
 													Port: netv1.ServiceBackendPort{
 														Number: 80,
 													},
@@ -357,7 +357,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							},
 						},
 						{
-							Host: "raw-foo-predictor-default-default.example.com",
+							Host: "raw-foo-predictor-default.example.com",
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -366,7 +366,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 											PathType: &pathType,
 											Backend: netv1.IngressBackend{
 												Service: &netv1.IngressServiceBackend{
-													Name: "raw-foo-predictor-default",
+													Name: "raw-foo-predictor",
 													Port: netv1.ServiceBackendPort{
 														Number: 80,
 													},
@@ -777,7 +777,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 											PathType: &pathType,
 											Backend: netv1.IngressBackend{
 												Service: &netv1.IngressServiceBackend{
-													Name: fmt.Sprintf("%s-predictor-default", serviceName),
+													Name: fmt.Sprintf("%s-predictor", serviceName),
 													Port: netv1.ServiceBackendPort{
 														Number: 80,
 													},
@@ -789,7 +789,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							},
 						},
 						{
-							Host: fmt.Sprintf("%s-predictor-default-default.example.com", serviceName),
+							Host: fmt.Sprintf("%s-predictor-default.example.com", serviceName),
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -798,7 +798,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 											PathType: &pathType,
 											Backend: netv1.IngressBackend{
 												Service: &netv1.IngressServiceBackend{
-													Name: fmt.Sprintf("%s-predictor-default", serviceName),
+													Name: fmt.Sprintf("%s-predictor", serviceName),
 													Port: netv1.ServiceBackendPort{
 														Number: 80,
 													},
@@ -1210,7 +1210,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 											PathType: &pathType,
 											Backend: netv1.IngressBackend{
 												Service: &netv1.IngressServiceBackend{
-													Name: fmt.Sprintf("%s-predictor-default", serviceName),
+													Name: fmt.Sprintf("%s-predictor", serviceName),
 													Port: netv1.ServiceBackendPort{
 														Number: 80,
 													},
@@ -1222,7 +1222,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							},
 						},
 						{
-							Host: fmt.Sprintf("%s-predictor-default.%s.%s", serviceName, serviceKey.Namespace, domain),
+							Host: fmt.Sprintf("%s-predictor.%s.%s", serviceName, serviceKey.Namespace, domain),
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -1231,7 +1231,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 											PathType: &pathType,
 											Backend: netv1.IngressBackend{
 												Service: &netv1.IngressServiceBackend{
-													Name: fmt.Sprintf("%s-predictor-default", serviceName),
+													Name: fmt.Sprintf("%s-predictor", serviceName),
 													Port: netv1.ServiceBackendPort{
 														Number: 80,
 													},

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -19,8 +19,9 @@ package inferenceservice
 import (
 	"context"
 	"fmt"
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"time"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
@@ -178,7 +179,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			actualDeployment := &appsv1.Deployment{}
-			predictorDeploymentKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorDeploymentKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment) }, timeout).
 				Should(Succeed())
@@ -281,7 +282,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 			//check service
 			actualService := &v1.Service{}
-			predictorServiceKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorServiceKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
 				Should(Succeed())
@@ -294,7 +295,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: v1.ServiceSpec{
 					Ports: []v1.ServicePort{
 						{
-							Name:       "raw-foo-predictor-default",
+							Name:       constants.PredictorServiceName(serviceName),
 							Protocol:   "TCP",
 							Port:       80,
 							TargetPort: intstr.IntOrString{Type: 0, IntVal: 8080, StrVal: ""},
@@ -303,7 +304,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					Type:            "ClusterIP",
 					SessionAffinity: "None",
 					Selector: map[string]string{
-						"app": "isvc.raw-foo-predictor-default",
+						"app": fmt.Sprintf("isvc.%s", constants.PredictorServiceName(serviceName)),
 					},
 				},
 			}
@@ -413,7 +414,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						LatestCreatedRevision: "",
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   "raw-foo-predictor-default-default.example.com",
+							Host:   "raw-foo-predictor-default.example.com",
 						},
 					},
 				},
@@ -437,7 +438,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			var stabilizationWindowSeconds int32 = 0
 			selectPolicy := v2beta2.MaxPolicySelect
 			actualHPA := &v2beta2.HorizontalPodAutoscaler{}
-			predictorHPAKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorHPAKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorHPAKey, actualHPA) }, timeout).
 				Should(Succeed())
@@ -446,7 +447,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					ScaleTargetRef: v2beta2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
-						Name:       constants.DefaultPredictorServiceName(serviceKey.Name),
+						Name:       constants.PredictorServiceName(serviceKey.Name),
 					},
 					MinReplicas: &minReplicas,
 					MaxReplicas: maxReplicas,
@@ -610,7 +611,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			actualDeployment := &appsv1.Deployment{}
-			predictorDeploymentKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorDeploymentKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment) }, timeout).
 				Should(Succeed())
@@ -713,7 +714,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 			//check service
 			actualService := &v1.Service{}
-			predictorServiceKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorServiceKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
 				Should(Succeed())
@@ -726,7 +727,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: v1.ServiceSpec{
 					Ports: []v1.ServicePort{
 						{
-							Name:       fmt.Sprintf("%s-predictor-default", serviceName),
+							Name:       constants.PredictorServiceName(serviceName),
 							Protocol:   "TCP",
 							Port:       80,
 							TargetPort: intstr.IntOrString{Type: 0, IntVal: 8080, StrVal: ""},
@@ -735,7 +736,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					Type:            "ClusterIP",
 					SessionAffinity: "None",
 					Selector: map[string]string{
-						"app": fmt.Sprintf("isvc.%s-predictor-default", serviceName),
+						"app": fmt.Sprintf("isvc.%s", constants.PredictorServiceName(serviceName)),
 					},
 				},
 			}
@@ -845,7 +846,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						LatestCreatedRevision: "",
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   fmt.Sprintf("%s-predictor-default-default.example.com", serviceName),
+							Host:   fmt.Sprintf("%s-predictor-default.example.com", serviceName),
 						},
 					},
 				},
@@ -869,7 +870,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			var stabilizationWindowSeconds int32 = 0
 			selectPolicy := v2beta2.MaxPolicySelect
 			actualHPA := &v2beta2.HorizontalPodAutoscaler{}
-			predictorHPAKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorHPAKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorHPAKey, actualHPA) }, timeout).
 				Should(Succeed())
@@ -878,7 +879,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					ScaleTargetRef: v2beta2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
-						Name:       constants.DefaultPredictorServiceName(serviceKey.Name),
+						Name:       constants.PredictorServiceName(serviceKey.Name),
 					},
 					MinReplicas: &minReplicas,
 					MaxReplicas: maxReplicas,
@@ -1043,7 +1044,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			actualDeployment := &appsv1.Deployment{}
-			predictorDeploymentKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorDeploymentKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment) }, timeout).
 				Should(Succeed())
@@ -1146,7 +1147,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 			//check service
 			actualService := &v1.Service{}
-			predictorServiceKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorServiceKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
 				Should(Succeed())
@@ -1159,7 +1160,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: v1.ServiceSpec{
 					Ports: []v1.ServicePort{
 						{
-							Name:       fmt.Sprintf("%s-predictor-default", serviceName),
+							Name:       constants.PredictorServiceName(serviceName),
 							Protocol:   "TCP",
 							Port:       80,
 							TargetPort: intstr.IntOrString{Type: 0, IntVal: 8080, StrVal: ""},
@@ -1168,7 +1169,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					Type:            "ClusterIP",
 					SessionAffinity: "None",
 					Selector: map[string]string{
-						"app": fmt.Sprintf("isvc.%s-predictor-default", serviceName),
+						"app": fmt.Sprintf("isvc.%s", constants.PredictorServiceName(serviceName)),
 					},
 				},
 			}
@@ -1278,7 +1279,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						LatestCreatedRevision: "",
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   fmt.Sprintf("%s-predictor-default.%s.%s", serviceName, serviceKey.Namespace, domain),
+							Host:   fmt.Sprintf("%s-predictor.%s.%s", serviceName, serviceKey.Namespace, domain),
 						},
 					},
 				},
@@ -1302,7 +1303,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			var stabilizationWindowSeconds int32 = 0
 			selectPolicy := v2beta2.MaxPolicySelect
 			actualHPA := &v2beta2.HorizontalPodAutoscaler{}
-			predictorHPAKey := types.NamespacedName{Name: constants.DefaultPredictorServiceName(serviceKey.Name),
+			predictorHPAKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace}
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorHPAKey, actualHPA) }, timeout).
 				Should(Succeed())
@@ -1311,7 +1312,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					ScaleTargetRef: v2beta2.CrossVersionObjectReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
-						Name:       constants.DefaultPredictorServiceName(serviceKey.Name),
+						Name:       constants.PredictorServiceName(serviceKey.Name),
 					},
 					MinReplicas: &minReplicas,
 					MaxReplicas: maxReplicas,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -37,6 +37,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/network"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"strings"
@@ -74,8 +75,13 @@ func getServiceHost(isvc *v1beta1.InferenceService) string {
 		} else if transformerStatus.URL == nil {
 			return ""
 		} else {
-			return strings.Replace(transformerStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Transformer)), "",
-				1)
+			if strings.Contains(transformerStatus.URL.Host, "-default") {
+				return strings.Replace(transformerStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Transformer)), "",
+					1)
+			} else {
+				return strings.Replace(transformerStatus.URL.Host, fmt.Sprintf("-%s", string(constants.Transformer)), "",
+					1)
+			}
 		}
 	}
 
@@ -84,8 +90,13 @@ func getServiceHost(isvc *v1beta1.InferenceService) string {
 	} else if predictorStatus.URL == nil {
 		return ""
 	} else {
-		return strings.Replace(predictorStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Predictor)), "",
-			1)
+		if strings.Contains(predictorStatus.URL.Host, "-default") {
+			return strings.Replace(predictorStatus.URL.Host, fmt.Sprintf("-%s-default", string(constants.Predictor)), "",
+				1)
+		} else {
+			return strings.Replace(predictorStatus.URL.Host, fmt.Sprintf("-%s", string(constants.Predictor)), "",
+				1)
+		}
 	}
 }
 
@@ -132,11 +143,15 @@ func getHostBasedServiceUrl(isvc *v1beta1.InferenceService, config *v1beta1.Ingr
 		} else {
 			url := transformerStatus.URL
 			url.Scheme = urlScheme
+			urlString := url.String()
 			if disableIstioVirtualHost == false {
-				return strings.Replace(url.String(), fmt.Sprintf("-%s-default", string(constants.Transformer)), "", 1)
-			} else {
-				return url.String()
+				if strings.Contains(urlString, "-default") {
+					return strings.Replace(urlString, fmt.Sprintf("-%s-default", string(constants.Transformer)), "", 1)
+				} else {
+					return strings.Replace(urlString, fmt.Sprintf("-%s", string(constants.Transformer)), "", 1)
+				}
 			}
+			return urlString
 		}
 	}
 
@@ -147,11 +162,15 @@ func getHostBasedServiceUrl(isvc *v1beta1.InferenceService, config *v1beta1.Ingr
 	} else {
 		url := predictorStatus.URL
 		url.Scheme = urlScheme
+		urlString := url.String()
 		if disableIstioVirtualHost == false {
-			return strings.Replace(url.String(), fmt.Sprintf("-%s-default", string(constants.Predictor)), "", 1)
-		} else {
-			return url.String()
+			if strings.Contains(urlString, "-default") {
+				return strings.Replace(urlString, fmt.Sprintf("-%s-default", string(constants.Predictor)), "", 1)
+			} else {
+				return strings.Replace(urlString, fmt.Sprintf("-%s", string(constants.Predictor)), "", 1)
+			}
 		}
+		return urlString
 	}
 }
 
@@ -205,7 +224,7 @@ func (r *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceServ
 	return nil
 }
 
-func createHTTPRouteDestination(targetHost, namespace string, gatewayService string) *istiov1alpha3.HTTPRouteDestination {
+func createHTTPRouteDestination(gatewayService string) *istiov1alpha3.HTTPRouteDestination {
 	httpRouteDestination := &istiov1alpha3.HTTPRouteDestination{
 		Destination: &istiov1alpha3.Destination{
 			Host: gatewayService,
@@ -253,7 +272,7 @@ func createHTTPMatchRequest(prefix, targetHost, internalHost string, isInternal 
 	return matchRequests
 }
 
-func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig) *v1alpha3.VirtualService {
+func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1beta1.IngressConfig) *v1alpha3.VirtualService {
 	serviceHost := getServiceHost(isvc)
 	if serviceHost == "" {
 		return nil
@@ -267,10 +286,16 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 		})
 		return nil
 	}
-	backend := constants.DefaultPredictorServiceName(isvc.Name)
+	backend := constants.PredictorServiceName(isvc.Name)
+	if useDefault {
+		backend = constants.DefaultPredictorServiceName(isvc.Name)
+	}
 
 	if isvc.Spec.Transformer != nil {
-		backend = constants.DefaultTransformerServiceName(isvc.Name)
+		backend = constants.TransformerServiceName(isvc.Name)
+		if useDefault {
+			backend = constants.DefaultTransformerServiceName(isvc.Name)
+		}
 		if !isvc.Status.IsConditionReady(v1beta1.TransformerReady) {
 			isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
 				Type:   v1beta1.IngressReady,
@@ -291,6 +316,10 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 	}
 	httpRoutes := []*istiov1alpha3.HTTPRoute{}
 	// Build explain route
+	expBackend := constants.ExplainerServiceName(isvc.Name)
+	if useDefault {
+		expBackend = constants.DefaultExplainerServiceName(isvc.Name)
+	}
 	if isvc.Spec.Explainer != nil {
 		if !isvc.Status.IsConditionReady(v1beta1.ExplainerReady) {
 			isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
@@ -304,12 +333,12 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 			Match: createHTTPMatchRequest(constants.ExplainPrefix(), serviceHost,
 				network.GetServiceHostname(isvc.Name, isvc.Namespace), isInternal, config),
 			Route: []*istiov1alpha3.HTTPRouteDestination{
-				createHTTPRouteDestination(constants.DefaultExplainerServiceName(isvc.Name), isvc.Namespace, config.LocalGatewayServiceName),
+				createHTTPRouteDestination(config.LocalGatewayServiceName),
 			},
 			Headers: &istiov1alpha3.Headers{
 				Request: &istiov1alpha3.Headers_HeaderOperations{
 					Set: map[string]string{
-						"Host": network.GetServiceHostname(constants.DefaultExplainerServiceName(isvc.Name), isvc.Namespace),
+						"Host": network.GetServiceHostname(expBackend, isvc.Namespace),
 					},
 				},
 			},
@@ -321,7 +350,7 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 		Match: createHTTPMatchRequest("", serviceHost,
 			network.GetServiceHostname(isvc.Name, isvc.Namespace), isInternal, config),
 		Route: []*istiov1alpha3.HTTPRouteDestination{
-			createHTTPRouteDestination(backend, isvc.Namespace, config.LocalGatewayServiceName),
+			createHTTPRouteDestination(config.LocalGatewayServiceName),
 		},
 		Headers: &istiov1alpha3.Headers{
 			Request: &istiov1alpha3.Headers_HeaderOperations{
@@ -427,7 +456,13 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 	// When Istio virtual host is disabled, we return the underlying component url.
 	// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
 	if disableIstioVirtualHost == false {
-		desiredIngress := createIngress(isvc, ir.ingressConfig)
+		defaultNameExisting := &knservingv1.Service{}
+		useDefault := false
+		err := ir.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, defaultNameExisting)
+		if err == nil {
+			useDefault = true
+		}
+		desiredIngress := createIngress(isvc, useDefault, ir.ingressConfig)
 		if desiredIngress == nil {
 			return nil
 		}
@@ -442,7 +477,7 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 		}
 
 		existing := &v1alpha3.VirtualService{}
-		err := ir.client.Get(context.TODO(), types.NamespacedName{Name: desiredIngress.Name, Namespace: desiredIngress.Namespace}, existing)
+		err = ir.client.Get(context.TODO(), types.NamespacedName{Name: desiredIngress.Name, Namespace: desiredIngress.Namespace}, existing)
 		if err != nil {
 			if apierr.IsNotFound(err) {
 				log.Info("Creating Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -413,7 +413,7 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 				Uri: "/",
 			},
 			Route: []*istiov1alpha3.HTTPRouteDestination{
-				createHTTPRouteDestination(backend, isvc.Namespace, config.LocalGatewayServiceName),
+				createHTTPRouteDestination(config.LocalGatewayServiceName),
 			},
 			Headers: &istiov1alpha3.Headers{
 				Request: &istiov1alpha3.Headers_HeaderOperations{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -99,7 +99,7 @@ func TestCreateVirtualService(t *testing.T) {
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace),
+							Host:   network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace),
 						},
 					},
 				},
@@ -121,7 +121,7 @@ func TestCreateVirtualService(t *testing.T) {
 						},
 						Headers: &istiov1alpha3.Headers{
 							Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-								"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)}},
+								"Host": network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace)}},
 						},
 					},
 				},
@@ -142,12 +142,12 @@ func TestCreateVirtualService(t *testing.T) {
 				v1beta1.PredictorComponent: {
 					URL: &apis.URL{
 						Scheme: "http",
-						Host:   network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace),
+						Host:   network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace),
 					},
 					Address: &duckv1.Addressable{
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace),
+							Host:   network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace),
 						},
 					},
 				},
@@ -178,7 +178,7 @@ func TestCreateVirtualService(t *testing.T) {
 						},
 						Headers: &istiov1alpha3.Headers{
 							Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-								"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)}},
+								"Host": network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace)}},
 						},
 					},
 				},
@@ -229,7 +229,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Address: &duckv1.Addressable{
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+								Host:   network.GetServiceHostname(constants.TransformerServiceName(serviceName), namespace),
 							},
 						},
 					},
@@ -241,7 +241,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Address: &duckv1.Addressable{
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace),
+								Host:   network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace),
 							},
 						},
 					},
@@ -263,7 +263,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-									"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+									"Host": network.GetServiceHostname(constants.TransformerServiceName(serviceName), namespace),
 								}},
 							},
 						},
@@ -294,7 +294,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Address: &duckv1.Addressable{
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+								Host:   network.GetServiceHostname(constants.TransformerServiceName(serviceName), namespace),
 							},
 						},
 					},
@@ -328,7 +328,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-									"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+									"Host": network.GetServiceHostname(constants.TransformerServiceName(serviceName), namespace),
 								}},
 							},
 						},
@@ -379,7 +379,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Address: &duckv1.Addressable{
 							URL: &apis.URL{
 								Scheme: "http",
-								Host:   network.GetServiceHostname(constants.DefaultExplainerServiceName(serviceName), namespace),
+								Host:   network.GetServiceHostname(constants.ExplainerServiceName(serviceName), namespace),
 							},
 						},
 					},
@@ -440,7 +440,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-									"Host": network.GetServiceHostname(constants.DefaultExplainerServiceName(serviceName), namespace)},
+									"Host": network.GetServiceHostname(constants.ExplainerServiceName(serviceName), namespace)},
 								},
 							},
 						},
@@ -454,7 +454,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Headers: &istiov1alpha3.Headers{
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-									"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)},
+									"Host": network.GetServiceHostname(constants.PredictorServiceName(serviceName), namespace)},
 								},
 							},
 						},
@@ -493,7 +493,7 @@ func TestCreateVirtualService(t *testing.T) {
 				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
 			}
 
-			actualService := createIngress(testIsvc, ingressConfig)
+			actualService := createIngress(testIsvc, false, ingressConfig)
 			if diff := cmp.Diff(tc.expectedService, actualService); diff != "" {
 				t.Errorf("Test %q unexpected status (-want +got): %v", tc.name, diff)
 			}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -100,11 +100,11 @@ func generateMetadata(isvc *v1beta1api.InferenceService,
 	var name string
 	switch componentType {
 	case constants.Transformer:
-		name = constants.DefaultTransformerServiceName(isvc.Name)
+		name = constants.TransformerServiceName(isvc.Name)
 	case constants.Explainer:
-		name = constants.DefaultExplainerServiceName(isvc.Name)
+		name = constants.ExplainerServiceName(isvc.Name)
 	case constants.Predictor:
-		name = constants.DefaultPredictorServiceName(isvc.Name)
+		name = constants.PredictorServiceName(isvc.Name)
 	}
 	//get annotations from isvc
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
@@ -169,11 +169,11 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1api.InferenceService,
 			if err != nil {
 				return nil, fmt.Errorf("failed creating explainer ingress host: %v", err)
 			}
-			rules = append(rules, generateRule(explainerHost, constants.DefaultExplainerServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
+			rules = append(rules, generateRule(explainerHost, constants.ExplainerServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
 		}
 		// :predict routes to the transformer when there are both predictor and transformer
-		rules = append(rules, generateRule(host, constants.DefaultTransformerServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
-		rules = append(rules, generateRule(transformerHost, constants.DefaultTransformerServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
+		rules = append(rules, generateRule(host, constants.TransformerServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
+		rules = append(rules, generateRule(transformerHost, constants.TransformerServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
 	} else if isvc.Spec.Explainer != nil {
 		if !isvc.Status.IsConditionReady(v1beta1api.ExplainerReady) {
 			isvc.Status.SetCondition(v1beta1api.IngressReady, &apis.Condition{
@@ -193,11 +193,11 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1api.InferenceService,
 		}
 		// :predict routes to the predictor when there is only predictor and explainer
 		if len(isvc.Spec.Predictor.Containers) != 0 && len(isvc.Spec.Predictor.Containers[0].Ports) != 0 {
-			rules = append(rules, generateRule(host, constants.DefaultPredictorServiceName(isvc.Name), "/", isvc.Spec.Predictor.Containers[0].Ports[0].ContainerPort))
+			rules = append(rules, generateRule(host, constants.PredictorServiceName(isvc.Name), "/", isvc.Spec.Predictor.Containers[0].Ports[0].ContainerPort))
 		} else {
-			rules = append(rules, generateRule(host, constants.DefaultPredictorServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
+			rules = append(rules, generateRule(host, constants.PredictorServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
 		}
-		rules = append(rules, generateRule(explainerHost, constants.DefaultExplainerServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
+		rules = append(rules, generateRule(explainerHost, constants.ExplainerServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
 	} else {
 		host, err := generateIngressHost(ingressConfig, isvc, string(constants.Predictor), true)
 		if err != nil {
@@ -205,10 +205,10 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1api.InferenceService,
 		}
 
 		if len(isvc.Spec.Predictor.Containers) != 0 && len(isvc.Spec.Predictor.Containers[0].Ports) != 0 {
-			rules = append(rules, generateRule(host, constants.DefaultPredictorServiceName(isvc.Name), "/", isvc.Spec.Predictor.Containers[0].Ports[0].ContainerPort))
+			rules = append(rules, generateRule(host, constants.PredictorServiceName(isvc.Name), "/", isvc.Spec.Predictor.Containers[0].Ports[0].ContainerPort))
 
 		} else {
-			rules = append(rules, generateRule(host, constants.DefaultPredictorServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
+			rules = append(rules, generateRule(host, constants.PredictorServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
 		}
 	}
 	//add predictor rule
@@ -217,9 +217,9 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1api.InferenceService,
 		return nil, fmt.Errorf("failed creating predictor ingress host: %v", err)
 	}
 	if len(isvc.Spec.Predictor.Containers) != 0 && len(isvc.Spec.Predictor.Containers[0].Ports) != 0 {
-		rules = append(rules, generateRule(predictorHost, constants.DefaultPredictorServiceName(isvc.Name), "/", isvc.Spec.Predictor.Containers[0].Ports[0].ContainerPort))
+		rules = append(rules, generateRule(predictorHost, constants.PredictorServiceName(isvc.Name), "/", isvc.Spec.Predictor.Containers[0].Ports[0].ContainerPort))
 	} else {
-		rules = append(rules, generateRule(predictorHost, constants.DefaultPredictorServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
+		rules = append(rules, generateRule(predictorHost, constants.PredictorServiceName(isvc.Name), "/", constants.CommonDefaultHttpPort))
 	}
 
 	ingress := &netv1.Ingress{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR is to remove the suffix '-default' in inference service components.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1397 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- I tested by using an existing predictor service and then updating the controller with this change to verify if the service is still working as expected

- I tested by using the existing service with both predictor and transformer and then updating the controller with this change to verify if the service is still working as expected

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Remove the suffix '-default' in inference service component names for predictor, transformer and explainer ksvc or service. 
The change is only for new inference services and for existing services the behavior is unchanged.
```