### PR TITLE
Loosen protobuf and numpy dependency

### DIFF
--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -8,7 +8,7 @@ minio>=4.0.9,<=7.1.3
 google-cloud-storage>=1.20.0
 adal>=1.2.7
 tabulate>=0.9.0
-numpy>=1.21.5,<1.24.0
+numpy>=1.21.5
 azure-storage-blob==12.9.0
 azure-storage-file-share==12.7.0
 azure-identity>=1.8.0

--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -19,7 +19,7 @@ psutil>=5.9.0
 ray[serve]==2.0.0
 grpcio>=1.34.0
 tritonclient==2.18.0
-protobuf~=3.19.0
+protobuf>=3.19.0
 prometheus-client>=0.13.1
 orjson>=3.8.0
 httpx>=0.23.0

--- a/python/kserve/requirements.txt
+++ b/python/kserve/requirements.txt
@@ -7,7 +7,7 @@ argparse>=1.4.0
 minio>=4.0.9,<=7.1.3
 google-cloud-storage>=1.20.0
 adal>=1.2.7
-table_logger>=0.3.6
+tabulate>=0.9.0
 numpy>=1.21.5,<1.24.0
 azure-storage-blob==12.9.0
 azure-storage-file-share==12.7.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Loosens protobuf and numpy.
Numpy was restricted to <1.24 by tabble-logger. Using a different library to tabulate watch logs.
Protobuf version was restricted to <=3.19 because of a breaking change made by >v4.00.
However, ray now adds a restriction for protobuf to less than <= 4.00, in which case we can remove the restriction for 4.0 for now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2607, #2641

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

**Checklist**:
- [x] Has code been commented, particularly in hard-to-understand areas?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
