### PR TITLE
Fix qpext metrics port

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -93,7 +93,7 @@ var (
 	PrometheusPathAnnotationKey                 = "prometheus.io/path"
 	DefaultPrometheusPath                       = "/metrics"
 	QueueProxyAggregatePrometheusMetricsPort    = "9088"
-	DefaultPodPrometheusPort                    = "9090"
+	DefaultPodPrometheusPort                    = "9091"
 )
 
 // InferenceService Internal Annotations


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When using qpext for scraping queue proxy metrics without turning on the metrics aggregation, it uses the wrong queue proxy metrics port 9090 which is for autoscaler metrics not the user metrics.

```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    autoscaling.knative.dev/class: kpa.autoscaling.knative.dev
    autoscaling.knative.dev/min-scale: "1"
    autoscaling.knative.dev/target: "5"
    autoscaling.knative.dev/targetBurstCapacity: "0"
    container.seccomp.security.alpha.kubernetes.io/queue-proxy: runtime/default
    identities.bloomberg.com/initContainerNames: storage-initializer
    prometheus.io/path: /metrics
    prometheus.io/port: "9090"    <---- this is incorrect
    prometheus.io/scrape: "true"
    prometheus.kserve.io/path: /metrics
    prometheus.kserve.io/port: "8080"
    serving.knative.dev/creator: system:serviceaccount:kserve:kserve-controller-manager
    serving.kserve.io/enable-metric-aggregation: "false"
    serving.kserve.io/enable-prometheus-scraping: "true"
    sidecar.istio.io/inject: "false"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
