### PR TITLE
Add mirroring graph node type

### DIFF
--- a/pkg/apis/serving/v1alpha1/inference_graph.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph.go
@@ -54,7 +54,7 @@ type InferenceGraphSpec struct {
 
 // InferenceRouterType constant for inference routing types
 // +k8s:openapi-gen=true
-// +kubebuilder:validation:Enum=Sequence;Splitter;Ensemble;Switch
+// +kubebuilder:validation:Enum=Sequence;Splitter;Ensemble;Switch;Mirroring
 type InferenceRouterType string
 
 // InferenceRouterType Enum
@@ -70,6 +70,9 @@ const (
 
 	// Switch routes the request to the model based on certain condition
 	Switch InferenceRouterType = "Switch"
+
+	// Mirroring: Copy the request to mirror routes, and ignore mirror response.
+	Mirroring InferenceRouterType = "Mirroring"
 )
 
 const (
@@ -208,6 +211,7 @@ type InferenceRouter struct {
 	//
 	// - `Switch:` routes the request to one of the steps based on condition
 	//
+	// - `Mirroring:` routes the request to `main` service and `mirroring` service. `main` service is `step[0]`, other `steps` are `mirror` service
 	RouterType InferenceRouterType `json:"routerType"`
 
 	// Steps defines destinations for the current router node

--- a/pkg/apis/serving/v1alpha1/inference_graph_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph_validation_test.go
@@ -18,11 +18,12 @@ package v1alpha1
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func makeTestInferenceGraph() InferenceGraph {
@@ -256,6 +257,25 @@ func TestInferenceGraph_ValidateCreate(t *testing.T) {
 				},
 			},
 			errMatcher:      gomega.MatchError(fmt.Errorf(DuplicateStepNameError, GraphRootNodeName, "foo-bar", "step1")),
+			warningsMatcher: gomega.BeEmpty(),
+		},
+		"mirroring node have less than 2 steps": {
+			ig: makeTestInferenceGraph(),
+			nodes: map[string]InferenceRouter{
+				GraphRootNodeName: {
+					RouterType: "Mirroring",
+					Steps: []InferenceStep{
+						{
+							StepName: "step1",
+							Weight:   proto.Int64(80),
+							InferenceTarget: InferenceTarget{
+								ServiceName: "service1",
+							},
+						},
+					},
+				},
+			},
+			errMatcher:      gomega.MatchError(fmt.Errorf(InvalidMirroringSpecError, "foo-bar", GraphRootNodeName)),
 			warningsMatcher: gomega.BeEmpty(),
 		},
 	}


### PR DESCRIPTION
Signed-off-by: iamlovingit <freecode666@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We are facing a new use case: we want to add a testing branch to an online service(main branch), this testing branch will get some of online queries, but we don't want the testing branch response. So far, inference graph has no type of routing node can slove this, so we want to add an new routing type: Mirroring. A mirroring routing node need 2 fields: serviceName and mirroring percent.



**Which issue(s) this PR fixes** 
Fixes #2240 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Design
```
                           +--------------+
      <---------Res--------+              |
Client          100%       |              |
      ----+-----Req-------->     Main     |
          |                |              |
          |                |              |
          |                +--------------+
          |
          |
          |                +--------------+
          |                |              |
          |  20%           |              |
           +-----Req-------->   Testing   |
                           |              |
          <-------X--------+              |
                           +--------------+
```

### Example yaml
```yaml
apiVersion: "serving.kserve.io/v1alpha1"
kind: InferenceGraph
metadata:
  name: model-mirroring
spec:
  nodes:
    root:
      routerType: Mirroring
      steps:
      - serviceUrl: http://single-1.default.${domain}/switch # Main route
      - serviceUrl: http://single-2.default.${domain}/switch # Mirroring route
        weight: 100
      - serviceUrl: http://single-3.default.${domain}/switch # Mirroring route
        weight: 20
```

### Other test yamls
#### Default weight
```yaml
apiVersion: "serving.kserve.io/v1alpha1"
kind: InferenceGraph
metadata:
  name: model-mirroring
spec:
  nodes:
    root:
      routerType: Mirroring
      steps:
      - serviceUrl: http://single-1.default.${domain}/switch # Main route
      - serviceUrl: http://single-2.default.${domain}/switch # Mirroring route, default weight 100
      - serviceUrl: http://single-3.default.${domain}/switch # Mirroring route
        weight: 20
```
#### Wrong node type
```yaml
apiVersion: "serving.kserve.io/v1alpha1"
kind: InferenceGraph
metadata:
  name: model-mirroring
spec:
  nodes:
    root:
      routerType: WrongType
      steps:
      - serviceUrl: http://single-1.default.${domain}/switch # Main route
      - serviceUrl: http://single-2.default.${domain}/switch # Mirroring route, default weight 100
      - serviceUrl: http://single-3.default.${domain}/switch # Mirroring route
        weight: 20
```
#### Wrong mirroring weight
```yaml
apiVersion: "serving.kserve.io/v1alpha1"
kind: InferenceGraph
metadata:
  name: model-mirroring
spec:
  nodes:
    root:
      routerType: Mirroring
      steps:
      - serviceUrl: http://single-1.default.${domain}/switch # Main route
      - serviceUrl: http://single-2.default.${domain}/switch # Mirroring route
         weight: 101
      - serviceUrl: http://single-3.default.${domain}/switch # Mirroring route
        weight: -20
```

