### PR TITLE
Make postprocess interface consistent with V2 protocol

### DIFF
--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -49,6 +49,10 @@ class PredictorProtocol(Enum):
     GRPC_V2 = "grpc-v2"
 
 
+def is_v2(protocol: PredictorProtocol) -> bool:
+    return protocol != PredictorProtocol.REST_V1
+
+
 def get_latency_ms(start: float, end: float) -> float:
     return round((end - start) * 1000, 9)
 
@@ -202,13 +206,9 @@ class Model:
 
         return payload
 
-    def postprocess(self, response: Union[Dict, InferResponse, ModelInferResponse], headers: Dict[str, str] = None) \
-            -> Union[Dict, ModelInferResponse]:
+    def postprocess(self, response: Union[Dict, InferResponse], headers: Dict[str, str] = None) \
+            -> Union[Dict, InferResponse]:
         """The postprocess handler can be overridden for inference response transformation.
-        The default implementation converts the v2 infer response types to gRPC or REST.
-        For gRPC request it converts InferResponse to gRPC message or directly returns ModelInferResponse from
-        predictor call.
-        For REST request it converts ModelInferResponse to Dict or directly returns from predictor call.
 
         Args:
             response (Dict|InferResponse|ModelInferResponse): The response passed from ``predict`` handler.
@@ -217,18 +217,6 @@ class Model:
         Returns:
             Dict: post-processed response.
         """
-        if headers:
-            if "grpc" in headers.get("user-agent", ""):
-                if isinstance(response, ModelInferResponse):
-                    return response
-                elif isinstance(response, InferResponse):
-                    return response.to_grpc()
-            if "application/json" in headers.get("content-type", ""):
-                # If the original request is REST, convert the gRPC predict response to dict
-                if isinstance(response, ModelInferResponse):
-                    return InferResponse.from_grpc(response).to_rest()
-                elif isinstance(response, InferResponse):
-                    return response.to_rest()
         return response
 
     async def _http_predict(self, payload: Union[Dict, InferRequest], headers: Dict[str, str] = None) -> Dict:
@@ -280,7 +268,7 @@ class Model:
         return async_result
 
     async def predict(self, payload: Union[Dict, InferRequest, ModelInferRequest],
-                      headers: Dict[str, str] = None) -> Union[Dict, InferResponse, ModelInferResponse]:
+                      headers: Dict[str, str] = None) -> Union[Dict, InferResponse]:
         """
 
         Args:
@@ -294,9 +282,12 @@ class Model:
         if not self.predictor_host:
             raise NotImplementedError("Could not find predictor_host.")
         if self.protocol == PredictorProtocol.GRPC_V2.value:
-            return await self._grpc_predict(payload, headers)
+            res = await self._grpc_predict(payload, headers)
+            return InferResponse.from_grpc(res)
         else:
-            return await self._http_predict(payload, headers)
+            res = await self._http_predict(payload, headers)
+            # return an InferResponse if this is REST V2, otherwise just return the dictionary
+            return InferResponse.from_rest(self.name, res) if is_v2(PredictorProtocol(self.protocol)) else res
 
     async def explain(self, payload: Dict, headers: Dict[str, str] = None) -> Dict:
         """`explain` handler can be overridden to implement the model explanation.

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -204,7 +204,7 @@ class DataPlane:
 
         return self._model_registry.is_model_ready(model_name)
 
-    def decode(self, body, headers) -> Tuple[Union[Dict, InferRequest, CloudEvent], Dict]:
+    def decode(self, body, headers) -> Tuple[Union[Dict, InferRequest], Dict]:
         t1 = time.time()
         decoded_body = body
         attributes = {}
@@ -223,7 +223,7 @@ class DataPlane:
         logging.debug(f"decoded request in {round((t2 - t1) * 1000, 9)}ms")
         return decoded_body, attributes
 
-    def decode_cloudevent(self, body) -> Tuple[Union[Dict, InferRequest, CloudEvent], Dict]:
+    def decode_cloudevent(self, body) -> Tuple[Union[Dict, InferRequest], Dict]:
         decoded_body = body
         attributes = {}
         if isinstance(body, CloudEvent):
@@ -283,7 +283,7 @@ class DataPlane:
 
         Args:
             model_name (str): Model name.
-            body (bytes|Dict): Request body data.
+            request (bytes|Dict): Request body data.
             headers: (Optional[Dict[str, str]]): Request headers.
 
         Returns:
