### PR TITLE
Add "--load" to "docker buildx build" commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,14 +157,14 @@ manifests: controller-gen kustomize
 	#remove the required property on framework as name field needs to be optional
 	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml
 	#remove ephemeralContainers properties for compress crd size https://github.com/kubeflow/kfserving/pull/1141#issuecomment-714170602
-	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.ephemeralContainers)' -i config/crd/serving.kserve.io_inferenceservices.yaml 
+	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.ephemeralContainers)' -i config/crd/serving.kserve.io_inferenceservices.yaml
 	#knative does not allow setting port on liveness or readiness probe
-	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.properties.readinessProbe.properties.httpGet.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml 
-	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.properties.livenessProbe.properties.httpGet.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml 
-	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.properties.readinessProbe.properties.tcpSocket.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml 
-	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.properties.livenessProbe.properties.tcpSocket.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml 
-	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.containers.items.properties.livenessProbe.properties.httpGet.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml 
-	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.containers.items.properties.readinessProbe.properties.httpGet.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml 
+	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.properties.readinessProbe.properties.httpGet.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml
+	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.properties.livenessProbe.properties.httpGet.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml
+	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.properties.readinessProbe.properties.tcpSocket.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml
+	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.properties.livenessProbe.properties.tcpSocket.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml
+	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.containers.items.properties.livenessProbe.properties.httpGet.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml
+	yq 'del(.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*.properties.containers.items.properties.readinessProbe.properties.httpGet.required)' -i config/crd/serving.kserve.io_inferenceservices.yaml
 	#With v1 and newer kubernetes protocol requires default
 	yq '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties | .. | select(has("protocol")) | path' config/crd/serving.kserve.io_inferenceservices.yaml -o j | jq -r '. | map(select(numbers)="["+tostring+"]") | join(".")' | awk '{print "."$$0".protocol.default"}' | xargs -n1 -I{} yq '{} = "TCP"' -i config/crd/serving.kserve.io_inferenceservices.yaml
 	yq '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties | .. | select(has("protocol")) | path' config/crd/serving.kserve.io_clusterservingruntimes.yaml -o j | jq -r '. | map(select(numbers)="["+tostring+"]") | join(".")' | awk '{print "."$$0".protocol.default"}' | xargs -n1 -I{} yq '{} = "TCP"' -i config/crd/serving.kserve.io_clusterservingruntimes.yaml
@@ -195,7 +195,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker buildx build . -t ${IMG}
+	docker buildx build --load . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
 
 	# Use perl instead of sed to avoid OSX/Linux compatibility issue:
@@ -207,10 +207,10 @@ docker-push:
 	docker push ${IMG}
 
 docker-build-agent:
-	docker buildx build -f agent.Dockerfile . -t ${KO_DOCKER_REPO}/${AGENT_IMG}
+	docker buildx build --load -f agent.Dockerfile . -t ${KO_DOCKER_REPO}/${AGENT_IMG}
 
 docker-build-router:
-	docker buildx build -f router.Dockerfile . -t ${KO_DOCKER_REPO}/${ROUTER_IMG}
+	docker buildx build --load -f router.Dockerfile . -t ${KO_DOCKER_REPO}/${ROUTER_IMG}
 
 docker-push-agent:
 	docker push ${KO_DOCKER_REPO}/${AGENT_IMG}
@@ -219,85 +219,85 @@ docker-push-router:
 	docker push ${KO_DOCKER_REPO}/${ROUTER_IMG}
 
 docker-build-sklearn:
-	cd python && docker buildx build --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${SKLEARN_IMG} -f sklearn.Dockerfile .
+	cd python && docker buildx build --load --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${SKLEARN_IMG} -f sklearn.Dockerfile .
 
 docker-push-sklearn: docker-build-sklearn
 	docker push ${KO_DOCKER_REPO}/${SKLEARN_IMG}
 
 docker-build-xgb:
