### PR TITLE
Make status.address.url consistent across installations

### DIFF
--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -91,6 +91,17 @@ func (c *CustomPredictor) GetContainer(metadata metav1.ObjectMeta, extensions *C
 }
 
 func (c *CustomPredictor) GetProtocol() constants.InferenceServiceProtocol {
+	// Handle collocation of transformer and predictor scenario
+	for _, container := range c.Containers {
+		if container.Name == constants.TransformerContainerName {
+			for _, envVar := range container.Env {
+				if envVar.Name == constants.CustomSpecProtocolEnvVarKey {
+					return constants.InferenceServiceProtocol(envVar.Value)
+				}
+			}
+			return constants.ProtocolV1
+		}
+	}
 	for _, envVar := range c.Containers[0].Env {
 		if envVar.Name == constants.CustomSpecProtocolEnvVarKey {
 			return constants.InferenceServiceProtocol(envVar.Value)

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -84,7 +84,7 @@ func (c *CustomPredictor) GetStorageSpec() *StorageSpec {
 	return nil
 }
 
-// GetContainers transforms the resource into a container spec
+// GetContainer transforms the resource into a container spec
 func (c *CustomPredictor) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
 	predictorHost ...string) *v1.Container {
 	return &c.Containers[0]

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -330,6 +330,68 @@ func TestCustomPredictorGetProtocol(t *testing.T) {
 			},
 			matcher: gomega.Equal(constants.ProtocolV2),
 		},
+		"Collocation With Protocol Specified": {
+			spec: PredictorSpec{
+				PodSpec: PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "kserve/testImage:1.0",
+							Env: []v1.EnvVar{
+								{
+									Name:  "STORAGE_URI",
+									Value: "s3://modelzoo",
+								},
+							},
+						},
+						{
+							Name:  constants.TransformerContainerName,
+							Image: "kserve/transformer:1.0",
+							Env: []v1.EnvVar{
+								{
+									Name:  "STORAGE_URI",
+									Value: "s3://modelzoo",
+								},
+								{
+									Name:  constants.CustomSpecProtocolEnvVarKey,
+									Value: string(constants.ProtocolV2),
+								},
+							},
+						},
+					},
+				},
+			},
+			matcher: gomega.Equal(constants.ProtocolV2),
+		},
+		"Collocation Default Protocol": {
+			spec: PredictorSpec{
+				PodSpec: PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "kserve/testImage:1.0",
+							Env: []v1.EnvVar{
+								{
+									Name:  "STORAGE_URI",
+									Value: "s3://modelzoo",
+								},
+							},
+						},
+						{
+							Name:  constants.TransformerContainerName,
+							Image: "kserve/transformer:1.0",
+							Env: []v1.EnvVar{
+								{
+									Name:  "STORAGE_URI",
+									Value: "s3://modelzoo",
+								},
+							},
+						},
+					},
+				},
+			},
+			matcher: gomega.Equal(constants.ProtocolV1),
+		},
 	}
 	for _, scenario := range scenarios {
 		customPredictor := NewCustomPredictor(&scenario.spec.PodSpec)

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm.go
@@ -44,5 +44,8 @@ func (x *LightGBMSpec) GetContainer(metadata metav1.ObjectMeta, extensions *Comp
 }
 
 func (x *LightGBMSpec) GetProtocol() constants.InferenceServiceProtocol {
+	if x.ProtocolVersion != nil {
+		return *x.ProtocolVersion
+	}
 	return constants.ProtocolV1
 }

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm_test.go
@@ -278,6 +278,17 @@ func TestLightGBMGetProtocol(t *testing.T) {
 			},
 			matcher: gomega.Equal(constants.ProtocolV1),
 		},
