### PR TITLE
Use kubectl -k instead of kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,10 @@ deploy-dev-storageInitializer: docker-push-storageInitializer
 	kustomize build config/overlays/dev-image-config | kubectl apply -f -
 
 deploy-ci: manifests
-	kustomize build config/overlays/test | kubectl apply -f -
+	kubectl apply -k config/overlays/test
 	# TODO: Add runtimes as part of default deployment
 	kubectl wait --for=condition=ready pod -l control-plane=kserve-controller-manager -n kserve --timeout=300s
-	kustomize build config/overlays/test/runtimes | kubectl apply -f -
+	kubectl apply -k config/overlays/test/runtimes
 
 deploy-helm: manifests
 	helm install kserve-crd charts/kserve-crd/ --wait --timeout 180s

--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -23,5 +23,5 @@ protobuf~=3.19.0
 prometheus-client>=0.13.1
 orjson>=3.8.0
 httpx>=0.23.0
-fastapi>=0.85.0
+fastapi>=0.85.0,<=0.88.0
 uvicorn>=0.16.0

--- a/test/scripts/gh-actions/setup-deps.sh
+++ b/test/scripts/gh-actions/setup-deps.sh
@@ -41,7 +41,7 @@ pushd istio_tmp >/dev/null
 popd
 
 kubectl create ns istio-system
-kubectl apply -k test/overlays/istio
+for i in 1 2 3 ; do kubectl apply -k test/overlays/istio && break || sleep 15; done
 
 echo "Waiting for Istio to be ready ..."
 kubectl wait --for=condition=Ready pods --all --timeout=240s -n istio-system
@@ -66,7 +66,7 @@ pushd ${SCRIPT_DIR}/../../overlays/knative >/dev/null
   sed -i 's/8443:/"8443":/g' release.yaml
 popd
 
-kubectl apply -k test/overlays/knative
+for i in 1 2 3 ; do kubectl apply -k test/overlays/knative && break || sleep 15; done
 
 echo "Waiting for Knative to be ready ..."
 kubectl wait --for=condition=Ready pods --all --timeout=300s -n knative-serving -l 'app in (webhook, activator,autoscaler,autoscaler-hpa,controller,net-istio-controller,net-istio-webhook)'

--- a/test/scripts/gh-actions/setup-deps.sh
+++ b/test/scripts/gh-actions/setup-deps.sh
@@ -26,13 +26,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 ISTIO_VERSION="1.12.0"
 KNATIVE_VERSION="knative-v1.4.0"
 CERT_MANAGER_VERSION="v1.5.0"
-KUSTOMIZE_VERSION="4.2.0"
 YQ_VERSION="v4.28.1"
-
-echo "Installing/Updating kustomize ..."
-KUSTOMIZE_PATH=$(which kustomize)
-rm -rf ${KUSTOMIZE_PATH}
-curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- ${KUSTOMIZE_VERSION} ${KUSTOMIZE_PATH::-10}
 
 echo "Installing yq ..."
 wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq
@@ -47,7 +41,7 @@ pushd istio_tmp >/dev/null
 popd
 
 kubectl create ns istio-system
-for i in 1 2 3 ; do kustomize build test/overlays/istio | kubectl apply -f - && break || sleep 15; done
+kubectl apply -k test/overlays/istio
 
 echo "Waiting for Istio to be ready ..."
 kubectl wait --for=condition=Ready pods --all --timeout=240s -n istio-system
@@ -72,7 +66,7 @@ pushd ${SCRIPT_DIR}/../../overlays/knative >/dev/null
   sed -i 's/8443:/"8443":/g' release.yaml
 popd
 
-for i in 1 2 3 ; do kustomize build test/overlays/knative | kubectl apply -f - && break || sleep 15; done
+kubectl apply -k test/overlays/knative
 
 echo "Waiting for Knative to be ready ..."
 kubectl wait --for=condition=Ready pods --all --timeout=300s -n knative-serving -l 'app in (webhook, activator,autoscaler,autoscaler-hpa,controller,net-istio-controller,net-istio-webhook)'


### PR DESCRIPTION
Signed-off-by: Dan Sun <dsun20@bloomberg.net>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Use `kubectl apply -k` instead of installing kustomize as it always gets rate limit error when all github actions are triggered.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2633 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Special notes for your reviewer**:

1. Also need to pin fastapi to 0.88 as 0.89 requires response type be pandatic models.
**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
