### PR TITLE
Expose qpext aggregate metrics port on container

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -92,7 +92,7 @@ var (
 	PrometheusPortAnnotationKey                 = "prometheus.io/port"
 	PrometheusPathAnnotationKey                 = "prometheus.io/path"
 	DefaultPrometheusPath                       = "/metrics"
-	QueueProxyAggregatePrometheusMetricsPort    = "9088"
+	QueueProxyAggregatePrometheusMetricsPort    = 9088
 	DefaultPodPrometheusPort                    = "9091"
 )
 
@@ -258,6 +258,7 @@ const (
 	InferenceServiceDefaultAgentPortStr = "9081"
 	InferenceServiceDefaultAgentPort    = 9081
 	CommonDefaultHttpPort               = 80
+	AggregateMetricsPortName            = "aggr-metric"
 )
 
 // Labels to put on kservice

--- a/pkg/webhook/admission/pod/metrics_aggregate_injector.go
+++ b/pkg/webhook/admission/pod/metrics_aggregate_injector.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/kserve/kserve/pkg/constants"
 	v1 "k8s.io/api/core/v1"
+	"strconv"
 )
 
 const (
@@ -46,7 +47,7 @@ func newMetricsAggregator(configMap *v1.ConfigMap) (*MetricsAggregator, error) {
 	return ma, nil
 }
 
-func setMetricAggregationEnvVars(pod *v1.Pod) {
+func setMetricAggregationEnvVarsAndPorts(pod *v1.Pod) {
 	for i, container := range pod.Spec.Containers {
 		if container.Name == "queue-proxy" {
 			// The kserve-container prometheus port/path is inherited from the ClusterServingRuntime YAML.
@@ -67,7 +68,13 @@ func setMetricAggregationEnvVars(pod *v1.Pod) {
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.KServeContainerPrometheusMetricsPathEnvVarKey, Value: kserveContainerPromPath})
 
 			// Set the port that queue-proxy will use to expose the aggregate metrics.
-			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: constants.QueueProxyAggregatePrometheusMetricsPort})
+			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: strconv.Itoa(constants.QueueProxyAggregatePrometheusMetricsPort)})
+
+			pod.Spec.Containers[i].Ports = append(pod.Spec.Containers[i].Ports, v1.ContainerPort{
+				Name:          constants.AggregateMetricsPortName,
+				ContainerPort: int32(constants.QueueProxyAggregatePrometheusMetricsPort),
+				Protocol:      "TCP",
+			})
 
 		}
 	}
@@ -86,7 +93,7 @@ func (ma *MetricsAggregator) InjectMetricsAggregator(pod *v1.Pod) error {
 		enableMetricAggregation = ma.EnableMetricAggregation
 	}
 	if enableMetricAggregation == "true" {
-		setMetricAggregationEnvVars(pod)
+		setMetricAggregationEnvVarsAndPorts(pod)
 	}
 
 	// Handle setting the pod prometheus annotations
@@ -100,7 +107,7 @@ func (ma *MetricsAggregator) InjectMetricsAggregator(pod *v1.Pod) error {
 		// If enableMetricAggregation is true, set it as the queue proxy metrics aggregation port.
 		podPromPort := constants.DefaultPodPrometheusPort
 		if enableMetricAggregation == "true" {
-			podPromPort = constants.QueueProxyAggregatePrometheusMetricsPort
+			podPromPort = strconv.Itoa(constants.QueueProxyAggregatePrometheusMetricsPort)
 		}
 		pod.ObjectMeta.Annotations[constants.PrometheusPortAnnotationKey] = podPromPort
 		pod.ObjectMeta.Annotations[constants.PrometheusPathAnnotationKey] = constants.DefaultPrometheusPath

--- a/pkg/webhook/admission/pod/metrics_aggregate_injector_test.go
+++ b/pkg/webhook/admission/pod/metrics_aggregate_injector_test.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmp"
+	"strconv"
 
 	"testing"
 )