@@ -314,7 +314,7 @@ class DataPlane:
 
         Args:
             model_name (str): Model name to be used for explanation.
-            body (bytes|Dict): Request body data.
+            request (bytes|Dict): Request body data.
             headers: (Optional[Dict[str, str]]): Request headers.
 
         Returns:

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -26,9 +26,8 @@ from ..errors import InvalidInput, ModelNotFound
 from ..model import ModelType
 from ..model_repository import ModelRepository
 from ..utils.utils import create_response_cloudevent, is_structured_cloudevent
-from .infer_type import InferRequest
+from .infer_type import InferRequest, InferResponse
 from ..constants import constants
-from .grpc import grpc_predict_v2_pb2 as pb
 import time
 import logging
 
@@ -253,6 +252,8 @@ class DataPlane:
         # if we received a cloudevent, then also return a cloudevent
         is_cloudevent = False
         is_binary_cloudevent = False
+        if isinstance(response, InferResponse):
+            response = response.to_rest()
         if headers:
             if has_binary_headers(headers):
                 is_cloudevent = True
@@ -272,9 +273,9 @@ class DataPlane:
     async def infer(
             self,
             model_name: str,
-            body: Union[bytes, Dict, InferRequest],
+            request: Union[Dict, InferRequest],
             headers: Optional[Dict[str, str]] = None
-    ) -> Tuple[Union[str, bytes, Dict, pb.ModelInferResponse], Dict[str, str]]:
+    ) -> Tuple[Union[Dict, InferResponse], Dict[str, str]]:
         """Performs inference on the specified model with the provided body and headers.
 
         If the ``body`` contains an encoded `CloudEvent`_, then it will be decoded and processed.
@@ -295,23 +296,20 @@ class DataPlane:
 
         .. _CloudEvent: https://cloudevents.io/
         """
-        body, req_attributes = self.decode(body, headers)
-
         # call model locally or remote model workers
         model = self.get_model(model_name)
         if not isinstance(model, RayServeHandle):
-            response = await model(body, headers=headers)
+            response = await model(request, headers=headers)
         else:
             model_handle: RayServeHandle = model
-            response = await model_handle.remote(body, headers=headers)
+            response = await model_handle.remote(request, headers=headers)
 
-        response, response_headers = self.encode(model_name, response, headers, req_attributes)
-        return response, response_headers
+        return response, headers
 
     async def explain(self, model_name: str,
-                      body: Union[bytes, Dict, InferRequest],
+                      request: Union[bytes, Dict, InferRequest],
                       headers: Optional[Dict[str, str]] = None
-                      ) -> Tuple[Union[str, bytes, Dict], Dict[str, str]]:
+                      ) -> Tuple[Union[str, bytes, Dict, InferResponse], Dict[str, str]]:
         """Performs explanation for the specified model.
 
         Args:
@@ -325,14 +323,11 @@ class DataPlane:
         Raises:
             InvalidInput: An error when the body bytes can't be decoded as JSON.
         """
-        body, req_attributes = self.decode(body, headers)
-
         # call model locally or remote model workers
         model = self.get_model(model_name)
         if not isinstance(model, RayServeHandle):
-            response = await model(body, model_type=ModelType.EXPLAINER)
+            response = await model(request, model_type=ModelType.EXPLAINER)
         else:
             model_handle = model
-            response = await model_handle.remote(body, model_type=ModelType.EXPLAINER)
-        response, response_headers = self.encode(model_name, response, headers, req_attributes)
-        return response, response_headers
+            response = await model_handle.remote(request, model_type=ModelType.EXPLAINER)
+        return response, headers

--- a/python/kserve/kserve/protocol/grpc/servicer.py
+++ b/python/kserve/kserve/protocol/grpc/servicer.py
@@ -15,7 +15,7 @@
 
 from . import grpc_predict_v2_pb2 as pb
 from . import grpc_predict_v2_pb2_grpc
-from kserve.protocol.infer_type import InferRequest
+from kserve.protocol.infer_type import InferRequest, InferResponse
 from kserve.protocol.dataplane import DataPlane
 from kserve.protocol.model_repository_extension import ModelRepositoryExtension
 from kserve.utils.utils import to_headers
@@ -95,6 +95,9 @@ class InferenceServicer(grpc_predict_v2_pb2_grpc.GRPCInferenceServiceServicer):
                                                         model_name=request.model_name)
         if isinstance(response_body, pb.ModelInferResponse):
             return response_body
