### PR TITLE
Fix qpext hangs during shutdown

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -524,14 +524,6 @@ jobs:
         run: |
           ./test/scripts/gh-actions/build-qpext-image.sh
           docker image ls
-      - name: Upload qpext image
-        uses: ishworkh/docker-image-artifact-upload@v1
-        with:
-          image: "kserve/qpext:${{ github.sha }}"
-      - name: Download qpext image
-        uses: ishworkh/docker-image-artifact-download@v1
-        with:
-          image: "kserve/qpext:${{ github.sha }}"
       - name: Download sklearn server image
         uses: ishworkh/docker-image-artifact-download@v1
         with:

--- a/.github/workflows/qpext-docker-publish.yml
+++ b/.github/workflows/qpext-docker-publish.yml
@@ -35,8 +35,7 @@ jobs:
             docker-compose --file docker-compose.test.yml build
             docker-compose --file docker-compose.test.yml run sut
           else
-            cd qpext
-            docker buildx build . --file qpext.Dockerfile
+            docker buildx build . --file qpext/qpext.Dockerfile
           fi
 
   # Push image to GitHub Packages.
@@ -86,7 +85,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
-          context: "{{defaultContext}}:qpext"
-          file: qpext.Dockerfile
+          context: "."
+          file: qpext/qpext.Dockerfile
           push: true
           tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ALIBI_IMG ?= alibi-explainer
 AIF_IMG ?= aiffairness
 ART_IMG ?= art-explainer
 STORAGE_INIT_IMG ?= storage-initializer
-QPEXT_IMG ?= qpext
+QPEXT_IMG ?= qpext:latest
 CRD_OPTIONS ?= "crd:maxDescLen=0"
 KSERVE_ENABLE_SELF_SIGNED_CA ?= false
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -296,10 +296,13 @@ docker-push-storageInitializer: docker-build-storageInitializer
 	docker push ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG}
 
 docker-build-qpext:
-	cd qpext && docker buildx build -t ${KO_DOCKER_REPO}/${QPEXT_IMG} -f qpext.Dockerfile .
+	docker buildx build -t ${KO_DOCKER_REPO}/${QPEXT_IMG} -f qpext/qpext.Dockerfile .
 
 docker-build-push-qpext: docker-build-qpext
 	docker push ${KO_DOCKER_REPO}/${QPEXT_IMG}
+
+deploy-dev-qpext: docker-build-push-qpext
+	kubectl patch cm config-deployment -n knative-serving --type merge --patch '{"data": {"queue-sidecar-image": "${KO_DOCKER_REPO}/${QPEXT_IMG}"}}'
 
 docker-build-success-200-isvc:
 	cd python && docker buildx build -t ${KO_DOCKER_REPO}/${SUCCESS_200_ISVC_IMG} -f success_200_isvc.Dockerfile .

--- a/qpext/README.md
+++ b/qpext/README.md
@@ -138,9 +138,13 @@ pushing the image to dockerhub/container registry, and patching the knative depl
 the test image. The pods will then pick up the new configuration.
 
 
-(1) To build the qpext image in the kserve/qpext directory (as an example, `some_docker_repo` in dockerhub), run 
+(1) To build the qpext image in the ${KO_DOCKER_REPO}/qpext directory (as an example, `some_docker_repo` in dockerhub), run 
 ```shell
 make docker-build-push-qpext
+```
+(2) To build, push and patch the image, run
+```shell
+make deploy-dev-qpext
 ```
 
 Alternatively, build and push the image step by step yourself.

--- a/qpext/qpext.Dockerfile
+++ b/qpext/qpext.Dockerfile
@@ -1,9 +1,6 @@
 # Build the inference qpext binary
 FROM golang:1.21 as builder
 
-# To stamp vcs info on the binary
-COPY .git .git
-
 # Copy in the go src
 WORKDIR /go/src/github.com/kserve/kserve/qpext
 COPY qpext/go.mod  go.mod

--- a/qpext/qpext.Dockerfile
+++ b/qpext/qpext.Dockerfile
@@ -1,15 +1,18 @@
 # Build the inference qpext binary
 FROM golang:1.21 as builder
 
