### PR TITLE
Fixing custom model example by pinning reqs.

### DIFF
--- a/python/custom_model/requirements.txt
+++ b/python/custom_model/requirements.txt
@@ -1,2 +1,3 @@
-kserve
+kserve==v0.10.0-rc1
 torchvision
+fastapi==0.85.0

--- a/python/custom_model/requirements.txt
+++ b/python/custom_model/requirements.txt
@@ -1,3 +1,6 @@
+# Custom model uses from kserve.utils.utils import generate_uuid
+# which is only present in this release candidate
 kserve==v0.10.0-rc1
 torchvision
+# Without pinning this, it gives an error on response_model typing
 fastapi==0.85.0


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes the example provided in the section ["How to write a custom predictor"](https://kserve.github.io/website/modelserving/v1beta1/custom/custom_model/). Currently, if you follow the instructions, the custom model returns some errors based on the fact that the current version on `master` branch, is using functions that are only available in `kserve==v0.10.0-rc1`. 

Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Without pinning the versions and by following the instructions of building the `custom_model` with 

```bash
pack build --builder=heroku/buildpacks:20 ${DOCKER_USER}/custom-model:v1
```

you get `kserve-0.9.0` since it's the latest stable version. 

![image](https://user-images.githubusercontent.com/6526276/212027156-c26fa2dc-f934-4fc2-82fb-21c3cfdd72e1.png)



- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