+		"ProtocolSpecified": {
+			spec: PredictorSpec{
+				LightGBM: &LightGBMSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						StorageURI:      proto.String("s3://modelzoo"),
+						ProtocolVersion: (*constants.InferenceServiceProtocol)(proto.String(string(constants.ProtocolV2))),
+					},
+				},
+			},
+			matcher: gomega.Equal(constants.ProtocolV2),
+		},
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -66,5 +66,8 @@ func (o *ONNXRuntimeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *C
 }
 
 func (o *ONNXRuntimeSpec) GetProtocol() constants.InferenceServiceProtocol {
+	if o.ProtocolVersion != nil {
+		return *o.ProtocolVersion
+	}
 	return constants.ProtocolV1
 }

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime_test.go
@@ -202,6 +202,24 @@ func TestONNXRuntimeSpec_GetProtocol(t *testing.T) {
 			},
 			expected: constants.ProtocolV1,
 		},
+		"ProtocolSpecified": {
+			spec: PredictorSpec{
+				ONNX: &ONNXRuntimeSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						ProtocolVersion: (*constants.InferenceServiceProtocol)(proto.String(string(constants.ProtocolV2))),
+						StorageURI:      proto.String("s3://modelzoo"),
+						Container: v1.Container{
+							Image:     "image:0.1",
+							Args:      nil,
+							Env:       nil,
+							Resources: v1.ResourceRequirements{},
+						},
+					},
+				},
+				ComponentExtensionSpec: ComponentExtensionSpec{},
+			},
+			expected: constants.ProtocolV2,
+		},
 	}
 
 	for name, scenario := range scenarios {

--- a/pkg/apis/serving/v1beta1/predictor_paddle.go
+++ b/pkg/apis/serving/v1beta1/predictor_paddle.go
@@ -37,5 +37,8 @@ func (p *PaddleServerSpec) GetContainer(metadata metav1.ObjectMeta, extensions *
 }
 
 func (p *PaddleServerSpec) GetProtocol() constants.InferenceServiceProtocol {
+	if p.ProtocolVersion != nil {
+		return *p.ProtocolVersion
+	}
 	return constants.ProtocolV1
 }

--- a/pkg/apis/serving/v1beta1/predictor_paddle_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_paddle_test.go
@@ -175,6 +175,24 @@ func TestPaddleServerSpec_GetProtocol(t *testing.T) {
 			},
 			expected: constants.ProtocolV1,
 		},
+		"ProtocolSpecified": {
+			spec: PredictorSpec{
+				Paddle: &PaddleServerSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						ProtocolVersion: (*constants.InferenceServiceProtocol)(proto.String(string(constants.ProtocolV2))),
+						StorageURI:      proto.String("s3://modelzoo"),
+						Container: v1.Container{
+							Image:     "image:0.1",
+							Args:      nil,
+							Env:       nil,
+							Resources: v1.ResourceRequirements{},
+						},
+					},
+				},
+				ComponentExtensionSpec: ComponentExtensionSpec{},
+			},
+			expected: constants.ProtocolV2,
+		},
 	}
 
 	for name, scenario := range scenarios {

--- a/pkg/apis/serving/v1beta1/predictor_pmml.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml.go
@@ -53,5 +53,8 @@ func (p *PMMLSpec) GetContainer(metadata metav1.ObjectMeta, extensions *Componen
 }
 
 func (p *PMMLSpec) GetProtocol() constants.InferenceServiceProtocol {
+	if p.ProtocolVersion != nil {
+		return *p.ProtocolVersion
+	}
 	return constants.ProtocolV1
 }

--- a/pkg/apis/serving/v1beta1/predictor_pmml_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml_test.go
@@ -147,6 +147,24 @@ func TestPMMLSpec_GetProtocol(t *testing.T) {
 			},
 			expected: constants.ProtocolV1,
 		},