@@ -45,7 +46,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -67,7 +69,11 @@ func TestInjectMetricsAggregator(t *testing.T) {
 							Env: []v1.EnvVar{
 								{Name: constants.KServeContainerPrometheusMetricsPortEnvVarKey, Value: sklearnPrometheusPort},
 								{Name: constants.KServeContainerPrometheusMetricsPathEnvVarKey, Value: constants.DefaultPrometheusPath},
-								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: constants.QueueProxyAggregatePrometheusMetricsPort},
+								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: strconv.Itoa(constants.QueueProxyAggregatePrometheusMetricsPort)},
+							},
+							Ports: []v1.ContainerPort{
+								{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"},
+								{Name: constants.AggregateMetricsPortName, ContainerPort: int32(constants.QueueProxyAggregatePrometheusMetricsPort), Protocol: "TCP"},
 							},
 						},
 					},
@@ -85,7 +91,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -103,7 +110,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -123,7 +131,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -141,7 +150,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -162,7 +172,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -174,7 +185,7 @@ func TestInjectMetricsAggregator(t *testing.T) {
 					Annotations: map[string]string{
 						constants.EnableMetricAggregation:     "true",
 						constants.SetPrometheusAnnotation:     "true",
-						constants.PrometheusPortAnnotationKey: constants.QueueProxyAggregatePrometheusMetricsPort,
+						constants.PrometheusPortAnnotationKey: strconv.Itoa(constants.QueueProxyAggregatePrometheusMetricsPort),
 						constants.PrometheusPathAnnotationKey: constants.DefaultPrometheusPath,
 					},
 				},
@@ -187,7 +198,11 @@ func TestInjectMetricsAggregator(t *testing.T) {
 							Env: []v1.EnvVar{
 								{Name: constants.KServeContainerPrometheusMetricsPortEnvVarKey, Value: sklearnPrometheusPort},
 								{Name: constants.KServeContainerPrometheusMetricsPathEnvVarKey, Value: constants.DefaultPrometheusPath},
-								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: constants.QueueProxyAggregatePrometheusMetricsPort},
+								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: strconv.Itoa(constants.QueueProxyAggregatePrometheusMetricsPort)},
+							},
+							Ports: []v1.ContainerPort{
+								{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"},
+								{Name: constants.AggregateMetricsPortName, ContainerPort: int32(constants.QueueProxyAggregatePrometheusMetricsPort), Protocol: "TCP"},
 							},
 						},
 					},
@@ -209,7 +224,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -230,7 +246,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -251,7 +268,8 @@ func TestInjectMetricsAggregator(t *testing.T) {
 						Name: "sklearn",
 					},
 						{
-							Name: "queue-proxy",
+							Name:  "queue-proxy",
+							Ports: []v1.ContainerPort{{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"}},
 						},
 					},
 				},
@@ -274,7 +292,11 @@ func TestInjectMetricsAggregator(t *testing.T) {
 							Env: []v1.EnvVar{
 								{Name: constants.KServeContainerPrometheusMetricsPortEnvVarKey, Value: sklearnPrometheusPort},
 								{Name: constants.KServeContainerPrometheusMetricsPathEnvVarKey, Value: constants.DefaultPrometheusPath},
-								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: constants.QueueProxyAggregatePrometheusMetricsPort},
+								{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: strconv.Itoa(constants.QueueProxyAggregatePrometheusMetricsPort)},
+							},
+							Ports: []v1.ContainerPort{
+								{Name: "http-usermetric", ContainerPort: 9091, Protocol: "TCP"},
+								{Name: constants.AggregateMetricsPortName, ContainerPort: int32(constants.QueueProxyAggregatePrometheusMetricsPort), Protocol: "TCP"},
 							},
 						},
 					},

--- a/qpext/README.md
+++ b/qpext/README.md
@@ -59,7 +59,7 @@ spec:
   predictor:
     sklearn:
       protocolVersion: v2
-      storageUri: "gs://seldon-models/sklearn/iris"
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
 ```
 
 To view the runtime specific defaults for the `kserve-container` prometheus port and path, view the spec annotations in `kserve/config/runtimes`.
@@ -79,7 +79,7 @@ spec:
   predictor:
     sklearn:
       protocolVersion: v2
-      storageUri: "gs://seldon-models/sklearn/iris"
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
 ```
 The default port for sklearn runtime is `8080`, and the default path is `/metrics`. 
 By setting the annotations in the InferenceService YAML, the default runtime configurations are overridden.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3241

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose qpext aggregate metrics port on container
```
