### PR TITLE
Add Triton FasterTransformer example

### DIFF
--- a/docs/samples/v1beta1/triton/fastertransformer/README.md
+++ b/docs/samples/v1beta1/triton/fastertransformer/README.md
@@ -1,0 +1,230 @@
+
+# Deploying a BLOOM LLM model using the FasterTransformer backend
+The BigScience BLOOM LM is an open source large language model (LLM) that can be used for a variety of natural language processing tasks including text generation, text classification, and question answering. In this example we will deploy a small version of the BLOOM model (560 million parameters) to KServe using Triton with the FasterTransformer (FT) backend as our inference server.
+
+> **Note**  
+> This example requires access to a KServe cluster with GPU support
+
+In this example we will demonstrate:
+- Building a custom Triton image that includes the FasterTransformer backend
+- Defining a custom `ClusterServingRuntime`
+- Exporting the [BLOOM 560m](https://huggingface.co/bigscience/bloom-560m) model for FasterTransformer
+- Preparing the model for loading in Triton
+- Setting up and building our KServe transformer
+- Defining and deploying our inference service
+- Running inference on our model
+
+## Building our custom Triton image
+
+Since the officially supported Triton images do not contain the FasterTransformer backend we will need to build our own custom image. The FasterTransformer backend repo [provides detailed instructions on building a custom image](https://github.com/triton-inference-server/fastertransformer_backend#prepare-docker-images). Build the image according to the instructions and push it to a container repository that is accessible by your KServe cluster.
+
+## Setting up a `ClusterServingRuntime`
+
+In order to allow our inference services to easily use our new image we will setup a custom cluster serving runtime. Apply the resource to your cluster as follows, making sure to replace the `image` field with the one you created in the previous step.
+
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: tritonserver-ft
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8002"
+  containers:
+  - args:
+    - tritonserver
+    - --model-store=/mnt/models
+    - --grpc-port=9000
+    - --http-port=8080
+    - --allow-grpc=true
+    - --allow-http=true
+    image: <my-custom-triton-image>
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+  protocolVersions:
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - name: triton
+    version: "2"
+```
+
+## Exporting the BLOOM 560m model
+
+The FasterTransformer repo provides a script for converting the HuggingFace BLOOM model to FasterTransformer format. The following directions are based on those outlined in the [FasterTransformer backend repo](https://github.com/triton-inference-server/fastertransformer_backend/blob/main/docs/gpt_guide.md#run-bloom).
+
+1. Create a working directory
+```sh
+mkdir ~/triton-bloom
+cd ~/triton-bloom
+```
+
+2. Clone the HuggingFace BLOOM 560m repository
+
+```sh
+# Make sure you have git-lfs installed (https://git-lfs.com)
+git lfs install
+git clone https://huggingface.co/bigscience/bloom-560m
+```
+
+3. Fetch the conversion script
+
+```sh
+curl -LO https://raw.githubusercontent.com/NVIDIA/FasterTransformer/main/examples/pytorch/gpt/utils/huggingface_bloom_convert.py
+```
+
+4. Convert the HuggingFace model to FT format
+
+```sh
+python3 huggingface_bloom_convert.py -o bloom -i ./bloom-560m/ -tp 1
+``` 
+
+Once this command completes execution you should have a new directory `bloom/1-cpu` that contains the model in FT format.
+
+## Preparing the model for loading into Triton
+
+Now that we have exported our model we need to prepare it for loading into Triton.
+
+1. Store the model according to the Triton repository layout
+
+Triton requires the filesystem to be arranged according to the [model repository specification](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md#repository-layout).
+
+```sh
+# Create a folder for our model. Our model will have the name 'fastertransformer'
+mkdir -p model-repo/fastertransformer
+# Our model will be version 1
+cp -r bloom/1-gpu model-repo/fastertransformer/1
+# Add the tokenizer artifacts. These will be used by the KServe transformer
+mkdir model-repo/fastertransformer/1/tokenizer
+cp bloom-560m/tokenizer*.json model-repo/fastertransformer/1/tokenizer
+```
+
+2. Fetch the sample BLOOM model config
+
+```sh
+curl -L https://raw.githubusercontent.com/triton-inference-server/fastertransformer_backend/main/all_models/bloom/fastertransformer/config.pbtxt \
+> model-repo/fastertransformer/config.pbtxt
+```
+
+3. Update the config to point to the correct checkpoint path
+
+The FasterTransformer backend requires the `model_checkpoint_path` parameter to point to the absolute path of the exported model on disk. We need to set this to the location that the KServe storage initializer will download the model to.
+
+```sh
+parameters {
+  key: "model_checkpoint_path"
+  value: {
+    string_value: "/mnt/models/fastertransformer/1"
+  }
+}
+```
+
+4. Upload your model to a storage location
+
+For this example we will use [S3](https://kserve.github.io/website/0.10/modelserving/storage/s3/s3/) but you may also use any of the other storage providers supported by KServe.
+
+```sh
+aws s3 cp --recursive model-repo s3://example-bucket/bloom-ft-example
+```
+
+### Building our custom transformer
+
+Our KServe transformer will provide a user friendly interface to our model. The string input provided by the caller will be tokenized before being passed into the model running on Triton. The tokenized result generated by the model will be converted to a string representation before being returned to the caller.
+
+Build and push the container image:
+
+```
+docker build -t <my-transformer-image> -f transformer/Dockerfile transformer
+docker push <my-transformer-image>
+```
+
+
+### Defining and deploying our inference service
+
+Now we will put everything together by defining our inference service. Make sure to replace the transformer image and both storage URIs (predictor and transformer) with the correct values.
+
+```sh
+kubectl apply -f - << EOF
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: bloom-560m
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+        version: "2"
+      name: ""
+      resources:
+        limits:
+          cpu: "1"
+          memory: 8Gi
+          nvidia.com/gpu: "1"
+        requests:
+          cpu: "1"
+          memory: 4Gi
+          nvidia.com/gpu: "1"
+      runtime: tritonserver-ft
+      storageUri: s3://example-bucket/bloom-ft-example
+  transformer:
+    containers:
+    - args:
+      - --model_name
+      - fastertransformer
+      - --protocol
+      - v2
+      - --tokenizer_path
+      - /mnt/models/
+      command:
+      - python
+      - transformer.py
+      env:
+      - name: STORAGE_URI
+        value: s3://example-bucket/bloom-ft-example/fastertransformer/1/tokenizer
+      image: <my-transformer-image>
+      name: kserve-container
+      resources:
+        limits:
+          cpu: "1"
+          memory: 2Gi
+        requests:
+          cpu: "1"
+          memory: 2Gi
+EOF
+```
+
+### Running inference on our model
+
+Wait for the inference service to reach the ready status.
+
+```sh
+kubectl get isvc -w
+```
+
+Once it is ready we should see something like this:
+```sh
+NAME           URL                                        READY   LATESTREADYREVISION                    AGE
+bloom-560m     http://bloom-560m-default.example.com      True    bloom-560m-predictor-default-00001     1m
+```
+
+Let's send a request!
+
+```sh
+curl -d '{"inputs":[{"input":"Kubernetes is the best platform to serve your models because","output_len":"18"}]}' \
+  http://bloom-560m-default.example.com/v1/models/fastertransformer:predict
+```
+
+This should output something like the following:
+```sh
+[["Kubernetes is the best platform to serve your models because it is a 
+cloud-based service that is built on top of the Kubernetes API."]]
+```

--- a/docs/samples/v1beta1/triton/fastertransformer/README.md
+++ b/docs/samples/v1beta1/triton/fastertransformer/README.md
@@ -84,6 +84,7 @@ curl -LO https://raw.githubusercontent.com/NVIDIA/FasterTransformer/main/example
 4. Convert the HuggingFace model to FT format
 
 ```sh
+pip3 install numpy transformers torch
 python3 huggingface_bloom_convert.py -o bloom -i ./bloom-560m/ -tp 1
 ``` 
 

--- a/docs/samples/v1beta1/triton/fastertransformer/README.md
+++ b/docs/samples/v1beta1/triton/fastertransformer/README.md
@@ -88,6 +88,8 @@ pip3 install numpy transformers torch
 python3 huggingface_bloom_convert.py -o bloom -i ./bloom-560m/ -tp 1
 ``` 
 
+The `-tp` flag specifies the level of tensor parallelism we would like the exported model to have. Tensor parallelism corresponds to the number of GPU that will be used to load and execute the model.
+
 Once this command completes execution you should have a new directory `bloom/1-cpu` that contains the model in FT format.
 
 ## Preparing the model for loading into Triton

--- a/docs/samples/v1beta1/triton/fastertransformer/transformer/Dockerfile
+++ b/docs/samples/v1beta1/triton/fastertransformer/transformer/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.9-slim-bullseye
+WORKDIR /code
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+COPY transformer.py transformer.py

--- a/docs/samples/v1beta1/triton/fastertransformer/transformer/requirements.txt
+++ b/docs/samples/v1beta1/triton/fastertransformer/transformer/requirements.txt
@@ -1,0 +1,2 @@
+kserve
+transformers

--- a/docs/samples/v1beta1/triton/fastertransformer/transformer/transformer.py
+++ b/docs/samples/v1beta1/triton/fastertransformer/transformer/transformer.py
@@ -1,0 +1,140 @@
+import argparse
+import logging
+import json
+from uuid import uuid4
+from typing import Dict, List, Optional, Union
+
+import kserve
+from kserve.protocol.infer_type import (
+    InferInput,
+    InferOutput,
+    InferRequest,
+    InferResponse,
+)
+from kserve.protocol.grpc.grpc_predict_v2_pb2 import ModelInferResponse
+import numpy as np
+from transformers import AutoTokenizer
+
+import multiprocessing as mp
+
+mp.set_start_method("fork")
+
+
+logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
+logger = logging.getLogger(__name__)
+
+from pydantic import BaseModel
+
+
+def get_output(outputs: List[InferOutput], name: str) -> InferOutput:
+    for o in outputs:
+        if o.name == name:
+            return o
+    raise KeyError("Unknown output name: {}".format(name))
+
+
+class Input(BaseModel):
+    input: str
+    output_len: int
+
+
+class Request(BaseModel):
+    inputs: List[Input]
+
+
+class Transformer(kserve.Model):
+    def __init__(
+        self,
+        name: str,
+        predictor_host: str,
+        protocol: str,
+        tokenizer_path: str,
+    ):
+        super().__init__(name)
+        self.predictor_host = predictor_host
+        self.protocol = protocol
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_path, local_files_only=True, 
+        )
+        logger.info(self.tokenizer)
+
+    def preprocess(self, _request: Dict, headers: Dict) -> InferRequest:
+        request = Request(**_request)
+        input_token_ids, input_lengths = self._tokenize_input(request)
+        output_lens = np.array(
+            [[i.output_len] for i in request.inputs], dtype=np.uint32
+        )
+        infer_inputs = [
+            InferInput(
+                name="input_ids",
+                shape=input_token_ids.shape,
+                datatype="UINT32",
+                data=input_token_ids,
+            ),
+            InferInput(
+                name="input_lengths",
+                shape=input_lengths.shape,
+                datatype="UINT32",
+                data=input_lengths,
+            ),
+            InferInput(
+                name="request_output_len",
+                shape=output_lens.shape,
+                datatype="UINT32",
+                data=output_lens,
+            ),
+        ]
+        return InferRequest(
+            self.name, infer_inputs=infer_inputs, request_id=str(uuid4())
+        )
+
+    def postprocess(
+        self, response: Union[ModelInferResponse, Dict], headers: Dict
+    ) -> str:
+        if isinstance(response, ModelInferResponse):
+            outputs = InferResponse.from_grpc(response).outputs
+        else:
+            outputs = [InferOutput(**o) for o in response["outputs"]]
+        output_ids = get_output(outputs, "output_ids").as_numpy()
+        results = []
+        for o in output_ids:
+            outputs = [self.tokenizer.decode(beam) for beam in o]
+            results.append(outputs)
+        return json.dumps(results)
+
+    def _tokenize_input(self, request: Request):
+        """
+        Convert input strings to tokens
+        """
+        inputs = [i.input for i in request.inputs]
+        encoded_inputs = self.tokenizer(inputs, padding=True, return_tensors='np')
+        input_token_ids = encoded_inputs["input_ids"].astype(np.uint32)
+        input_lengths = (
+            encoded_inputs["attention_mask"].sum(axis=-1, dtype=np.uint32).reshape((-1, 1))
+        )
+        input_lengths = np.array(input_lengths, dtype=np.uint32)
+        return input_token_ids, input_lengths
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
+    parser.add_argument("--model_name", help="The name that the model is served under.")
+    parser.add_argument(
+        "--predictor_host", help="The URL for the model predict function", required=True
+    )
+    parser.add_argument(
+        "--protocol", help="The protocol for the predictor", default="v2"
+    )
+    parser.add_argument(
+        "--tokenizer_path", help="The path to the tokenizer", required=True
+    )
+    args, _ = parser.parse_known_args()
+
+    transformer = Transformer(
+        name=args.model_name,
+        predictor_host=args.predictor_host,
+        protocol=args.protocol,
+        tokenizer_path=args.tokenizer_path,
+    )
+    server = kserve.ModelServer()
+    server.start(models=[transformer])

--- a/docs/samples/v1beta1/triton/fastertransformer/transformer/transformer.py
+++ b/docs/samples/v1beta1/triton/fastertransformer/transformer/transformer.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import json
 from uuid import uuid4
-from typing import Dict, List, Optional, Union
+from typing import Dict, List,  Union
 
 import kserve
 from kserve.protocol.infer_type import (
@@ -14,7 +14,7 @@ from kserve.protocol.infer_type import (
 from kserve.protocol.grpc.grpc_predict_v2_pb2 import ModelInferResponse
 import numpy as np
 from transformers import AutoTokenizer
-
+from pydantic import BaseModel
 import multiprocessing as mp
 
 mp.set_start_method("fork")
@@ -22,8 +22,6 @@ mp.set_start_method("fork")
 
 logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
 logger = logging.getLogger(__name__)
-
-from pydantic import BaseModel
 
 
 def get_output(outputs: List[InferOutput], name: str) -> InferOutput:
@@ -54,7 +52,7 @@ class Transformer(kserve.Model):
         self.predictor_host = predictor_host
         self.protocol = protocol
         self.tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_path, local_files_only=True, 
+            tokenizer_path, local_files_only=True,
         )
         logger.info(self.tokenizer)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
 This PR adds an end-to-end example for deploying a large language model on KServe.

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

```release-note
Add example for LLM on Triton with FasterTransformer
```
