### PR TITLE
fix trained model ready status

### DIFF
--- a/docs/samples/multimodelserving/triton/README.md
+++ b/docs/samples/multimodelserving/triton/README.md
@@ -119,9 +119,6 @@ status:
   conditions:
   - lastTransitionTime: "2021-05-22T20:56:12Z"
     status: "True"
-    type: FrameworkSupported
-  - lastTransitionTime: "2021-05-22T20:56:12Z"
-    status: "True"
     type: InferenceServiceReady
   - lastTransitionTime: "2021-05-22T20:56:12Z"
     status: "True"
@@ -184,9 +181,6 @@ status:
   address:
     url: http://triton-mms.default.svc.cluster.local/v2/models/simple-string/infer
   conditions:
-  - lastTransitionTime: "2021-05-23T00:02:42Z"
-    status: "True"
-    type: FrameworkSupported
   - lastTransitionTime: "2021-05-23T00:02:42Z"
     status: "True"
     type: InferenceServiceReady

--- a/pkg/apis/serving/v1alpha1/trained_model_status.go
+++ b/pkg/apis/serving/v1alpha1/trained_model_status.go
@@ -39,8 +39,6 @@ type TrainedModelStatus struct {
 const (
 	// InferenceServiceReady is set when inference service reported readiness
 	InferenceServiceReady apis.ConditionType = "InferenceServiceReady"
-	// FrameworkSupported is set when predictor reports framework check
-	FrameworkSupported apis.ConditionType = "FrameworkSupported"
 	// MemoryResourceAvailable is set when inference service reported resources availability
 	MemoryResourceAvailable apis.ConditionType = "MemoryResourceAvailable"
 	// IsMMSPredictor is set when inference service predictor is set to multi-model serving
@@ -51,7 +49,6 @@ const (
 // TODO: Similar to above, add the constants here
 var conditionSet = apis.NewLivingConditionSet(
 	InferenceServiceReady,
-	FrameworkSupported,
 	MemoryResourceAvailable,
 	IsMMSPredictor,
 )

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -133,7 +133,7 @@ func (r *TrainedModelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// Check inferenceserviceready, frameworksupported, and memoryavailability
+	// Check inferenceserviceready, and memoryavailability
 	if err := r.updateConditions(req, tm); err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This change would fix the issue with trained model status showing unknown even the model is ready and responding for requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
