### PR TITLE
template out kube-rbac-proxy image

### DIFF
--- a/charts/kserve-resources/templates/clusterrole.yaml
+++ b/charts/kserve-resources/templates/clusterrole.yaml
@@ -306,3 +306,22 @@ rules:
   - get
   - patch
   - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kserve-addressable-resolver
+  labels:
+    contrib.eventing.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
+rules:
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  - inferenceservices/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/kserve-resources/templates/deployment.yaml
+++ b/charts/kserve-resources/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: "{{ .Values.kserve.controller.rbacProxyImage }}"
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -26,6 +26,7 @@ kserve:
     enablePrometheusScraping: "false"
   controller:
     deploymentMode: "Serverless"
+    rbacProxyImage: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
     gateway:
       domain: example.com
       domainTemplate: "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Templates out `kube-rbac-proxy` image in Helm charts so it can be overridden in `values.yaml`.

**Type of changes**

- [x] New feature (non-breaking change which adds functionality)

**Release note**:
```release-note
NONE.
```
