### PR TITLE
Add support to inject http middleware into the fastapi app

### DIFF
--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -62,7 +62,7 @@ parser.add_argument("--log_config_file", default=None, type=str,
                     help="File path containing UvicornServer's log config. Needs to be a yaml or json file.")
 parser.add_argument("--access_log_format", default=None, type=str,
                     help="Format to set for the access log (provided by asgi-logger).")
-parser.add_argument("--http_middleware", default=None, type=str,
+parser.add_argument("--http_middleware", default=None, type=typing.Type[BaseHTTPMiddleware],
                     help="Http Middleware to be added to the fastapi app. (eg:capture logging context)")
 
 args, _ = parser.parse_known_args()

--- a/python/kserve/test/logging_middleware.py
+++ b/python/kserve/test/logging_middleware.py
@@ -1,0 +1,61 @@
+import contextvars
+import logging
+from contextlib import contextmanager
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response, JSONResponse
+
+REQUEST_ID = 'request_id'
+
+request_id_context: contextvars.ContextVar[frozenset] = contextvars.ContextVar(
+    REQUEST_ID, default=frozenset()
+)
+
+
+def reset_context(state: contextvars.Token):
+    """Resets the state of the logging context to that at the given state."""
+    request_id_context.reset(state)
+
+
+def clear_context():
+    """Resets the state of the logging context to empty."""
+    request_id_context.set(frozenset())
+
+
+def update_context(**kwargs) -> contextvars.Token:
+    """Updates the state of the logging context.
+    Returns a token that can be used to recover the previous state using `reset_context`
+    """
+    context = request_id_context.get()
+    return request_id_context.set(context.union(kwargs.items()))
+
+
+def get_from_context(key: str, default: Any = None) -> Any:
+    """Fetch a key from the logging context variable"""
+    ctx = request_id_context.get()
+    for k, v in ctx:
+        if k == key:
+            return v
+    return default
+
+
+@contextmanager
+def logging_context(**kwargs):
+    token = update_context(**kwargs)
+    try:
+        yield
+    finally:
+        reset_context(token)
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+            self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request_id = request.headers.get(REQUEST_ID, 'NA')
+        with logging_context(request_id=request_id):
+            response: Response = await call_next(request)
+            response.headers[REQUEST_ID] = request_id
+            return response


### PR DESCRIPTION

**What this PR does / why we need it**:
Adds the ability to configure http middleware in the fastapi app. This helps capture additional contextual information from the http request in a python contextvar which can then be logged using custom formatter.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2953 

**Type of changes**
Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test TestTFHttpServerLoggingMiddleware: There are both positive and negative scenarios where http request header as captured as a contextvar and then returned in the http response as a header.

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works? Yes
- [ ] Has code been commented, particularly in hard-to-understand areas? Yes
- [ ] Have you made corresponding changes to the documentation? Yes

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
