### PR TITLE
Change the default domain template

### DIFF
--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -17,7 +17,7 @@ kserve:
     deploymentMode: "Serverless"
     gateway:
       domain: example.com
-      domainTemplate: "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"
+      domainTemplate: "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}"
       urlScheme: http
       localGateway:
         gateway: knative-serving/knative-local-gateway

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -58,7 +58,7 @@ data:
         "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
         "ingressDomain"  : "example.com",
         "ingressClassName" : "istio",
-        "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
+        "domainTemplate": "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}",
         "urlScheme": "http",
         "disableIstioVirtualHost": false
     }

--- a/config/overlays/test/configmap/inferenceservice-ingress.yaml
+++ b/config/overlays/test/configmap/inferenceservice-ingress.yaml
@@ -11,7 +11,7 @@ data:
         "localGateway": "knative-serving/knative-local-gateway",
         "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
         "ingressClassName" : "istio",
-        "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
+        "domainTemplate": "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}",
         "urlScheme": "http",
         "pathTemplate": "/serving/{{ .Namespace }}/{{ .Name }}",
         "ingressDomain": "mydomain.com"

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -40,7 +40,7 @@ data:
         "localGateway": "knative-serving/knative-local-gateway",
         "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
         "ingressClassName" : "istio",
-        "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"
+        "domainTemplate": "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}"
     }
   logger: |-
     {

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -37,7 +37,7 @@ const (
 	IngressConfigKeyName = "ingress"
 	DeployConfigName     = "deploy"
 
-	DefaultDomainTemplate = "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"
+	DefaultDomainTemplate = "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}"
 	DefaultIngressDomain  = "example.com"
 
 	DefaultUrlScheme = "http"

--- a/pkg/apis/serving/v1beta1/configmap_test.go
+++ b/pkg/apis/serving/v1beta1/configmap_test.go
@@ -61,7 +61,7 @@ func createFakeClient() client.WithWatch {
      				"localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",                                                                                                                             │
      				"ingressDomain"  : "example.com",                                                                                                                                                                           │
      				"ingressClassName" : "istio",                                                                                                                                                                               │
-     				"domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",                                                                                                                                      │
+     				"domainTemplate": "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}",                                                                                                                                      │
      				"urlScheme": "http"                                                                                                                                                                                         │
  			}`),
 			DeployConfigName: []byte(`{                                                                                                                                                                                                               │

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -336,7 +336,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: netv1.IngressSpec{
 					Rules: []netv1.IngressRule{
 						{
-							Host: "raw-foo-default.example.com",
+							Host: "raw-foo.default.example.com",
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -357,7 +357,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							},
 						},
 						{
-							Host: "raw-foo-predictor-default.example.com",
+							Host: "raw-foo-predictor.default.example.com",
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -401,7 +401,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				},
 				URL: &apis.URL{
 					Scheme: "http",
-					Host:   "raw-foo-default.example.com",
+					Host:   "raw-foo.default.example.com",
 				},
 				Address: &duckv1.Addressable{
 					URL: &apis.URL{
@@ -414,7 +414,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						LatestCreatedRevision: "",
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   "raw-foo-predictor-default.example.com",
+							Host:   "raw-foo-predictor.default.example.com",
 						},
 					},
 				},
@@ -768,7 +768,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: netv1.IngressSpec{
 					Rules: []netv1.IngressRule{
 						{
-							Host: fmt.Sprintf("%s-default.example.com", serviceName),
+							Host: fmt.Sprintf("%s.default.example.com", serviceName),
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -789,7 +789,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							},
 						},
 						{
-							Host: fmt.Sprintf("%s-predictor-default.example.com", serviceName),
+							Host: fmt.Sprintf("%s-predictor.default.example.com", serviceName),
 							IngressRuleValue: netv1.IngressRuleValue{
 								HTTP: &netv1.HTTPIngressRuleValue{
 									Paths: []netv1.HTTPIngressPath{
@@ -833,7 +833,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				},
 				URL: &apis.URL{
 					Scheme: "http",
-					Host:   fmt.Sprintf("%s-default.example.com", serviceName),
+					Host:   fmt.Sprintf("%s.default.example.com", serviceName),
 				},
 				Address: &duckv1.Addressable{
 					URL: &apis.URL{
@@ -846,7 +846,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						LatestCreatedRevision: "",
 						URL: &apis.URL{
 							Scheme: "http",
-							Host:   fmt.Sprintf("%s-predictor-default.example.com", serviceName),
+							Host:   fmt.Sprintf("%s-predictor.default.example.com", serviceName),
 						},
 					},
 				},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain_test.go
@@ -58,7 +58,7 @@ func TestGenerateDomainName(t *testing.T) {
 					DomainTemplate: v1beta1.DefaultDomainTemplate,
 				},
 			},
-			want: "model-test.example.com",
+			want: "model.test.example.com",
 		},
 		{
 			name: "template with dot",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2879 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
The default domain template is changed from "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}" to "{{ .Name }}.{{ .Namespace }}.{{ .IngressDomain }}". For example, the older version generated a url `sklearn-default.example.com`, now it generates `sklearn.default.example.com`. This change only affects the raw deployment.
```
