### PR TITLE
Fix: Unexpected Panic in Inference graph when it fails to create http request

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -46,6 +46,10 @@ func callService(serviceUrl string, input []byte, headers http.Header) ([]byte, 
 	defer timeTrack(time.Now(), "step", serviceUrl)
 	log.Info("Entering callService", "url", serviceUrl)
 	req, err := http.NewRequest("POST", serviceUrl, bytes.NewBuffer(input))
+	if err != nil { 
+		log.Error(err, "An error occurred while preparing request object with serviceUrl.", "serviceUrl", serviceUrl) 
+		return nil,500, err 
+	}
 	for _, h := range headersToPropagate {
 		if values, ok := headers[h]; ok {
 			for _, v := range values {

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -515,3 +515,24 @@ func TestCallServiceWhenMultipleHeadersToPropagate(t *testing.T) {
 	fmt.Printf("final response:%v\n", response)
 	assert.Equal(t, expectedResponse, response)
 }
+
+
+func TestMalformedURL(t *testing.T) {
+
+
+
+        malformedURL := "http://single-1.default.{$your-domain}/switch"
+
+        _, _, err := callService(malformedURL, []byte{}, http.Header{})
+
+        if err == nil {
+
+                t.Fatal("Eexpect error from malformed URL  \n")
+
+        }
+
+
+
+}
+
+

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -523,11 +523,11 @@ func TestMalformedURL(t *testing.T) {
 
         malformedURL := "http://single-1.default.{$your-domain}/switch"
 
-        _, _, err := callService(malformedURL, []byte{}, http.Header{})
+        _, response, err := callService(malformedURL, []byte{}, http.Header{})
 
-        if err == nil {
+        if err != nil {
 
-                t.Fatal("Eexpect error from malformed URL  \n")
+                assert.Equal(t, 500, response)
 
         }
 

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -518,21 +518,11 @@ func TestCallServiceWhenMultipleHeadersToPropagate(t *testing.T) {
 
 
 func TestMalformedURL(t *testing.T) {
-
-
-
         malformedURL := "http://single-1.default.{$your-domain}/switch"
-
         _, response, err := callService(malformedURL, []byte{}, http.Header{})
-
         if err != nil {
-
                 assert.Equal(t, 500, response)
-
         }
-
-
-
 }
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add  Error handling
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3078

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:
Only add  Error handling , no need test plan.

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
