### PR TITLE
Do not create GRPCServer when grpc is not enabled

### DIFF
--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -99,7 +99,10 @@ class ModelServer:
         self.dataplane = DataPlane(model_registry=registered_models)
         self.model_repository_extension = ModelRepositoryExtension(
             model_registry=self.registered_models)
-        self._grpc_server = GRPCServer(grpc_port, self.dataplane, self.model_repository_extension)
+        self._grpc_server = None
+        if self.enable_grpc:
+            self._grpc_server = GRPCServer(grpc_port, self.dataplane,
+                                           self.model_repository_extension)
 
     def start(self, models: Union[List[Model], Dict[str, Deployment]]) -> None:
         if isinstance(models, list):


### PR DESCRIPTION
**What this PR does / why we need it**: set self._grpc_server in ModelServer to None if enable_grpc=False. This fixes #2870 that an exception is thrown when `self._grpc_server.stop` is called during termination because `server.start` was not called.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2870 

**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

This is difficult to reproduce because I cannot see any exception from the logs for some reason. It seems that nobody is awaiting on this async task.
I had to add `asyncio.get_event_loop().set_exception_handler(print)` to https://github.com/kserve/kserve/blob/47bd3cc89f8509d4afbabf2a30be94d61277a3b6/python/kserve/kserve/model_server.py#L172

Then I got the exception in the logs.
```
2023-05-04 16:56:15.534 50190 root INFO [register_model():189] Registering model: custom-model
2023-05-04 16:56:15.534 50190 root INFO [start():130] Setting max asyncio worker threads as 14
2023-05-04 16:56:15.534 50190 root INFO [serve():140] Starting uvicorn with 1 workers
2023-05-04 16:56:15.550 50190 uvicorn.error INFO [serve():84] Started server process [50190]
2023-05-04 16:56:15.550 50190 uvicorn.error INFO [startup():45] Waiting for application startup.
2023-05-04 16:56:15 DEBUG [timing_asgi.middleware:40] ASGI scope of type lifespan is not supported yet
2023-05-04 16:56:15.550 50190 uvicorn.error INFO [startup():59] Application startup complete.
^C2023-05-04 16:56:19.618 50190 root INFO [stop():172] Stopping the model server
2023-05-04 16:56:19.618 50190 root INFO [stop():174] Stopping the rest server
2023-05-04 16:56:19.618 50190 root INFO [stop():177] Stopping the grpc server
2023-05-04 16:56:19.619 50190 root INFO [stop():67] Waiting for gRPC server shutdown
<_UnixSelectorEventLoop running=True closed=False debug=False> {'message': 'Task exception was never retrieved', 'exception': AttributeError("'NoneType' object has no attribute 'stop'"), 'future': <Task finished name='Task-4' coro=<ModelServer.stop() done, defined at /Users/jdong183/Projects/kserve/python/kserve/kserve/model_server.py:170> exception=AttributeError("'NoneType' object has no attribute 'stop'")>}
2023-05-04 16:56:19.709 50190 uvicorn.error INFO [shutdown():263] Shutting down
2023-05-04 16:56:19.811 50190 uvicorn.error INFO [shutdown():64] Waiting for application shutdown.
2023-05-04 16:56:19.812 50190 uvicorn.error INFO [shutdown():75] Application shutdown complete.
2023-05-04 16:56:19.812 50190 uvicorn.error INFO [serve():94] Finished server process [50190]
```

This exception is not thrown after fixing it.

I also ran `pytest -q test_server.py` locally to test related code.

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. 
No changes to image versions

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Fix: do not throw an exception on exit when enable_grpc=False
```
