### PR TITLE
Storage Initializer: Support virtual path style in S3

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -140,10 +140,10 @@ class Storage(object):  # pylint: disable=too-few-public-methods
         c = Config()
 
         # anon environment variable defined in s3_secret.go
-        anon = ("True" == os.getenv("awsAnonymousCredential", "false").capitalize())
+        anon = ("true" == os.getenv("awsAnonymousCredential", "false").lower())
         # S3UseVirtualBucket environment variable defined in s3_secret.go
         # use virtual hosted-style URLs if enabled
-        virtual = ("True" == os.getenv("S3_USER_VIRTUAL_BUCKET", "false").capitalize())
+        virtual = ("true" == os.getenv("S3_USER_VIRTUAL_BUCKET", "false").lower())
 
         if anon:
             c = c.merge(Config(signature_version=UNSIGNED))

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -136,12 +136,21 @@ class Storage(object):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def get_S3_config():
+        # default s3 config
+        c = Config()
+
         # anon environment variable defined in s3_secret.go
         anon = ("True" == os.getenv("awsAnonymousCredential", "false").capitalize())
+        # S3UseVirtualBucket environment variable defined in s3_secret.go
+        # use virtual hosted-style URLs if enabled
+        virtual = ("True" == os.getenv("S3_USER_VIRTUAL_BUCKET", "false").capitalize())
+
         if anon:
-            return Config(signature_version=UNSIGNED)
-        else:
-            return None
+            c = c.merge(Config(signature_version=UNSIGNED))
+        if virtual:
+            c = c.merge(Config(s3={"addressing_style": "virtual"}))
+
+        return c
 
     @staticmethod
     def _download_s3(uri, temp_dir: str):

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -141,8 +141,9 @@ AWS_TEST_CREDENTIALS = {"AWS_ACCESS_KEY_ID": "testing",
 
 
 def test_get_S3_config():
+    DEFAULT_CONFIG = Config()
     ANON_CONFIG = Config(signature_version=UNSIGNED)
-    DEFAULT_CONFIG = None
+    VIRTUAL_CONFIG = Config(s3={"addressing_style": "virtual"})
 
     with mock.patch.dict(os.environ, {}):
         config1 = Storage.get_S3_config()
@@ -165,3 +166,11 @@ def test_get_S3_config():
     with mock.patch.dict(os.environ, credentials_and_anon):
         config5 = Storage.get_S3_config()
     assert config5.signature_version == ANON_CONFIG.signature_version
+
+    with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "False"}):
+        config6 = Storage.get_S3_config()
+    assert config6 == DEFAULT_CONFIG
+
+    with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "True"}):
+        config7 = Storage.get_S3_config()
+    assert config7.s3["addressing_style"] == VIRTUAL_CONFIG.s3["addressing_style"]

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -147,15 +147,15 @@ def test_get_S3_config():
 
     with mock.patch.dict(os.environ, {}):
         config1 = Storage.get_S3_config()
-    assert config1 == DEFAULT_CONFIG
+    assert vars(config1) == vars(DEFAULT_CONFIG)
 
     with mock.patch.dict(os.environ, {"awsAnonymousCredential": "False"}):
         config2 = Storage.get_S3_config()
-    assert config2 == DEFAULT_CONFIG
+    assert vars(config2) == vars(DEFAULT_CONFIG)
 
     with mock.patch.dict(os.environ, AWS_TEST_CREDENTIALS):
         config3 = Storage.get_S3_config()
-    assert config3 == DEFAULT_CONFIG
+    assert vars(config3) == vars(DEFAULT_CONFIG)
 
     with mock.patch.dict(os.environ, {"awsAnonymousCredential": "True"}):
         config4 = Storage.get_S3_config()
@@ -169,7 +169,7 @@ def test_get_S3_config():
 
     with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "False"}):
         config6 = Storage.get_S3_config()
-    assert config6 == DEFAULT_CONFIG
+    assert vars(config6) == vars(DEFAULT_CONFIG)
 
     with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "True"}):
         config7 = Storage.get_S3_config()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Support virtual path style in S3 so other S3 compatible storage like `Alibaba Cloud OSS` can be supported via `s3://`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2883 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Unit tests on the S3 config
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. - No

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Storage initializer supports virtual path style in S3
```
