### PR TITLE
adding prom labels

### DIFF
--- a/.github/workflows/scheduled-image-scan.yml
+++ b/.github/workflows/scheduled-image-scan.yml
@@ -1,0 +1,105 @@
+name: Twice a week image scan
+# Temporarily adding on push for testing
+on:
+  schedule:
+    - cron: '0 0 * * 0,3'
+  workflow_dispatch: {}
+
+jobs:
+  base-image-scan:
+    name: scan images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [{ name: kserve-controller, file: Dockerfile},
+                { name: agent, file: agent.Dockerfile}, 
+                { name: storage-initializer, file: python/storage-initializer.Dockerfile},
+                { name: router, file: router.Dockerfile}]
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Security scan on docker image
+        uses: snyk/actions/docker@master
+        id: docker-image-scan
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: kserve/${{ matrix.image.name }}
+          args: --severity-threshold=low
+                --file=${{ matrix.image.file }}
+                --sarif-file-output=./application/${{ matrix.image.name }}/docker.snyk.sarif
+          sarif: false
+
+      - name: Upload sarif file to Github Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: application/${{ matrix.image.name }}/docker.snyk.sarif
+  
+  predictor-image-scan:
+    name: scan predictor images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [{ name: sklearnserver, file: python/sklearn.Dockerfile},
+                { name: xgbserver, file: python/xgb.Dockerfile},
+                { name: pmmlserver, file: python/pmml.Dockerfile},
+                { name: paddleserver, file: python/paddle.Dockerfile}]
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Security scan on docker image
+        uses: snyk/actions/docker@master
+        id: docker-image-scan
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: kserve/${{ matrix.image.name }}
+          args: --severity-threshold=low
+                --file=${{ matrix.image.file }}
+                --sarif-file-output=./application/${{ matrix.image.name }}/docker.snyk.sarif
+          sarif: false
+
+      - name: Upload sarif file to Github Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: application/${{ matrix.image.name }}/docker.snyk.sarif
+  
+  explainer-image-scan:
+    name: scan explainer images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [{ name: aix-explainer, file: python/aixexplainer.Dockerfile},
+                { name: alibi-explainer, file: python/alibiexplainer.Dockerfile},
+                { name: art-explainer, file: python/artexplainer.Dockerfile}]
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Security scan on docker image
+        uses: snyk/actions/docker@master
+        id: docker-image-scan
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: kserve/${{ matrix.image.name }}
+          args: --severity-threshold=low
+                --file=${{ matrix.image.file }}
+                --sarif-file-output=./application/${{ matrix.image.name }}/docker.snyk.sarif
+          sarif: false
+
+      - name: Upload sarif file to Github Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: application/${{ matrix.image.name }}/docker.snyk.sarif

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kserve/kserve/pkg/constants"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -57,7 +57,7 @@ func callService(serviceUrl string, input []byte, headers http.Header) ([]byte, 
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error(err, "error while reading the response")
 	}
