### PR TITLE
[bugfix]: support kubectl server version correctly

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -36,8 +36,8 @@ export KSERVE_VERSION=v0.10.0-rc0
 export CERT_MANAGER_VERSION=v1.3.0
 export SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
 
-KUBE_VERSION=$(kubectl version --short=true)
-if [ ${KUBE_VERSION:43:2} -lt 22 ];
+KUBE_VERSION=$(kubectl version --short=true | awk 'FNR == 2 {print}'| awk -F '.' '{print $2}')
+if [ ${KUBE_VERSION} -lt 22 ];
 then
    echo "😱 install requires at least Kubernetes 1.22";
    exit 1;


### PR DESCRIPTION
**What this PR does / why we need it**:
Parse kubernetes server version `KUBE_VERSION` in general.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
The current parsing check the length of the character, but it may parse wrong version sometimes.
For my case, my kubectl was built on my own from git repo(kubernetes).
So the result of `kubectl version --short=true` was as following:
```
Client Version: v1.23.0-alpha.3.605+9bcfa71e3121ec-dirty
Server Version: v1.24.1
```

Since the previsious parsing depends on the number of characters, `KUBE_VERSION` became `e3`.
So I couldn't use `quick_install.sh` now.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