+		"ProtocolSpecified": {
+			spec: PredictorSpec{
+				PMML: &PMMLSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						ProtocolVersion: (*constants.InferenceServiceProtocol)(proto.String(string(constants.ProtocolV2))),
+						StorageURI:      proto.String("s3://modelzoo"),
+						Container: v1.Container{
+							Image:     "image:0.1",
+							Args:      nil,
+							Env:       nil,
+							Resources: v1.ResourceRequirements{},
+						},
+					},
+				},
+				ComponentExtensionSpec: ComponentExtensionSpec{},
+			},
+			expected: constants.ProtocolV2,
+		},
 	}
 
 	for name, scenario := range scenarios {

--- a/pkg/apis/serving/v1beta1/predictor_tfserving.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving.go
@@ -81,5 +81,8 @@ func (t *TFServingSpec) GetContainer(metadata metav1.ObjectMeta, extensions *Com
 }
 
 func (t *TFServingSpec) GetProtocol() constants.InferenceServiceProtocol {
+	if t.ProtocolVersion != nil {
+		return *t.ProtocolVersion
+	}
 	return constants.ProtocolV1
 }

--- a/pkg/apis/serving/v1beta1/predictor_tfserving_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving_test.go
@@ -210,6 +210,24 @@ func TestTFServingSpec_GetProtocol(t *testing.T) {
 			},
 			expected: constants.ProtocolV1,
 		},
+		"ProtocolSpecified": {
+			spec: PredictorSpec{
+				Tensorflow: &TFServingSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						ProtocolVersion: (*constants.InferenceServiceProtocol)(proto.String(string(constants.ProtocolV2))),
+						StorageURI:      proto.String("s3://modelzoo"),
+						Container: v1.Container{
+							Image:     "image:0.1",
+							Args:      nil,
+							Env:       nil,
+							Resources: v1.ResourceRequirements{},
+						},
+					},
+				},
+				ComponentExtensionSpec: ComponentExtensionSpec{},
+			},
+			expected: constants.ProtocolV2,
+		},
 	}
 
 	for name, scenario := range scenarios {

--- a/pkg/apis/serving/v1beta1/predictor_torchserve.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve.go
@@ -83,5 +83,8 @@ func (t *TorchServeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *Co
 }
 
 func (t *TorchServeSpec) GetProtocol() constants.InferenceServiceProtocol {
+	if t.ProtocolVersion != nil {
+		return *t.ProtocolVersion
+	}
 	return constants.ProtocolV1
 }

--- a/pkg/apis/serving/v1beta1/predictor_torchserve_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve_test.go
@@ -191,6 +191,17 @@ func TestTorchServeSpec_GetProtocol(t *testing.T) {
 			},
 			expected: constants.ProtocolV1,
 		},
+		"ProtocolSpecified": {
+			spec: PredictorSpec{
+				PyTorch: &TorchServeSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						ProtocolVersion: (*constants.InferenceServiceProtocol)(proto.String(string(constants.ProtocolV2))),
+					},
+				},
+				ComponentExtensionSpec: ComponentExtensionSpec{},
+			},
+			expected: constants.ProtocolV2,
+		},
 	}
 
 	for name, scenario := range scenarios {

--- a/pkg/apis/serving/v1beta1/predictor_triton.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton.go
@@ -43,5 +43,8 @@ func (t *TritonSpec) GetContainer(metadata metav1.ObjectMeta, extensions *Compon
 }
 
 func (t *TritonSpec) GetProtocol() constants.InferenceServiceProtocol {
+	if t.ProtocolVersion != nil {
+		return *t.ProtocolVersion
+	}
 	return constants.ProtocolV2
 }

--- a/pkg/apis/serving/v1beta1/predictor_triton_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton_test.go
@@ -240,6 +240,24 @@ func TestTritonSpec_GetProtocol(t *testing.T) {
 			},
 			expected: constants.ProtocolV2,
 		},
