### PR TITLE
put back PredictorReady in living condition set

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -266,7 +266,7 @@ func (ss *InferenceServiceStatus) InitializeConditions() {
 	conditionSet.Manage(ss).InitializeConditions()
 }
 
-// IsReady returns the readiness for the latest revision.
+// IsReady returns the overall readiness for the inference service.
 func (ss *InferenceServiceStatus) IsReady() bool {
 	return conditionSet.Manage(ss).IsHappy()
 }

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -255,7 +255,10 @@ var conditionsMapIndex = map[apis.ConditionType]map[ComponentType]apis.Condition
 }
 
 // InferenceService Ready condition is depending on predictor and route readiness condition
-var conditionSet = apis.NewLivingConditionSet(IngressReady)
+var conditionSet = apis.NewLivingConditionSet(
+	PredictorReady,
+	IngressReady,
+)
 
 var _ apis.ConditionsAccessor = (*InferenceServiceStatus)(nil)
 

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -267,8 +267,6 @@ func (r *InferenceServiceReconciler) updateStatus(desiredService *v1beta1api.Inf
 	return nil
 }
 
-// inferenceServiceReadiness checks for the readiness of the inference
-// service's latest revision/deployment.
 func inferenceServiceReadiness(status v1beta1api.InferenceServiceStatus) bool {
 	return status.Conditions != nil &&
 		status.GetCondition(apis.ConditionReady) != nil &&

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -615,9 +615,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Status: "True",
 						},
 						{
-							Type:     v1beta1.PredictorReady,
-							Severity: "Info",
-							Status:   "True",
+							Type:   v1beta1.PredictorReady,
+							Status: "True",
 						},
 						{
 							Type:     v1beta1.PredictorRouteReady,
@@ -926,9 +925,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Status: "True",
 						},
 						{
-							Type:     v1beta1.PredictorReady,
-							Severity: "Info",
-							Status:   "True",
+							Type:   v1beta1.PredictorReady,
+							Status: "True",
 						},
 						{
 							Type:     v1beta1.PredictorRouteReady,

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -388,9 +388,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Status: "True",
 						},
 						{
-							Type:     v1beta1.PredictorReady,
-							Severity: "Info",
-							Status:   "True",
+							Type:   v1beta1.PredictorReady,
+							Status: "True",
 						},
 						{
 							Type:   apis.ConditionReady,
@@ -821,9 +820,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Status: "True",
 						},
 						{
-							Type:     v1beta1.PredictorReady,
-							Severity: "Info",
-							Status:   "True",
+							Type:   v1beta1.PredictorReady,
+							Status: "True",
 						},
 						{
 							Type:   apis.ConditionReady,
@@ -1255,9 +1253,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Status: "True",
 						},
 						{
-							Type:     v1beta1.PredictorReady,
-							Severity: "Info",
-							Status:   "True",
+							Type:   v1beta1.PredictorReady,
+							Status: "True",
 						},
 						{
 							Type:   apis.ConditionReady,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -272,11 +272,6 @@ func createHTTPMatchRequest(prefix, targetHost, internalHost string, isInternal 
 }
 
 func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1beta1.IngressConfig) *v1alpha3.VirtualService {
-	serviceHost := getServiceHost(isvc)
-	if serviceHost == "" {
-		return nil
-	}
-
 	if !isvc.Status.IsConditionReady(v1beta1.PredictorReady) {
 		status := corev1.ConditionFalse
 		if isvc.Status.IsConditionUnknown(v1beta1.PredictorReady) {
@@ -313,6 +308,7 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 		}
 	}
 	isInternal := false
+	serviceHost := getServiceHost(isvc)
 	//if service is labelled with cluster local or knative domain is configured as internal
 	if val, ok := isvc.Labels[constants.VisibilityLabel]; ok && val == constants.ClusterLocalVisibility {
 		isInternal = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Puts back `PredictorReady` in the living condition set for inference service status to fix empty `Ready` status when `IngressReady` condition isn't set yet.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced. Please also list any relevant details for your test configuration.

Manually created inference services to test.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE.
```
