### PR TITLE
fix: Incorrect URL when making predictions via curl

### DIFF
--- a/docs/samples/v1beta1/tensorflow/README.md
+++ b/docs/samples/v1beta1/tensorflow/README.md
@@ -42,7 +42,7 @@ The first step is to [determine the ingress IP and ports](../../../../README.md#
 MODEL_NAME=flower-sample
 INPUT_PATH=@./input.json
 SERVICE_HOSTNAME=$(kubectl get inferenceservice ${MODEL_NAME} -o jsonpath='{.status.url}' | cut -d "/" -f 3)
-curl -v -H "Host: ${SERVICE_HOSTNAME}" http://${INGRESS_HOST}:${INGRESS_PORT}/v1/models/$MODEL_NAME:predict -d $INPUT_PATH
+curl -v -H "Host: ${SERVICE_HOSTNAME}" "http://${INGRESS_HOST}:${INGRESS_PORT}/v1/models/$MODEL_NAME:predict" -d $INPUT_PATH
 ```
 
 Expected Output


### PR DESCRIPTION
This fixes the following error:
```
curl: (3) URL using bad/illegal format or missing URL
```

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
