### PR TITLE
chore: Add new PR reviewers and approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,17 @@
 approvers:
   - njhill
+  - rachitchauhan43
   - yuzisun
 reviewers:
+  - andyi2it
   - adriangonz
   - alexagriffith
   - ckadner
+  - cmaddalozzo
   - iamlovingit
+  - lizzzcai
   - rachitchauhan43
+  - sivanantha321
   - sukumargaonkar
   - theofpa
   - njhill


### PR DESCRIPTION
**Dear nominees,**

Please approve this PR to confirm that you agree to become a new `reviewer`, `approver` for the `kserve/kserve` project and that you would like to accept the responsibilities and the commitment to the KServe project that come with those roles as outlined in the [KServe contributor guidelines](https://github.com/kserve/community/blob/main/CONTRIBUTING.md#becoming-a-committer).

**Consent from new reviewers/committers checklist**:

- [x] Rachit Chauhan (@rachitchauhan43)  
- [x] Sivanantham Chinnaiyan (@sivanantha321)
- [x] Lize Cai (@lizzzcai) 
- [x] Curtis Maddalozzo (@cmaddalozzo) 
- [x] Andrews Arokiam (@andyi2it)

**Note**: @yuzisun pointed out that most of the nominated contributors are not currently reviewers. Those contributors would be promoted to the role of `reviewers` instead of skipping ahead to become `approvers` for now.

---

<img width="50%" alt="OWNERS" src="https://github.com/kserve/kserve/assets/12246093/f989fe7c-453a-47d0-b383-1bb67a8b39d2"/>



---

Closes kserve/community#5
