### PR TITLE
Fix kubeflow overlay kustomization

### DIFF
--- a/config/overlays/kubeflow/kustomization.yaml
+++ b/config/overlays/kubeflow/kustomization.yaml
@@ -20,6 +20,90 @@ generatorOptions:
 configurations:
 - params.yaml
 
+replacements:
+  - source:
+      group: cert-manager.io
+      kind: Certificate
+      name: serving-cert
+      version: v1
+      fieldPath: metadata.namespace
+    targets:
+      - select:
+          kind: CustomResourceDefinition
+          name: inferenceservices.serving.kserve.io
+        fieldPaths:
+          - spec.conversion.webhook.clientConfig.service.namespace
+      - select:
+          kind: MutatingWebhookConfiguration
+          name: inferenceservice.serving.kserve.io
+        fieldPaths:
+          - webhooks.*.clientConfig.service.namespace
+      - select:
+          kind: ValidatingWebhookConfiguration
+          name: inferenceservice.serving.kserve.io
+        fieldPaths:
+          - webhooks.*.clientConfig.service.namespace
+      - select:
+          kind: ValidatingWebhookConfiguration
+          name: trainedmodel.serving.kserve.io
+        fieldPaths:
+          - webhooks.*.clientConfig.service.namespace
+      - select:
+          kind: ValidatingWebhookConfiguration
+          name: inferencegraph.serving.kserve.io
+        fieldPaths:
+          - webhooks.*.clientConfig.service.namespace
+      - select:
+          kind: Certificate
+          name: serving-cert
+          namespace: kserve
+        fieldPaths:
+          - spec.commonName
+          - spec.dnsNames.0
+        options:
+          delimiter: '.'
+          index: 1
+      - select:
+          kind: CustomResourceDefinition
+          name: inferenceservices.serving.kserve.io
+        fieldPaths:
+          - metadata.annotations.[cert-manager.io/inject-ca-from]
+        options:
+          delimiter: '/'
+          index: 0
+      - select:
+          kind: MutatingWebhookConfiguration
+          name: inferenceservice.serving.kserve.io
+        fieldPaths:
+          - metadata.annotations.[cert-manager.io/inject-ca-from]
+        options:
+          delimiter: '/'
+          index: 0
+      - select:
+          kind: ValidatingWebhookConfiguration
+          name: inferenceservice.serving.kserve.io
+        fieldPaths:
+          - metadata.annotations.[cert-manager.io/inject-ca-from]
+        options:
+          delimiter: '/'
+          index: 0
+      - select:
+          kind: ValidatingWebhookConfiguration
+          name: trainedmodel.serving.kserve.io
+        fieldPaths:
+          - metadata.annotations.[cert-manager.io/inject-ca-from]
+        options:
+          delimiter: '/'
+          index: 0
+      - select:
+          kind: ValidatingWebhookConfiguration
+          name: inferencegraph.serving.kserve.io
+        fieldPaths:
+          - metadata.annotations.[cert-manager.io/inject-ca-from]
+        options:
+          delimiter: '/'
+          index: 0
+
 patches:
 - path: patches/statefulset.yaml
 - path: patches/namespace.yaml

--- a/hack/generate-install.sh
+++ b/hack/generate-install.sh
@@ -66,7 +66,7 @@ RUNTIMES_INSTALL_PATH=$INSTALL_DIR/kserve-runtimes.yaml
 mkdir -p $INSTALL_DIR
 kustomize build config/default | sed s/:latest/:$TAG/ > $INSTALL_PATH
 kustomize build config/overlays/kubeflow | sed s/:latest/:$TAG/ > $KUBEFLOW_INSTALL_PATH
-kustomize build config/runtimes | sed s/:latest/:$TAG/ >> $RUNTIMES_INSTALL_PATH
+kustomize build config/runtimes | sed s/:latest/:$TAG/ > $RUNTIMES_INSTALL_PATH
 
 # Update ingressGateway in inferenceservice configmap as 'kubeflow/kubeflow-gateway'
 yq -i 'select(.metadata.name == "inferenceservice-config").data.ingress |= (fromjson | .ingressGateway = "kubeflow/kubeflow-gateway" | tojson)' $KUBEFLOW_INSTALL_PATH

--- a/install/v0.11.0/kserve_kubeflow.yaml
+++ b/install/v0.11.0/kserve_kubeflow.yaml
@@ -2394,7 +2394,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/serving-cert
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
     app: kserve
@@ -20607,9 +20607,9 @@ metadata:
   name: serving-cert
   namespace: kubeflow
 spec:
-  commonName: kserve-webhook-server-service.kserve.svc
+  commonName: kserve-webhook-server-service.kubeflow.svc
   dnsNames:
-    - kserve-webhook-server-service.kserve.svc
+    - kserve-webhook-server-service.kubeflow.svc
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
@@ -20630,7 +20630,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/serving-cert
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
   creationTimestamp: null
   labels:
     app: kserve
@@ -20692,7 +20692,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/serving-cert
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
   creationTimestamp: null
   labels:
     app: kserve
@@ -20725,7 +20725,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/serving-cert
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
   creationTimestamp: null
   labels:
     app: kserve
@@ -20758,7 +20758,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/serving-cert
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
   creationTimestamp: null
   labels:
     app: kserve


### PR DESCRIPTION
**What this PR does / why we need it**:
We are using replacements instead of vars in kustomization file because the vars is deprecated in kustomize 5.0. We are replacing the namespace in the base kustomization file. Even though we are overriding the namespace in kubeflow overlay, unlike vars,  in replacements the overridden namespace is not propagated. So the namespace remained as kserve. We need to replace the namespace in the overlay kustomization file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3081

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
