### PR TITLE
Allow using SSL between transformer and predictor/explainer

### DIFF
--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -16,10 +16,18 @@ kubectl port-forward pods/{name-of-predictor-pod} 8081:8080
 ```
 Since the predictor pod will expose 8080, pick another port to use with localhost. Here, 8081 is used.
 
+*Note that if you use KServe 0.11 or later, you can skip this step and add `--use_ssl` flag to the command below.*
+
 (4) Use `localhost:8081` as the {predictor-url} to run the following command from this directory. Pass in the `-config_path="local_config.properties"` to use a local config file. If you deploy the transformer to Kubernetes, it will pull the file from GCS.
 
 ```bash
 python3 -m image_transformer --predictor_host={predictor-url}  --workers=1 --config_path="local_config.properties"
+```
+
+With KServe 0.11 or later, you can connect to the predictor host via ssl.
+
+```bash
+python3 -m image_transformer --use_ssl --predictor_host={predictor-url}  --workers=1 --config_path="local_config.properties"
 ```
 
 Now your service is running and you can send a request via localhost! 

--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -24,11 +24,16 @@ Since the predictor pod will expose 8080, pick another port to use with localhos
 python3 -m image_transformer --predictor_host={predictor-url}  --workers=1 --config_path="local_config.properties"
 ```
 
-With KServe 0.11 or later, you can connect to the predictor host via ssl.
-
+With KServe 0.11 or later, you can connect to the predictor host via ssl. 
 ```bash
 python3 -m image_transformer --use_ssl --predictor_host={predictor-url}  --workers=1 --config_path="local_config.properties"
 ```
+
+If you need to use a custom certificate file, you can set an environment variable.
+
+1. For GRPC, `export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=tls-ca-bundle.pem`. You can find more gRPC environment variables  [here](https://github.com/grpc/grpc/blob/0526a51734003180862331e2527503a5d1898c95/doc/environment_variables.md).
+2. For REST, `export SSL_CERT_FILE=tls-ca-bundle.pem`.
+
 
 Now your service is running and you can send a request via localhost! 
 

--- a/python/custom_transformer/model.py
+++ b/python/custom_transformer/model.py
@@ -53,10 +53,11 @@ def image_transform(model_name, data):
 
 
 class ImageTransformer(Model):
-    def __init__(self, name: str, predictor_host: str, protocol: str):
+    def __init__(self, name: str, predictor_host: str, protocol: str, use_ssl: bool):
         super().__init__(name)
         self.predictor_host = predictor_host
         self.protocol = protocol
+        self.use_ssl = use_ssl
         self.ready = True
 
     def preprocess(self, payload: Union[Dict, InferRequest], headers: Dict[str, str] = None) \
@@ -103,9 +104,12 @@ parser.add_argument(
 parser.add_argument(
     "--model_name", help="The name that the model is served under."
 )
+parser.add_argument(
+    "--use_ssl", help="Use ssl for connecting to the predictor", action='store_true'
+)
 args, _ = parser.parse_known_args()
 
 if __name__ == "__main__":
     model = ImageTransformer(args.model_name, predictor_host=args.predictor_host,
-                             protocol=args.protocol)
+                             protocol=args.protocol, use_ssl=args.use_ssl)
     ModelServer().start([model])

--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -143,7 +143,7 @@ class Model:
             # requires appending the port to the predictor host for gRPC to work
             if ":" not in self.predictor_host:
                 port = 443 if self.use_ssl else 80
-                self.predictor_host = self.predictor_host + f":{port}"
+                self.predictor_host = f"{self.predictor_host}:{port}"
             if self.use_ssl:
                 _channel = grpc.aio.secure_channel(self.predictor_host, grpc.ssl_channel_credentials())
             else:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Currently the transformer is hard-coded to [use http to communicate with the predictor](https://github.com/kserve/kserve/blob/master/python/kserve/kserve/model.py#L36). We add a `use_ssl` property to `Model` class to allow using SSL between transformer and predictor/explainer for both rest and grpc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2863

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Run a local transformer with a remote predictor with REST v2 with ssl enabled. Make sure we get the inference result.
- [x] Run a local transformer with a remote predictor with GRPC with ssl enabled. Make sure we get the inference result.

Note that if you need a custom root CA, you can set an environment variable like this `export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=bundle.pem`

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
No.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Added `use_ssl` property to `Model` to allow using SSL between transformer and predictor/explainer.
```
