### PR TITLE
Fix S3 Storage Initialiser downloading additional files when given file path does not include file extension

### DIFF
--- a/python/kserve/kserve/storage.py
+++ b/python/kserve/kserve/storage.py
@@ -181,7 +181,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             target_key = (
                 obj.key.rsplit("/", 1)[-1]
                 if bucket_path == obj.key
-                else obj.key.replace(bucket_path.rsplit("/",1)[0], "", 1).lstrip("/")
+                else obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
             )
             target = f"{temp_dir}/{target_key}"
             if not os.path.exists(os.path.dirname(target)):

--- a/python/kserve/kserve/storage.py
+++ b/python/kserve/kserve/storage.py
@@ -180,7 +180,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             # (without any subpaths).
             if bucket_path == obj.key:
                 target_key = obj.key.rsplit("/", 1)[-1]
-            elif bucket_path.rsplit("/", 1)[-1] in obj.key.rsplit("/", 1)[-1]:
+            elif obj.key.rsplit("/", 1)[-1].startswith(bucket_path.rsplit("/", 1)[-1]):
                 target_key = obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
             else:
                 target_key = obj.key.replace(bucket_path, "").lstrip("/")

--- a/python/kserve/kserve/storage.py
+++ b/python/kserve/kserve/storage.py
@@ -181,7 +181,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             target_key = (
                 obj.key.rsplit("/", 1)[-1]
                 if bucket_path == obj.key
-                else obj.key.replace(bucket_path, "", 1).lstrip("/")
+                else obj.key.replace(bucket_path.rsplit("/",1)[0], "", 1).lstrip("/")
             )
             target = f"{temp_dir}/{target_key}"
             if not os.path.exists(os.path.dirname(target)):

--- a/python/kserve/kserve/storage.py
+++ b/python/kserve/kserve/storage.py
@@ -178,11 +178,13 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             # If 'uri' is set to "s3://test-bucket/a/b/c/model.bin", then
             # the downloader will add to temp dir: model.bin
             # (without any subpaths).
-            target_key = (
-                obj.key.rsplit("/", 1)[-1]
-                if bucket_path == obj.key
-                else obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
-            )
+            if bucket_path == obj.key:
+                target_key = obj.key.rsplit("/", 1)[-1]
+            elif bucket_path.rsplit("/", 1)[-1] in obj.key.rsplit("/", 1)[-1]:
+                target_key = obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
+            else:
+                target_key = obj.key.replace(bucket_path, "").lstrip("/")
+
             target = f"{temp_dir}/{target_key}"
             if not os.path.exists(os.path.dirname(target)):
                 os.makedirs(os.path.dirname(target), exist_ok=True)

--- a/python/kserve/test/test_s3_storage.py
+++ b/python/kserve/test/test_s3_storage.py
@@ -140,6 +140,25 @@ AWS_TEST_CREDENTIALS = {"AWS_ACCESS_KEY_ID": "testing",
                         "AWS_SESSION_TOKEN": "testing"}
 
 
+@mock.patch('kserve.storage.boto3')
+def test_files_with_no_extension(mock_storage):
+
+    # given
+    bucket_name = 'foo'
+    paths = ['churn-pickle', 'churn-pickle-logs', 'churn-pickle-report']
+    object_paths = ['test/' + p for p in paths]
+
+    # when
+    mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, object_paths)
+    kserve.Storage._download_s3(f's3://{bucket_name}/test/churn-pickle', 'dest_path')
+
+    # then
+    arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
+    assert arg_list == expected_call_args_list('test', 'dest_path', paths)
+
+    mock_boto3_bucket.objects.filter.assert_called_with(Prefix='test/churn-pickle')
+
+
 def test_get_S3_config():
 
     ANON_CONFIG = Config(signature_version=UNSIGNED)

--- a/python/kserve/test/test_s3_storage.py
+++ b/python/kserve/test/test_s3_storage.py
@@ -141,6 +141,24 @@ AWS_TEST_CREDENTIALS = {"AWS_ACCESS_KEY_ID": "testing",
 
 
 @mock.patch('kserve.storage.boto3')
+def test_multikey(mock_storage):
+    # given
+    bucket_name = 'foo'
+    paths = ['b/model.bin']
+    object_paths = ['test/a/' + p for p in paths]
+
+    # when
+    mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, object_paths)
+    kserve.Storage._download_s3(f's3://{bucket_name}/test/a', 'dest_path')
+
+    # then
+    arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
+    assert arg_list == expected_call_args_list('test/a', 'dest_path', paths)
+
+    mock_boto3_bucket.objects.filter.assert_called_with(Prefix='test/a')
+
+
+@mock.patch('kserve.storage.boto3')
 def test_files_with_no_extension(mock_storage):
 
     # given


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** :
Fixes #2473

**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue)



