### PR TITLE
Add RBAC for inferencegraphs/finalizers

### DIFF
--- a/charts/kserve-resources/templates/clusterrole.yaml
+++ b/charts/kserve-resources/templates/clusterrole.yaml
@@ -225,6 +225,7 @@ rules:
   - serving.kserve.io
   resources:
   - inferencegraphs
+  - inferencegraphs/finalizers
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -214,6 +214,7 @@ rules:
   - serving.kserve.io
   resources:
   - inferencegraphs
+  - inferencegraphs/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds the permissions to set `finalizers` on `inferencegraphs`. See https://github.com/kserve/kserve/issues/2838 for context.

**Which issue(s) this PR fixes**:
Fixes #2838

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:
Tested on OCP 4.12 with example from https://kserve.github.io/website/0.10/modelserving/inference_graph/image_pipeline/.

**Release note**:
NONE
