### PR TITLE
Upgrade the K8s version to 1.24 for tests

### DIFF
--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -5,18 +5,15 @@ runs:
   using: "composite"
   steps:
     - name: Setup Minikube
-      shell: bash
-      run: |
-        wget --no-verbose https://github.com/kubernetes/minikube/releases/download/v1.28.0/minikube-linux-amd64
-        sudo cp minikube-linux-amd64 /usr/local/bin/minikube
-        sudo chmod 755 /usr/local/bin/minikube
-        sudo apt-get install -y conntrack socat
-        minikube start --driver=none --kubernetes-version v1.24.9
+      uses: manusa/actions-setup-minikube@v2.7.1
+      with:
+        minikube version: 'v1.28.0'
+        kubernetes version: 'v1.24.9'
+        driver: 'none'
+        start args: --wait-timeout=60s
     - name: Check Kubernetes pods
       shell: bash
-      run: |
-        sleep 40
-        kubectl get pods -n kube-system
+      run: kubectl get pods -n kube-system
     - name: Setup KServe dependencies
       shell: bash
       run: |

--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -11,6 +11,7 @@ runs:
         kubernetes version: 'v1.24.9'
         driver: 'none'
         start args: --wait-timeout=60s
+        github token: ${{ env.GITHUB_TOKEN }}
     - name: Setup port-forward
       shell: bash
       run: sudo apt-get install -y conntrack socat

--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -11,6 +11,9 @@ runs:
         kubernetes version: 'v1.24.9'
         driver: 'none'
         start args: --wait-timeout=60s
+    - name: Setup port-forward
+      shell: bash
+      run: sudo apt-get install -y conntrack socat
     - name: Check Kubernetes pods
       shell: bash
       run: kubectl get pods -n kube-system

--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Minikube
-      uses: manusa/actions-setup-minikube@v2.7.1
+      uses: manusa/actions-setup-minikube@v2.7.2
       with:
         minikube version: 'v1.28.0'
         kubernetes version: 'v1.24.9'

--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -7,11 +7,11 @@ runs:
     - name: Setup Minikube
       shell: bash
       run: |
-        wget --no-verbose https://github.com/kubernetes/minikube/releases/download/v1.25.1/minikube-linux-amd64
+        wget --no-verbose https://github.com/kubernetes/minikube/releases/download/v1.28.0/minikube-linux-amd64
         sudo cp minikube-linux-amd64 /usr/local/bin/minikube
         sudo chmod 755 /usr/local/bin/minikube
         sudo apt-get install -y conntrack socat
-        minikube start --driver=none --kubernetes-version v1.22.10
+        minikube start --driver=none --kubernetes-version v1.24.9
     - name: Check Kubernetes pods
       shell: bash
       run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -148,16 +148,6 @@ jobs:
         with:
           image: "kserve/pmmlserver:${{ github.sha }}"
 
-      # This is workaround.
-      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
-      # ref:
-      # - https://github.com/kubernetes/minikube/issues/14806
-      # - https://github.com/kubernetes/minikube/issues/14789
-      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
-      # - https://github.com/manusa/actions-setup-minikube/pull/77
-      - name: Download seldonio/mlserver
-        run: docker pull docker.io/seldonio/mlserver:1.0.0
-
       - name: Install KServe
         run: |
           ./test/scripts/gh-actions/setup-kserve.sh
@@ -205,16 +195,6 @@ jobs:
         uses: ishworkh/docker-image-artifact-download@v1
         with:
           image: "kserve/paddleserver:${{ github.sha }}"
-
-      # This is workaround.
-      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
-      # ref:
-      # - https://github.com/kubernetes/minikube/issues/14806
-      # - https://github.com/kubernetes/minikube/issues/14789
-      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
-      # - https://github.com/manusa/actions-setup-minikube/pull/77
-      - name: Download seldonio/mlserver
-        run: docker pull docker.io/seldonio/mlserver:1.0.0
 
       - name: Install KServe
         run: |
