### PR TITLE
add model_ready v2 endpoint

### DIFF
--- a/python/kserve/kserve/handlers/v2_datamodels.py
+++ b/python/kserve/kserve/handlers/v2_datamodels.py
@@ -97,6 +97,19 @@ class ModelMetadataResponse(BaseModel):
     outputs: List[MetadataTensor]
 
 
+class ModelReadyResponse(BaseModel):
+    """ModelReadyResponse
+
+        $ready_model_response =
+        {
+          "name": $string,
+          "ready": $bool
+        }
+    """
+    name: str
+    ready: bool
+
+
 class RequestInput(BaseModel):
     """RequestInput Model
 

--- a/python/kserve/kserve/handlers/v2_endpoints.py
+++ b/python/kserve/kserve/handlers/v2_endpoints.py
@@ -96,7 +96,6 @@ class V2Endpoints:
 
         return ModelReadyResponse.parse_obj({"name": model_name, "ready": model_ready})
 
-
     async def infer(
         self,
         raw_request: Request,

--- a/python/kserve/kserve/handlers/v2_endpoints.py
+++ b/python/kserve/kserve/handlers/v2_endpoints.py
@@ -17,8 +17,9 @@ from fastapi.requests import Request
 from fastapi.responses import Response
 from kserve.handlers.v2_datamodels import (
     InferenceRequest, ServerMetadataResponse, ServerLiveResponse, ServerReadyResponse,
-    ModelMetadataResponse, InferenceResponse
+    ModelMetadataResponse, InferenceResponse, ModelReadyResponse
 )
+from kserve.errors import ModelNotReady
 from kserve.handlers.dataplane import DataPlane
 from kserve.handlers.model_repository_extension import ModelRepositoryExtension
 
@@ -73,6 +74,28 @@ class V2Endpoints:
 
         metadata = await self.dataplane.model_metadata(model_name)
         return ModelMetadataResponse.parse_obj(metadata)
+
+    async def model_ready(self, model_name: str, model_version: Optional[str] = None) -> ModelReadyResponse:
+        """Check if a given model is ready.
+
+        Args:
+            model_name (str): Model name.
+            model_version (str): Model version.
+
+        Returns:
+            ModelReadyResponse: Model ready object
+        """
+        # TODO: support model_version
+        if model_version:
+            raise NotImplementedError("Model versioning not supported yet.")
+
+        model_ready = self.dataplane.model_ready(model_name)
+
+        if not model_ready:
+            raise ModelNotReady(model_name)
+
+        return ModelReadyResponse.parse_obj({"name": model_name, "ready": model_ready})
+
 
     async def infer(
         self,

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -35,7 +35,7 @@ from kserve.handlers import V1Endpoints, V2Endpoints
 from kserve.handlers.dataplane import DataPlane
 from kserve.handlers.model_repository_extension import ModelRepositoryExtension
 from kserve.handlers.v2_datamodels import InferenceResponse, ServerMetadataResponse, ServerLiveResponse, \
-    ServerReadyResponse, ModelMetadataResponse
+    ServerReadyResponse, ModelMetadataResponse, ModelReadyResponse
 from kserve.model_repository import ModelRepository
 
 
@@ -151,6 +151,10 @@ class ModelServer:
                              v2_endpoints.model_metadata, response_model=ModelMetadataResponse, tags=["V2"]),
                 FastAPIRoute(r"/v2/models/{model_name}/versions/{model_version}",
                              v2_endpoints.model_metadata, tags=["V2"], include_in_schema=False),
+                FastAPIRoute(r"/v2/models/{model_name}/ready",
+                             v2_endpoints.model_ready, response_model=ModelReadyResponse, tags=["V2"]),
+                FastAPIRoute(r"v2/models/{model_name}/versions/{model_version}/ready",
+                             v2_endpoints.model_ready, response_model=ModelReadyResponse, tags=["V2"]),
                 FastAPIRoute(r"/v2/models/{model_name}/infer",
                              v2_endpoints.infer, methods=["POST"], response_model=InferenceResponse, tags=["V2"]),
                 FastAPIRoute(r"/v2/models/{model_name}/versions/{model_version}/infer",

--- a/python/kserve/test/test_dataplane.py
+++ b/python/kserve/test/test_dataplane.py
@@ -108,6 +108,14 @@ class TestDataPlane:
         }
         assert dataplane.metadata() == expected_metadata
 
+    async def test_model_metadata(self, dataplane_with_model):
+        assert await dataplane_with_model.model_metadata(self.MODEL_NAME) == {
+            "name": self.MODEL_NAME,
+            "platform": "",
+            "inputs": [],
+            "outputs": []
+        }
+
     async def test_infer(self, dataplane_with_model):
         body = b'{"instances":[[1,2]]}'
         resp = await dataplane_with_model.infer(self.MODEL_NAME, body)

--- a/python/kserve/test/test_dataplane.py
+++ b/python/kserve/test/test_dataplane.py
@@ -108,14 +108,6 @@ class TestDataPlane:
         }
         assert dataplane.metadata() == expected_metadata
 
-    async def test_model_metadata(self, dataplane_with_model):
-        assert await dataplane_with_model.model_metadata(self.MODEL_NAME) == {
-            "name": self.MODEL_NAME,
-            "platform": "",
-            "inputs": [],
-            "outputs": []
-        }
-
     async def test_infer(self, dataplane_with_model):
         body = b'{"instances":[[1,2]]}'
         resp = await dataplane_with_model.infer(self.MODEL_NAME, body)


### PR DESCRIPTION
Fixes issue where we are missing the model_ready endpoint for the v2 protocol. Found this while writing up v0.10 website docs. https://github.com/kserve/website/pull/205

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update **(incoming to kserve/website)**

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Test A - deployed kubernetes pod using python sdk and 

curl -v localhost:8080/v2/models/custom-server-test/ready
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /v2/models/custom-server-test/ready HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< date: Thu, 22 Dec 2022 20:18:04 GMT
< server: uvicorn
< content-length: 42
< content-type: application/json
<
* Connection #0 to host localhost left intact
{"name":"custom-server-test","ready":true}

