### PR TITLE
Fix knative config-defaults values overrided by kserve

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -27,9 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/kmp"
-	"knative.dev/pkg/ptr"
-	knservingdefaults "knative.dev/serving/pkg/apis/config"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
 )
@@ -136,13 +135,12 @@ var _ = Describe("Inference Graph controller test", func() {
 								},
 							},
 							Spec: knservingv1.RevisionSpec{
-								ContainerConcurrency: ptr.Int64(knservingdefaults.DefaultContainerConcurrency),
-								TimeoutSeconds:       ptr.Int64(knservingdefaults.DefaultRevisionTimeoutSeconds),
+								ContainerConcurrency: nil,
+								TimeoutSeconds:       nil,
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
 											Image: "kserve/router:v0.10.0",
-											Name:  knservingdefaults.DefaultUserContainerName,
 											Env: []v1.EnvVar{
 												{
 													Name:  "PROPAGATE_HEADERS",
@@ -171,7 +169,13 @@ var _ = Describe("Inference Graph controller test", func() {
 					},
 				},
 			}
-			expectedKnService.SetDefaults(context.TODO())
+			// Set ResourceVersion which is required for update operation.
+			expectedKnService.ResourceVersion = actualKnServiceCreated.ResourceVersion
+
+			// Do a dry-run update. This will populate our local knative service object with any default values
+			// that are present on the remote version.
+			err := k8sClient.Update(context.TODO(), expectedKnService, client.DryRunAll)
+			Expect(err).Should(BeNil())
 			Expect(kmp.SafeDiff(actualKnServiceCreated.Spec, expectedKnService.Spec)).To(Equal(""))
 		})
 	})
@@ -260,13 +264,12 @@ var _ = Describe("Inference Graph controller test", func() {
 								},
 							},
 							Spec: knservingv1.RevisionSpec{
-								ContainerConcurrency: ptr.Int64(knservingdefaults.DefaultContainerConcurrency),
-								TimeoutSeconds:       ptr.Int64(knservingdefaults.DefaultRevisionTimeoutSeconds),
+								ContainerConcurrency: nil,
+								TimeoutSeconds:       nil,
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
 											Image: "kserve/router:v0.10.0",
-											Name:  knservingdefaults.DefaultUserContainerName,
 											Env: []v1.EnvVar{
 												{
 													Name:  "PROPAGATE_HEADERS",
@@ -295,7 +298,13 @@ var _ = Describe("Inference Graph controller test", func() {
 					},
 				},
 			}
-			expectedKnService.SetDefaults(context.TODO())
+			// Set ResourceVersion which is required for update operation.
+			expectedKnService.ResourceVersion = actualKnServiceCreated.ResourceVersion
+
+			// Do a dry-run update. This will populate our local knative service object with any default values
+			// that are present on the remote version.
+			err := k8sClient.Update(context.TODO(), expectedKnService, client.DryRunAll)
+			Expect(err).Should(BeNil())
 			Expect(kmp.SafeDiff(actualKnServiceCreated.Spec, expectedKnService.Spec)).To(Equal(""))
 		})
 	})
@@ -398,13 +407,12 @@ var _ = Describe("Inference Graph controller test", func() {
 								},
 							},
 							Spec: knservingv1.RevisionSpec{
-								ContainerConcurrency: ptr.Int64(knservingdefaults.DefaultContainerConcurrency),
-								TimeoutSeconds:       ptr.Int64(knservingdefaults.DefaultRevisionTimeoutSeconds),
+								ContainerConcurrency: nil,
+								TimeoutSeconds:       nil,
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
 											Image: "kserve/router:v0.10.0",
-											Name:  knservingdefaults.DefaultUserContainerName,
 											Env: []v1.EnvVar{
 												{
 													Name:  "PROPAGATE_HEADERS",
@@ -456,7 +464,13 @@ var _ = Describe("Inference Graph controller test", func() {
 					},
 				},
 			}
-			expectedKnService.SetDefaults(context.TODO())
+			// Set ResourceVersion which is required for update operation.
+			expectedKnService.ResourceVersion = actualKnServiceCreated.ResourceVersion
+
+			// Do a dry-run update. This will populate our local knative service object with any default values
+			// that are present on the remote version.
+			err := k8sClient.Update(context.TODO(), expectedKnService, client.DryRunAll)
+			Expect(err).Should(BeNil())
 			Expect(kmp.SafeDiff(actualKnServiceCreated.Spec, expectedKnService.Spec)).To(Equal(""))
 		})
 	})

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -257,9 +257,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							},
 						},
 					},
+					RouteSpec: knservingv1.RouteSpec{
+						Traffic: []knservingv1.TrafficTarget{{LatestRevision: proto.Bool(true), Percent: proto.Int64(100)}},
+					},
 				},
 			}
