### PR TITLE
Support verify variable with storage-config json style (fix-3263)

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -117,6 +117,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             os.environ["AWS_SECRET_ACCESS_KEY"] = storage_secret_json.get("secret_access_key", "")
             os.environ["AWS_DEFAULT_REGION"] = storage_secret_json.get("region", "")
             os.environ["AWS_CA_BUNDLE"] = storage_secret_json.get("certificate", "")
+            os.environ["S3_VERIFY_SSL"] = storage_secret_json.get("verify_ssl", "1")
             os.environ["awsAnonymousCredential"] = storage_secret_json.get("anonymous", "")
 
         if storage_secret_json.get("type", "") == "hdfs" or storage_secret_json.get("type", "") == "webhdfs":
@@ -168,7 +169,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             kwargs.update({"endpoint_url": endpoint_url})
         verify_ssl = os.getenv("S3_VERIFY_SSL")
         if verify_ssl:
-            verify_ssl = verify_ssl != "0"
+            verify_ssl = not verify_ssl.lower() in ["0", "false"]
             kwargs.update({"verify": verify_ssl})
         s3 = boto3.resource("s3", **kwargs)
         parsed = urlparse(uri, scheme='s3')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kserve/kserve/issues/3263

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.
Test cluster: 
- kind v0.20.0
- Kubernetes 1.27.3
  ~~~
  Server Version: version.Info{Major:"1", Minor:"27", GitVersion:"v1.27.3", GitCommit:"25b4e43193bcda6c7328a6d147b1fb73a33f1598", GitTreeState:"clean",   BuildDate:"2023-06-15T00:36:28Z", GoVersion:"go1.20.5", Compiler:"gc", Platform:"linux/amd64"}
  ~~~
  
Test environment setup:
- Deploy minio with SSL

~~~
# Create demo folder
export DEMO_HOME=/tmp/demo
mkdir $DEMO_HOME
cd $DEMO_HOME

# Deploy kubernetes
kind create cluster
kubectl cluster-info --context kind-kind

# Deploy Minio with SSL
git clone git@github.com:Jooho/jhouse_openshift.git
cd jhouse_openshift/Minio/minio-tls-kserve/
source env.sh
./1.setup.sh 
./2.generate-cert.sh 
kubectl create ns minio
kubectl config set-context --current --namespace minio

sed 's+quay.io/opendatahub/modelmesh-minio-examples:caikit-flan-t5+kserve/modelmesh-minio-examples+g'  -i ${DEMO_HOME}/minio.yaml
./3.deploy-minio.sh 
cp /tmp/minio/minio_certs/root.crt /tmp/minio/minio_certs/cabundle.crt
~~~


- [X] Test using global configuraiton

**Deploy KServe**
~~~
cd /tmp/demo 

git clone git@github.com:Jooho/kserve.git
cd kserve

# Create the cabundle secret in kserve namespace
kubectl create ns kserve
kubectl config set-context --current --namespace kserve
kubectl create configmap cabundle --from-file=/tmp/minio/minio_certs/cabundle.crt -n kserve

# Deploy Cert Manager
kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml

# Deploy KServer (RawDeployment version) - it should work with serverless version too
# Update controller/storage-initializer images built based on this PR
# Set caBundleSecretName in infereneservice-config cm

KSERVE_VERSION=0.11.1
wget https://github.com/kserve/kserve/releases/download/v${KSERVE_VERSION}/kserve.yaml
sed 's/Serverless/RawDeployment/g' -i ./kserve.yaml
sed 's+kserve/storage-initializer:v0.11.1+quay.io/jooholee/kserve-storage-initializer:fix-3263+g' -i ./kserve.yaml
kubectl apply -f ./kserve.yaml
~~~

**Verify if runtime can pull a model from the minio**
~~~
kubectl create ns kserve-demo
kubectl config set-context --current --namespace kserve-demo 

kustomize build ./config/runtimes/| sed 's/ClusterServingRuntime/ServingRuntime/g' |kubectl create -n kserve-demo -f -

cat <<EOF|kubectl apply -f -
apiVersion: v1
stringData:
  localMinIO: |
    {
      "type": "s3",
      "access_key_id": "THEACCESSKEY",
      "secret_access_key": "THEPASSWORD",
      "endpoint_url": "https://minio.minio.svc:9000",
      "bucket": "modelmesh-example-models",
      "region": "us-south",
      "verify_ssl": "0"
    }
kind: Secret
metadata:
  name: storage-config
type: Opaque   
EOF

cat<<EOF | oc create -f -
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  annotations:
    "serving.kserve.io/deploymentMode": "RawDeployment"
  name: sklearn-iris-v2-rest
  namespace: kserve-demo
spec:
  predictor:
    model:
      modelFormat:
        name: sklearn
      name: ""
      resources: {}
      runtime: kserve-mlserver
      storage:
        key: localMinIO
        path: sklearn/mnist-svm.joblib
EOF
~~~

- Check point
This should skip validation of ssl so it will pull a model. 

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