-        return pb.ModelInferResponse(id=response_body["id"],
-                                     model_name=response_body["model_name"],
-                                     outputs=response_body["outputs"])
+        elif isinstance(response_body, InferResponse):
+            return response_body.to_grpc()
+        else:
+            return pb.ModelInferResponse(id=response_body["id"],
+                                         model_name=response_body["model_name"],
+                                         outputs=response_body["outputs"])

--- a/python/kserve/kserve/protocol/grpc/servicer.py
+++ b/python/kserve/kserve/protocol/grpc/servicer.py
@@ -91,7 +91,7 @@ class InferenceServicer(grpc_predict_v2_pb2_grpc.GRPCInferenceServiceServicer):
     ) -> pb.ModelInferResponse:
         headers = to_headers(context)
         infer_request = InferRequest.from_grpc(request)
-        response_body, _ = await self._data_plane.infer(body=infer_request, headers=headers,
+        response_body, _ = await self._data_plane.infer(request=infer_request, headers=headers,
                                                         model_name=request.model_name)
         if isinstance(response_body, pb.ModelInferResponse):
             return response_body

--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -537,7 +537,7 @@ class InferResponse:
                 self.outputs[i]._raw_data = raw_output
 
     @classmethod
-    def from_grpc(cls, response: ModelInferResponse):
+    def from_grpc(cls, response: ModelInferResponse) -> 'InferResponse':
         infer_outputs = [InferOutput(name=output.name, shape=list(output.shape),
                                      datatype=output.datatype,
                                      data=get_content(output.datatype, output.contents),
@@ -545,6 +545,19 @@ class InferResponse:
                          for output in response.outputs]
         return cls(model_name=response.model_name, response_id=response.id, parameters=response.parameters,
                    infer_outputs=infer_outputs, raw_outputs=response.raw_output_contents, from_grpc=True)
+
+    @classmethod
+    def from_rest(cls, model_name: str, response: Dict) -> 'InferResponse':
+        infer_outputs = [InferOutput(name=output['name'],
+                                     shape=list(output['shape']),
+                                     datatype=output['datatype'],
+                                     data=output['data'],
+                                     parameters=output.get('parameters', {}))
+                         for output in response['outputs']]
+        return cls(model_name=model_name,
+                   response_id=response.get('id', None),
+                   parameters=response.get('parameters', {}),
+                   infer_outputs=infer_outputs)
 
     def to_rest(self) -> Dict:
         """ Converts the InferResponse object to v2 REST InferenceRequest message

--- a/python/kserve/kserve/protocol/rest/v1_endpoints.py
+++ b/python/kserve/kserve/protocol/rest/v1_endpoints.py
@@ -66,7 +66,15 @@ class V1Endpoints:
         """
         body = await request.body()
         headers = dict(request.headers.items())
-        response, response_headers = await self.dataplane.infer(model_name=model_name, body=body, headers=headers)
+        infer_request = self.dataplane.decode(body=body,
+                                              headers=headers)
+        response, response_headers = await self.dataplane.infer(model_name=model_name,
+                                                                request=infer_request,
+                                                                headers=headers)
+        response, response_headers = self.dataplane.encode(model_name=model_name,
+                                                           body=infer_request,
+                                                           response=response,
+                                                           headers=headers)
 
         if not isinstance(response, dict):
             return Response(content=response, headers=response_headers)
@@ -84,7 +92,15 @@ class V1Endpoints:
         """
         body = await request.body()
         headers = dict(request.headers.items())
-        response, response_headers = await self.dataplane.explain(model_name=model_name, body=body, headers=headers)
+        infer_request = self.dataplane.decode(body=body,
+                                              headers=headers)
+        response, response_headers = await self.dataplane.explain(model_name=model_name,
+                                                                  request=infer_request,
+                                                                  headers=headers)
+        response, response_headers = self.dataplane.encode(model_name=model_name,
+                                                           body=body,
+                                                           response=response,
+                                                           headers=headers)
 
         if not isinstance(response, dict):
             return Response(content=response, headers=response_headers)

--- a/python/kserve/kserve/protocol/rest/v1_endpoints.py
+++ b/python/kserve/kserve/protocol/rest/v1_endpoints.py
@@ -66,15 +66,14 @@ class V1Endpoints:
         """
         body = await request.body()
         headers = dict(request.headers.items())
-        infer_request = self.dataplane.decode(body=body,
-                                              headers=headers)
+        infer_request, req_attributes = self.dataplane.decode(body=body,
+                                                              headers=headers)
         response, response_headers = await self.dataplane.infer(model_name=model_name,
                                                                 request=infer_request,
                                                                 headers=headers)
         response, response_headers = self.dataplane.encode(model_name=model_name,
-                                                           body=infer_request,
                                                            response=response,
-                                                           headers=headers)
+                                                           headers=headers, req_attributes=req_attributes)
 
         if not isinstance(response, dict):
             return Response(content=response, headers=response_headers)
@@ -92,15 +91,14 @@ class V1Endpoints:
         """
         body = await request.body()
         headers = dict(request.headers.items())
-        infer_request = self.dataplane.decode(body=body,
-                                              headers=headers)
+        infer_request, req_attributes = self.dataplane.decode(body=body,
+                                                              headers=headers)
         response, response_headers = await self.dataplane.explain(model_name=model_name,
                                                                   request=infer_request,
                                                                   headers=headers)
         response, response_headers = self.dataplane.encode(model_name=model_name,
-                                                           body=body,
                                                            response=response,
-                                                           headers=headers)
+                                                           headers=headers, req_attributes=req_attributes)
 
         if not isinstance(response, dict):
             return Response(content=response, headers=response_headers)

--- a/python/kserve/kserve/protocol/rest/v2_endpoints.py
+++ b/python/kserve/kserve/protocol/rest/v2_endpoints.py
@@ -130,8 +130,14 @@ class V2Endpoints:
                                    ) for input in request_body.inputs]
         infer_request = InferRequest(model_name=model_name, infer_inputs=infer_inputs,
                                      parameters=request_body.parameters)
-        response, response_headers = await self.dataplane.infer(
-            model_name=model_name, body=infer_request, headers=request_headers)
+        response, response_headers = await self.dataplane.infer(model_name=model_name,
+                                                                request=infer_request,
+                                                                headers=request_headers)
+
+        response, response_headers = self.dataplane.encode(model_name=model_name,
+                                                           body=infer_request,
+                                                           response=response,
+                                                           headers=response_headers)
 
         if response_headers:
             raw_response.headers.update(response_headers)

--- a/python/kserve/kserve/protocol/rest/v2_endpoints.py
+++ b/python/kserve/kserve/protocol/rest/v2_endpoints.py
@@ -135,9 +135,8 @@ class V2Endpoints:
                                                                 headers=request_headers)
 
         response, response_headers = self.dataplane.encode(model_name=model_name,
-                                                           body=infer_request,
                                                            response=response,
-                                                           headers=response_headers)
+                                                           headers=response_headers, req_attributes={})
 
         if response_headers:
             raw_response.headers.update(response_headers)

--- a/python/kserve/test/test_dataplane.py
+++ b/python/kserve/test/test_dataplane.py
@@ -120,17 +120,26 @@ class TestDataPlane:
 
     async def test_infer(self, dataplane_with_model):
         body = b'{"instances":[[1,2]]}'
-        resp = await dataplane_with_model.infer(self.MODEL_NAME, body)
-        assert resp == (
+        infer_request = dataplane_with_model.decode(body, None)
+        resp, headers = await dataplane_with_model.infer(self.MODEL_NAME, infer_request)
+        resp, headers = dataplane_with_model.encode(self.MODEL_NAME,
+                                                    infer_request,
+                                                    resp,
+                                                    None)
+        assert (resp, headers) == (
             {"predictions": [[1, 2]]},  # body
-            {}  # headers
+            {}
         )
 
-    async def test_explain(self, dataplane_with_model):
+    async def test_explain(self, dataplane_with_model: DataPlane):
         body = b'{"instances":[[1,2]]}'
-        resp = await dataplane_with_model.explain(self.MODEL_NAME, body)
-
-        assert resp == (
+        infer_request = dataplane_with_model.decode(body, None)
+        resp, headers = await dataplane_with_model.explain(self.MODEL_NAME, infer_request)
+        resp, headers = dataplane_with_model.encode(self.MODEL_NAME,
+                                                    infer_request,
+                                                    resp,
+                                                    None)
+        assert (resp, headers) == (
             {"predictions": [[1, 2]]},
             {}
         )
@@ -148,13 +157,18 @@ class TestDataPlaneCloudEvent:
         dataplane._model_registry.update(model)
         return dataplane
 
-    async def test_infer_ce_structured(self, dataplane_with_ce_model):
+    async def test_infer_ce_structured(self, dataplane_with_ce_model: DataPlane):
         event: CloudEvent = dummy_cloud_event({"instances": [[1, 2]]})
         headers, body = to_structured(event)
-
-        resp = await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
-        body = json.loads(resp[0])
-        headers = resp[1]
+        infer_request = dataplane_with_ce_model.decode(body, headers)
+        resp, headers = await dataplane_with_ce_model.infer(self.MODEL_NAME,
+                                                            infer_request,
+                                                            headers)
+        resp, headers = dataplane_with_ce_model.encode(self.MODEL_NAME,
+                                                       infer_request,
+                                                       resp,
+                                                       headers)
+        body = json.loads(resp)
 
         assert headers['content-type'] == "application/cloudevents+json"
 
@@ -176,9 +190,12 @@ class TestDataPlaneCloudEvent:
             event = dummy_cloud_event({"instances": [[1, 2]]})
             headers, body = to_structured(event)
 
-            resp = await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
-            body = json.loads(resp[0])
-            headers = resp[1]
+            infer_request = dataplane_with_ce_model.decode(body, headers)
+            resp, headers = await dataplane_with_ce_model.infer(self.MODEL_NAME, infer_request, headers)
+            resp, headers = dataplane_with_ce_model.encode(self.MODEL_NAME,
+                                                           infer_request,
+                                                           resp, headers)
+            body = json.loads(resp)
 
             assert headers['content-type'] == "application/cloudevents+json"
 
@@ -187,14 +204,18 @@ class TestDataPlaneCloudEvent:
             assert body['source'] == "io.kserve.inference.CustomSource"
             assert body['type'] == "io.kserve.custom_type"
 
-    async def test_infer_merge_structured_ce_attributes(self, dataplane_with_ce_model):
+    async def test_infer_merge_structured_ce_attributes(self, dataplane_with_ce_model: DataPlane):
         with mock.patch.dict(os.environ, {"CE_MERGE": "true"}):
             event = dummy_cloud_event({"instances": [[1, 2]]}, add_extension=True)
             headers, body = to_structured(event)
 
-            resp = await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
-            body = json.loads(resp[0])
-            headers = resp[1]
+            infer_request = dataplane_with_ce_model.decode(body, headers)
+            resp, headers = await dataplane_with_ce_model.infer(self.MODEL_NAME, infer_request, headers)
+            resp, headers = dataplane_with_ce_model.encode(self.MODEL_NAME,
+                                                           infer_request,
+                                                           resp,
+                                                           headers)
+            body = json.loads(resp)
 
             assert headers['content-type'] == "application/cloudevents+json"
 
@@ -212,9 +233,9 @@ class TestDataPlaneCloudEvent:
                                       add_extension=True)
             headers, body = to_binary(event)
 
-            resp = await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
-            body = resp[0]
-            headers = resp[1]
+            infer_request = dataplane_with_ce_model.decode(body, headers)
+            resp, headers = await dataplane_with_ce_model.infer(self.MODEL_NAME, infer_request, headers)
+            resp, headers = dataplane_with_ce_model.encode(self.MODEL_NAME, infer_request, resp, headers)
 
             assert headers['content-type'] == "application/json"
             assert headers['ce-specversion'] == "1.0"
@@ -224,15 +245,20 @@ class TestDataPlaneCloudEvent:
             assert headers['ce-source'] == "io.kserve.inference.TestModel"
             assert headers['ce-type'] == "io.kserve.inference.response"
             assert headers['ce-time'] > "2021-01-28T21:04:43.144141+00:00"
-            assert body == b'{"predictions": [[1, 2]]}'
+            assert resp == b'{"predictions": [[1, 2]]}'
 
     async def test_infer_ce_binary_dict(self, dataplane_with_ce_model):
         event = dummy_cloud_event({"instances": [[1, 2]]}, set_contenttype=True)
         headers, body = to_binary(event)
 
-        resp = await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
-        body = resp[0]
-        headers = resp[1]
+        infer_request = dataplane_with_ce_model.decode(body, headers)
+        resp, headers = await dataplane_with_ce_model.infer(self.MODEL_NAME,
+                                                            infer_request,
+                                                            headers)
+        resp, headers = dataplane_with_ce_model.encode(self.MODEL_NAME,
+                                                       infer_request,
+                                                       resp,
+                                                       headers)
 
         assert headers['content-type'] == "application/json"
         assert headers['ce-specversion'] == "1.0"
@@ -240,30 +266,33 @@ class TestDataPlaneCloudEvent:
         assert headers['ce-source'] == "io.kserve.inference.TestModel"
         assert headers['ce-type'] == "io.kserve.inference.response"
         assert headers['ce-time'] > "2021-01-28T21:04:43.144141+00:00"
-        assert body == b'{"predictions": [[1, 2]]}'
+        assert resp == b'{"predictions": [[1, 2]]}'
 
     async def test_infer_ce_binary_bytes(self, dataplane_with_ce_model):
         event = dummy_cloud_event(b'{"instances":[[1,2]]}', set_contenttype=True)
         headers, body = to_binary(event)
 
-        resp = await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
-        body = resp[0]
-        headers = resp[1]
-
+        infer_request = dataplane_with_ce_model.decode(body, headers)
+        resp, headers = await dataplane_with_ce_model.infer(self.MODEL_NAME, infer_request, headers)
+        resp, headers = dataplane_with_ce_model.encode(self.MODEL_NAME,
+                                                       infer_request,
+                                                       resp,
+                                                       headers)
         assert headers['content-type'] == "application/json"
         assert headers['ce-specversion'] == "1.0"
         assert headers["ce-id"] != "36077800-0c23-4f38-a0b4-01f4369f670a"
         assert headers['ce-source'] == "io.kserve.inference.TestModel"
         assert headers['ce-type'] == "io.kserve.inference.response"
         assert headers['ce-time'] > "2021-01-28T21:04:43.144141+00:00"
-        assert body == b'{"predictions": [[1, 2]]}'
+        assert resp == b'{"predictions": [[1, 2]]}'
 
     async def test_infer_ce_bytes_bad_format_exception(self, dataplane_with_ce_model):
         event = dummy_cloud_event(b'{', set_contenttype=True)
         headers, body = to_binary(event)
 
         with pytest.raises(InvalidInput) as err:
-            await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
+            infer_request = dataplane_with_ce_model.decode(body, headers)
+            await dataplane_with_ce_model.infer(self.MODEL_NAME, infer_request, headers)
 
         error_regex = re.compile("Failed to decode or parse binary json cloudevent: "
                                  "unexpected end of data:*")
@@ -274,7 +303,8 @@ class TestDataPlaneCloudEvent:
         headers, body = to_binary(event)
 
         with pytest.raises(InvalidInput) as err:
-            await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
+            infer_request = dataplane_with_ce_model.decode(body, headers)
+            await dataplane_with_ce_model.infer(self.MODEL_NAME, infer_request, headers)
 
         error_regex = re.compile("Failed to decode or parse binary json cloudevent: 'utf-8' codec "
                                  "can't decode byte 0x80 in position 1: invalid start byte.*")
@@ -321,9 +351,15 @@ class TestDataPlaneAvroCloudEvent:
         # Creates the HTTP request representation of the CloudEvent in binary content mode
         headers, body = to_binary(event)
 
-        resp = await dataplane_with_ce_model.infer(self.MODEL_NAME, body, headers)
-        body = resp[0]
-        headers = resp[1]
+        infer_request = dataplane_with_ce_model.decode(body, headers)
+        resp, headers = await dataplane_with_ce_model.infer(self.MODEL_NAME,
+                                                            infer_request,
+                                                            headers)
+
+        resp, headers = dataplane_with_ce_model.encode(self.MODEL_NAME,
+                                                       infer_request,
+                                                       resp,
+                                                       headers)
 
         assert headers['content-type'] == "application/json"
         assert headers['ce-specversion'] == "1.0"
@@ -331,4 +367,4 @@ class TestDataPlaneAvroCloudEvent:
         assert headers['ce-source'] == "io.kserve.inference.TestModel"
         assert headers['ce-type'] == "io.kserve.inference.response"
         assert headers['ce-time'] > "2021-01-28T21:04:43.144141+00:00"
-        assert body == b'{"predictions": [["foo", 1, "pink"]]}'
+        assert resp == b'{"predictions": [["foo", 1, "pink"]]}'


### PR DESCRIPTION
**What this PR does / why we need it**:
This change makes the `postprocess` receive and allows it to return an `InferResponse` when the protocol is V2. This enables postprocess code to be agnostic to the transport mechanism (gRPC/HTTP). This is consistent with how `preprocess` functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2721

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Release note**:
```release-note
postprocess method receives an `InferResponse` and can return an `InferResponse` when the protocol is `V2`
```
