### PR TITLE
Update quick install to use v0.10.0-rc0

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -32,7 +32,7 @@ done
 
 export ISTIO_VERSION=1.15.0
 export KNATIVE_VERSION=knative-v1.7.0
-export KSERVE_VERSION=v0.9.0
+export KSERVE_VERSION=v0.10.0-rc0
 export CERT_MANAGER_VERSION=v1.3.0
 export SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updates quick start to use v0.10.0-rc0 release
