### PR TITLE
Add KServeModel abstract base class.

### DIFF
--- a/python/kserve/kserve/model_repository.py
+++ b/python/kserve/kserve/model_repository.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional, Union
-from .model import Model
-from ray.serve.api import RayServeHandle
 import os
+from typing import Dict, Optional
+
+from .model import KServeModel
 
 MODEL_MOUNT_DIRS = "/mnt/models"
 
@@ -30,7 +30,7 @@ class ModelRepository:
     """
 
     def __init__(self, models_dir: str = MODEL_MOUNT_DIRS):
-        self.models: Dict[str, Union[Model, RayServeHandle]] = {}
+        self.models: Dict[str, KServeModel] = {}
         self.models_dir = models_dir
 
     def load_models(self):
@@ -42,27 +42,18 @@ class ModelRepository:
     def set_models_dir(self, models_dir):  # used for unit tests
         self.models_dir = models_dir
 
-    def get_model(self, name: str) -> Optional[Union[Model, RayServeHandle]]:
+    def get_model(self, name: str) -> Optional[KServeModel]:
         return self.models.get(name, None)
 
-    def get_models(self) -> Dict[str, Union[Model, RayServeHandle]]:
+    def get_models(self) -> Dict[str, KServeModel]:
         return self.models
 
     def is_model_ready(self, name: str):
         model = self.get_model(name)
-        if not model:
-            return False
-        if isinstance(model, Model):
-            return False if model is None else model.ready
-        else:
-            # For Ray Serve, the models are guaranteed to be ready after deploying the model.
-            return True
+        return False if model is None else model.ready
 
-    def update(self, model: Model):
+    def update(self, model: KServeModel):
         self.models[model.name] = model
-
-    def update_handle(self, name: str, model_handle: RayServeHandle):
-        self.models[name] = model_handle
 
     def load(self, name: str) -> bool:
         pass

--- a/python/kserve/kserve/ray_model.py
+++ b/python/kserve/kserve/ray_model.py
@@ -1,0 +1,41 @@
+# Copyright 2022 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Union, Optional
+from ray.serve.handle import RayServeHandle
+from .protocol.infer_type import InferRequest
+from cloudevents.http import CloudEvent
+
+from .model import KServeModel, ModelType
+
+
+class RayServeModel(KServeModel):
+    handle: RayServeHandle
+
+    def __init__(self, name: str, ray_handle: RayServeHandle):
+        super().__init__(name)
+        self.handle = ray_handle
+        self.ready = True
+
+    async def __call__(self, body: Union[Dict, CloudEvent, InferRequest],
+                       model_type: ModelType = ModelType.PREDICTOR,
+                       headers: Optional[Dict[str, str]] = None) -> Dict:
+        res = await self.handle.remote(body, model_type=model_type, headers=headers)
+        return res
+
+    async def get_input_types(self) -> List[Dict]:
+        return await self.handle.get_input_types.remote()
+
+    async def get_output_types(self) -> List[Dict]:
+        return await self.handle.get_output_types.remote()

--- a/python/kserve/kserve/ray_model_server.py
+++ b/python/kserve/kserve/ray_model_server.py
@@ -1,0 +1,44 @@
+# Copyright 2022 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+try:
+    from ray import serve as rayserve
+    from ray.serve.deployment import Deployment
+    from .ray_model import RayServeModel
+except ImportError:
+    raise ImportError("Missing optional dependency 'ray.serve'. "
+                      "To use KServe with Ray Serve run pip install kserve[ray-serve]")
+
+
+from .model_server import ModelServer
+
+
+class RayModelServer(ModelServer):
+    """Ray ModelServer
+    """
+
+    def start(self, models: Dict[str, Deployment]) -> None:
+        _models = []
+        if all([isinstance(v, Deployment) for v in models.values()]):
+            # TODO: make this port number a variable
+            rayserve.start(detached=True, http_options={"host": "0.0.0.0", "port": 9071})
+            for key in models:
+                models[key].deploy()
+                handle = models[key].get_handle()
+                _models.append(RayServeModel(name=key, ray_handle=handle))
+        else:
+            raise RuntimeError("Model type should be RayServe Deployment")
+        super().start(_models)

--- a/python/kserve/test/test_dataplane.py
+++ b/python/kserve/test/test_dataplane.py
@@ -29,6 +29,7 @@ from ray import serve
 from kserve.errors import InvalidInput, ModelNotFound
 from kserve.protocol.dataplane import DataPlane
 from kserve.model_repository import ModelRepository
+from kserve.ray_model import RayServeModel
 from test.test_server import DummyModel, dummy_cloud_event, DummyCEModel, DummyAvroCEModel, \
     DummyServeModel
 
@@ -53,8 +54,8 @@ class TestDataPlane:
             serve.start(detached=False, http_options={"host": "0.0.0.0", "port": 9071})
             DummyServeModel.deploy(self.MODEL_NAME)
             handle = DummyServeModel.get_handle()
-            handle.load.remote()
-            dataplane._model_registry.update_handle(self.MODEL_NAME, handle)
+            ray_model = RayServeModel(name=self.MODEL_NAME, ray_handle=handle)
+            dataplane._model_registry.update(ray_model)
             yield dataplane
             serve.shutdown()
 


### PR DESCRIPTION
Refactor Ray code into a subclass of KServeModel

**What this PR does / why we need it**:
This adds the `KServeModel` abstract base class which is inherited from by the `Model` and `RayServeModel` classes. This allows us to isolate the Ray code so we can easily make it an optional dependency.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Updated the dataplane unit tests to work with this new code.

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
Add abstract base class for `KServeModel`. Move Ray Serve functionality into subclass.
```
