### PR TITLE
Make Pod mutator idempotent to support fluid

### DIFF
--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -154,8 +154,28 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 				SubPath:  pvcPath,
 				ReadOnly: true,
 			}
+
+			// Check if PVC source URIs is already mounted
+			// this may occur when mutator is triggered more than once
+			if userContainer.VolumeMounts != nil {
+				for _, volumeMount := range userContainer.VolumeMounts {
+					if strings.Compare(volumeMount.Name, PvcSourceMountName) == 0 {
+						return nil
+					}
+				}
+			}
+
 			userContainer.VolumeMounts = append(userContainer.VolumeMounts, pvcSourceVolumeMount)
 			if transformerContainer != nil {
+				// Check if PVC source URIs is already mounted
+				if transformerContainer.VolumeMounts != nil {
+					for _, volumeMount := range transformerContainer.VolumeMounts {
+						if strings.Compare(volumeMount.Name, PvcSourceMountName) == 0 {
+							return nil
+						}
+					}
+				}
+
 				transformerContainer.VolumeMounts = append(transformerContainer.VolumeMounts, pvcSourceVolumeMount)
 
 				// change the CustomSpecStorageUri env variable value


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Remove the watch for Pod UPDATE event in webhook `inferenceservice.serving.kserve.io` to make KServe compatible with fluid. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2895

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] follow this doc https://github.com/kserve/kserve/blob/master/docs/samples/fluid/README.md
- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.-No

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove the watch for Pod UPDATE event in webhook to support fluid
```
