### PR TITLE
Fix github workflow on release-0.10

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -41,17 +41,17 @@ jobs:
     - name: Test with pytest
       run: |
         cd python
-        pip install -e ./kserve[test]
+        pip install -e ./kserve[test] --config-settings editable_mode=compat
         pytest --cov=kserve ./kserve
-        pip install -e ./sklearnserver
+        pip install -e ./sklearnserver --config-settings editable_mode=compat
         pytest --cov=sklearnserver ./sklearnserver
-        pip install -e ./xgbserver
+        pip install -e ./xgbserver --config-settings editable_mode=compat
         pytest --cov=xgbserver ./xgbserver
-        pip install -e ./pmmlserver
+        pip install -e ./pmmlserver --config-settings editable_mode=compat
         pytest --cov=pmmlserver ./pmmlserver
-        pip install -e ./lgbserver
+        pip install -e ./lgbserver --config-settings editable_mode=compat
         pytest --cov=lgbserver ./lgbserver
-        pip install -e ./paddleserver[test]
+        pip install -e ./paddleserver[test] --config-settings editable_mode=compat
         pytest --cov=paddleserver ./paddleserver
-        pip install -e ./alibiexplainer
+        pip install -e ./alibiexplainer --config-settings editable_mode=compat
         pytest --cov=alibiexplainer ./alibiexplainer


### PR DESCRIPTION
Update python-test github workflow to be compatible with new pip and setuptools.

https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior

**What this PR does / why we need it**:
I tried to backport a fix https://github.com/kserve/kserve/pull/2886 into a new 0.10 release. However build failed here 
 https://github.com/kserve/kserve/actions/runs/4920110455/jobs/8788555585?pr=2886, and we got an import error.
```
________________ ERROR collecting tests/test_anchor_tabular.py _________________
ImportError while importing test module '/home/runner/work/kserve/kserve/python/alibiexplainer/tests/test_anchor_tabular.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
alibiexplainer/tests/test_anchor_tabular.py:19: in <module>
    from sklearnserver.model import SKLearnModel
E   ModuleNotFoundError: No module named 'sklearnserver'
```

I reproduced this issue in a local Ubuntu container. It only occurs on pip 23.1 and newer and we upgrade pip to the latest version in [GitHub actions](https://github.com/kserve/kserve/blob/65fd481908f172c1a30d054d47b1a1a9073459eb/.github/workflows/python-test.yml#L40). Pip 23.1 upgrades setuptools from [44.0.0](https://github.com/pypa/pip/blob/23.0.1/src/pip/_vendor/vendor.txt#L19) (pip 23.0.1) to [67.6.1](https://github.com/pypa/pip/blob/23.1/src/pip/_vendor/vendor.txt). setuptools 64.0.0 introduced [a change on editable install implementation](https://setuptools.pypa.io/en/latest/history.html#v64-0-0). 

I am adding `--config-settings editable_mode=compat` to `pip install` command as a workaround as suggested on [setuptools docs](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior). Not an expert on this, I am not sure how we can fix with the best practice. 

Some other libraries does this too, for example bentoml. https://docs.bentoml.org/en/latest/installation.html#editable-install (click to expand `For users using setuptools>=64.0.0` section).



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.
Fix a github workflow issue causing test failures. No change to kserve code.

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Python build checks passed for this pull request.

- Logs
N/A

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
None
```
