### PR TITLE
chore: Fix `no space left on device` error in `predictor-runtime-build`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Please delete options that are not relevant.
 
 **Feature/Issue validation/testing**:
 
-Please describe the tests that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced.
+Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
 Please also list any relevant details for your test configuration.
 
 - [ ] Test A

--- a/.github/actions/free-up-disk-space/action.yml
+++ b/.github/actions/free-up-disk-space/action.yml
@@ -1,0 +1,34 @@
+name: 'Free-up disk space action'
+description: 'Removes non-essential tools, libraries and cached files from GitHub action runner node'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Free up disk space
+      shell: bash
+      run: |
+        echo "Disk usage before cleanup:"
+        df -h
+
+        # remove non-essential tools and libraries, see:
+        # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/share/boost
+
+        # delete libraries for Android (12G), CodeQL (5.3G), PowerShell (1.3G), Swift (1.7G)
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf "${AGENT_TOOLSDIRECTORY}/CodeQL"
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/share/swift
+
+        echo "Disk usage after cleanup:"
+        df -h
+
+    - name: Prune docker images
+      shell: bash
+      run: |
+        echo "Pruning docker images"
+        docker image prune -a -f
+        docker system df
+        df -h

--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -4,27 +4,6 @@ description: 'Sets up minikube on the github runner'
 runs:
   using: "composite"
   steps:
-    - name: Free up disk space
-      shell: bash
-      run: |
-        echo "Disk usage before cleanup:"
-        df -h
-
-        # remove non-essential tools and libraries, see:
-        # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/share/boost
-
-        # delete libraries for Android (12G), CodeQL (5.3G), PowerShell (1.3G), Swift (1.7G)
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf "${AGENT_TOOLSDIRECTORY}/CodeQL"
-        sudo rm -rf /usr/local/share/powershell
-        sudo rm -rf /usr/share/swift
-
-        echo "Disk usage after cleanup:"
-        df -h
-
     - name: Install kubectl
       uses: azure/setup-kubectl@v3
       with:
@@ -42,11 +21,3 @@ runs:
     - name: Check Kubernetes pods
       shell: bash
       run: kubectl get pods -n kube-system
-
-    - name: Prune docker images
-      shell: bash
-      run: |
-        echo "Pruning docker images"
-        docker image prune -a -f
-        docker system df
-        df -h

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -62,6 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
       - name: Build runtime server images
         run: |
           ./test/scripts/gh-actions/build-server-runtimes.sh predictor,transformer

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -147,6 +147,9 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
       - name: Setup Minikube
         uses: ./.github/actions/minikube-setup
 
@@ -227,6 +230,7 @@ jobs:
         with:
           python-version: '3.9'
 
+      - uses: ./.github/actions/free-up-disk-space
       - uses: ./.github/actions/minikube-setup
       - uses: ./.github/actions/kserve-dep-setup
       - uses: ./.github/actions/base-download
@@ -285,6 +289,7 @@ jobs:
         with:
           python-version: '3.9'
 
+      - uses: ./.github/actions/free-up-disk-space
       - uses: ./.github/actions/minikube-setup
       - uses: ./.github/actions/kserve-dep-setup
       - uses: ./.github/actions/base-download
@@ -337,7 +342,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-          
+
+      - uses: ./.github/actions/free-up-disk-space
       - uses: ./.github/actions/minikube-setup
       - uses: ./.github/actions/kserve-dep-setup
       - uses: ./.github/actions/base-download
@@ -390,6 +396,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+      - uses: ./.github/actions/free-up-disk-space
       - uses: ./.github/actions/minikube-setup
       - uses: ./.github/actions/kserve-dep-setup
       - uses: ./.github/actions/base-download
@@ -442,6 +449,7 @@ jobs:
         with:
           python-version: '3.9'
 
+      - uses: ./.github/actions/free-up-disk-space
       - uses: ./.github/actions/minikube-setup
       - uses: ./.github/actions/kserve-dep-setup
       - uses: ./.github/actions/base-download
@@ -503,6 +511,7 @@ jobs:
         with:
           python-version: '3.9'
 
+      - uses: ./.github/actions/free-up-disk-space
       - uses: ./.github/actions/minikube-setup
       - uses: ./.github/actions/kserve-dep-setup
       - uses: ./.github/actions/base-download
@@ -541,6 +550,7 @@ jobs:
         with:
           python-version: '3.9'
 
+      - uses: ./.github/actions/free-up-disk-space
       - uses: ./.github/actions/minikube-setup
       - uses: ./.github/actions/kserve-dep-setup
       - uses: ./.github/actions/base-download
@@ -584,6 +594,7 @@ jobs:
         with:
           python-version: '3.9'
 
+      - uses: ./.github/actions/free-up-disk-space
       - uses: ./.github/actions/minikube-setup
       - uses: ./.github/actions/kserve-dep-setup
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

A few months back the E2E tests exhausted the available disk space on the GitHub action runner nodes (#2950).

We added an additional action step to the `minikube-setup` composite action to remove unnecessary tools, libraries and caches before installing Minikube (#2972). This provided about 20 GB of additional disk space to build kserve images or pull large third-party images.

More recently other actions are running into similar disk space limits, like the [`predictor-runtime-build`](https://github.com/kserve/kserve/actions/runs/5658618204/job/15330357354):
 
```
Run ishworkh/docker-image-artifact-upload@v1
Error: Error: Command failed: docker save kserve/custom-model-grpc:abf300d60f48813116af504c9357921d6199a754 -o /tmp/kserve_custom-model-grpc_abf300d60f48813116af504c9357921d6199a754
write /tmp/.docker_temp_2888533438: no space left on device
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

- [x] `predictor-runtime-build`


**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
NONE
```
