### PR TITLE
Fix running out of disk space in e2e

### DIFF
--- a/python/custom_transformer/requirements.txt
+++ b/python/custom_transformer/requirements.txt
@@ -1,3 +1,3 @@
 kserve
-torchvision
+torchvision==0.14.1
 pillow==9.3.0


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Torchvision has a new release 0.15.1 and the image size has increased by almost 1 Gb. Hence the build failures. Pinning torchvision to 0.14.1.
Upgrade to newer version of torchvision will be done in near future.

Fixes #2764 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


```release-note
NONE
```