+		"ProtocolSpecified": {
+			spec: PredictorSpec{
+				Triton: &TritonSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						ProtocolVersion: (*constants.InferenceServiceProtocol)(proto.String(string(constants.ProtocolV2))),
+						StorageURI:      proto.String("s3://modelzoo"),
+						Container: v1.Container{
+							Image:     "image:0.1",
+							Args:      nil,
+							Env:       nil,
+							Resources: v1.ResourceRequirements{},
+						},
+					},
+				},
+				ComponentExtensionSpec: ComponentExtensionSpec{},
+			},
+			expected: constants.ProtocolV2,
+		},
 	}
 
 	for name, scenario := range scenarios {

--- a/pkg/apis/serving/v1beta1/transformer_custom.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom.go
@@ -73,7 +73,7 @@ func (c *CustomTransformer) GetStorageSpec() *StorageSpec {
 	return nil
 }
 
-// GetContainers transforms the resource into a container spec
+// GetContainer transforms the resource into a container spec
 func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig,
 	predictorHost ...string) *v1.Container {
 	container := &c.Containers[0]
@@ -119,6 +119,11 @@ func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions 
 }
 
 func (c *CustomTransformer) GetProtocol() constants.InferenceServiceProtocol {
+	for _, envVar := range c.Containers[0].Env {
+		if envVar.Name == constants.CustomSpecProtocolEnvVarKey {
+			return constants.InferenceServiceProtocol(envVar.Value)
+		}
+	}
 	return constants.ProtocolV1
 }
 

--- a/pkg/apis/serving/v1beta1/transformer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom_test.go
@@ -368,3 +368,77 @@ func TestCreateTransformerContainer(t *testing.T) {
 		})
 	}
 }
+
+func TestTransformerGetProtocol(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	scenarios := map[string]struct {
+		spec    *CustomTransformer
+		matcher types.GomegaMatcher
+	}{
+		"DefaultProtocol": {
+			spec: &CustomTransformer{
+				PodSpec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "transformer:0.1.0",
+							Env: []v1.EnvVar{
+								{
+									Name:  "STORAGE_URI",
+									Value: "hdfs://modelzoo",
+								},
+							},
+							Args: []string{
+								"--model_name",
+								"someName",
+								"--predictor_host",
+								"localhost",
+								"--http_port",
+								"8080",
+								"--workers",
+								"1",
+							},
+						},
+					},
+				},
+			},
+
+			matcher: gomega.Equal(constants.ProtocolV1),
+		},
+		"ProtocolSpecified": {
+			spec: &CustomTransformer{
+				PodSpec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "transformer:0.1.0",
+							Env: []v1.EnvVar{
+								{
+									Name:  "STORAGE_URI",
+									Value: "hdfs://modelzoo",
+								},
+								{
+									Name:  constants.CustomSpecProtocolEnvVarKey,
+									Value: string(constants.ProtocolV2),
+								},
+							},
+							Args: []string{
+								"--model_name",
+								"someName",
+								"--predictor_host",
+								"localhost",
+								"--http_port",
+								"8080",
+								"--workers",
+								"1",
+							},
+						},
+					},
+				},
+			},
+			matcher: gomega.Equal(constants.ProtocolV2),
+		},
+	}
+	for _, scenario := range scenarios {
+		protocol := scenario.spec.GetProtocol()
+		g.Expect(protocol).To(scenario.matcher)
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -563,7 +563,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					URL: &apis.URL{
 						Scheme: "http",
 						Host:   network.GetServiceHostname(serviceKey.Name, serviceKey.Namespace),
-						Path:   constants.PredictPath(serviceKey.Name, constants.ProtocolV1),
 					},
 				},
 				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
@@ -787,7 +786,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					URL: &apis.URL{
 						Scheme: "http",
 						Host:   network.GetServiceHostname(serviceKey.Name, serviceKey.Namespace),
-						Path:   constants.PredictPath(serviceKey.Name, constants.ProtocolV1),
 					},
 				},
 				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
