### PR TITLE
image_patch_dev.sh: set pipefail

### DIFF
--- a/hack/image_patch_dev.sh
+++ b/hack/image_patch_dev.sh
@@ -2,6 +2,8 @@
 # Usage: image_patch_dev.sh [OVERLAY]
 set -u
 set -e
+set -o pipefail
+
 OVERLAY=$1
 IMG=$(ko resolve -f config/manager/manager.yaml | grep 'image:' | head -1 | awk '{print $2}')
 if [ -z ${IMG} ]; then exit; fi


### PR DESCRIPTION
This makes the script fail when something in a pipe fails.

With this `make deploy-dev` actually fail on the right line when something is failing instead of getting an unrelated error on on other scripts.

For the record: `ko resolve` was failing because `KO_DOCKER_REPO` was unset.
