### PR TITLE
Update sample YAMLs for s3 secrets to use right annotation

### DIFF
--- a/docs/samples/multimodelserving/triton/s3_secret.yaml
+++ b/docs/samples/multimodelserving/triton/s3_secret.yaml
@@ -3,10 +3,10 @@ kind: Secret
 metadata:
   name: mysecret
   annotations:
-     serving.kubeflow.org/s3-region: us-west-2
-     serving.kubeflow.org/s3-usevirtualbucket: "false"
-     serving.kubeflow.org/s3-endpoint: minio-service:9000 # replace with your s3 endpoint
-     serving.kubeflow.org/s3-usehttps: "0" # by default 1, for testing with minio you need to set to 0
+     serving.kserve.io/s3-region: us-west-2
+     serving.kserve.io/s3-usevirtualbucket: "false"
+     serving.kserve.io/s3-endpoint: minio-service:9000 # replace with your s3 endpoint
+     serving.kserve.io/s3-usehttps: "0" # by default 1, for testing with minio you need to set to 0
 type: Opaque
 data:
   AWS_ACCESS_KEY_ID: bWluaW8=

--- a/docs/samples/storage/s3/s3_secret.yaml
+++ b/docs/samples/storage/s3/s3_secret.yaml
@@ -3,10 +3,10 @@ kind: Secret
 metadata:
   name: mysecret
   annotations:
-     serving.kubeflow.org/s3-endpoint: s3.amazonaws.com # replace with your s3 endpoint
-     serving.kubeflow.org/s3-usehttps: "1" # by default 1, for testing with minio you need to set to 0
-     serving.kubeflow.org/s3-region: "us-east-2" # replace with the region the bucket is created in
-     serving.kubeflow.org/s3-useanoncredential: "false" # omitting this is the same as false, if true will ignore credential provided and use anonymous credentials
+     serving.kserve.io/s3-endpoint: s3.amazonaws.com # replace with your s3 endpoint
+     serving.kserve.io/s3-usehttps: "1" # by default 1, for testing with minio you need to set to 0
+     serving.kserve.io/s3-region: "us-east-2" # replace with the region the bucket is created in
+     serving.kserve.io/s3-useanoncredential: "false" # omitting this is the same as false, if true will ignore credential provided and use anonymous credentials
 type: Opaque
 data:
   AWS_ACCESS_KEY_ID: bWluaW8= # replace with your base64 encoded s3 credential


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the sample YAMLs for S3 secrets that were broken

S3 secrets YAML used in the samples are not working as expected updating the annotations to `kserve.io` makes it works as expected

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Ran test on local Kubernetes cluster using Minio server to test the annotations fixes which worked successfully

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:
- [X] Have you made corresponding changes to the documentation?