-	cd python && docker buildx build --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${XGB_IMG} -f xgb.Dockerfile .
+	cd python && docker buildx build --load --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${XGB_IMG} -f xgb.Dockerfile .
 
 docker-push-xgb: docker-build-xgb
 	docker push ${KO_DOCKER_REPO}/${XGB_IMG}
 
 docker-build-lgb:
-	cd python && docker buildx build --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${LGB_IMG} -f lgb.Dockerfile .
+	cd python && docker buildx build --load --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${LGB_IMG} -f lgb.Dockerfile .
 
 docker-push-lgb: docker-build-lgb
 	docker push ${KO_DOCKER_REPO}/${LGB_IMG}
 
 docker-build-pmml:
-	cd python && docker buildx build --build-arg BASE_IMAGE=${PMML_BASE_IMG} -t ${KO_DOCKER_REPO}/${PMML_IMG} -f pmml.Dockerfile .
+	cd python && docker buildx build --load --build-arg BASE_IMAGE=${PMML_BASE_IMG} -t ${KO_DOCKER_REPO}/${PMML_IMG} -f pmml.Dockerfile .
 
 docker-push-pmml: docker-build-pmml
 	docker push ${KO_DOCKER_REPO}/${PMML_IMG}
 
 docker-build-paddle:
-	cd python && docker buildx build --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${PADDLE_IMG} -f paddle.Dockerfile .
+	cd python && docker buildx build --load --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${PADDLE_IMG} -f paddle.Dockerfile .
 
 docker-push-paddle: docker-build-paddle
 	docker push ${KO_DOCKER_REPO}/${PADDLE_IMG}
 
 docker-build-custom-model:
-	cd python && docker buildx build -t ${KO_DOCKER_REPO}/${CUSTOM_MODEL_IMG} -f custom_model.Dockerfile .
+	cd python && docker buildx build --load -t ${KO_DOCKER_REPO}/${CUSTOM_MODEL_IMG} -f custom_model.Dockerfile .
 
 docker-push-custom-model: docker-build-custom-model
 	docker push ${KO_DOCKER_REPO}/${CUSTOM_MODEL_IMG}
 
 docker-build-custom-model-grpc:
-	cd python && docker buildx build -t ${KO_DOCKER_REPO}/${CUSTOM_MODEL_GRPC_IMG} -f custom_model_grpc.Dockerfile .
+	cd python && docker buildx build --load -t ${KO_DOCKER_REPO}/${CUSTOM_MODEL_GRPC_IMG} -f custom_model_grpc.Dockerfile .
 
 docker-push-custom-model-grpc: docker-build-custom-model-grpc
 	docker push ${KO_DOCKER_REPO}/${CUSTOM_MODEL_GRPC_IMG}
 
 docker-build-custom-transformer:
-	cd python && docker buildx build -t ${KO_DOCKER_REPO}/${CUSTOM_TRANSFORMER_IMG} -f custom_transformer.Dockerfile .
+	cd python && docker buildx build --load -t ${KO_DOCKER_REPO}/${CUSTOM_TRANSFORMER_IMG} -f custom_transformer.Dockerfile .
 
 docker-push-custom-transformer: docker-build-custom-transformer
 	docker push ${KO_DOCKER_REPO}/${CUSTOM_TRANSFORMER_IMG}
 
 docker-build-custom-transformer-grpc:
-	cd python && docker buildx build -t ${KO_DOCKER_REPO}/${CUSTOM_TRANSFORMER_GRPC_IMG} -f custom_transformer_grpc.Dockerfile .
+	cd python && docker buildx build --load -t ${KO_DOCKER_REPO}/${CUSTOM_TRANSFORMER_GRPC_IMG} -f custom_transformer_grpc.Dockerfile .
 
 docker-push-custom-transformer-grpc: docker-build-custom-transformer-grpc
 	docker push ${KO_DOCKER_REPO}/${CUSTOM_TRANSFORMER_GRPC_IMG}
 
 docker-build-alibi:
-	cd python && docker buildx build --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${ALIBI_IMG} -f alibiexplainer.Dockerfile .
+	cd python && docker buildx build --load --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${ALIBI_IMG} -f alibiexplainer.Dockerfile .
 
 docker-push-alibi: docker-build-alibi
 	docker push ${KO_DOCKER_REPO}/${ALIBI_IMG}
 
 docker-build-aif:
