### PR TITLE
Validation added for ensuring same model format has same priority for runtime

### DIFF
--- a/charts/kserve-resources/templates/clusterservingruntimes.yaml
+++ b/charts/kserve-resources/templates/clusterservingruntimes.yaml
@@ -44,7 +44,7 @@ spec:
     - name: sklearn
       version: "0"
       autoSelect: true
-      priority: 1
+      priority: 2
     - name: sklearn
       version: "1"
       autoSelect: true

--- a/config/runtimes/kserve-mlserver.yaml
+++ b/config/runtimes/kserve-mlserver.yaml
@@ -11,7 +11,7 @@ spec:
     - name: sklearn
       version: "0"
       autoSelect: true
-      priority: 1
+      priority: 2
     - name: sklearn
       version: "1"
       autoSelect: true

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/kserve/kserve/pkg/constants"
 	"net/http"
+	"strings"
+
+	"github.com/kserve/kserve/pkg/constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 
@@ -34,9 +35,12 @@ import (
 var log = logf.Log.WithName(constants.ServingRuntimeValidatorWebhookName)
 
 const (
-	InvalidPriorityError                      = "Same priority assigned for the model format %s"
-	InvalidPriorityServingRuntimeError        = "%s in the servingruntimes %s and %s in namespace %s"
-	InvalidPriorityClusterServingRuntimeError = "%s in the clusterservingruntimes %s and %s"
+	InvalidPriorityError                       = "Same priority assigned for the model format %s"
+	InvalidPriorityServingRuntimeError         = "%s in the servingruntimes %s and %s in namespace %s"
+	InvalidPriorityClusterServingRuntimeError  = "%s in the clusterservingruntimes %s and %s"
+	ProrityIsNotSameError                      = "Different priorities assigned for the model format %s"
+	ProrityIsNotSameServingRuntimeError        = "%s under the servingruntime %s"
+	ProrityIsNotSameClusterServingRuntimeError = "%s under the clusterservingruntime %s"
 )
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-serving-kserve-io-v1alpha1-clusterservingruntime,mutating=false,failurePolicy=fail,groups=serving.kserve.io,resources=clusterservingruntimes,versions=v1alpha1,name=clusterservingruntime.kserve-webhook-server.validator
@@ -72,6 +76,10 @@ func (sr *ServingRuntimeValidator) Handle(ctx context.Context, req admission.Req
 	}
 
 	for i := range ExistingRuntimes.Items {
+		if err := validateModelFormatPrioritySame(&servingRuntime.Spec, servingRuntime.Name); err != nil {
+			return admission.Denied(fmt.Sprintf(ProrityIsNotSameServingRuntimeError, err.Error(), servingRuntime.Name))
+		}
+
 		if err := validateServingRuntimePriority(&servingRuntime.Spec, &ExistingRuntimes.Items[i].Spec, servingRuntime.Name, ExistingRuntimes.Items[i].Name); err != nil {
 			return admission.Denied(fmt.Sprintf(InvalidPriorityServingRuntimeError, err.Error(), ExistingRuntimes.Items[i].Name, servingRuntime.Name, servingRuntime.Namespace))
 		}
@@ -99,6 +107,9 @@ func (csr *ClusterServingRuntimeValidator) Handle(ctx context.Context, req admis
 	}
 
 	for i := range ExistingRuntimes.Items {
+		if err := validateModelFormatPrioritySame(&clusterServingRuntime.Spec, clusterServingRuntime.Name); err != nil {
+			return admission.Denied(fmt.Sprintf(ProrityIsNotSameClusterServingRuntimeError, err.Error(), clusterServingRuntime.Name))
+		}
 		if err := validateServingRuntimePriority(&clusterServingRuntime.Spec, &ExistingRuntimes.Items[i].Spec, clusterServingRuntime.Name, ExistingRuntimes.Items[i].Name); err != nil {
 			return admission.Denied(fmt.Sprintf(InvalidPriorityClusterServingRuntimeError, err.Error(), ExistingRuntimes.Items[i].Name, clusterServingRuntime.Name))
 		}
@@ -112,6 +123,26 @@ func areSupportedModelFormatsEqual(m1 v1alpha1.SupportedModelFormat, m2 v1alpha1
 		return true
 	}
 	return false
+}
+
+func validateModelFormatPrioritySame(newSpec *v1alpha1.ServingRuntimeSpec, newRuntimeName string) error {
+	nameToPriority := make(map[string]*int32)
+
+	// Validate when same model format has same priority under same runtime.
+	// If the same model format has different prority value then throws the error
+	for _, newModelFormat := range newSpec.SupportedModelFormats {
+		// Only validate priority if autoselect is ture
+		if newModelFormat.IsAutoSelectEnabled() {
+			if existingPriority, ok := nameToPriority[newModelFormat.Name]; ok {
+				if existingPriority != nil && newModelFormat.Priority != nil && (*existingPriority != *newModelFormat.Priority) {
+					return errors.New(fmt.Sprintf(ProrityIsNotSameError, newModelFormat.Name))
+				}
+			} else {
+				nameToPriority[newModelFormat.Name] = newModelFormat.Priority
+			}
+		}
+	}
+	return nil
 }
 
 func validateServingRuntimePriority(newSpec *v1alpha1.ServingRuntimeSpec, existingSpec *v1alpha1.ServingRuntimeSpec, existingRuntimeName string, newRuntimeName string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3180 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