@@ -264,16 +244,6 @@ jobs:
         with:
           image: "kserve/art-explainer:${{ github.sha }}"
 
-      # This is workaround.
-      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
-      # ref:
-      # - https://github.com/kubernetes/minikube/issues/14806
-      # - https://github.com/kubernetes/minikube/issues/14789
-      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
-      # - https://github.com/manusa/actions-setup-minikube/pull/77
-      - name: Download seldonio/mlserver
-        run: docker pull docker.io/seldonio/mlserver:1.0.0
-
       - name: Install KServe
         run: |
           ./test/scripts/gh-actions/setup-kserve.sh
@@ -319,16 +289,6 @@ jobs:
         with:
           image: "kserve/xgbserver:${{ github.sha }}"
 
-      # This is workaround.
-      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
-      # ref:
-      # - https://github.com/kubernetes/minikube/issues/14806
-      # - https://github.com/kubernetes/minikube/issues/14789
-      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
-      # - https://github.com/manusa/actions-setup-minikube/pull/77
-      - name: Download seldonio/mlserver
-        run: docker pull docker.io/seldonio/mlserver:1.0.0
-
       - name: Install KServe
         run: |
           ./test/scripts/gh-actions/setup-kserve.sh
@@ -373,16 +333,6 @@ jobs:
         with:
           image: "kserve/sklearnserver:${{ github.sha }}"
 
-      # This is workaround.
-      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
-      # ref:
-      # - https://github.com/kubernetes/minikube/issues/14806
-      # - https://github.com/kubernetes/minikube/issues/14789
-      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
-      # - https://github.com/manusa/actions-setup-minikube/pull/77
-      - name: Download seldonio/mlserver
-        run: docker pull docker.io/seldonio/mlserver:1.0.0
-
       - name: Install KServe
         run: |
           ./test/scripts/gh-actions/setup-kserve.sh
@@ -422,16 +372,6 @@ jobs:
         uses: ishworkh/docker-image-artifact-download@v1
         with:
           image: "kserve/custom-image-transformer-grpc:${{ github.sha }}"
-
-      # This is workaround.
-      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
-      # ref:
-      # - https://github.com/kubernetes/minikube/issues/14806
-      # - https://github.com/kubernetes/minikube/issues/14789
-      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
-      # - https://github.com/manusa/actions-setup-minikube/pull/77
-      - name: Download seldonio/mlserver
-        run: docker pull docker.io/seldonio/mlserver:1.0.0
 
       - name: Install KServe
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -148,6 +148,16 @@ jobs:
         with:
           image: "kserve/pmmlserver:${{ github.sha }}"
 
+      # This is workaround.
+      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
+      # ref:
+      # - https://github.com/kubernetes/minikube/issues/14806
+      # - https://github.com/kubernetes/minikube/issues/14789
+      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
+      # - https://github.com/manusa/actions-setup-minikube/pull/77
+      - name: Download seldonio/mlserver
+        run: docker pull docker.io/seldonio/mlserver:1.0.0
+
       - name: Install KServe
         run: |
           ./test/scripts/gh-actions/setup-kserve.sh
@@ -195,6 +205,16 @@ jobs:
         uses: ishworkh/docker-image-artifact-download@v1
         with:
           image: "kserve/paddleserver:${{ github.sha }}"
+
+      # This is workaround.
+      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
+      # ref:
+      # - https://github.com/kubernetes/minikube/issues/14806
+      # - https://github.com/kubernetes/minikube/issues/14789
+      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
+      # - https://github.com/manusa/actions-setup-minikube/pull/77
+      - name: Download seldonio/mlserver
+        run: docker pull docker.io/seldonio/mlserver:1.0.0
 
       - name: Install KServe
         run: |
@@ -244,6 +264,16 @@ jobs:
         with:
           image: "kserve/art-explainer:${{ github.sha }}"
 