-	cd python && docker buildx build -t ${KO_DOCKER_REPO}/${AIF_IMG} -f aiffairness.Dockerfile .
+	cd python && docker buildx build --load -t ${KO_DOCKER_REPO}/${AIF_IMG} -f aiffairness.Dockerfile .
 
 docker-push-aif: docker-build-aif
 	docker push ${KO_DOCKER_REPO}/${AIF_IMG}
 
 docker-build-art:
-	cd python && docker buildx build -t ${KO_DOCKER_REPO}/${ART_IMG} -f artexplainer.Dockerfile .
+	cd python && docker buildx build --load -t ${KO_DOCKER_REPO}/${ART_IMG} -f artexplainer.Dockerfile .
 
 docker-push-art: docker-build-art
 	docker push ${KO_DOCKER_REPO}/${ART_IMG}
 
 docker-build-storageInitializer:
-	cd python && docker buildx build --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG} -f storage-initializer.Dockerfile .
+	cd python && docker buildx build --load --build-arg BASE_IMAGE=${BASE_IMG} -t ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG} -f storage-initializer.Dockerfile .
 
 docker-push-storageInitializer: docker-build-storageInitializer
 	docker push ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG}
 
 docker-build-qpext:
-	cd qpext && docker buildx build -t ${KO_DOCKER_REPO}/${QPEXT_IMG} -f qpext.Dockerfile .
+	cd qpext && docker buildx build --load -t ${KO_DOCKER_REPO}/${QPEXT_IMG} -f qpext.Dockerfile .
 
 docker-build-push-qpext: docker-build-qpext
 	docker push ${KO_DOCKER_REPO}/${QPEXT_IMG}
@@ -320,7 +320,7 @@ $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 apidocs:
-	docker buildx build -f docs/apis/Dockerfile --rm -t apidocs-gen . && \
+	docker buildx build --load -f docs/apis/Dockerfile --rm -t apidocs-gen . && \
 	docker run -it --rm -v $(CURDIR)/pkg/apis:/go/src/github.com/kserve/kserve/pkg/apis -v ${PWD}/docs/apis:/go/gen-crd-api-reference-docs/apidocs apidocs-gen
 
 .PHONY: check-doc-links


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

For creating Docker images, Docker BuildKit is used. However, "docker buildx build" just store the created image in the build cache so that a subsequent "docker push" won't work. 

In order to make targets like `make deploy-dev-sklearn` make work you either need to specify `--push` for `docker buildx build`, or, as in this PR use:

```
# Build and load the image into the Docker runtime
docker buildx build --load ....
...
# Docker push can only push images that are in the Docker Runtime
docker push
```

Without this fix I get this error:

```
cd python && docker buildx build --build-arg BASE_IMAGE=python:3.9-slim-bullseye -t docker.io/rhuss/sklearnserver -f sklearn.Dockerfile .
[+] Building 62.5s (21/21) FINISHED                                                                                        docker-container:xbuilder
 => [internal] load build definition from sklearn.Dockerfile                                                                                    0.0s
 => => transferring dockerfile: 1.53kB                                                                                                          0.0s
....
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
docker push docker.io/rhuss/sklearnserver
Using default tag: latest
The push refers to repository [docker.io/rhuss/sklearnserver]
tag does not exist: rhuss/sklearnserver:latest
make: *** [docker-push-sklearn] Error 1
```

