### PR TITLE
Add support for modelcars

### DIFF
--- a/charts/kserve-resources/templates/configmap.yaml
+++ b/charts/kserve-resources/templates/configmap.yaml
@@ -64,7 +64,10 @@ data:
            "memoryLimit": "1Gi",
            "cpuRequest": "100m",
            "cpuLimit": "1",
-           "enableDirectPvcVolumeMount": false
+           "enableDirectPvcVolumeMount": false,
+           "enableModelcar": false,
+           "cpuModelcar": "10m",
+           "memoryModelcar": "15Mi"
        }
      storageInitializer: |-
        {
@@ -86,7 +89,23 @@ data:
            # enableDirectPvcVolumeMount controls whether users can mount pvc volumes directly.
            # if pvc volume is provided in storageuri then the pvc volume is directly mounted to /mnt/models in the user container.
            # rather than symlink it to a shared volume. For more info see https://github.com/kserve/kserve/issues/2737
-           "enableDirectPvcVolumeMount": false
+           "enableDirectPvcVolumeMount": false,
+
+           # enableModelcar enabled allows you to directly access an OCI container image by
+           # using a source URL with an "oci://" schema.
+           "enableModelcar": false,
+
+           # cpuModelcar is the cpu request and limit that is used for the passive modelcar container. It can be
+           # set very low, but should be allowed by any Kubernetes LimitRange that might apply.
+           "cpuModelcar": "10m",
+
+           # cpuModelcar is the memory request and limit that is used for the passive modelcar container. It can be
+           # set very low, but should be allowed by any Kubernetes LimitRange that might apply.
+           "memoryModelcar": "15Mi",
+
+           # uidModelcar is the UID under with which the modelcar process and the main container is running.
+           # Some Kubernetes clusters might require this to be root (0). If not set the user id is left untouched (default)
+           "uidModelcar": 10
        }
 
      # ====================================== CREDENTIALS ======================================

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -66,6 +66,10 @@ data:
            "caBundleConfigMapName": "",
            "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
            "enableDirectPvcVolumeMount": false,
+           "enableOciImageSource": false,
+           "enableModelcar": false,
+           "cpuModelcar": "10m",
+           "memoryModelcar": "15Mi"
        }
      storageInitializer: |-
        {
@@ -93,7 +97,23 @@ data:
            # enableDirectPvcVolumeMount controls whether users can mount pvc volumes directly.
            # if pvc volume is provided in storageuri then the pvc volume is directly mounted to /mnt/models in the user container.
            # rather than symlink it to a shared volume. For more info see https://github.com/kserve/kserve/issues/2737
-           "enableDirectPvcVolumeMount": false
+           "enableDirectPvcVolumeMount": false,
+    
+           # enableModelcar enabled allows you to directly access an OCI container image by
+           # using a source URL with an "oci://" schema.
+           "enableModelcar": false,
+
+           # cpuModelcar is the cpu request and limit that is used for the passive modelcar container. It can be
+           # set very low, but should be allowed by any Kubernetes LimitRange that might apply.
+           "cpuModelcar": "10m",
+
+           # cpuModelcar is the memory request and limit that is used for the passive modelcar container. It can be
+           # set very low, but should be allowed by any Kubernetes LimitRange that might apply.
+           "memoryModelcar": "15Mi",
+
+           # uidModelcar is the UID under with which the modelcar process and the main container is running.
+           # Some Kubernetes clusters might require this to be root (0). If not set the user id is left untouched (default)
+           "uidModelcar": 10
        }
      
      # ====================================== CREDENTIALS ======================================
@@ -428,6 +448,10 @@ data:
         "caBundleConfigMapName": "",
         "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
         "enableDirectPvcVolumeMount": false
