### PR TITLE
sklearnserver Docker image: Enable running under arbitrary UID to enable OpenShift

### DIFF
--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -48,7 +48,7 @@ COPY --from=builder --chown=1000:0 kserve kserve/
 COPY --from=builder --chown=1000:0 sklearnserver sklearnserver/
 
 # Give users in the root group the same permissions as the users
-# to allow running the image wit arbitrary UIDs
+# to allow running the image with arbitrary UIDs
 RUN chmod -R g=u "$VIRTUAL_ENV" kserve sklearnserver
 
 USER 1000

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -42,9 +42,14 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
 
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder sklearnserver sklearnserver
+# Make all files also owned by the root group
+COPY --from=builder --chown=1000:0 $VIRTUAL_ENV $VIRTUAL_ENV
+COPY --from=builder --chown=1000:0 kserve kserve/
+COPY --from=builder --chown=1000:0 sklearnserver sklearnserver/
+
+# Give users in the root group the same permissions as the users
+# to allow running the image wit arbitrary UIDs
+RUN chmod -R g=u "$VIRTUAL_ENV" kserve sklearnserver
 
 USER 1000
 ENTRYPOINT ["python", "-m", "sklearnserver"]


### PR DESCRIPTION

**What this PR does / why we need it**:

Set file's group to the root group and give the group the same permissions as the users. This is the recommendation of OpenShift (https://docs.openshift.com/container-platform/4.13/openshift_images/create-images.html#use-uid_create-images) to run under arbitrary user ids (but with those users also being member of the "root" group).

This change does is non-intrusive and will work on any platform.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to #3041, could be expanded to all KServe images, like in #3038 for a different purpose

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Run `docker run -it --entrypoint bash rhuss/sklearnserver` and then

```
kserve@ed9703137c27:/$ id
uid=1000(kserve) gid=1000(kserve) groups=1000(kserve)
kserve@ed9703137c27:/$ cd /

kserve@ed9703137c27:/$ ls -ld kserve/ sklearnserver/ prod_venv/
drwxrwxr-x 1 kserve root 4096 Jul 18 06:00 kserve/
drwxrwxr-x 1 kserve root 4096 Jul 21 13:24 prod_venv/
drwxrwxr-x 1 kserve root 4096 Jul 21 12:59 sklearnserver/

kserve@ed9703137c27:/$ ls -l kserve
total 280
-rw-rw-r-- 1 kserve root    273 Jul 18 06:00 Makefile
-rw-rw-r-- 1 kserve root     36 Jul 18 06:00 OWNERS
-rw-rw-r-- 1 kserve root   6521 Jul 18 06:00 README.md
drwxrwxr-x 1 kserve root   4096 Jul 18 06:00 docs
drwxrwxr-x 1 kserve root   4096 Jul 18 06:00 kserve
-rw-rw-r-- 1 kserve root 246881 Jul 18 06:00 poetry.lock
-rw-rw-r-- 1 kserve root   2855 Jul 18 06:00 pyproject.toml
-rw-rw-r-- 1 kserve root     28 Jul 18 06:00 setup.cfg
drwxrwxr-x 1 kserve root   4096 Jul 18 06:00 test
```

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable images to run in OpenShift
```
