### PR TITLE
fix: Check if HPA has the same scaleTargetRef and behavior

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -144,7 +144,8 @@ func (r *HPAReconciler) checkHPAExist(client client.Client) (constants.CheckResu
 }
 
 func semanticHPAEquals(desired, existing *autoscalingv2.HorizontalPodAutoscaler) bool {
-	return equality.Semantic.DeepEqual(desired.Spec.Metrics, existing.Spec.Metrics) &&
+	return equality.Semantic.DeepEqual(desired.Spec.ScaleTargetRef, existing.Spec.ScaleTargetRef) &&
+		equality.Semantic.DeepEqual(desired.Spec.Metrics, existing.Spec.Metrics) &&
 		equality.Semantic.DeepEqual(desired.Spec.MaxReplicas, existing.Spec.MaxReplicas) &&
 		equality.Semantic.DeepEqual(*desired.Spec.MinReplicas, *existing.Spec.MinReplicas)
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -137,10 +137,14 @@ func (r *HPAReconciler) checkHPAExist(client client.Client) (constants.CheckResu
 	}
 
 	//existed, check equivalent
-	if equality.Semantic.DeepEqual(r.HPA.Spec, existingHPA.Spec) {
+	if semanticHPAEquals(r.HPA, existingHPA) {
 		return constants.CheckResultExisted, existingHPA, nil
 	}
 	return constants.CheckResultUpdate, existingHPA, nil
+}
+
+func semanticHPAEquals(desired, existing *autoscalingv2.HorizontalPodAutoscaler) bool {
+	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec)
 }
 
 // Reconcile ...

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -137,18 +137,10 @@ func (r *HPAReconciler) checkHPAExist(client client.Client) (constants.CheckResu
 	}
 
 	//existed, check equivalent
-	if semanticHPAEquals(r.HPA, existingHPA) {
+	if equality.Semantic.DeepEqual(r.HPA.Spec, existingHPA.Spec) {
 		return constants.CheckResultExisted, existingHPA, nil
 	}
 	return constants.CheckResultUpdate, existingHPA, nil
-}
-
-func semanticHPAEquals(desired, existing *autoscalingv2.HorizontalPodAutoscaler) bool {
-	return equality.Semantic.DeepEqual(desired.Spec.ScaleTargetRef, existing.Spec.ScaleTargetRef) &&
-	equality.Semantic.DeepEqual(desired.Spec.Behavior, existing.Spec.Behavior) &&
-		equality.Semantic.DeepEqual(desired.Spec.Metrics, existing.Spec.Metrics) &&
-		equality.Semantic.DeepEqual(desired.Spec.MaxReplicas, existing.Spec.MaxReplicas) &&
-		equality.Semantic.DeepEqual(*desired.Spec.MinReplicas, *existing.Spec.MinReplicas)
 }
 
 // Reconcile ...

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -145,6 +145,7 @@ func (r *HPAReconciler) checkHPAExist(client client.Client) (constants.CheckResu
 
 func semanticHPAEquals(desired, existing *autoscalingv2.HorizontalPodAutoscaler) bool {
 	return equality.Semantic.DeepEqual(desired.Spec.ScaleTargetRef, existing.Spec.ScaleTargetRef) &&
+	equality.Semantic.DeepEqual(desired.Spec.Behavior, existing.Spec.Behavior) &&
 		equality.Semantic.DeepEqual(desired.Spec.Metrics, existing.Spec.Metrics) &&
 		equality.Semantic.DeepEqual(desired.Spec.MaxReplicas, existing.Spec.MaxReplicas) &&
 		equality.Semantic.DeepEqual(*desired.Spec.MinReplicas, *existing.Spec.MinReplicas)


### PR DESCRIPTION
There maybe existing HPAs but incorrectly configured to target non-deployment resources. This PR adds additional check on scaleTargetRef.