+        "enableDirectPvcVolumeMount": false,
+        "enableModelcar": false,
+        "cpuModelcar": "10m",
+        "memoryModelcar": "15Mi"
     }
 
   credentials: |-

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -447,7 +447,6 @@ data:
         "cpuLimit": "1",
         "caBundleConfigMapName": "",
         "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-        "enableDirectPvcVolumeMount": false
         "enableDirectPvcVolumeMount": false,
         "enableModelcar": false,
         "cpuModelcar": "10m",

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -44,7 +44,7 @@ import (
 
 // Constants
 var (
-	SupportedStorageURIPrefixList = []string{"gs://", "s3://", "pvc://", "file://", "https://", "http://", "hdfs://", "webhdfs://"}
+	SupportedStorageURIPrefixList = []string{"gs://", "s3://", "pvc://", "file://", "https://", "http://", "hdfs://", "webhdfs://", "oci://"}
 )
 
 const (

--- a/pkg/webhook/admission/pod/mutator.go
+++ b/pkg/webhook/admission/pod/mutator.go
@@ -124,6 +124,10 @@ func (mutator *Mutator) mutate(pod *v1.Pod, configMap *v1.ConfigMap) error {
 		metricsAggregator.InjectMetricsAggregator,
 	}
 
+	if storageInitializer.config.EnableOciImageSource {
+		mutators = append(mutators, storageInitializer.InjectModelcar)
+	}
+
 	for _, mutator := range mutators {
 		if err := mutator(pod); err != nil {
 			return err

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -43,20 +43,29 @@ const (
 	StorageInitializerContainerImage        = "kserve/storage-initializer"
 	StorageInitializerContainerImageVersion = "latest"
 	PvcURIPrefix                            = "pvc://"
+	OciURIPrefix                            = "oci://"
 	PvcSourceMountName                      = "kserve-pvc-source"
 	PvcSourceMountPath                      = "/mnt/pvc"
 	CaBundleVolumeName                      = "cabundle-cert"
+	ModelcarContainerName                   = "modelcar"
+	ModelInitModeEnv                        = "MODEL_INIT_MODE"
+	CpuModelcarDefault                      = "10m"
+	MemoryModelcarDefault                   = "15Mi"
 )
 
 type StorageInitializerConfig struct {
 	Image                      string `json:"image"`
 	CpuRequest                 string `json:"cpuRequest"`
 	CpuLimit                   string `json:"cpuLimit"`
+	CpuModelcar                string `json:"cpuModelcar"`
 	MemoryRequest              string `json:"memoryRequest"`
 	MemoryLimit                string `json:"memoryLimit"`
 	CaBundleConfigMapName      string `json:"caBundleConfigMapName"`
 	CaBundleVolumeMountPath    string `json:"caBundleVolumeMountPath"`
+	MemoryModelcar             string `json:"memoryModelcar"`
 	EnableDirectPvcVolumeMount bool   `json:"enableDirectPvcVolumeMount"`
+	EnableOciImageSource       bool   `json:"enableModelcar"`
+	UidModelcar                *int64 `json:"uidModelcar"`
 }
 
 type StorageInitializerInjector struct {
@@ -110,6 +119,70 @@ func GetContainerSpecForStorageUri(storageUri string, client client.Client) (*v1
 	return nil, nil
 }
 
+// InjectModelcar injects a sidecar with the full model included to the Pod.
+// This so called "modelcar" is then directly accessed from the user container
+// via the proc filesystem (possible when `shareProcessNamespace` is enabled in the Pod spec)
+func (mi *StorageInitializerInjector) InjectModelcar(pod *v1.Pod) error {
+	srcURI, ok := pod.ObjectMeta.Annotations[constants.StorageInitializerSourceUriInternalAnnotationKey]
+	if !ok {
+		return nil
+	}
+
+	// Only inject modelcar if requested
+	if !strings.HasPrefix(srcURI, OciURIPrefix) {
+		return nil
+	}
+
+	// Add an emptyDir Volume to Pod
+	pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+		Name: StorageInitializerVolumeName,
+		VolumeSource: v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{},
+		},
+	})
+
+	// Extract image reference for modelcar from URI
+	image := strings.TrimPrefix(srcURI, OciURIPrefix)
+
+	userContainer := getContainerWithName(pod, constants.InferenceServiceContainerName)
+	if userContainer == nil {
+		return fmt.Errorf("no container found with name %s", constants.InferenceServiceContainerName)
+	}
+
+	// Indicate to the runtime that it the model directory could be
+	// available a bit later only so that it should wait and retry when
+	// starting up
+	addOrReplaceEnv(userContainer, ModelInitModeEnv, "async")
+
+	// Mount volume initialized by the modelcar container to the user container
+	userContainer.VolumeMounts = append(userContainer.VolumeMounts, v1.VolumeMount{
+		Name:      StorageInitializerVolumeName,
+		MountPath: getParentDirectory(constants.DefaultModelLocalMountPath),
+		ReadOnly:  false,
+	})
+
+	// If configured, run as the given user. There might be certain installations
+	// of Kubernetes where sharing the filesystem via the process namespace only works
+	// when both containers are running as root
+	if mi.config.UidModelcar != nil {
+		userContainer.SecurityContext = &v1.SecurityContext{
+			RunAsUser: mi.config.UidModelcar,
+		}
+	}
+
+	// Create the modelcar that is used as a sidecar in Pod and add it to the end
+	// of the containers
+	modelContainer := mi.createModelContainer(image, constants.DefaultModelLocalMountPath)
+	pod.Spec.Containers = append(pod.Spec.Containers, *modelContainer)
+
+	// Enable process namespace sharing so that the modelcar's root filesystem
+	// can be reached by the user container
+	shareProcessNamespace := true
+	pod.Spec.ShareProcessNamespace = &shareProcessNamespace
+
+	return nil
+}
+
 // InjectStorageInitializer injects an init container to provision model data
 // for the serving container in a unified way across storage tech by injecting
 // a provisioning INIT container. This is a work around because KNative does not
@@ -126,6 +199,11 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 		return nil
 	}
 
+	// Don't inject init-containers if a modelcar is used
+	if mi.config.EnableOciImageSource && strings.HasPrefix(srcURI, OciURIPrefix) {
+		return nil
+	}
+
 	// Don't inject if InitContainer already injected
 	for _, container := range pod.Spec.InitContainers {
 		if strings.Compare(container.Name, StorageInitializerContainerName) == 0 {
@@ -134,16 +212,8 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 	}
 
 	// Find the kserve-container (this is the model inference server) and transformer container
-	var userContainer *v1.Container
-	var transformerContainer *v1.Container
-	for idx, container := range pod.Spec.Containers {
-		if strings.Compare(container.Name, constants.InferenceServiceContainerName) == 0 {
-			userContainer = &pod.Spec.Containers[idx]
-		}
-		if container.Name == constants.TransformerContainerName {
-			transformerContainer = &pod.Spec.Containers[idx]
-		}
-	}
+	userContainer := getContainerWithName(pod, constants.InferenceServiceContainerName)
+	transformerContainer := getContainerWithName(pod, constants.TransformerContainerName)
 
 	if userContainer == nil {
 		return fmt.Errorf("Invalid configuration: cannot find container: %s", constants.InferenceServiceContainerName)
@@ -437,6 +507,99 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
 
 	return nil
+}
+
+func getContainerWithName(pod *v1.Pod, name string) *v1.Container {
+	for idx, container := range pod.Spec.Containers {
+		if strings.Compare(container.Name, name) == 0 {
+			return &pod.Spec.Containers[idx]
+		}
+	}
+	return nil
+}
+
+// Add an environment variable with the given value to the environments
+// variables of the given container, potentially replacing an env var that already exists
+// with this name
+func addOrReplaceEnv(container *v1.Container, envKey string, envValue string) {
+	if container.Env == nil {
+		container.Env = []v1.EnvVar{}
+	}
+
+	for i, envVar := range container.Env {
+		if envVar.Name == envKey {
+			container.Env[i].Value = envValue
+			return
+		}
+	}
+
+	container.Env = append(container.Env, v1.EnvVar{
+		Name:  envKey,
+		Value: envValue,
+	})
+}
+
+func (mi *StorageInitializerInjector) createModelContainer(image string, modelPath string) *v1.Container {
+	cpu := mi.config.CpuModelcar
+	if cpu == "" {
+		cpu = CpuModelcarDefault
+	}
+	memory := mi.config.MemoryModelcar
+	if memory == "" {
+		memory = MemoryModelcarDefault
+	}
+
+	modelContainer := &v1.Container{
+		Name:  ModelcarContainerName,
+		Image: image,
+		VolumeMounts: []v1.VolumeMount{
+			{
+				Name:      StorageInitializerVolumeName,
+				MountPath: getParentDirectory(modelPath),
+				ReadOnly:  false,
+			},
+		},
+		Args: []string{
+			"sh",
+			"-c",
+			// $$$$ gets escaped by YAML to $$, which is the current PID
+			fmt.Sprintf("ln -s /proc/$$$$/root/models %s && sleep infinity", modelPath),
+		},
+		Resources: v1.ResourceRequirements{
+			Limits: map[v1.ResourceName]resource.Quantity{
+				// Could possibly be reduced to even less
+				v1.ResourceCPU:    resource.MustParse(cpu),
+				v1.ResourceMemory: resource.MustParse(memory),
+			},
+			Requests: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse(cpu),
+				v1.ResourceMemory: resource.MustParse(memory),
+			},
+		},
+		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+	}
+
+	if mi.config.UidModelcar != nil {
+		modelContainer.SecurityContext = &v1.SecurityContext{
+			RunAsUser: mi.config.UidModelcar,
+		}
+	}
+
+	return modelContainer
+}
+
+// GetParentDirectory returns the parent directory of the given path,
+// or "/" if the path is a top-level directory.
+func getParentDirectory(path string) string {
+	// Get the parent directory
+	parentDir := filepath.Dir(path)
+
+	// Check if it's a top-level directory
+	if parentDir == "." || parentDir == "/" {
+		return "/"
+	}
+
+	return parentDir
 }
 
 // Use JSON Marshal/Unmarshal to merge Container structs using strategic merge patch.

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -18,6 +18,8 @@ package pod
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
+	"knative.dev/pkg/ptr"
 	"strings"
 	"testing"
 
@@ -2610,6 +2612,263 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 		}
 		if diff, _ := kmp.SafeDiff(scenario.expected.Spec, scenario.original.Spec); diff != "" {
 			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}