I wonder how this ever has worked before (except maybe that you have used "docker build" before to load the image into the runtime automatically.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

(no issue yet, but I can open one if required)

**Type of changes**
Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

`make deploy-dev-sklearn` works now without an error:

```
cd python && docker buildx build --load --build-arg BASE_IMAGE=python:3.9-slim-bullseye -t docker.io/rhuss/sklearnserver -f sklearn.Dockerfile .
[+] Building 26.0s (24/24) FINISHED                                                                                        docker-container:xbuilder
 => [internal] load .dockerignore                                                                                                               0.0s
 => => transferring context: 2B                                                                                                                 0.0s
 => [internal] load build definition from sklearn.Dockerfile                                                                                    0.0s
 => => transferring dockerfile: 1.53kB                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/python:3.9-slim-bullseye                                                                     1.6s
 => [auth] library/python:pull token for registry-1.docker.io                                                                                   0.0s
 => [internal] load build context                                                                                                               0.0s
 => => transferring context: 20.52kB                                                                                                            0.0s
 => [builder  1/12] FROM docker.io/library/python:3.9-slim-bullseye@sha256:a9dbc6bcdd10b7d174452901747f84cbd711c7a5c3ad16fa4286fbf69c9c6af6     0.0s
 => => resolve docker.io/library/python:3.9-slim-bullseye@sha256:a9dbc6bcdd10b7d174452901747f84cbd711c7a5c3ad16fa4286fbf69c9c6af6               0.0s
 => CACHED [builder  2/12] RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential                         0.0s
 => CACHED [builder  3/12] RUN python3 -m venv /opt/poetry && /opt/poetry/bin/pip install poetry==1.4.0                                         0.0s
 => CACHED [builder  4/12] RUN python3 -m venv /prod_venv                                                                                       0.0s
 => CACHED [builder  5/12] COPY kserve/pyproject.toml kserve/poetry.lock kserve/                                                                0.0s
 => CACHED [builder  6/12] RUN cd kserve && poetry install --no-root --no-interaction --no-cache                                                0.0s
 => CACHED [builder  7/12] COPY kserve kserve                                                                                                   0.0s
 => CACHED [builder  8/12] RUN cd kserve && poetry install --no-interaction --no-cache                                                          0.0s
 => CACHED [builder  9/12] COPY sklearnserver/pyproject.toml sklearnserver/poetry.lock sklearnserver/                                           0.0s
 => CACHED [builder 10/12] RUN cd sklearnserver && poetry install --no-root --no-interaction --no-cache                                         0.0s
 => CACHED [builder 11/12] COPY sklearnserver sklearnserver                                                                                     0.0s
 => CACHED [builder 12/12] RUN cd sklearnserver && poetry install --no-interaction --no-cache                                                   0.0s
 => CACHED [prod 2/6] COPY third_party third_party                                                                                              0.0s
 => CACHED [prod 3/6] RUN useradd kserve -m -u 1000 -d /home/kserve                                                                             0.0s
 => [prod 4/6] COPY --from=builder --chown=kserve:kserve /prod_venv /prod_venv                                                                  3.0s
 => [prod 5/6] COPY --from=builder kserve kserve                                                                                                0.1s
 => [prod 6/6] COPY --from=builder sklearnserver sklearnserver                                                                                  0.0s
 => exporting to docker image format                                                                                                           21.1s
 => => exporting layers                                                                                                                        17.4s
 => => exporting manifest sha256:7748d281a1c7ab329ad0122a75367b4ed24c01942c3210c9455a9586dd5b5a0b                                               0.0s
 => => exporting config sha256:7b3b32fcdc643d05dd7184c2f32274a2f86f7decfa6ffaa6449d9c10b23eb3aa                                                 0.0s
 => => sending tarball                                                                                                                          3.7s
 => importing to docker                                                                                                                         0.0s
docker push docker.io/rhuss/sklearnserver
Using default tag: latest
The push refers to repository [docker.io/rhuss/sklearnserver]
a0ff923410f2: Layer already exists
68027a0c9046: Layer already exists
50bbb9a48135: Layer already exists
a4eca0514297: Layer already exists
29819c6a2c24: Layer already exists
df2aa92a12cd: Layer already exists
c5162a55bbec: Layer already exists
37905cb0bd1e: Layer already exists
87e4e6063607: Layer already exists
039b1ee32061: Layer already exists
latest: digest: sha256:6b78c68ef5762bf9ea7933d0ed131fb1dd5816a498062ccd3a2808f41ac23bec size: 2419
./hack/serving_runtime_image_patch.sh "kserve-sklearnserver.yaml" "docker.io/rhuss/sklearnserver"
clusterservingruntime.serving.kserve.io/kserve-sklearnserver unchanged
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
