### PR TITLE
Storage initializer fix so that it downloads only specific file when provided uri is not a folder

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -191,11 +191,13 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             # If 'uri' is set to "s3://test-bucket/a/b/c/model.bin", then
             # the downloader will add to temp dir: model.bin
             # (without any subpaths).
-            target_key = (
-                obj.key.rsplit("/", 1)[-1]
-                if bucket_path == obj.key
-                else obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
-            )
+            if bucket_path == obj.key:
+                target_key = obj.key.rsplit("/", 1)[-1]
+            elif bucket_path.rsplit("/", 1)[-1] in obj.key.rsplit("/", 1)[-1]:
+                target_key = obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
+            else:
+                target_key = obj.key.replace(bucket_path, "").lstrip("/")
+
             target = f"{temp_dir}/{target_key}"
             if not os.path.exists(os.path.dirname(target)):
                 os.makedirs(os.path.dirname(target), exist_ok=True)

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -192,11 +192,17 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             # If 'uri' is set to "s3://test-bucket/a/b/c/model.bin", then
             # the downloader will add to temp dir: model.bin
             # (without any subpaths).
+            # If the bucket path is s3://test/models
+            # Objects: churn, churn-pickle, churn-pickle-logs
+            bucket_path_last_part = bucket_path.split("/")[-1]
+            object_last_path = obj.key.split("/")[-1]
+            bucket_path_parent_part = bucket_path.rsplit("/", 1)[0]
+
             if bucket_path == obj.key:
                 target_key = obj.key.rsplit("/", 1)[-1]
                 exact_obj_found = True
-            elif obj.key.rsplit("/", 1)[-1].startswith(bucket_path.rsplit("/", 1)[-1]):
-                target_key = obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
+            elif object_last_path.startswith(bucket_path_last_part):
+                target_key = obj.key.replace(bucket_path_parent_part, "", 1).lstrip("/")
             else:
                 target_key = obj.key.replace(bucket_path, "").lstrip("/")
 

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -194,7 +194,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             target_key = (
                 obj.key.rsplit("/", 1)[-1]
                 if bucket_path == obj.key
-                else obj.key.replace(bucket_path, "", 1).lstrip("/")
+                else obj.key.replace(bucket_path.rsplit("/",1)[0], "", 1).lstrip("/")
             )
             target = f"{temp_dir}/{target_key}"
             if not os.path.exists(os.path.dirname(target)):

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -193,7 +193,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             # (without any subpaths).
             if bucket_path == obj.key:
                 target_key = obj.key.rsplit("/", 1)[-1]
-            elif bucket_path.rsplit("/", 1)[-1] in obj.key.rsplit("/", 1)[-1]:
+            elif obj.key.rsplit("/", 1)[-1].startswith(bucket_path.rsplit("/", 1)[-1]):
                 target_key = obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
             else:
                 target_key = obj.key.replace(bucket_path, "").lstrip("/")

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -194,7 +194,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             target_key = (
                 obj.key.rsplit("/", 1)[-1]
                 if bucket_path == obj.key
-                else obj.key.replace(bucket_path.rsplit("/",1)[0], "", 1).lstrip("/")
+                else obj.key.replace(bucket_path.rsplit("/", 1)[0], "", 1).lstrip("/")
             )
             target = f"{temp_dir}/{target_key}"
             if not os.path.exists(os.path.dirname(target)):

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -141,6 +141,24 @@ AWS_TEST_CREDENTIALS = {"AWS_ACCESS_KEY_ID": "testing",
 
 
 @mock.patch('kserve.storage.boto3')
+def test_multikey(mock_storage):
+    # given
+    bucket_name = 'foo'
+    paths = ['b/model.bin']
+    object_paths = ['test/a/' + p for p in paths]
+
+    # when
+    mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, object_paths)
+    kserve.Storage._download_s3(f's3://{bucket_name}/test/a', 'dest_path')
+
+    # then
+    arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
+    assert arg_list == expected_call_args_list('test/a', 'dest_path', paths)
+
+    mock_boto3_bucket.objects.filter.assert_called_with(Prefix='test/a')
+
+
+@mock.patch('kserve.storage.boto3')
 def test_files_with_no_extension(mock_storage):
 
     # given

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -17,7 +17,6 @@ import unittest.mock as mock
 
 from botocore.client import Config
 from botocore import UNSIGNED
-
 from kserve.storage import Storage
 
 STORAGE_MODULE = 'kserve.storage.storage'
@@ -149,7 +148,7 @@ def test_multikey(mock_storage):
 
     # when
     mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, object_paths)
-    kserve.Storage._download_s3(f's3://{bucket_name}/test/a', 'dest_path')
+    Storage._download_s3(f's3://{bucket_name}/test/a', 'dest_path')
 
     # then
     arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
@@ -168,7 +167,7 @@ def test_files_with_no_extension(mock_storage):
 
     # when
     mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, object_paths)
-    kserve.Storage._download_s3(f's3://{bucket_name}/test/churn-pickle', 'dest_path')
+    Storage._download_s3(f's3://{bucket_name}/test/churn-pickle', 'dest_path')
 
     # then
     arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -139,7 +139,7 @@ AWS_TEST_CREDENTIALS = {"AWS_ACCESS_KEY_ID": "testing",
                         "AWS_SESSION_TOKEN": "testing"}
 
 
-@mock.patch('kserve.storage.boto3')
+@mock.patch(STORAGE_MODULE + '.boto3')
 def test_multikey(mock_storage):
     # given
     bucket_name = 'foo'
@@ -157,7 +157,7 @@ def test_multikey(mock_storage):
     mock_boto3_bucket.objects.filter.assert_called_with(Prefix='test/a')
 
 
-@mock.patch('kserve.storage.boto3')
+@mock.patch(STORAGE_MODULE + '.boto3')
 def test_files_with_no_extension(mock_storage):
 
     # given
@@ -171,7 +171,9 @@ def test_files_with_no_extension(mock_storage):
 
     # then
     arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
-    assert arg_list == expected_call_args_list('test', 'dest_path', paths)
+
+    # Download only the exact file if found; otherwise, download all files with the given prefix
+    assert arg_list[0] == expected_call_args_list('test', 'dest_path', paths)[0]
 
     mock_boto3_bucket.objects.filter.assert_called_with(Prefix='test/churn-pickle')
 

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -140,6 +140,25 @@ AWS_TEST_CREDENTIALS = {"AWS_ACCESS_KEY_ID": "testing",
                         "AWS_SESSION_TOKEN": "testing"}
 
 
+@mock.patch('kserve.storage.boto3')
+def test_files_with_no_extension(mock_storage):
+
+    # given
+    bucket_name = 'foo'
+    paths = ['churn-pickle', 'churn-pickle-logs', 'churn-pickle-report']
+    object_paths = ['test/' + p for p in paths]
+
+    # when
+    mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, object_paths)
+    kserve.Storage._download_s3(f's3://{bucket_name}/test/churn-pickle', 'dest_path')
+
+    # then
+    arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
+    assert arg_list == expected_call_args_list('test', 'dest_path', paths)
+
+    mock_boto3_bucket.objects.filter.assert_called_with(Prefix='test/churn-pickle')
+
+
 def test_get_S3_config():
     DEFAULT_CONFIG = Config()
     ANON_CONFIG = Config(signature_version=UNSIGNED)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2473 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Feature/Issue validation/testing**:


- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
