### PR TITLE
fix: Surface errors when writing graphHandler response

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -46,9 +46,9 @@ func callService(serviceUrl string, input []byte, headers http.Header) ([]byte, 
 	defer timeTrack(time.Now(), "step", serviceUrl)
 	log.Info("Entering callService", "url", serviceUrl)
 	req, err := http.NewRequest("POST", serviceUrl, bytes.NewBuffer(input))
-	if err != nil { 
-		log.Error(err, "An error occurred while preparing request object with serviceUrl.", "serviceUrl", serviceUrl) 
-		return nil,500, err 
+	if err != nil {
+		log.Error(err, "An error occurred while preparing request object with serviceUrl.", "serviceUrl", serviceUrl)
+		return nil, 500, err
 	}
 	for _, h := range headersToPropagate {
 		if values, ok := headers[h]; ok {
@@ -281,14 +281,19 @@ func graphHandler(w http.ResponseWriter, req *http.Request) {
 		log.Error(err, "failed to process request")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
-		w.Write(prepareErrorResponse(err, "Failed to process request"))
+		_, writeErr := w.Write(prepareErrorResponse(err, "Failed to process request"))
+		if writeErr != nil {
+			log.Error(writeErr, "failed to write graphHandler response")
+		}
 	} else {
 		if json.Valid(response) {
 			w.Header().Set("Content-Type", "application/json")
 		}
 		w.WriteHeader(statusCode)
-		w.Write(response)
-
+		_, writeErr := w.Write(response)
+		if writeErr != nil {
+			log.Error(writeErr, "failed to write graphHandler response")
+		}
 	}
 }
 


### PR DESCRIPTION
Currently, the errors are not handled and hidden.