@@ -183,7 +183,7 @@ func executeStep(step *v1alpha1.InferenceStep, graph v1alpha1.InferenceGraphSpec
 var inferenceGraph *v1alpha1.InferenceGraphSpec
 
 func graphHandler(w http.ResponseWriter, req *http.Request) {
-	inputBytes, _ := ioutil.ReadAll(req.Body)
+	inputBytes, _ := io.ReadAll(req.Body)
 	if response, err := routeStep(v1alpha1.GraphRootNodeName, *inferenceGraph, inputBytes, req.Header); err != nil {
 		log.Error(err, "failed to process request")
 		w.WriteHeader(500) //TODO status code tbd

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"knative.dev/pkg/apis"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +15,7 @@ import (
 func TestSimpleModelChainer(t *testing.T) {
 	// Start a local HTTP server
 	model1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -29,7 +29,7 @@ func TestSimpleModelChainer(t *testing.T) {
 	}
 	defer model1.Close()
 	model2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -89,7 +89,7 @@ func TestSimpleModelChainer(t *testing.T) {
 func TestSimpleModelEnsemble(t *testing.T) {
 	// Start a local HTTP server
 	model1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -103,7 +103,7 @@ func TestSimpleModelEnsemble(t *testing.T) {
 	}
 	defer model1.Close()
 	model2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -166,7 +166,7 @@ func TestSimpleModelEnsemble(t *testing.T) {
 func TestInferenceGraphWithCondition(t *testing.T) {
 	// Start a local HTTP server
 	model1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -189,7 +189,7 @@ func TestInferenceGraphWithCondition(t *testing.T) {
 	}
 	defer model1.Close()
 	model2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -214,7 +214,7 @@ func TestInferenceGraphWithCondition(t *testing.T) {
 
 	// Start a local HTTP server
 	model3 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -237,7 +237,7 @@ func TestInferenceGraphWithCondition(t *testing.T) {
 	}
 	defer model3.Close()
 	model4 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -359,7 +359,7 @@ func TestInferenceGraphWithCondition(t *testing.T) {
 func TestCallServiceWhenNoneHeadersToPropagateIsEmpty(t *testing.T) {
 	// Start a local HTTP server
 	model1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -404,7 +404,7 @@ func TestCallServiceWhenNoneHeadersToPropagateIsEmpty(t *testing.T) {
 func TestCallServiceWhen1HeaderToPropagate(t *testing.T) {
 	// Start a local HTTP serverq
 	model1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}
@@ -450,7 +450,7 @@ func TestCallServiceWhen1HeaderToPropagate(t *testing.T) {
 func TestCallServiceWhenMultipleHeadersToPropagate(t *testing.T) {
 	// Start a local HTTP server
 	model1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		if err != nil {
 			return
 		}

--- a/pkg/agent/downloader.go
+++ b/pkg/agent/downloader.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -61,7 +60,7 @@ func (d *Downloader) DownloadModel(modelName string, modelSpec *v1alpha1.ModelSp
 			if err != nil {
 				return errors.Wrapf(createErr, "failed to encode model spec")
 			}
-			err = ioutil.WriteFile(successFile, encodedJson, 0644)
+			err = os.WriteFile(successFile, encodedJson, 0644)
 			if err != nil {
 				return errors.Wrapf(createErr, "failed to write the success file")
 			}

--- a/pkg/agent/downloader_test.go
+++ b/pkg/agent/downloader_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package agent
 
 import (
-	"io/ioutil"
 	logger "log"
 	"os"
 
@@ -34,7 +33,7 @@ var _ = Describe("Downloader", func() {
 	var modelDir string
 	var downloader *Downloader
 	BeforeEach(func() {
-		dir, err := ioutil.TempDir("", "example")
+		dir, err := os.MkdirTemp("", "example")
 		if err != nil {
 			logger.Fatal(err)
 		}

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -19,7 +19,7 @@ package agent
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"sync"
@@ -167,7 +167,7 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 					if resp.StatusCode == 200 {
 						p.logger.Infof("Successfully loaded model %s", modelName)
 					} else {
-						body, err := ioutil.ReadAll(resp.Body)
+						body, err := io.ReadAll(resp.Body)
 						if err == nil {
 							p.logger.Infof("Failed to load model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
 						}
@@ -192,7 +192,7 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 					if resp.StatusCode == 200 {
 						p.logger.Infof("Successfully unloaded model %s", modelName)
 					} else {
-						body, err := ioutil.ReadAll(resp.Body)
+						body, err := io.ReadAll(resp.Body)
 						if err == nil {
 							p.logger.Infof("Failed to unload model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
 						}

--- a/pkg/agent/storage/gcs.go
+++ b/pkg/agent/storage/gcs.go
@@ -23,7 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 	"google.golang.org/api/iterator"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,7 +124,7 @@ func (g *GCSObjectDownloader) DownloadFile(client stiface.Client, attrs *gstorag
 		)
 	}
 	defer reader.Close()
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("failed to read object(%s) in bucket(%s): %v",
 			attrs.Name,

--- a/pkg/agent/storage/https.go
+++ b/pkg/agent/storage/https.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -143,7 +142,7 @@ func createNewFile(fileFullName string) (*os.File, error) {
 }
 
 func extractZipFiles(reader io.Reader, dest string) error {
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/storage/utils_test.go
+++ b/pkg/agent/storage/utils_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package storage
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -34,7 +33,7 @@ func TestCreate(t *testing.T) {
 	// This would get called in StartPullerAndProcessModels
 	syscall.Umask(0)
 
-	tmpDir, _ := ioutil.TempDir("", "test-create-")
+	tmpDir, _ := os.MkdirTemp("", "test-create-")
 	defer os.RemoveAll(tmpDir)
 
 	folderPath := path.Join(tmpDir, "foo")
@@ -54,7 +53,7 @@ func TestCreate(t *testing.T) {
 func TestFileExists(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	syscall.Umask(0)
-	tmpDir, _ := ioutil.TempDir("", "test")
+	tmpDir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(tmpDir)
 
 	// Test case for existing file
@@ -74,8 +73,8 @@ func TestFileExists(t *testing.T) {
 func TestRemoveDir(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	syscall.Umask(0)
-	tmpDir, _ := ioutil.TempDir("", "test")
-	subDir, _ := ioutil.TempDir(tmpDir, "test")
+	tmpDir, _ := os.MkdirTemp("", "test")
+	subDir, _ := os.MkdirTemp(tmpDir, "test")
 	os.CreateTemp(subDir, "tmp")
 	os.CreateTemp(tmpDir, "tmp")
 

--- a/pkg/agent/syncer.go
+++ b/pkg/agent/syncer.go
@@ -19,7 +19,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +52,7 @@ func SyncModelDir(modelDir string, logger *zap.SugaredLogger) (map[string]modelW
 				if err != nil {
 					return errors.Wrapf(err, "failed to parse success file")
 				}
-				byteValue, err := ioutil.ReadAll(jsonFile)
+				byteValue, err := io.ReadAll(jsonFile)
 				if err != nil {
 					return errors.Wrapf(err, "failed to read from model spec")
 				}

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -19,7 +19,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/fsnotify/fsnotify"
@@ -62,7 +62,7 @@ type modelWrapper struct {
 }
 
 func (w *Watcher) syncModelConfig(modelConfigFile string, initializing bool) error {
-	file, err := ioutil.ReadFile(modelConfigFile)
+	file, err := os.ReadFile(modelConfigFile)
 	if err != nil {
 		return err
 	} else {

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	logger "log"
 	"net/http"
 	"net/http/httptest"
@@ -46,7 +45,7 @@ var _ = Describe("Watcher", func() {
 	var modelDir string
 	var sugar *zap.SugaredLogger
 	BeforeEach(func() {
-		dir, err := ioutil.TempDir("", "example")
+		dir, err := os.MkdirTemp("", "example")
 		if err != nil {
 			logger.Fatal(err)
 		}
@@ -91,7 +90,7 @@ var _ = Describe("Watcher", func() {
 				}
 
 				file, _ := json.MarshalIndent(modelConfigs, "", " ")
-				if err := ioutil.WriteFile("/tmp/configs/"+constants.ModelConfigFileName, file, os.ModePerm); err != nil {
+				if err := os.WriteFile("/tmp/configs/"+constants.ModelConfigFileName, file, os.ModePerm); err != nil {
 					logger.Fatal(err, " Failed to write config files")
 				}
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
@@ -375,7 +374,7 @@ var _ = Describe("Watcher", func() {
 				Expect(err).To(BeNil())
 
 				testFile := filepath.Join(modelDir, modelName, "testModel1")
-				dat, err := ioutil.ReadFile(testFile)
+				dat, err := os.ReadFile(testFile)
 				Expect(err).To(BeNil())
 				Expect(string(dat)).To(Equal(modelContents))
 			})
@@ -590,7 +589,7 @@ var _ = Describe("Watcher", func() {
 					Expect(err).To(BeNil())
 
 					testFile := filepath.Join(modelDir, modelName, modelFile)
-					dat, err := ioutil.ReadFile(testFile)
+					dat, err := os.ReadFile(testFile)
 					Expect(err).To(BeNil())
 					Expect(string(dat)).To(Equal(modelContents + "\n"))
 				}

--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -86,6 +86,9 @@ func (isvc *InferenceService) DefaultInferenceService(config *InferenceServicesC
 	if !ok && deployConfig != nil {
 		if deployConfig.DefaultDeploymentMode == string(constants.ModelMeshDeployment) ||
 			deployConfig.DefaultDeploymentMode == string(constants.RawDeployment) {
+			if isvc.ObjectMeta.Annotations == nil {
+				isvc.ObjectMeta.Annotations = map[string]string{}
+			}
 			isvc.ObjectMeta.Annotations[constants.DeploymentMode] = deployConfig.DefaultDeploymentMode
 		}
 	}

--- a/pkg/batcher/handler.go
+++ b/pkg/batcher/handler.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"github.com/satori/go.uuid"
 	"go.uber.org/zap"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -227,7 +227,7 @@ func (handler *BatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req Request
 	var err error
 	// Read Payload
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "can't read body", http.StatusBadRequest)
 		return

--- a/pkg/batcher/handler_test.go
+++ b/pkg/batcher/handler_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/onsi/gomega"
-	"io/ioutil"
+	"io"
 	pkglogging "knative.dev/pkg/logging"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +41,7 @@ func serveRequest(batchHandler *BatchHandler, wg *sync.WaitGroup, index int) {
 	w := httptest.NewRecorder()
 	batchHandler.ServeHTTP(w, r)
 
-	b2, _ := ioutil.ReadAll(w.Result().Body)
+	b2, _ := io.ReadAll(w.Result().Body)
 	var res Response
 	_ = json.Unmarshal(b2, &res)
 	fmt.Printf("Got response %v\n", res)
@@ -55,7 +55,7 @@ func TestBatcher(t *testing.T) {
 	responseChan := make(chan Response)
 	// Start a local HTTP server
 	predictor := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		g.Expect(err).To(gomega.BeNil())
 		var request Request
 		err = json.Unmarshal(b, &request)
@@ -96,7 +96,7 @@ func TestBatcherFail(t *testing.T) {
 	responseChan := make(chan Response)
 	// Start a local HTTP server
 	predictor := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		g.Expect(err).To(gomega.BeNil())
 		var request Request
 		err = json.Unmarshal(b, &request)
@@ -136,7 +136,7 @@ func TestBatcherDefaults(t *testing.T) {
 	responseChan := make(chan Response)
 	// Start a local HTTP server
 	predictor := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		g.Expect(err).To(gomega.BeNil())
 		var request Request
 		err = json.Unmarshal(b, &request)

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/clientv1alpha1/clientset/versioned/fake/register.go
+++ b/pkg/clientv1alpha1/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/clientv1alpha1/clientset/versioned/scheme/register.go
+++ b/pkg/clientv1alpha1/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -18,7 +18,7 @@ package logger
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -76,7 +76,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Read Payload
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "can't read body", http.StatusBadRequest)
 		return
@@ -104,7 +104,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Proxy Request
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
 	rr := httptest.NewRecorder()
 	eh.next.ServeHTTP(rr, r)
 	responseBody := rr.Body.Bytes()

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -18,7 +18,7 @@ package logger
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -42,7 +42,7 @@ func TestLogger(t *testing.T) {
 	responseChan := make(chan string)
 	// Start a local HTTP server
 	logSvc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		g.Expect(err).To(gomega.BeNil())
 		println(string(b))
 		responseChan <- string(b)
@@ -55,7 +55,7 @@ func TestLogger(t *testing.T) {
 
 	// Start a local HTTP server
 	predictor := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		g.Expect(err).To(gomega.BeNil())
 		g.Expect(b).To(gomega.Or(gomega.Equal(predictorRequest), gomega.Equal(predictorResponse)))
 		_, err = rw.Write(predictorResponse)
@@ -82,7 +82,7 @@ func TestLogger(t *testing.T) {
 
 	oh.ServeHTTP(w, r)
 
-	b2, _ := ioutil.ReadAll(w.Result().Body)
+	b2, _ := io.ReadAll(w.Result().Body)
 	g.Expect(b2).To(gomega.Equal(predictorResponse))
 	// get logRequest
 	<-responseChan
@@ -99,7 +99,7 @@ func TestBadResponse(t *testing.T) {
 
 	// Start a local HTTP server
 	predictor := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		g.Expect(err).To(gomega.BeNil())
 		g.Expect(b).To(gomega.Or(gomega.Equal(predictorRequest), gomega.Equal(predictorResponse)))
 		http.Error(rw, "BadRequest", http.StatusBadRequest)

--- a/python/kserve/README.md
+++ b/python/kserve/README.md
@@ -59,12 +59,12 @@ It supports the following storage providers:
 For latency metrics, send a request to `/metrics`. Prometheus latency histograms are emitted for each of the steps (pre/postprocessing, explain, predict).
 Additionally, the latencies of each step are logged per request.
 
-| Metric Name                        | Description                    | Type      |
-|------------------------------------|--------------------------------|-----------| 
-| request_preprocessing_seconds      | pre-processing request latency | Histogram | 
-| request_explain_processing_seconds | explain request latency        | Histogram | 
-| request_predict_processing_seconds | prediction request latency     | Histogram |
-| request_postprocessing_seconds     | pre-processing request latency | Histogram | 
+| Metric Name                       | Description                    | Type      |
+|-----------------------------------|--------------------------------|-----------| 
+| request_preprocess_seconds        | pre-processing request latency | Histogram | 
+| request_explain_seconds | explain request latency        | Histogram | 
+| request_predict_seconds | prediction request latency     | Histogram |
+| request_postprocess_seconds    | pre-processing request latency | Histogram | 
 
 
 ## KServe Client

--- a/python/kserve/kserve/metrics.py
+++ b/python/kserve/kserve/metrics.py
@@ -1,0 +1,20 @@
+from prometheus_client import Histogram
+import os
+
+PROM_KEYS = {"K_SERVICE": "service_name", "K_CONFIGURATION": "configuration_name",
+             "K_REVISION": "revision_name"}
+PRE_HIST_TIME = Histogram('request_preprocess_seconds', 'pre-process request latency', PROM_KEYS.values())
+POST_HIST_TIME = Histogram('request_postprocess_seconds', 'post-process request latency', PROM_KEYS.values())
+PREDICT_HIST_TIME = Histogram('request_predict_seconds', 'predict request latency', PROM_KEYS.values())
+EXPLAIN_HIST_TIME = Histogram('request_explain_seconds', 'explain request latency', PROM_KEYS.values())
+
+# get_labels adds the service, configuration, and revision labels from the container onto the prometheus metric.
+# this way, when the metrics are exported, they can be queried with the same labels that the
+# queue-proxy has. https://github.com/knative/serving/blob/026291c4a46eea99cba66beadbc2180b35ab433d/pkg/metrics/key.go
+def get_labels():
+    labels = {}
+    for env_key, tag in PROM_KEYS.items():
+        # if the environment variable doesn't exist/is empty, we are not in serverless mode and will set the label to
+        # "".
+        labels[tag] = os.environ.get(env_key, "")
+    return labels

--- a/python/kserve/test/test_metrics.py
+++ b/python/kserve/test/test_metrics.py
@@ -1,0 +1,47 @@
+# Copyright 2021 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# coding: utf-8
+
+import unittest
+from kserve.metrics import PRE_HIST_TIME, PROM_KEYS, get_labels
+import os
+
+
+def create_labels(value):
+    expected_labels = {}
+    for env_var, label in PROM_KEYS.items():
+        # set the env vars for get_labels to read from
+        os.environ[env_var] = value
+        # create the expected labels to compare the result with
+        expected_labels[label] = value
+    return expected_labels
+
+
+class TestGetLabels(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_get_labels(self):
+        expected_labels = create_labels(value="something")
+        result_labels = get_labels()
+        assert PRE_HIST_TIME.labels(**result_labels) == PRE_HIST_TIME.labels(**expected_labels)
+
+    def test_get_labels_empty(self):
+        expected_labels = create_labels(value="")
+        result_labels = get_labels()
+        assert PRE_HIST_TIME.labels(**result_labels) == PRE_HIST_TIME.labels(**expected_labels)

--- a/tools/tf2openapi/cmd/e2e_test.go
+++ b/tools/tf2openapi/cmd/e2e_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,7 +140,7 @@ func TestOutputToFileTargetDirectoryError(t *testing.T) {
 
 func readFile(fName string, t *testing.T) []byte {
 	fPath := filepath.Join("testdata", fName)
-	openAPI, err := ioutil.ReadFile(fPath)
+	openAPI, err := os.ReadFile(fPath)
 	if err != nil {
 		t.Fatalf("failed reading %s: %s", fPath, err)
 	}

--- a/tools/tf2openapi/cmd/main.go
+++ b/tools/tf2openapi/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -53,7 +52,7 @@ func main() {
 }
 
 func viewAPI(cmd *cobra.Command, args []string) {
-	modelPb, err := ioutil.ReadFile(modelBasePath)
+	modelPb, err := os.ReadFile(modelBasePath)
 	if err != nil {
 		log.Fatalf(ModelBasePathError, modelBasePath, err.Error())
 	}

--- a/tools/tf2openapi/generator/generate_test.go
+++ b/tools/tf2openapi/generator/generate_test.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -262,7 +262,7 @@ func defaultGenerator() Generator {
 func model(t *testing.T, fName string) *pb.SavedModel {
 	model := &pb.SavedModel{}
 	fPath := filepath.Join("testdata", fName+".pb")
-	modelPb, err := ioutil.ReadFile(fPath)
+	modelPb, err := os.ReadFile(fPath)
 	if err != nil {
 		t.Fatalf("failed reading %s: %s", fPath, err)
 	}
@@ -274,7 +274,7 @@ func model(t *testing.T, fName string) *pb.SavedModel {
 
 func openAPI(t *testing.T, fName string) []byte {
 	fPath := filepath.Join("testdata", fName+".golden.json")
-	openAPI, err := ioutil.ReadFile(fPath)
+	openAPI, err := os.ReadFile(fPath)
 	if err != nil {
 		t.Fatalf("failed reading %s: %s", fPath, err)
 	}
@@ -312,7 +312,7 @@ func loadSwagger(t *testing.T, fName string) *openapi3.T {
 
 func loadPayload(t *testing.T, fName string) []byte {
 	fPath := filepath.Join("testdata", fName+"Req.json")
-	payload, err := ioutil.ReadFile(fPath)
+	payload, err := os.ReadFile(fPath)
 	if err != nil {
 		t.Fatalf("failed reading %s: %s", fPath, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

upon building a grafana dashboard from the prometheus metrics, I noticed we don't have the tags we add on from knative/queueproxy. if someone is using these metrics, these tags will most likely be wanted to be able to run queries using the service name and configuration and revision names. these tags make the dashboards much easier to make and much more useful. Here I add the `K_SERVICE`, `K_CONFIGURATION`, and `K_REVISION` environment values from kserve-container to the prom metric labels. 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ x] Test A added in unit tests
- [x ] Test B visualized in grafana testing a pod on kubernetes 

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

