### PR TITLE
Change cluster-local label to networking.knative.dev/visibility

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -207,7 +207,7 @@ type InferenceServiceProtocol string
 const (
 	KnativeLocalGateway   = "knative-serving/knative-local-gateway"
 	KnativeIngressGateway = "knative-serving/knative-ingress-gateway"
-	VisibilityLabel       = "serving.knative.dev/visibility"
+	VisibilityLabel       = "networking.knative.dev/visibility"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I changed the label for making a kservices private services to `networking.knative.dev/visibility` since the `serving.knative.dev/visibility` is only supported in so older knative versions (v0.19 or lower).

- [knative v0.19 docs](https://github.com/knative/docs/blob/release-0.19/docs/serving/cluster-local-route.md#label-a-service-to-be-cluster-local)
> To configure a KService to only be available on the cluster-local network (and not on the public Internet), you can apply the serving.knative.dev/visibility=cluster-local label to the KService, Route or Kubernetes Service object.

- [knative v0.20 docs](https://github.com/knative/docs/blob/release-0.20/docs/serving/cluster-local-route.md#label-a-service-to-be-cluster-local):
> To configure a KService to only be available on the cluster-local network (and not on the public Internet), you can apply the networking.knative.dev/visibility=cluster-local label to the KService, Route or Kubernetes Service object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change cluster-local label from serving.knative.dev/visibility to networking.knative.dev/visibility
```
