### PR TITLE
Update the data plane link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
 # Architecture Overview
 
 Please review KServe [Control Plane](https://github.com/kserve/website/blob/main/docs/modelserving/control_plane.md)
-and [Data Plane](https://github.com/kserve/website/blob/main/docs/modelserving/data_plane.md) docs.
+and [Data Plane](https://github.com/kserve/website/blob/main/docs/modelserving/data_plane/data_plane.md) docs.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed the data plane link. The data plane link was broken on this page, returning a 404.

**Feature/Issue validation/testing**:

A preview of the markdown page pulls up the correct data plane architecture link.




