### PR TITLE
fix IngressReady condition

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -283,7 +283,7 @@ func (ss *InferenceServiceStatus) IsConditionFalse(t apis.ConditionType) bool {
 // IsConditionUnknown returns if a given condition is Unknown
 func (ss *InferenceServiceStatus) IsConditionUnknown(t apis.ConditionType) bool {
 	condition := conditionSet.Manage(ss).GetCondition(t)
-	return condition != nil && condition.Status == v1.ConditionUnknown
+	return condition == nil || condition.Status == v1.ConditionUnknown
 }
 
 func (ss *InferenceServiceStatus) PropagateRawStatus(

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -270,7 +270,20 @@ func (ss *InferenceServiceStatus) GetCondition(t apis.ConditionType) *apis.Condi
 
 // IsConditionReady returns the readiness for a given condition
 func (ss *InferenceServiceStatus) IsConditionReady(t apis.ConditionType) bool {
-	return conditionSet.Manage(ss).GetCondition(t) != nil && conditionSet.Manage(ss).GetCondition(t).Status == v1.ConditionTrue
+	condition := conditionSet.Manage(ss).GetCondition(t)
+	return condition != nil && condition.Status == v1.ConditionTrue
+}
+
+// IsConditionFalse returns if a given condition is False
+func (ss *InferenceServiceStatus) IsConditionFalse(t apis.ConditionType) bool {
+	condition := conditionSet.Manage(ss).GetCondition(t)
+	return condition != nil && condition.Status == v1.ConditionFalse
+}
+
+// IsConditionUnknown returns if a given condition is Unknown
+func (ss *InferenceServiceStatus) IsConditionUnknown(t apis.ConditionType) bool {
+	condition := conditionSet.Manage(ss).GetCondition(t)
+	return condition != nil && condition.Status == v1.ConditionUnknown
 }
 
 func (ss *InferenceServiceStatus) PropagateRawStatus(

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -278,9 +278,13 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 	}
 
 	if !isvc.Status.IsConditionReady(v1beta1.PredictorReady) {
+		status := corev1.ConditionFalse
+		if isvc.Status.IsConditionUnknown(v1beta1.PredictorReady) {
+			status = corev1.ConditionUnknown
+		}
 		isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
 			Type:   v1beta1.IngressReady,
-			Status: corev1.ConditionFalse,
+			Status: status,
 			Reason: "Predictor ingress not created",
 		})
 		return nil
@@ -296,9 +300,13 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 			backend = constants.DefaultTransformerServiceName(isvc.Name)
 		}
 		if !isvc.Status.IsConditionReady(v1beta1.TransformerReady) {
+			status := corev1.ConditionFalse
+			if isvc.Status.IsConditionUnknown(v1beta1.TransformerReady) {
+				status = corev1.ConditionUnknown
+			}
 			isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
 				Type:   v1beta1.IngressReady,
-				Status: corev1.ConditionFalse,
+				Status: status,
 				Reason: "Transformer ingress not created",
 			})
 			return nil
@@ -321,9 +329,13 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 	}
 	if isvc.Spec.Explainer != nil {
 		if !isvc.Status.IsConditionReady(v1beta1.ExplainerReady) {
+			status := corev1.ConditionFalse
+			if isvc.Status.IsConditionUnknown(v1beta1.ExplainerReady) {
+				status = corev1.ConditionUnknown
+			}
 			isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
 				Type:   v1beta1.IngressReady,
-				Status: corev1.ConditionFalse,
+				Status: status,
 				Reason: "Explainer ingress not created",
 			})
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes the IngressReady condition to not automatically switch to False when service is being deployed, which in turn fixes the Ready status being set to False prematurely.

This PR is the first step to fix https://github.com/kserve/kserve/issues/2733

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Tested manually by creating an inference service and watching its Ready status and spec updates. Also tested edge cases: isvc with failed transformer, isvc with failed predictor.

Validation: The Ready status stays Unknown while deployment is in progress.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE.
```