+# To stamp vcs info on the binary
+COPY .git .git
+
 # Copy in the go src
 WORKDIR /go/src/github.com/kserve/kserve/qpext
-COPY go.mod  go.mod
-COPY go.sum  go.sum
+COPY qpext/go.mod  go.mod
+COPY qpext/go.sum  go.sum
 
 RUN go mod download
 
-COPY cmd/qpext cmd/qpext
-COPY logger.go logger.go
+COPY qpext/cmd/qpext cmd/qpext
+COPY qpext/logger.go logger.go
 
 # Build
 RUN CGO_ENABLED=0 go build -a -o qpext ./cmd/qpext

--- a/test/scripts/gh-actions/build-qpext-image.sh
+++ b/test/scripts/gh-actions/build-qpext-image.sh
@@ -22,8 +22,6 @@ set -o pipefail
 echo "Github SHA ${GITHUB_SHA}"
 export QPEXT_IMG=kserve/qpext:${GITHUB_SHA}
 
-pushd qpext >/dev/null
 echo "Building queue proxy extension image"
-docker buildx build -t ${QPEXT_IMG} -f qpext.Dockerfile .
-popd
+docker buildx build -t ${QPEXT_IMG} -f qpext/qpext.Dockerfile .
 echo "Done building image"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3186

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.


- Test Logs
```bash
{"level":"info","ts":1700904968.7264776,"caller":"qpext/main.go:331","msg":"Starting stats server on port 9088"}
{"severity":"INFO","timestamp":"2023-11-25T09:36:08.727104975Z","logger":"queueproxy","caller":"sharedmain/main.go:259","message":"Starting queue-proxy","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:36:08.727189831Z","logger":"queueproxy","caller":"sharedmain/main.go:265","message":"Starting http server metrics:9090","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:36:08.727192307Z","logger":"queueproxy","caller":"sharedmain/main.go:265","message":"Starting http server main:8012","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:36:08.72721828Z","logger":"queueproxy","caller":"sharedmain/main.go:265","message":"Starting http server admin:8022","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:37:39.718175736Z","logger":"queueproxy","caller":"sharedmain/main.go:289","message":"Received TERM signal, attempting to gracefully shutdown servers.","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:37:39.718284384Z","logger":"queueproxy","caller":"sharedmain/main.go:290","message":"Sleeping 30s to allow K8s propagation of non-ready state","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:37:39.732586087Z","logger":"queueproxy","caller":"sharedmain/handlers.go:107","message":"Attached drain handler from user-container&{GET /wait-for-drain HTTP/1.1 1 1 map[Accept:[*/*] Accept-Encoding:[gzip] User-Agent:[kube-lifecycle/1.27]] {} <nil> 0 [] false 10.244.0.171:8022 map[] map[] <nil> map[] 10.244.0.1:35182 /wait-for-drain <nil> <nil> <nil> 0xc0004bcfa0}","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:38:09.718643721Z","logger":"queueproxy","caller":"sharedmain/main.go:294","message":"Shutting down server: main","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:38:09.718847644Z","logger":"queueproxy","caller":"sharedmain/main.go:294","message":"Shutting down server: admin","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:38:09.718920555Z","logger":"queueproxy","caller":"sharedmain/main.go:294","message":"Shutting down server: metrics","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"severity":"INFO","timestamp":"2023-11-25T09:38:09.718996462Z","logger":"queueproxy","caller":"sharedmain/main.go:305","message":"Shutdown complete, exiting...","commit":"9059f54-dirty","knative.dev/key":"default/sklearn-irisv2-predictor-00001","knative.dev/pod":"sklearn-irisv2-predictor-00001-deployment-55844b4f84-tfdbm"}
{"level":"info","ts":1700905089.7190366,"caller":"qpext/main.go:353","msg":"Attempting graceful shutdown of stats server"}
{"level":"info","ts":1700905089.7190783,"caller":"qpext/main.go:360","msg":"Stats server has successfully terminated"}
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix qpext hangs during shutdown
```
