### PR TITLE
Use standard socket for single process

### DIFF
--- a/python/kserve/kserve/protocol/rest/server.py
+++ b/python/kserve/kserve/protocol/rest/server.py
@@ -172,7 +172,7 @@ class UvicornServer:
         asyncio.run(server.serve(sockets=self.sockets))
 
     async def run(self):
-        await self.server.serve(sockets=self.sockets)
+        await self.server.serve()
 
     async def stop(self, sig: Optional[int] = None):
         if self.server:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2996

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] Compare performance between 0.10.1 and the fixed branch

* for 0.10.1:
```bash
docker run --rm -it -p 8080:8080 -v /Users/dsun20/github/kserve/python/kserve/model/:/mnt/models  kserve/xgbserver:v0.10.1 --model_name=my_model --model_dir=/mnt/models --http_port=8080 --nthread=1
vegeta attack -duration=1m --targets=./target.txt | tee results.bin | vegeta report
```

```
Requests      [total, rate, throughput]         3000, 50.02, 49.97
Duration      [total, attack, wait]             1m0s, 59.98s, 50.874ms
Latencies     [min, mean, 50, 90, 95, 99, max]  5.384ms, 21.378ms, 8.914ms, 49.327ms, 51.31ms, 60.566ms, 95.41ms
Bytes In      [total, mean]                     75000, 25.00
Bytes Out     [total, mean]                     180000, 60.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:3000  
Error Set:
```

* After the fix using standard socket
```
docker run --rm -it -p 8080:8080 -v /Users/dsun20/github/kserve/python/kserve/model/:/mnt/models  yuzisun/xgbserver:latest --model_name=my_model --model_dir=/mnt/models --http_port=8080 --nthread=1

vegeta attack -duration=1m --targets=./target.txt | tee results.bin | vegeta report
```

```
Requests      [total, rate, throughput]         3000, 50.02, 50.01
Duration      [total, attack, wait]             59.988s, 59.98s, 8.299ms
Latencies     [min, mean, 50, 90, 95, 99, max]  5.883ms, 9.919ms, 8.853ms, 13.31ms, 15.055ms, 24.73ms, 122.518ms
Bytes In      [total, mean]                     75000, 25.00
Bytes Out     [total, mean]                     180000, 60.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:3000  
Error Set:
```

- Logs

**Special notes for your reviewer**:

1. The custom serversocket is created for multi-processing case to reuse the PORT but seems like it negatively affects the performance and throughput of the model server, so we switch to use the standard socket created by uvicorn.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
