### PR TITLE
[#3091] support ovms clusterservingruntime

### DIFF
--- a/charts/kserve-resources/templates/clusterservingruntimes.yaml
+++ b/charts/kserve-resources/templates/clusterservingruntimes.yaml
@@ -344,3 +344,48 @@ spec:
         limits:
           cpu: "1"
           memory: 2Gi
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: kserve-ovms
+spec:
+  annotations:
+    prometheus.kserve.io/port: '8888'
+    prometheus.kserve.io/path: "/metrics"
+  supportedModelFormats:
+    - name: openvino_ir
+      version: opset11
+      autoSelect: true
+    - name: onnx
+      version: "1"
+    - name: tensorflow
+      version: "1"
+      autoSelect: true
+    - name: tensorflow
+      version: "2"
+      autoSelect: true
+    - name: paddle
+      version: "2"
+      autoSelect: true
+  protocolVersions:
+    - v2
+    - grpc-v2
+  containers:
+    - name: kserve-container
+      image: "{{ .Values.kserve.servingruntime.ovms.image }}:{{ .Values.kserve.servingruntime.ovms.tag }}"
+      args:
+        - --model_name={{.Name}}
+        - --port=8001
+        - --rest_port=8888
+        - --model_path=/mnt/models
+        - --file_system_poll_wait_seconds=0
+        - --grpc_bind_address=127.0.0.1
+        - --rest_bind_address=127.0.0.1
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -123,3 +123,6 @@ kserve:
     art:
       image: kserve/art-explainer
       defaultVersion: *defaultVersion
+    ovms:
+      image: docker.io/openvino/model_server
+      tag: "2023.1"

--- a/config/runtimes/kserve-ovms.yaml
+++ b/config/runtimes/kserve-ovms.yaml
@@ -10,17 +10,22 @@ spec:
     - name: openvino_ir
       version: opset11
       autoSelect: true
+      priority: 1
     - name: onnx
       version: "1"
+      priority: 1
     - name: tensorflow
       version: "1"
       autoSelect: true
+      priority: 1
     - name: tensorflow
       version: "2"
       autoSelect: true
+      priority: 1
     - name: paddle
       version: "2"
       autoSelect: true
+      priority: 1
   protocolVersions:
     - v2
     - grpc-v2

--- a/config/runtimes/kserve-ovms.yaml
+++ b/config/runtimes/kserve-ovms.yaml
@@ -4,11 +4,11 @@ metadata:
   name: kserve-ovms
 spec:
   annotations:
-    prometheus.kserve.io/port: '8000'
+    prometheus.kserve.io/port: '8888'
     prometheus.kserve.io/path: "/metrics"
   supportedModelFormats:
-    - name: openvino
-      version: "1"
+    - name: openvino_ir
+      version: opset11
       autoSelect: true
     - name: onnx
       version: "1"

--- a/config/runtimes/kserve-ovms.yaml
+++ b/config/runtimes/kserve-ovms.yaml
@@ -1,0 +1,44 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: kserve-ovms
+spec:
+  annotations:
+    prometheus.kserve.io/port: '8000'
+    prometheus.kserve.io/path: "/metrics"
+  supportedModelFormats:
+    - name: openvino
+      version: "1"
+      autoSelect: true
+    - name: onnx
+      version: "1"
+    - name: tensorflow
+      version: "1"
+      autoSelect: true
+    - name: tensorflow
+      version: "2"
+      autoSelect: true
+    - name: paddle
+      version: "2"
+      autoSelect: true
+  protocolVersions:
+    - v2
+    - grpc-v2
+  containers:
+    - name: kserve-container
+      image: kserve-ovms:replace
+      args:
+        - --model_name={{.Name}}
+        - --port=8001
+        - --rest_port=8888
+        - --model_path=/mnt/models
+        - --file_system_poll_wait_seconds=0
+        - --grpc_bind_address=127.0.0.1
+        - --rest_bind_address=127.0.0.1
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - kserve-paddleserver.yaml
 - kserve-lgbserver.yaml
 - kserve-torchserve.yaml
+- kserve-ovms.yaml
 
 images:
   # SMS Only Runtimes
@@ -33,6 +34,10 @@ images:
 - name: kserve-tritonserver
   newName: nvcr.io/nvidia/tritonserver
   newTag: 23.05-py3
+
+- name: kserve-ovms
+  newName: docker.io/openvino/model_server
+  newTag: "2023.1"
 
 - name: kserve-pmmlserver
   newName: kserve/pmmlserver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

[Support openvino-model-server(ovms) servingruntime #3091](https://github.com/kserve/kserve/issues/3091)


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?


~~~shell
❯ kubectl get clusterservingruntimes
NAME                        DISABLED   MODELTYPE     CONTAINERS         AGE
kserve-lgbserver                       lightgbm      kserve-container   17m
kserve-mlserver                        sklearn       kserve-container   17m
kserve-ovms                            openvino_ir   kserve-container   17m # <--- added
kserve-paddleserver                    paddle        kserve-container   17m
kserve-pmmlserver                      pmml          kserve-container   17m
kserve-sklearnserver                   sklearn       kserve-container   17m
kserve-tensorflow-serving              tensorflow    kserve-container   17m
kserve-torchserve                      pytorch       kserve-container   17m
kserve-tritonserver                    tensorrt      kserve-container   17m
kserve-xgbserver                       xgboost       kserve-container   17m


~~~
