### PR TITLE
Made changes to fix issues with quick-install version parsing

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -98,8 +98,10 @@ cd ..
 echo "😀 Successfully installed Cert Manager"
 
 # Install KServe
-KSERVE_CONFIG=kfserving.yaml
-if [ ${KSERVE_VERSION:3:1} -gt 6 ]; then KSERVE_CONFIG=kserve.yaml; fi
+KSERVE_CONFIG=kserve.yaml
+MAJOR_VERSION=$(echo ${KSERVE_VERSION:1} | cut -d "." -f1)
+MINOR_VERSION=$(echo ${KSERVE_VERSION} | cut -d "." -f2)
+if [ ${MAJOR_VERSION} -eq 0 ] && [ ${MINOR_VERSION} -le 6 ]; then KSERVE_CONFIG=kfserving.yaml; fi
 
 # Retry inorder to handle that it may take a minute or so for the TLS assets required for the webhook to function to be provisioned
 kubectl apply -f https://github.com/kserve/kserve/releases/download/${KSERVE_VERSION}/${KSERVE_CONFIG}


### PR DESCRIPTION
Signed-off-by: Andrews Arokiam <andrews.arokiam@ideas2it.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes the quick-install script where the new version 0.10.0-rc0 set as default broke the script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2561 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
