### PR TITLE
Sanitize a command line argument in agent

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -48,7 +48,7 @@ import (
 
 var (
 	port          = flag.String("port", "9081", "Agent port")
-	componentPort = flag.String("component-port", "8080", "Component port")
+	componentPort = flag.Int("component-port", 8080, "Component port")
 	// model puller flags
 	enablePuller = flag.Bool("enable-puller", false, "Enable model puller")
 	configDir    = flag.String("config-dir", "/mnt/configs", "directory for model config files")
@@ -298,13 +298,13 @@ func buildProbe(logger *zap.SugaredLogger, probeJSON string) *readiness.Probe {
 	return newProbe
 }
 
-func buildServer(ctx context.Context, port string, userPort string, loggerArgs *loggerArgs, batcherArgs *batcherArgs,
+func buildServer(ctx context.Context, port string, userPort int, loggerArgs *loggerArgs, batcherArgs *batcherArgs,
 	probeContainer func() bool, logging *zap.SugaredLogger) (server *http.Server, drain func()) {
 
 	logging.Infof("Building server user port %s port %s", userPort, port)
 	target := &url.URL{
 		Scheme: "http",
-		Host:   net.JoinHostPort("127.0.0.1", userPort),
+		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(userPort)),
 	}
 
 	maxIdleConns := 1000 // TODO: somewhat arbitrary value for CC=0, needs experimental validation.


### PR DESCRIPTION
**What this PR does / why we need it**:

A static code analysis states that unsanitized usage of the `--component-port` flag can potentially lead to SSRF. In practice, this may be very hard to happen, given that the source of the flag is always an integer (taken from `containerPort` of a Pod). Anyways, this is switching that flag to an Integer to be on the safe side (and to prevent the warning from the static code analysis tool).

**Type of changes**

- [X] Bug fix (non-breaking change which fixes an issue)


**Release note**:

```release-note
NONE
```
