### PR TITLE
Add lint check for go

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,35 @@
+# REF: https://github.com/golangci/golangci-lint-action
+
+name: GO Lint Check
+
+on:
+  push:
+    branches: [master, release*]
+  pull_request:
+    branches: []
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Go Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          only-new-issues: true
+          version: v1.55.2
+          args: --go=1.21

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+run:
+  timeout: 5m
+
+output:
+  print-issued-lines: false
+  print-linter-name: true
+  uniq-by-line: false
+  path-prefix: ""
+  sort-results: true
+
+# REF: https://golangci-lint.run/usage/linters/
+linters:
+  enable:
+    - errorlint
+    - gosec
+    - prealloc
+    - unconvert
+    - unparam
+    - gofmt
+  disable:
+    - errcheck


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes #

The current implementation will lint check and show errors as part of PR.
The lint checks will be done to files that are changed as part of the PR.

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

This is how it would show up in files changed

![image](https://github.com/kserve/kserve/assets/87992092/5549363c-b4a5-469d-82f9-b2b6771786cb)

