### PR TITLE
Update quick install script to add Cluster Autoscaler and istiod memory leakage fix fields

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -69,14 +69,25 @@ spec:
   meshConfig:
     accessLogFile: /dev/stdout
 
-  addonComponents:
-    pilot:
-      enabled: true
-
   components:
     ingressGateways:
       - name: istio-ingressgateway
         enabled: true
+        k8s:
+          podAnnotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+    pilot:
+      enabled: true
+      k8s:
+        resources:
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        podAnnotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        env:
+        - name: PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING
+          value: "false"
 EOF
 
 bin/istioctl manifest apply -f istio-minimal-operator.yaml -y;


### PR DESCRIPTION
Signed-off-by: Swapnesh Khare <swapkh91@gmail.com>

**What this PR does / why we need it**:
1. Kubernetes Cluster Autoscaler (tested on GKE) expects pods to have `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"` annotation to mark them safe for eviction from a node and scale down the node ([ref](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node)). Istio specific pods do not have these annotations and hence are not scaled down if created on a new node during autoscaling.

2. As of Istio version 1.15, the `istiod` component suffers from memory leakage ([ref](https://github.com/istio/istio/issues/38716)), which is fixed in 1.16 ([ref](https://istio.io/latest/news/releases/1.16.x/announcing-1.16/change-notes/)) by disabling `PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING` environment variable.

3. `istiod` now takes 0.5M CPU and 2GB memory by default. These can be changed by setting fields in `k8s` key.

**Type of changes**
Please delete options that are not relevant.
- [x] Installation fix (fix or feature that would cause existing functionality to not work as expected)

**Feature/Issue validation/testing**:
- [x] Ran `quick_install.sh` with the updated script on cluster with Kubernetes version 1.22 (1.22.16-gke.1300)
- [x] Checked `istiod` and `istio-ingressgateway` pods to contain safe-to-evict annotation
- [x] Cluster Autoscaler successfully downscaled a new node 

- Logs
Annotation set
![image](https://user-images.githubusercontent.com/5755405/208650971-1ca54460-2402-489f-83f4-bc3f50b3fbbb.png)

CPU and memory leakage before setting `PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING` flag `false`
![image](https://user-images.githubusercontent.com/5755405/208651356-c7abeb49-c90c-47d8-8ce6-c2a3e1fb8c11.png)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
