### PR TITLE
Fix KUBE_VERSION variable in `quick_install.sh` file

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -36,7 +36,7 @@ export KSERVE_VERSION=v0.10.0
 export CERT_MANAGER_VERSION=v1.3.0
 export SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
 
-KUBE_VERSION=$(kubectl version --short=true | awk 'FNR == 2 {print}'| awk -F '.' '{print $2}')
+KUBE_VERSION=$(kubectl version --short=true | grep "Server Version" | awk -F '.' '{print $2}')
 if [ ${KUBE_VERSION} -lt 22 ];
 then
    echo "😱 install requires at least Kubernetes 1.22";


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- correctly populate `KUBE_VERSION` variable in quick_install.sh file by grepping the server version line, instead of relying on line numbers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
- Fixes #2661

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- Crossed checked `KUBE_VERSION` variable on my machine with Kubernetes Server Version: v1.25.3 and Kubernetes Server Version: v1.22

```
ajaynagar@LJD43D kserve % kubectl version --short=true | grep "Server Version" | awk -F '.' '{print $2}'
25
```

**Special notes for your reviewer**:

- Flag `--short` has been deprecated and will be removed in the future. The --short output will become the default. Contributors will need to update this again when the --short flag is completely deprecated in next releases. Contributors will also need to consider the fact if kubernetes keeps the output backward compatible or not.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
