### PR TITLE
fix light gbm model format

### DIFF
--- a/config/runtimes/kserve-lgbserver.yaml
+++ b/config/runtimes/kserve-lgbserver.yaml
@@ -8,7 +8,7 @@ spec:
     prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
     - name: lightgbm
-      version: "2"
+      version: "3"
       autoSelect: true
   protocolVersions:
     - v1


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a bug where the lightgbm runtime YAML version is out of date. 

lightgbm version defined as 3.3.2 https://github.com/kserve/kserve/blob/master/python/lgbserver/setup.py#L41, but runtime YAML was not updated and only supports major version 2. 

We should use 3.3.2 as source of truth since this is what we use to build the image. 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