@@ -1883,7 +1881,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			Expect(actualIsvc.Status.Address.URL).To(gomega.Equal(&apis.URL{
 				Scheme: "http",
 				Host:   network.GetServiceHostname(fmt.Sprintf("%s-%s-default", serviceKey.Name, string(constants.Predictor)), serviceKey.Namespace),
-				Path:   constants.PredictPath(serviceKey.Name, constants.ProtocolV1),
 			}))
 		})
 	})

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
-	isvcutils "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/utils"
 	utils "github.com/kserve/kserve/pkg/utils"
 	"github.com/pkg/errors"
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
@@ -499,28 +498,11 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 
 	if url, err := apis.ParseURL(serviceUrl); err == nil {
 		isvc.Status.URL = url
-		path := ""
-		modelName := isvcutils.GetModelName(isvc)
-		if isvc.Spec.Transformer != nil {
-			// As of now transformer only supports protocol V1
-			path = constants.PredictPath(modelName, constants.ProtocolV1)
-		} else if !isvcutils.IsMMSPredictor(&isvc.Spec.Predictor) {
-
-			protocol := isvc.Spec.Predictor.GetImplementation().GetProtocol()
-
-			if protocol == constants.ProtocolV1 {
-				path = constants.PredictPath(modelName, constants.ProtocolV1)
-			} else if protocol == constants.ProtocolV2 {
-				path = constants.PredictPath(modelName, constants.ProtocolV2)
-			}
-
-		}
 		hostPrefix := getHostPrefix(isvc, disableIstioVirtualHost)
 		isvc.Status.Address = &duckv1.Addressable{
 			URL: &apis.URL{
 				Host:   network.GetServiceHostname(hostPrefix, isvc.Namespace),
 				Scheme: "http",
-				Path:   path,
 			},
 		}
 		isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{

--- a/test/e2e/graph/test_inference_graph.py
+++ b/test/e2e/graph/test_inference_graph.py
@@ -81,9 +81,9 @@ def test_inference_graph():
     )
 
     kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-    # kserve_client.create(sklearn_isvc)
-    # kserve_client.create(xgb_isvc)
-    # kserve_client.create_inference_graph(ig)
+    kserve_client.create(sklearn_isvc)
+    kserve_client.create(xgb_isvc)
+    kserve_client.create_inference_graph(ig)
 
     kserve_client.wait_isvc_ready(sklearn_name, namespace=KSERVE_TEST_NAMESPACE)
     kserve_client.wait_isvc_ready(xgb_name, namespace=KSERVE_TEST_NAMESPACE)

--- a/test/e2e/graph/test_inference_graph.py
+++ b/test/e2e/graph/test_inference_graph.py
@@ -12,8 +12,8 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_ig
 
 @pytest.mark.graph
 def test_inference_graph():
-    sklearn_name = "isvc-sklearn"
-    xgb_name = "isvc-xgboost"
+    sklearn_name = "isvc-sklearn-graph"
+    xgb_name = "isvc-xgboost-graph"
     graph_name = "model-chainer"
 
     sklearn_predictor = V1beta1PredictorSpec(
@@ -81,9 +81,9 @@ def test_inference_graph():
     )
 
     kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-    kserve_client.create(sklearn_isvc)
-    kserve_client.create(xgb_isvc)
-    kserve_client.create_inference_graph(ig)
+    # kserve_client.create(sklearn_isvc)
+    # kserve_client.create(xgb_isvc)
+    # kserve_client.create_inference_graph(ig)
 
     kserve_client.wait_isvc_ready(sklearn_name, namespace=KSERVE_TEST_NAMESPACE)
     kserve_client.wait_isvc_ready(xgb_name, namespace=KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_raw_deployment.py
+++ b/test/e2e/predictor/test_raw_deployment.py
@@ -113,7 +113,7 @@ def test_raw_deployment_runtime_kserve():
 
 @pytest.mark.grpc
 def test_isvc_with_multiple_container_port():
-    service_name = "custom-model-grpc"
+    service_name = "raw-multiport-custom-model"
     model_name = "custom-model"
 
     predictor = V1beta1PredictorSpec(

--- a/test/e2e/predictor/test_xgboost.py
+++ b/test/e2e/predictor/test_xgboost.py
@@ -61,7 +61,7 @@ def test_xgboost_kserve():
 
 @pytest.mark.fast
 def test_xgboost_v2_mlserver():
-    service_name = "isvc-xgboost-v2"
+    service_name = "isvc-xgboost-v2-mlserver"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         xgboost=V1beta1XGBoostSpec(


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2874 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
Now, The `status.address.url` points to the hostname only. For example, the older versions point to the url `http://sklearn-iris.default.svc.cluster.local/v2/models/sklearn-irisv2/infer`. But now it points to the url `http://sklearn-iris.default.svc.cluster.local`
```
