### PR TITLE
fix: Fix typo in S3_USE_VIRTUAL_BUCKET

### DIFF
--- a/pkg/credentials/s3/s3_secret.go
+++ b/pkg/credentials/s3/s3_secret.go
@@ -36,7 +36,7 @@ const (
 	S3Endpoint             = "S3_ENDPOINT"
 	S3UseHttps             = "S3_USE_HTTPS"
 	S3VerifySSL            = "S3_VERIFY_SSL"
-	S3UseVirtualBucket     = "S3_USER_VIRTUAL_BUCKET"
+	S3UseVirtualBucket     = "S3_USE_VIRTUAL_BUCKET"
 	AWSAnonymousCredential = "awsAnonymousCredential"
 	AWSCABundle            = "AWS_CA_BUNDLE"
 	AWSCABundleConfigMap   = "AWS_CA_BUNDLE_CONFIGMAP"

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -148,7 +148,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
         anon = ("true" == os.getenv("awsAnonymousCredential", "false").lower())
         # S3UseVirtualBucket environment variable defined in s3_secret.go
         # use virtual hosted-style URLs if enabled
-        virtual = ("true" == os.getenv("S3_USER_VIRTUAL_BUCKET", "false").lower())
+        virtual = ("true" == os.getenv("S3_USE_VIRTUAL_BUCKET", "false").lower())
 
         if anon:
             c = c.merge(Config(signature_version=UNSIGNED))

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -206,11 +206,11 @@ def test_get_S3_config():
         config5 = Storage.get_S3_config()
     assert config5.signature_version == ANON_CONFIG.signature_version
 
-    with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "False"}):
+    with mock.patch.dict(os.environ, {"S3_USE_VIRTUAL_BUCKET": "False"}):
         config6 = Storage.get_S3_config()
     assert vars(config6) == vars(DEFAULT_CONFIG)
 
-    with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "True"}):
+    with mock.patch.dict(os.environ, {"S3_USE_VIRTUAL_BUCKET": "True"}):
         config7 = Storage.get_S3_config()
     assert config7.s3["addressing_style"] == VIRTUAL_CONFIG.s3["addressing_style"]
 


### PR DESCRIPTION
Small typo fix: `S3_USER_VIRTUAL_BUCKET` should be `S3_USE_VIRTUAL_BUCKET`.