### PR TITLE
s3 storage initializer: only set environment variables if variables are set in storage secret json

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -112,13 +112,17 @@ class Storage(object):  # pylint: disable=too-few-public-methods
                 storage_secret_json[key] = value
 
         if storage_secret_json.get("type", "") == "s3":
-            os.environ["AWS_ENDPOINT_URL"] = storage_secret_json.get("endpoint_url", "")
-            os.environ["AWS_ACCESS_KEY_ID"] = storage_secret_json.get("access_key_id", "")
-            os.environ["AWS_SECRET_ACCESS_KEY"] = storage_secret_json.get("secret_access_key", "")
-            os.environ["AWS_DEFAULT_REGION"] = storage_secret_json.get("region", "")
-            os.environ["AWS_CA_BUNDLE"] = storage_secret_json.get("certificate", "")
-            os.environ["S3_VERIFY_SSL"] = storage_secret_json.get("verify_ssl", "1")
-            os.environ["awsAnonymousCredential"] = storage_secret_json.get("anonymous", "")
+            for env_var, key in (
+                ("AWS_ENDPOINT_URL", "endpoint_url"),
+                ("AWS_ACCESS_KEY_ID", "access_key_id"),
+                ("AWS_SECRET_ACCESS_KEY", "secret_access_key"),
+                ("AWS_DEFAULT_REGION", "region"),
+                ("AWS_CA_BUNDLE", "certificate"),
+                ("S3_VERIFY_SSL", "verify_ssl"),
+                ("awsAnonymousCredential", "anonymous"),
+            ):
+                if key in storage_secret_json:
+                    os.environ[env_var] = storage_secret_json.get(key)
 
         if storage_secret_json.get("type", "") == "hdfs" or storage_secret_json.get("type", "") == "webhdfs":
             temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
By setting environment variables to the result of `.get(..., "")`, the corresponding env variables are set to an empty value.

This is an issue for some values, such as `AWS_CA_BUNDLE`, which should be set to a path pointing to a valid CA bundle. When set to an empty string, it is propagated all the way down to `botocore.httpsession.URLLib3Session._setup_ssl_cert`,
 which interprets it as `False` and disables verification.

See https://github.com/boto/botocore/blob/6e0ec833714ed88d46e294048cdb0d3869eb2ab5/botocore/httpsession.py#L376-L382


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

See the original issue on https://github.com/opendatahub-io/kserve/issues/137: `InsecureRequestWarning: Unverified HTTPS request` warnings were being printed when retrieving data from S3 (using https)

Setting  `AWS_CA_BUNDLE` to a non-null value gets rid of the warning.

---
Release notes:

```release-note
fix processing of storage secrets
```