### PR TITLE
chown python virtual env path to runtime user

### DIFF
--- a/python/aiffairness.Dockerfile
+++ b/python/aiffairness.Dockerfile
@@ -37,10 +37,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder aiffairness aiffairness
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "aifserver"]

--- a/python/aixexplainer.Dockerfile
+++ b/python/aixexplainer.Dockerfile
@@ -40,10 +40,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder aixexplainer aixexplainer
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "aixserver"]

--- a/python/alibiexplainer.Dockerfile
+++ b/python/alibiexplainer.Dockerfile
@@ -37,11 +37,12 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder alibiexplainer alibiexplainer
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "alibiexplainer"]
 

--- a/python/artexplainer.Dockerfile
+++ b/python/artexplainer.Dockerfile
@@ -37,10 +37,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder artexplainer artexplainer
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "artserver"]

--- a/python/custom_model.Dockerfile
+++ b/python/custom_model.Dockerfile
@@ -37,10 +37,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder custom_model custom_model
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "custom_model.model"]

--- a/python/custom_model_grpc.Dockerfile
+++ b/python/custom_model_grpc.Dockerfile
@@ -37,10 +37,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder custom_model custom_model
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "custom_model.model_grpc"]

--- a/python/custom_transformer.Dockerfile
+++ b/python/custom_transformer.Dockerfile
@@ -37,11 +37,12 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder custom_transformer custom_transformer
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "custom_transformer.model"]
 

--- a/python/custom_transformer_grpc.Dockerfile
+++ b/python/custom_transformer_grpc.Dockerfile
@@ -37,11 +37,12 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder custom_transformer custom_transformer
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "custom_transformer.model_grpc"]
 

--- a/python/lgb.Dockerfile
+++ b/python/lgb.Dockerfile
@@ -42,10 +42,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder lgbserver lgbserver
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "lgbserver"]

--- a/python/paddle.Dockerfile
+++ b/python/paddle.Dockerfile
@@ -42,10 +42,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder paddleserver paddleserver
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "paddleserver"]

--- a/python/pmml.Dockerfile
+++ b/python/pmml.Dockerfile
@@ -52,10 +52,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder pmmlserver pmmlserver
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python3", "-m", "pmmlserver"]

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -37,10 +37,11 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder sklearnserver sklearnserver
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "sklearnserver"]

--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -42,7 +42,9 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY ./storage-initializer /storage-initializer
 
@@ -50,6 +52,5 @@ RUN chmod +x /storage-initializer/scripts/initializer-entrypoint
 RUN mkdir /work
 WORKDIR /work
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["/storage-initializer/scripts/initializer-entrypoint"]

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -42,11 +42,12 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
 COPY --from=builder kserve kserve
 COPY --from=builder xgbserver xgbserver
 
-RUN useradd kserve -m -u 1000 -d /home/kserve
 USER 1000
 ENTRYPOINT ["python", "-m", "xgbserver"]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/kserve/kserve/issues/2844

**Which issue(s) this PR fixes**:
Fixes #2844

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:
Tested on OCP 4.12 with the explainer example from website.


**Special notes for your reviewer**:
No

**Release note**:
```release-note
The permissions of /prod_venv in all python docker images are now aligned with the runtime user `uid=1000(kserve)`
```
