### PR TITLE
make prom metric names consistent

### DIFF
--- a/python/kserve/README.md
+++ b/python/kserve/README.md
@@ -59,12 +59,12 @@ It supports the following storage providers:
 For latency metrics, send a request to `/metrics`. Prometheus latency histograms are emitted for each of the steps (pre/postprocessing, explain, predict).
 Additionally, the latencies of each step are logged per request.
 
-| Metric Name                        | Description                    | Type      |
-|------------------------------------|--------------------------------|-----------| 
-| request_preprocessing_seconds      | pre-processing request latency | Histogram | 
-| request_explain_processing_seconds | explain request latency        | Histogram | 
-| request_predict_processing_seconds | prediction request latency     | Histogram |
-| request_postprocessing_seconds     | pre-processing request latency | Histogram | 
+| Metric Name                       | Description                    | Type      |
+|-----------------------------------|--------------------------------|-----------| 
+| request_preprocess_seconds        | pre-processing request latency | Histogram | 
+| request_explain_seconds | explain request latency        | Histogram | 
+| request_predict_seconds | prediction request latency     | Histogram |
+| request_postprocess_seconds    | pre-processing request latency | Histogram | 
 
 
 ## KServe Client

--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -35,10 +35,10 @@ EXPLAINER_URL_FORMAT = "http://{0}/v1/models/{1}:explain"
 PREDICTOR_V2_URL_FORMAT = "http://{0}/v2/models/{1}/infer"
 EXPLAINER_V2_URL_FORMAT = "http://{0}/v2/models/{1}/explain"
 
-PRE_HIST_TIME = Histogram('request_preprocessing_seconds', 'pre-processing request latency')
-POST_HIST_TIME = Histogram('request_postprocessing_seconds', 'post-processing request latency')
-PREDICT_HIST_TIME = Histogram('request_predict_processing_seconds', 'prediction request latency')
-EXPLAIN_HIST_TIME = Histogram('request_explain_processing_seconds', 'explain request latency')
+PRE_HIST_TIME = Histogram('request_preprocess_seconds', 'pre-process request latency')
+POST_HIST_TIME = Histogram('request_postprocess_seconds', 'post-process request latency')
+PREDICT_HIST_TIME = Histogram('request_predict_seconds', 'predict request latency')
+EXPLAIN_HIST_TIME = Histogram('request_explain_seconds', 'explain request latency')
 
 
 class ModelType(Enum):


### PR DESCRIPTION
**What this PR does / why we need it**:
the previous metric names weren't consistent with the name of the method and also made no sense because predict and explain had `processing` as part of the name. I missed this in the [original PR](https://github.com/kserve/kserve/pull/2425).

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update