+      # This is workaround.
+      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
+      # ref:
+      # - https://github.com/kubernetes/minikube/issues/14806
+      # - https://github.com/kubernetes/minikube/issues/14789
+      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
+      # - https://github.com/manusa/actions-setup-minikube/pull/77
+      - name: Download seldonio/mlserver
+        run: docker pull docker.io/seldonio/mlserver:1.0.0
+
       - name: Install KServe
         run: |
           ./test/scripts/gh-actions/setup-kserve.sh
@@ -289,6 +319,16 @@ jobs:
         with:
           image: "kserve/xgbserver:${{ github.sha }}"
 
+      # This is workaround.
+      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
+      # ref:
+      # - https://github.com/kubernetes/minikube/issues/14806
+      # - https://github.com/kubernetes/minikube/issues/14789
+      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
+      # - https://github.com/manusa/actions-setup-minikube/pull/77
+      - name: Download seldonio/mlserver
+        run: docker pull docker.io/seldonio/mlserver:1.0.0
+
       - name: Install KServe
         run: |
           ./test/scripts/gh-actions/setup-kserve.sh
@@ -332,6 +372,17 @@ jobs:
         uses: ishworkh/docker-image-artifact-download@v1
         with:
           image: "kserve/sklearnserver:${{ github.sha }}"
+
+      # This is workaround.
+      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
+      # ref:
+      # - https://github.com/kubernetes/minikube/issues/14806
+      # - https://github.com/kubernetes/minikube/issues/14789
+      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
+      # - https://github.com/manusa/actions-setup-minikube/pull/77
+      - name: Download seldonio/mlserver
+        run: docker pull docker.io/seldonio/mlserver:1.0.0
+
       - name: Install KServe
         run: |
           ./test/scripts/gh-actions/setup-kserve.sh
@@ -371,6 +422,16 @@ jobs:
         uses: ishworkh/docker-image-artifact-download@v1
         with:
           image: "kserve/custom-image-transformer-grpc:${{ github.sha }}"
+
+      # This is workaround.
+      # TODO (tenzen-y): Once the cri-dockerd is upgraded to v0.2.6 in manusa/actions-setup-minikube, we can remove the below.
+      # ref:
+      # - https://github.com/kubernetes/minikube/issues/14806
+      # - https://github.com/kubernetes/minikube/issues/14789
+      # - https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6
+      # - https://github.com/manusa/actions-setup-minikube/pull/77
+      - name: Download seldonio/mlserver
+        run: docker pull docker.io/seldonio/mlserver:1.0.0
 
       - name: Install KServe
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,6 +10,9 @@ on:
       - '!**.md'
       - '.github/workflows/e2e-test.yml'
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   kserve-image-build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ QPEXT_IMG ?= qpext
 CRD_OPTIONS ?= "crd:maxDescLen=0"
 KSERVE_ENABLE_SELF_SIGNED_CA ?= false
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.22
+ENVTEST_K8S_VERSION = 1.24
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin

--- a/config/overlays/test/runtimes/kustomization.yaml
+++ b/config/overlays/test/runtimes/kustomization.yaml
@@ -17,3 +17,6 @@ images:
   - name: kserve/lgbserver
     newTag: latest
 
+  - name: mlserver
+    newName: docker.io/seldonio/mlserver
+    newTag: 1.0.1-slim


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
If the `--arch` flag does not exist, setup-envtest tries to download K8s binaries for the arch (e.g., amd64 and arm64) of the local machine. Although, setup-envtest does not provide binaries for arm64 in K8s 1.23 or lower version.

ref: https://github.com/kubernetes-sigs/kubebuilder/issues/2664#issuecomment-1149956592

Mainly, this issue is faced when developers are using the M1 Mac.

~~So, I added that flag with `amd64` to setup-envtest.~~

Also, since the K8s v1.22 that we are using in our tests is the EoL version and the K8s v1.23 will reach EoL soon, I upgraded the K8s version to 1.24 for tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade the K8s version to 1.24 for tests
```