+
+func TestAddOrReplaceEnv(t *testing.T) {
+	tests := []struct {
+		name       string
+		container  *v1.Container
+		envKey     string
+		envValue   string
+		wantEnvLen int
+		wantValue  string
+	}{
+		{
+			name:       "nil env array",
+			container:  &v1.Container{},
+			envKey:     "TEST_KEY",
+			envValue:   "test_value",
+			wantEnvLen: 1,
+			wantValue:  "test_value",
+		},
+		{
+			name: "env array without key",
+			container: &v1.Container{
+				Env: []v1.EnvVar{
+					{Name: "EXISTING_KEY", Value: "existing_value"},
+				},
+			},
+			envKey:     "TEST_KEY",
+			envValue:   "test_value",
+			wantEnvLen: 2,
+			wantValue:  "test_value",
+		},
+		{
+			name: "env array with existing key",
+			container: &v1.Container{
+				Env: []v1.EnvVar{
+					{Name: "TEST_KEY", Value: "old_value"},
+				},
+			},
+			envKey:     "TEST_KEY",
+			envValue:   "new_value",
+			wantEnvLen: 1,
+			wantValue:  "new_value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addOrReplaceEnv(tt.container, tt.envKey, tt.envValue)
+
+			if len(tt.container.Env) != tt.wantEnvLen {
+				t.Errorf("Expected env length %d, but got %d", tt.wantEnvLen, len(tt.container.Env))
+			}
+
+			for _, envVar := range tt.container.Env {
+				if envVar.Name == tt.envKey && envVar.Value != tt.wantValue {
+					t.Errorf("Expected value for %s to be %s, but got %s", tt.envKey, tt.wantValue, envVar.Value)
+				}
+			}
+		})
+	}
+}
+
+func TestInjectModelcar(t *testing.T) {
+	// Test when annotation key is not set
+	{
+		pod := &v1.Pod{}
+		mi := &StorageInitializerInjector{}
+		err := mi.InjectModelcar(pod)
+
+		if err != nil {
+			t.Errorf("Expected nil error but got %v", err)
+		}
+		if len(pod.Spec.Containers) != 0 {
+			t.Errorf("Expected no containers but got %d", len(pod.Spec.Containers))
+		}
+	}
+
+	// Test when srcURI does not start with OciURIPrefix
+	{
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					constants.StorageInitializerSourceUriInternalAnnotationKey: "s3://bla/blub",
+				},
+			},
+		}
+		mi := &StorageInitializerInjector{}
+		err := mi.InjectModelcar(pod)
+
+		if err != nil {
+			t.Errorf("Expected nil error but got %v", err)
+		}
+		if len(pod.Spec.Containers) != 0 {
+			t.Errorf("Expected no containers but got %d", len(pod.Spec.Containers))
+		}
+	}
+
+	// Test when srcURI starts with OciURIPrefix
+	{
+		pod := createTestPodForModelcar()
+		mi := &StorageInitializerInjector{
+			config: &StorageInitializerConfig{},
+		}
+		err := mi.InjectModelcar(pod)
+
+		if err != nil {
+			t.Errorf("Expected nil error but got %v", err)
+		}
+
+		// Check that an emptyDir volume has been attached
+		if len(pod.Spec.Volumes) != 1 || pod.Spec.Volumes[0].Name != StorageInitializerVolumeName {
+			t.Errorf("Expected one volume with name %s, but got %v", StorageInitializerVolumeName, pod.Spec.Volumes)
+		}
+
+		// Check that a sidecar container has been injected
+		if len(pod.Spec.Containers) != 2 {
+			t.Errorf("Expected two containers but got %d", len(pod.Spec.Containers))
+		}
+
+		// Check that the user-container has an env var set
+		found := false
+		if pod.Spec.Containers[0].Env != nil {
+			for _, env := range pod.Spec.Containers[0].Env {
+				if env.Name == ModelInitModeEnv && env.Value == "async" {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Errorf("Expected env var %s=async but did not find it", ModelInitModeEnv)
+		}
+
+		// Check volume mounts in both containers
+		if len(pod.Spec.Containers[0].VolumeMounts) != 1 || len(pod.Spec.Containers[1].VolumeMounts) != 1 {
+			t.Errorf("Expected one volume mount in each container but got user-container: %d, sidecar-container: %d",
+				len(pod.Spec.Containers[0].VolumeMounts), len(pod.Spec.Containers[1].VolumeMounts))
+		}
+
+		// Check ShareProcessNamespace
+		if pod.Spec.ShareProcessNamespace == nil || *pod.Spec.ShareProcessNamespace != true {
+			t.Errorf("Expected ShareProcessNamespace to be true but got %v", pod.Spec.ShareProcessNamespace)
+		}
+	}
+}
+
+func createTestPodForModelcar() *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.StorageInitializerSourceUriInternalAnnotationKey: OciURIPrefix + "myrepo/mymodelimage",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: constants.InferenceServiceContainerName},
+			},
+		},
+	}
+	return pod
+}
+
+func TestStorageInitializerInjectorWithConfig(t *testing.T) {
+
+	t.Run("Test empty config", func(t *testing.T) {
+		config := &StorageInitializerConfig{}
+		injector := &StorageInitializerInjector{config: config}
+
+		pod := createTestPodForModelcar()
+		err := injector.InjectModelcar(pod)
+		assert.Nil(t, err)
+
+		// Assertions
+		modelcarContainer := getContainerWithName(pod, ModelcarContainerName)
+		assert.NotNil(t, modelcarContainer)
+		assert.Equal(t, resource.MustParse(CpuModelcarDefault), modelcarContainer.Resources.Limits["cpu"])
+		assert.Equal(t, resource.MustParse(MemoryModelcarDefault), modelcarContainer.Resources.Limits["memory"])
+		assert.Equal(t, resource.MustParse(CpuModelcarDefault), modelcarContainer.Resources.Requests["cpu"])
+		assert.Equal(t, resource.MustParse(MemoryModelcarDefault), modelcarContainer.Resources.Requests["memory"])
+		assert.Nil(t, modelcarContainer.SecurityContext)
+	})
+
+	t.Run("Test uidModelcar config", func(t *testing.T) {
+		config := &StorageInitializerConfig{UidModelcar: ptr.Int64(10)}
+		injector := &StorageInitializerInjector{config: config}
+
+		pod := createTestPodForModelcar()
+		err := injector.InjectModelcar(pod)
+		assert.Nil(t, err)
+
+		// Assertions
+		modelcarContainer := getContainerWithName(pod, ModelcarContainerName)
+		userContainer := getContainerWithName(pod, constants.InferenceServiceContainerName)
+		assert.NotNil(t, modelcarContainer)
+		assert.NotNil(t, userContainer)
+		assert.Equal(t, int64(10), *modelcarContainer.SecurityContext.RunAsUser)
+		assert.Equal(t, int64(10), *userContainer.SecurityContext.RunAsUser)
+	})
+
+	t.Run("Test CPU and Memory config", func(t *testing.T) {
+		config := &StorageInitializerConfig{CpuModelcar: "50m", MemoryModelcar: "50Mi"}
+		injector := &StorageInitializerInjector{config: config}
+
+		pod := createTestPodForModelcar()
+		err := injector.InjectModelcar(pod)
+		assert.Nil(t, err)
+
+		// Assertions
+		modelcarContainer := getContainerWithName(pod, ModelcarContainerName)
+		assert.NotNil(t, modelcarContainer)
+		assert.Equal(t, resource.MustParse("50m"), modelcarContainer.Resources.Limits["cpu"])
+		assert.Equal(t, resource.MustParse("50Mi"), modelcarContainer.Resources.Requests["memory"])
+		assert.Equal(t, resource.MustParse("50m"), modelcarContainer.Resources.Limits["cpu"])
+		assert.Equal(t, resource.MustParse("50Mi"), modelcarContainer.Resources.Requests["memory"])
+	})
+}
+
+func TestGetContainerWithName(t *testing.T) {
+	// Test case: Container exists
+	{
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "container-1"},
+					{Name: "container-2"},
+				},
+			},
+		}
+
+		seekName := "container-1"
+		got := getContainerWithName(pod, seekName)
+
+		if got == nil {
+			t.Errorf("Expected a container, but got nil")
+		} else if got.Name != seekName {
+			t.Errorf("Expected container name %s, but got %s", seekName, got.Name)
+		}
+	}
+
+	// Test case: Container does not exist
+	{
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "container-1"},
+					{Name: "container-2"},
+				},
+			},
+		}
+
+		seekName := "non-existent-container"
+		got := getContainerWithName(pod, seekName)
+
+		if got != nil {
+			t.Errorf("Expected nil, but got a container")
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR supports an "oci://" schema for the storage URL, which allows accessing models direct from OCI image containers without copying the model data from, somewhere.

The benefits of this approach compared to the traditional `storageInitializer` methods are:

* Only pull the model data once per node, not every time a Pod starts. This greatly benefits cold start times, especially when dealing with large models. See some initial numbers below.
* Distributing images (also large images; Windows images used to be 9GB and larger) is a well-known business that any decent OCI registry can handle.
* There are techniques to preload images to nodes to reduce cold starts to be close to zero.
* In the future, additional optimizations for image loading could be implemented, benefiting from the layered nature of images. I am not sure if the current models do support layering (e.g., for foundational and extended models), but hypothetically, such models could benefit from lazy loading 

Design document for "modelcars" can be found in this [document](https://docs.google.com/document/d/1Bs4fnP8rhPMaoPoLSYVvuRq-z9vkGPQ0rKbmfH4I7js/edit?usp=sharing)

Here is a very raw [modelcar demo](https://www.youtube.com/watch?v=KzWH8v6CcR0) (please forgive me some errors :), but it should give you a good initial impression of  modelcars and how they work:

Fixes #3043 

**Type of changes**
Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

**Feature/Issue validation/testing**:

This initial PR implements these features:

* Add new storageUri schema "oci" that points to a OCI image
* New injector that adds a so-called "modelcar" container to "kserve-container" as a sidecar
* Setup pod for sharing the process namespace (shareProcessNamespace = true)
* Add new feature flag "enableOciImageSource" to switch on support for "oci" URLs

------------------

Some initial smoke tests indicate that performance can be improved by a magnitude of order for large models.

The test has been run on Minikube on a MacBook M1 with Docker and a 6 CPU, 16 GB VM. Times are hand-stopped and start counting before the initial creation of the inference service:

| Model Name       | SI or OCI | First Run | Second Run |
|------------------|-----------|-----------|------------|
| SKLearn Iris (500 Bytes)   | SI        | 31s        | 31s        |
| SKLearn Iris (500 Bytes)   | OCI       | 12s        | 21s        |
| Bloom-56 (3.2 Gb)  | SI        | 300s       | 300s       |
| Bloom-56 (3.2 Gb)  | OCI       | 305s       | 13s        |

As you can see, the second run is more or less the same regardless of the model size (which is to be expected as the only time needed is to create the symlink, which goes immediately). The first run includes the pull times of the container image, which is not much slower than downloading it from an S3 bucket.


_Please describe the tests you ran to verify your changes and the relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration._

A handful of unit tests have been added. To test the functionality, perform the following steps:

* Run `make deploy-dev` from a checked version of this branch

* Enable the model car feature by setting the corresponding feature flag to true, e.g. with 

```
kubectl get cm inferenceservice-config -n kserve -o json | \ 
sed 's/\\"enableOciImageSource\\": false/\\"enableOciImageSource\\": true/' | \
kubectl apply -f -
```

* Restart controller pod (not sure if needed, just to be sure)

* Create an `InferenceService` with

```
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "sklearn-iris"
spec:
  predictor:
    model:
      modelFormat:
        name: sklearn
      storageUri: "oci://rhuss/sklearn-sample-model"
```  
Note the `oci://` schema of the `storageUri`.
The Dockerfile for this image looks like this:

```
FROM busybox
COPY models /models
```

With the local `models/` directory holding the model:

```
ls -l models
.rw-r--r-- roland staff 5.3 KB Wed Aug 30 23:35:21 2023 model.joblib
```

* When running, check that the link has been set up properly:

```
pod=$(kubectl get pods -o name -l serving.kserve.io/inferenceservice=sklearn-iris)

# In the kserve-container /mnt/models is a symlink into the modelcar container:
kubectl exec $pod -c kserve-container -- ls -ld /mnt/models
lrwxrwxrwx 1 root root 20 Sep  3 15:00 /mnt/models -> /proc/32/root/models

# All process are shared, as wells as their root filesystem:
# (pid 32 is the id of the modelcar process, so appears above as part of the symlink)
kubectl exec $pod -c modelcar -- ps
PID   USER     TIME  COMMAND
    1 65535     0:00 /pause
    7 root      0:07 python -m sklearnserver --model_name=sklearn-iris --model_dir=/mnt/models --http_port=8080
   13 65532     0:01 /ko-app/queue
   32 root      0:00 tail -f /dev/null
   93 root      0:00 ps
```
**Special notes for your reviewer**:

A quick (and raw) code walkthrough can be found in this [10 minute video](https://www.youtube.com/watch?v=axegGpQ6nHs)

The overall architecture for this feature looks like in this diagram:

![Modelcar_2](https://github.com/kserve/kserve/assets/99080/09a3ae1d-75c7-4bcb-b136-bb20a7992c8e)

* A user creates a container image that only contains the model data. The only prerequisite for the base image is that it contains an `ln` and `tail` command. In order to even make the base images smaller, one could consider to move that into a small golang binary that could be compiled statically.

* The main entry point is a [StorageInitializerInjector](StorageInitializerInjector) which runs for an `oci://` storageUri. 

* The important trick here is to [set the symbolic link as part of the startup command](https://github.com/rhuss/kserve/blob/00e699d79baafa9fab944aa806670100803bbdc3/pkg/webhook/admission/pod/storage_initializer_injector.go#L499) of the modelcar container.

* Resources of the modelcar are minimal (only so much that an idling tail can run). Currently, this is set to 10MB but can be even smaller. The resource consumption of the modelcar sidecar is negligible (in contrast to e.g. a fluent sidecar with a fuse layer).

There are still the following limitations or things to take care of:

* The "kserve-container" must run with [UID 0](https://github.com/rhuss/kserve/blob/00e699d79baafa9fab944aa806670100803bbdc3/pkg/webhook/admission/pod/storage_initializer_injector.go#L160) to be able to follow the symbolic link created by the modelcar. It's not yet clear whether this is a general limitation or specific to Minikube on which I have tested this PR
* Since user containers start in parallel (in contrast to init-containers that start in sequence), there could be a rare situation that the kserve-container starts before the modelcar container could set the symbolic link in the shared volume. For that storage.py has been [extended](https://github.com/rhuss/kserve/blob/00e699d79baafa9fab944aa806670100803bbdc3/python/kserve/kserve/storage/storage.py#L63) with a retry mechanism when checking for the model. To enable this check, the environment variable "MODEL_INIT_MODE" needs to be set to "async". This means that runtime themselves have to assume that the model directory is not immediately available but maybe only after some (short) time. This never has happened in the experiments that I did, but this is not an academic question. Alternatively, a supervisord could be added before starting third-party runtimes that could perform this async wait.

* No support for `StorageSpec` yet (not sure if this is needed)

* No documentation has been added, as I wanted first to agree on whether adding this feature makes sense. Also, some pointers on where to add the documentation would be great. 

**Checklist**:

- [X] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Add support for modelcar contains for speeding up initialization of runtimes. This feature is provided as alpha and needs to be enabled by setting the configuration flag `enableOciImageSource` to `true` for the storage initializer configuration.
```
