### PR TITLE
Fix minimum k8s version in quick install

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -37,9 +37,9 @@ export CERT_MANAGER_VERSION=v1.3.0
 export SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
 
 KUBE_VERSION=$(kubectl version --short=true | grep "Server Version" | awk -F '.' '{print $2}')
-if [ ${KUBE_VERSION} -lt 22 ];
+if [ ${KUBE_VERSION} -lt 24 ];
 then
-   echo "😱 install requires at least Kubernetes 1.22";
+   echo "😱 install requires at least Kubernetes 1.24";
    exit 1;
 fi
 


### PR DESCRIPTION

**What this PR does / why we need it**:
  Updates the minimum kubernetes version to 1.24 in quick install as knative 1.9.0 only supports k8s 1.24+
  
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
NONE
```release-note

```
