### PR TITLE
Bump the Go version for the builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.20.3 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/kserve/kserve

--- a/agent.Dockerfile
+++ b/agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the inference-agent binary
-FROM golang:1.18 as builder
+FROM golang:1.20.3 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/kserve/kserve

--- a/docs/samples/graph/bgtest/Dockerfile
+++ b/docs/samples/graph/bgtest/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 AS build
+FROM golang:1.20.3 AS build
 WORKDIR /
 COPY bgtest /project/bgtest/
 RUN cd /project/bgtest && go build -mod vendor -o bgtest -ldflags '-linkmode "external" -extldflags "-static"'

--- a/qpext/qpext.Dockerfile
+++ b/qpext/qpext.Dockerfile
@@ -1,5 +1,5 @@
 # Build the inference qpext binary
-FROM golang:1.18 as builder
+FROM golang:1.20.3 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/kserve/kserve/qpext

--- a/router.Dockerfile
+++ b/router.Dockerfile
@@ -1,5 +1,5 @@
 # Build the inference-router binary
-FROM golang:1.18 as builder
+FROM golang:1.20.3 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/kserve/kserve


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

fixes #2862 

Go builder images use go version 1.18.10 which has several vulnerabilities as reported by the
Check [here](https://gist.github.com/skonto/4e5ca84b2d3dd8b6767e1b6861bc3141) for the list. Moving to 1.20.3 for builds solves them all.


**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Tested by building locally the affected images.

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
NONE
