### PR TITLE
model_server.py: fix documentation for enable_latency_logging

### DIFF
--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -75,7 +75,7 @@ class ModelServer:
         registered_models (ModelRepository): Model repository with registered models.
         enable_grpc (bool): Whether to turn on grpc server. Default: ``True``
         enable_docs_url (bool): Whether to turn on ``/docs`` Swagger UI. Default: ``False``.
-        enable_latency_logging (bool): Whether to log latency metric. Default: ``False``.
+        enable_latency_logging (bool): Whether to log latency metric. Default: ``True``.
     """
 
     def __init__(self, http_port: int = args.http_port,


### PR DESCRIPTION
**What this PR does / why we need it**:
Simple documentation fix for the `enable_latency_logging` option.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

