### PR TITLE
Load Kubeconfig from python dict

### DIFF
--- a/python/kserve/kserve/api/kserve_client.py
+++ b/python/kserve/kserve/api/kserve_client.py
@@ -27,21 +27,31 @@ from ..utils import utils
 
 class KServeClient(object):
 
-    def __init__(self, config_file=None, context=None,  # pylint: disable=too-many-arguments
+    def __init__(self, config_file=None, config_dict=None, context=None,  # pylint: disable=too-many-arguments
                  client_configuration=None, persist_config=True):
         """
         KServe client constructor
         :param config_file: kubeconfig file, defaults to ~/.kube/config
+        :param config_dict: Takes the config file as a dict.
         :param context: kubernetes context
         :param client_configuration: kubernetes configuration object
         :param persist_config:
         """
-        if config_file or not utils.is_running_in_k8s():
-            config.load_kube_config(
-                config_file=config_file,
-                context=context,
-                client_configuration=client_configuration,
-                persist_config=persist_config)
+        if config_file or config_dict or not utils.is_running_in_k8s():
+            if config_dict:
+                config.load_kube_config_from_dict(
+                    config_dict=config_dict,
+                    context=context,
+                    client_configuration=None,
+                    persist_config=True
+                )
+            else:
+                config.load_kube_config(
+                    config_file=config_file,
+                    context=context,
+                    client_configuration=client_configuration,
+                    persist_config=persist_config
+                )
         else:
             config.load_incluster_config()
         self.core_api = client.CoreV1Api()

--- a/python/kserve/test/test_kubeconfig_dict.py
+++ b/python/kserve/test/test_kubeconfig_dict.py
@@ -1,0 +1,112 @@
+# Copyright 2021 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from kubernetes import client
+
+from kserve import V1beta1PredictorSpec
+from kserve import V1beta1TFServingSpec
+from kserve import V1beta1InferenceServiceSpec
+from kserve import V1beta1InferenceService
+from kserve import KServeClient
+
+
+KUBECONFIG_DICT = {
+    "apiVersion": "v1",
+    "kind": "Config",
+    "metadata": {
+        "name": "example-cluster"
+    },
+    "clusters": [
+        {
+            "name": "example-cluster",
+            "cluster": {
+                "certificate-authority": "./ca.pem",
+                "server": "http://127.0.0.1:8080"
+            }
+        }
+    ],
+    "contexts": [
+        {
+            "name": "example-cluster-context",
+            "context": {
+                "cluster": "example-cluster",
+                "namespace": "example",
+                "user": "example-cluster-admin"
+            }
+        }
+    ],
+    "users": [
+        {
+            "name": "example-cluster-admin",
+            "user": {
+                "client-certificate": "./admin.pem",
+                "client-key": "./admin-key.pem"
+            }
+        }
+    ],
+    "current-context": "example-cluster-context"
+}
+
+kserve_client = KServeClient(config_dict=KUBECONFIG_DICT)
+
+mocked_unit_result = \
+    '''
+{
+    "api_version": "serving.kserve.io/v1beta1",
+    "kind": "InferenceService",
+    "metadata": {
+        "name": "flower-sample",
+        "namespace": "kubeflow"
+    },
+    "spec": {
+        "predictor": {
+            "tensorflow": {
+                "storage_uri": "gs://kfserving-samples/models/tensorflow/flowers"
+            }
+        }
+    }
+}
+ '''
+
+
+def generate_inferenceservice():
+    tf_spec = V1beta1TFServingSpec(
+        storage_uri='gs://kfserving-samples/models/tensorflow/flowers')
+    predictor_spec = V1beta1PredictorSpec(tensorflow=tf_spec)
+
+    isvc = V1beta1InferenceService(
+        api_version='serving.kserve.io/v1beta1',
+        kind='InferenceService',
+        metadata=client.V1ObjectMeta(name='flower-sample'),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor_spec))
+    return isvc
+
+
+def test_inferenceservice_client_create():
+    '''Unit test for kserve create api'''
+    with patch('kserve.api.kserve_client.KServeClient.create',
+               return_value=mocked_unit_result):
+        isvc = generate_inferenceservice()
+        assert mocked_unit_result == kserve_client.create(
+            isvc, namespace='kubeflow')
+
+
+def test_inferenceservice_client_get():
+    '''Unit test for kserve get api'''
+    with patch('kserve.api.kserve_client.KServeClient.get',
+               return_value=mocked_unit_result):
+        assert mocked_unit_result == kserve_client.get(
+            'flower-sample', namespace='kubeflow')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**Loading kubeconfig from python dict**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2918 

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing:**
The `KServeClient` accepts `config_dict` arg to load kubeconfig from a python dictionary.
 
**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes - No.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow loading kubeconfig from a python dictionary
```