-			expectedService.SetDefaults(context.TODO())
+			// Set ResourceVersion which is required for update operation.
+			expectedService.ResourceVersion = actualService.ResourceVersion
+
+			// Do a dry-run update. This will populate our local knative service object with any default values
+			// that are present on the remote version.
+			err := k8sClient.Update(context.TODO(), expectedService, client.DryRunAll)
+			Expect(err).Should(BeNil())
 			Expect(kmp.SafeDiff(actualService.Spec, expectedService.Spec)).To(Equal(""))
 			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
 			// update predictor
@@ -557,7 +566,13 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					},
 				},
 			}
-			expectedTransformerService.SetDefaults(context.TODO())
+			// Set ResourceVersion which is required for update operation.
+			expectedTransformerService.ResourceVersion = transformerService.ResourceVersion
+
+			// Do a dry-run update. This will populate our local knative service object with any default values
+			// that are present on the remote version.
+			err := k8sClient.Update(context.TODO(), expectedTransformerService, client.DryRunAll)
+			Expect(err).Should(BeNil())
 			Expect(cmp.Diff(transformerService.Spec, expectedTransformerService.Spec)).To(gomega.Equal(""))
 
 			// mock update knative service status since knative serving controller is not running in test
@@ -852,7 +867,13 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					},
 				},
 			}
-			expectedExplainerService.SetDefaults(context.TODO())
+			// Set ResourceVersion which is required for update operation.
+			expectedExplainerService.ResourceVersion = explainerService.ResourceVersion
+
+			// Do a dry-run update. This will populate our local knative service object with any default values
+			// that are present on the remote version.
+			err := k8sClient.Update(context.TODO(), explainerService, client.DryRunAll)
+			Expect(err).Should(BeNil())
 			Expect(cmp.Diff(explainerService.Spec, expectedExplainerService.Spec)).To(gomega.Equal(""))
 
 			// mock update knative service status since knative serving controller is not running in test
@@ -1472,7 +1493,13 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				},
 			}
 
-			expectedPredictorService.SetDefaults(context.TODO())
+			// Set ResourceVersion which is required for update operation.
+			expectedPredictorService.ResourceVersion = predictorService.ResourceVersion
+
+			// Do a dry-run update. This will populate our local knative service object with any default values
+			// that are present on the remote version.
+			err := k8sClient.Update(context.TODO(), predictorService, client.DryRunAll)
+			Expect(err).Should(BeNil())
 			Expect(cmp.Diff(predictorService.Spec, expectedPredictorService.Spec)).To(gomega.Equal(""))
 
 		})

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -28,14 +28,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	knserving "knative.dev/serving/pkg/apis/serving"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -177,9 +178,6 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 			},
 		},
 	}
-	//Call setDefaults on desired knative service here to avoid diffs generated because knative defaulter webhook is
-	//called when creating or updating the knative service
-	service.SetDefaults(context.TODO())
 	return service
 }
 
@@ -225,6 +223,19 @@ func (r *KsvcReconciler) Reconcile() (*knservingv1.ServiceStatus, error) {
 			log.Info("Creating knative service", "namespace", desired.Namespace, "name", desired.Name)
 			return &desired.Status, r.client.Create(context.TODO(), desired)
 		}
+		return nil, err
+	}
+	// Set ResourceVersion which is required for update operation.
+	desired.ResourceVersion = existing.ResourceVersion
+	// Add immutable annotations to avoid validation error during dry-run update.
+	desired.Annotations[knserving.CreatorAnnotation] = existing.Annotations[knserving.CreatorAnnotation]
+	desired.Annotations[knserving.UpdaterAnnotation] = existing.Annotations[knserving.UpdaterAnnotation]
+
+	// Do a dry-run update to avoid diffs generated because knative defaulter webhook is
+	// called when creating or updating the knative service. This will populate our local knative service object with any default values
+	// that are present on the remote version.
+	if err = r.client.Update(context.TODO(), desired, kclient.DryRunAll); err != nil {
+		log.Error(err, "Failed to perform dry-run create of knative service", "service", desired.Name)
 		return nil, err
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -36,7 +36,6 @@ import (
 	knserving "knative.dev/serving/pkg/apis/serving"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -234,7 +233,7 @@ func (r *KsvcReconciler) Reconcile() (*knservingv1.ServiceStatus, error) {
 	// Do a dry-run update to avoid diffs generated because knative defaulter webhook is
 	// called when creating or updating the knative service. This will populate our local knative service object with any default values
 	// that are present on the remote version.
-	if err = r.client.Update(context.TODO(), desired, kclient.DryRunAll); err != nil {
+	if err = r.client.Update(context.TODO(), desired, client.DryRunAll); err != nil {
 		log.Error(err, "Failed to perform dry-run create of knative service", "service", desired.Name)
 		return nil, err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -42,7 +42,7 @@ type RawKubeReconciler struct {
 	URL        *knapis.URL
 }
 
-// RawKubeReconciler creates raw kubernetes resource reconciler.
+// NewRawKubeReconciler creates raw kubernetes resource reconciler.
 func NewRawKubeReconciler(client client.Client,
 	scheme *runtime.Scheme,
 	componentMeta metav1.ObjectMeta,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3092

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
