### PR TITLE
Fixes for Integrating KServe with Openshift

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -31,12 +31,13 @@ import (
 
 // KServe Constants
 var (
-	KServeName                     = "kserve"
-	KServeAPIGroupName             = "serving.kserve.io"
-	KnativeAutoscalingAPIGroupName = "autoscaling.knative.dev"
-	KnativeServingAPIGroupName     = "serving.knative.dev"
-	KServeNamespace                = getEnvOrDefault("POD_NAMESPACE", "kserve")
-	KServeDefaultVersion           = "v0.5.0"
+	KServeName                       = "kserve"
+	KServeAPIGroupName               = "serving.kserve.io"
+	KnativeAutoscalingAPIGroupName   = "autoscaling.knative.dev"
+	KnativeServingAPIGroupNamePrefix = "serving.knative"
+	KnativeServingAPIGroupName       = KnativeServingAPIGroupNamePrefix + ".dev"
+	KServeNamespace                  = getEnvOrDefault("POD_NAMESPACE", "kserve")
+	KServeDefaultVersion             = "v0.5.0"
 )
 
 // InferenceService Constants
@@ -131,8 +132,10 @@ var (
 
 // Controller Constants
 var (
-	ControllerLabelName = KServeName + "-controller-manager"
-	DefaultMinReplicas  = 1
+	ControllerLabelName              = KServeName + "-controller-manager"
+	DefaultMinReplicas               = 1
+	IstioCniDnsProxyEnabledEnvVarKey = "ISTIO_CNI_DNS_PROXY_ENABLED"
+	IstioSidecarUID                  = int64(1337)
 )
 
 type AutoscalerClassType string

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -84,6 +84,7 @@ var (
 	MinScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/min-scale"
 	MaxScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/max-scale"
 	RollOutDurationAnnotationKey                = KnativeServingAPIGroupName + "/rollout-duration"
+	KnativeOpenshiftEnablePassthroughKey        = "serving.knative.openshift.io/enablePassthrough"
 	EnableMetricAggregation                     = KServeAPIGroupName + "/enable-metric-aggregation"
 	SetPrometheusAnnotation                     = KServeAPIGroupName + "/enable-prometheus-scraping"
 	KserveContainerPrometheusPortKey            = "prometheus.kserve.io/port"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -132,10 +132,9 @@ var (
 
 // Controller Constants
 var (
-	ControllerLabelName              = KServeName + "-controller-manager"
-	DefaultMinReplicas               = 1
-	IstioCniDnsProxyEnabledEnvVarKey = "ISTIO_CNI_DNS_PROXY_ENABLED"
-	IstioSidecarUID                  = int64(1337)
+	ControllerLabelName          = KServeName + "-controller-manager"
+	DefaultMinReplicas           = 1
+	IstioSidecarUIDAnnotationKey = KServeAPIGroupName + "/storage-initializer-uid"
 )
 
 type AutoscalerClassType string

--- a/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
+++ b/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
@@ -133,12 +133,9 @@ func createKnativeService(componentMeta metav1.ObjectMeta, graph *v1alpha1api.In
 	// ksvc metadata.annotations
 	ksvcAnnotations := make(map[string]string)
 
-	// Allow custom annotations for ksvcs that start with serving.knative but not part of serving.knative.dev group name.
-	for aKey, _ := range annotations {
-		if !strings.HasPrefix(aKey, constants.KnativeServingAPIGroupName) && strings.HasPrefix(aKey, constants.KnativeServingAPIGroupNamePrefix) {
-			ksvcAnnotations[aKey] = annotations[aKey]
-			delete(annotations, aKey)
-		}
+	if value, ok := annotations[constants.KnativeOpenshiftEnablePassthroughKey]; ok {
+		ksvcAnnotations[constants.KnativeOpenshiftEnablePassthroughKey] = value
+		delete(annotations, constants.KnativeOpenshiftEnablePassthroughKey)
 	}
 
 	labels = utils.Filter(componentMeta.Labels, func(key string) bool {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -19,8 +19,6 @@ package knative
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
@@ -45,6 +43,8 @@ var log = logf.Log.WithName("KsvcReconciler")
 
 var managedKsvcAnnotations = map[string]bool{
 	constants.RollOutDurationAnnotationKey: true,
+	// Required for the integration of Openshift Serverless with Openshift Service Mesh
+	constants.KnativeOpenshiftEnablePassthroughKey: true,
 }
 
 type KsvcReconciler struct {
@@ -106,14 +106,6 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 		if value, ok := annotations[ksvcAnnotationKey]; ok {
 			ksvcAnnotations[ksvcAnnotationKey] = value
 			delete(annotations, ksvcAnnotationKey)
-		}
-	}
-
-	// Allow custom annotations for ksvcs that start with serving.knative but not part of serving.knative.dev group name.
-	for aKey, _ := range annotations {
-		if !strings.HasPrefix(aKey, constants.KnativeServingAPIGroupName) && strings.HasPrefix(aKey, constants.KnativeServingAPIGroupNamePrefix) {
-			ksvcAnnotations[aKey] = annotations[aKey]
-			delete(annotations, aKey)
 		}
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -19,6 +19,7 @@ package knative
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -105,6 +106,14 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 		if value, ok := annotations[ksvcAnnotationKey]; ok {
 			ksvcAnnotations[ksvcAnnotationKey] = value
 			delete(annotations, ksvcAnnotationKey)
+		}
+	}
+
+	// Allow custom annotations for ksvcs that start with serving.knative but not part of serving.knative.dev group name.
+	for aKey, _ := range annotations {
+		if !strings.HasPrefix(aKey, constants.KnativeServingAPIGroupName) && strings.HasPrefix(aKey, constants.KnativeServingAPIGroupNamePrefix) {
+			ksvcAnnotations[aKey] = annotations[aKey]
+			delete(annotations, aKey)
 		}
 	}
 

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -19,7 +19,6 @@ package pod
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -333,9 +332,9 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 
 	// Allow to override the uid for the case where ISTIO CNI with DNS proxy is enabled
 	// See for more: https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers.
-	if v := os.Getenv(constants.IstioCniDnsProxyEnabledEnvVarKey); v != "" {
-		if b, _ := strconv.ParseBool(v); b {
-			initContainer.SecurityContext.RunAsUser = ptr.Int64(constants.IstioSidecarUID)
+	if value, ok := pod.GetAnnotations()[constants.IstioSidecarUIDAnnotationKey]; ok {
+		if uid, err := strconv.ParseInt(value, 10, 64); err == nil {
+			initContainer.SecurityContext.RunAsUser = ptr.Int64(uid)
 		}
 	}
 

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -19,6 +19,8 @@ package pod
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,6 +29,8 @@ import (
 	"github.com/kserve/kserve/pkg/credentials"
 
 	v1 "k8s.io/api/core/v1"
+
+	"knative.dev/pkg/ptr"
 )
 
 const (
@@ -324,6 +328,14 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 			&pod.Spec.Volumes,
 		); err != nil {
 			return err
+		}
+	}
+
+	// Allow to override the uid for the case where ISTIO CNI with DNS proxy is enabled
+	// See for more: https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers.
+	if v := os.Getenv(constants.IstioCniDnsProxyEnabledEnvVarKey); v != "" {
+		if b, _ := strconv.ParseBool(v); b {
+			initContainer.SecurityContext.RunAsUser = ptr.Int64(constants.IstioSidecarUID)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This adds the following fixes for running KServe on Openshift:
- Adds the capability to inject custom annotations to the ksvc required by the [Openshift Serverless (deploys Knative Serving) and Service Mesh Integration](https://docs.openshift.com/container-platform/4.8/serverless/admin_guide/serverless-ossm-setup.html#serverless-ossm-setup_serverless-ossm-setup).
The annotation for example ` serving.knative.openshift.io/enablePassthrough: “true”` needs to be added at the ksvc level for inference services and graphs. This will not allow to add arbitrary annotations, thus should not change current semantics.
- Adds the ability to run the storage injector with user id 1337 in order to solve the issue when [Istio cni and dns proxy are enabled](https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers).
Right now the security context is copied from the user container but we cant use the same user id there for many reasons eg. [is not allowed](https://istio.io/latest/docs/reference/config/analysis/ist0144/), security etc. The latter applies if we use pod security context or some other workaround.  
The uid can be set to an arbitrary value using the annotation: `serving.kserve.io/storage-initializer-uid: "..."`.
Note that on Openshift that uid is not 1337 but project_id_range+1, so we need this to be configurable.
Note: In a future PR we should be able to setup the Knative Serving init-containers feature flag and avoid the custom injection done or provide some template to allow the user to configure that part.

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

**Feature/Issue validation/testing**:

Tested on OCP 4.12 with the following inference service:
```
oc apply -n test -f - <<EOF
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: sklearn-from-uri
  annotations:
    sidecar.istio.io/inject: "true"
    sidecar.istio.io/rewriteAppHTTPProbers: "true"
    serving.knative.openshift.io/enablePassthrough: “true”
spec:
  predictor:
    sklearn:
      storageUri: https://github.com/skonto/serverless-guides/blob/main/kserve/kfserving-examples/models/sklearn/1.0/model/model.joblib?raw=true
EOF
```
The manager deployment was started with the right env var. 

**Special notes for your reviewer**:

No

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Openshift integration improvements.
```
