### PR TITLE
python: allow to override the UvicornServer's default log config

### DIFF
--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -55,6 +55,10 @@ parser.add_argument("--enable_docs_url", default=False, type=lambda x: bool(strt
                     help="Enable docs url '/docs' to display Swagger UI.")
 parser.add_argument("--enable_latency_logging", default=True, type=lambda x: bool(strtobool(x)),
                     help="Output a log per request with latency metrics.")
+parser.add_argument("--log_config_file", default=None, type=str,
+                    help="File path containing UvicornServer's log config. Needs to be a yaml or json file.")
+parser.add_argument("--access_log_format", default=None, type=str,
+                    help="Format to set for the access log (provided by asgi-logger).")
 
 args, _ = parser.parse_known_args()
 
@@ -76,6 +80,8 @@ class ModelServer:
         enable_grpc (bool): Whether to turn on grpc server. Default: ``True``
         enable_docs_url (bool): Whether to turn on ``/docs`` Swagger UI. Default: ``False``.
         enable_latency_logging (bool): Whether to log latency metric. Default: ``True``.
+        log_config_file (dict): File path containing UvicornServer's log config. Default: ``None``.
+        access_log_format (string): Format to set for the access log (provided by asgi-logger). Default: ``None``
     """
 
     def __init__(self, http_port: int = args.http_port,
@@ -86,7 +92,9 @@ class ModelServer:
                  registered_models: ModelRepository = ModelRepository(),
                  enable_grpc: bool = args.enable_grpc,
                  enable_docs_url: bool = args.enable_docs_url,
-                 enable_latency_logging: bool = args.enable_latency_logging):
+                 enable_latency_logging: bool = args.enable_latency_logging,
+                 log_config_file: str = args.log_config_file,
+                 access_log_format: str = args.access_log_format):
         self.registered_models = registered_models
         self.http_port = http_port
         self.grpc_port = grpc_port
@@ -100,6 +108,8 @@ class ModelServer:
         self.model_repository_extension = ModelRepositoryExtension(
             model_registry=self.registered_models)
         self._grpc_server = GRPCServer(grpc_port, self.dataplane, self.model_repository_extension)
+        self.log_config_file = log_config_file
+        self.access_log_format = access_log_format
 
     def start(self, models: Union[List[Model], Dict[str, Deployment]]) -> None:
         if isinstance(models, list):
@@ -143,7 +153,9 @@ class ModelServer:
                     sig, lambda s=sig: asyncio.create_task(self.stop(sig=s))
                 )
             self._rest_server = UvicornServer(self.http_port, [serversocket],
-                                              self.dataplane, self.model_repository_extension, self.enable_docs_url)
+                                              self.dataplane, self.model_repository_extension,
+                                              self.enable_docs_url, log_config_file=self.log_config_file,
+                                              access_log_format=self.access_log_format)
             if self.workers == 1:
                 await self._rest_server.run()
             else:
@@ -153,7 +165,8 @@ class ModelServer:
                 # https://github.com/tiangolo/fastapi/issues/1586
                 multiprocessing.set_start_method('fork')
                 server = UvicornServer(self.http_port, [serversocket],
-                                       self.dataplane, self.model_repository_extension, self.enable_docs_url)
+                                       self.dataplane, self.model_repository_extension,
+                                       self.enable_docs_url, custom_log_config=self.log_config)
                 for _ in range(self.workers):
                     p = Process(target=server.run_sync)
                     p.start()

--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -204,6 +204,21 @@ test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (>=0.16,<0.22)"]
 
 [[package]]
+name = "asgi-logger"
+version = "0.1.0"
+description = "Middleware based uvicorn access logger! :tada:"
+category = "main"
+optional = true
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "asgi-logger-0.1.0.tar.gz", hash = "sha256:b289f530bf49d14320242a567580ffc8ad053ba5667eece27d25a97822d3a0aa"},
+    {file = "asgi_logger-0.1.0-py3-none-any.whl", hash = "sha256:f2d1252cfc48b4a806d1810f0308ba2979fa73aca06ecc809903a8ebc5a6ef23"},
+]
+
+[package.dependencies]
+asgiref = ">=3.4.1,<4.0.0"
+
+[[package]]
 name = "asgiref"
 version = "3.6.0"
 description = "ASGI specs, helper code, and adapters"
@@ -3126,6 +3141,7 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
+logging = ["asgi-logger"]
 storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "boto3", "google-cloud-storage", "requests", "urllib3"]
 
 [metadata]

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -61,6 +61,9 @@ azure-storage-file-share = { version = "~12.7.0", optional = true }
 azure-identity = { version = "^1.8.0", optional = true }
 boto3 = { version = "^1.21.0", optional = true }
 
+# Logging dependencies. They can be opted into by apps.
+asgi-logger = { version = "^0.1.0", optional = true, python = ">3.8.0,<3.11" }
+
 [tool.poetry.extras]
 storage = [
     "urllib3",
@@ -70,6 +73,9 @@ storage = [
     "azure-storage-file-share",
     "azure-identity",
     "boto3",
+]
+logging = [
+    "asgi-logger"
 ]
 
 [tool.poetry.group.test]


### PR DESCRIPTION
**What this PR does / why we need it**:
It is useful to be able to change Uvicorn's log settings, for example to be able to change the access log's format.

The Uvicorn's Config class provides a "configure_logging" function that is smart about the log_config parameter - if it is a string, and not a dictionary, it is interpreted as a file containing logging directives and that needs to be loaded from disk. This is very convenient for the KServe use case: one can either use the default config, hardcoded in a dictionary, or anything provided as yaml or json file.

This change fixes also the default UvicornServer's config.

Sadly the current Uvicorn implementation doesn't support
changing the access log format, but they suggest to use
asgi-logger:

https://github.com/encode/uvicorn/pull/947#issuecomment-1283006367

It seems the only way forward to allow a decent customization
of a vital sign like the access log.

The main issue is that `asgi-logger` requires Python 3.8, so the dependency is added
as extra to Poetry's config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #2778

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

I tried to use the following snippet:

```
import kserve
from typing import Dict
import argparse
import logging

logger = logging.getLogger()

class CustomPredictor(kserve.Model):
    def __init__(self, name: str):
        super().__init__(name)
        self.name = name
        self.load()

    def load(self):
        self.ready = True

    def predict(self, request: Dict, headers: Dict) -> Dict:
        return {"predictions": True}

if __name__ == "__main__":
    model = CustomPredictor("test")
    kserve.ModelServer(workers=1, enable_latency_logging=False, log_config_file="/tmp/test1.yaml").start([model])
```
I saved in `/tmp/test1.yaml` a logging config, and ran the above script. I was able to observe access logs following the configuration that I passed in the file.

Moreover, if I run the `ModelServer` class without `log_config_file`, I see access logs as expected (as opposed to now that I don't see them, IIUC due to the wrong default config hardcoded in the `UvicornServer`'s class).

I also tried the new `access_log_format` parameter, that works as expected (namely I am able to use something like `'%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'` to customize the access logs:

```
127.0.0.1:48276 - - [01/Apr/2023:12:02:07 +0000] "GET /v1/ HTTP/1.1" 404 - "-" "curl/7.74.0"
```

For the moment the support is only for the asgi-logger's default, namely stdout, but we can surely add an option to log to disk or similar (but not sure if KServe users really need it).

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
No idea if unit tests are needed in this case, lemme know if you fell differently.
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
Not sure if any are needed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Fix the default Uvicorn's log configuration and allow to override it using a custom json or yaml file. Add an experimental parameter to the model server class to support gunicorn's access_log_format config.
```
