### PR TITLE
Add compatibility for Istio CNI plugin

### DIFF
--- a/charts/kserve-resources/templates/webhookconfiguration.yaml
+++ b/charts/kserve-resources/templates/webhookconfiguration.yaml
@@ -35,6 +35,7 @@ webhooks:
     failurePolicy: Fail
     name: inferenceservice.kserve-webhook-server.pod-mutator
     sideEffects: None
+    reinvocationPolicy: IfNeeded
     admissionReviewVersions: ["v1beta1"]
     objectSelector:
       matchExpressions:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -34,6 +34,7 @@ webhooks:
     failurePolicy: Fail
     name: inferenceservice.kserve-webhook-server.pod-mutator
     sideEffects: None
+    reinvocationPolicy: IfNeeded
     admissionReviewVersions: ["v1beta1"]
     namespaceSelector:
       matchExpressions:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -132,9 +132,14 @@ var (
 
 // Controller Constants
 var (
-	ControllerLabelName          = KServeName + "-controller-manager"
-	DefaultMinReplicas           = 1
-	IstioSidecarUIDAnnotationKey = KServeAPIGroupName + "/storage-initializer-uid"
+	ControllerLabelName             = KServeName + "-controller-manager"
+	DefaultIstioSidecarUID          = int64(1337)
+	DefaultMinReplicas              = 1
+	IstioInitContainerName          = "istio-init"
+	IstioInterceptModeRedirect      = "REDIRECT"
+	IstioInterceptionModeAnnotation = "sidecar.istio.io/interceptionMode"
+	IstioSidecarUIDAnnotationKey    = KServeAPIGroupName + "/storage-initializer-uid"
+	IstioSidecarStatusAnnotation    = "sidecar.istio.io/status"
 )
 
 type AutoscalerClassType string

--- a/pkg/webhook/admission/pod/mutator.go
+++ b/pkg/webhook/admission/pod/mutator.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// +kubebuilder:webhook:path=/mutate-pods,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=inferenceservice.kserve-webhook-server.pod-mutator
+// +kubebuilder:webhook:path=/mutate-pods,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=inferenceservice.kserve-webhook-server.pod-mutator,reinvocationPolicy=IfNeeded
 var log = logf.Log.WithName(constants.PodMutatorWebhookName)
 
 // Mutator is a webhook that injects incoming pods
@@ -120,6 +120,7 @@ func (mutator *Mutator) mutate(pod *v1.Pod, configMap *v1.ConfigMap) error {
 	mutators := []func(pod *v1.Pod) error{
 		InjectGKEAcceleratorSelector,
 		storageInitializer.InjectStorageInitializer,
+		storageInitializer.SetIstioCniSecurityContext,
 		agentInjector.InjectAgent,
 		metricsAggregator.InjectMetricsAggregator,
 	}

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -481,16 +481,127 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 		}
 	}
 
+	// Add init container to the spec
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
+
+	return nil
+}
+
+// SetIstioCniSecurityContext determines if Istio is installed in using the CNI plugin. If so,
+// the UserID of the storage initializer is changed to match the UserID of the Istio sidecar.
+// This is to ensure that the storage initializer can access the network.
+func (mi *StorageInitializerInjector) SetIstioCniSecurityContext(pod *v1.Pod) error {
+	// Find storage initializer container
+	var storageInitializerContainer *v1.Container
+	for idx, c := range pod.Spec.InitContainers {
+		if c.Name == StorageInitializerContainerName {
+			storageInitializerContainer = &pod.Spec.InitContainers[idx]
+		}
+	}
+
+	// If the storage initializer is not injected, there is no action to do
+	if storageInitializerContainer == nil {
+		return nil
+	}
+
 	// Allow to override the uid for the case where ISTIO CNI with DNS proxy is enabled
 	// See for more: https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers.
 	if value, ok := pod.GetAnnotations()[constants.IstioSidecarUIDAnnotationKey]; ok {
 		if uid, err := strconv.ParseInt(value, 10, 64); err == nil {
-			initContainer.SecurityContext.RunAsUser = ptr.Int64(uid)
+			if storageInitializerContainer.SecurityContext == nil {
+				storageInitializerContainer.SecurityContext = &v1.SecurityContext{}
+			}
+			storageInitializerContainer.SecurityContext.RunAsUser = ptr.Int64(uid)
+		}
+	} else {
+		// When Istio CNI is disabled, the istio-init container would be present.
+		// If it is there, there is no need to touch the security context of the pod.
+		// Reference: https://github.com/istio/istio/blob/d533e52acc54b4721d23b1332aea1f234ecbe3e6/pkg/config/analysis/analyzers/maturity/maturity.go#L134
+		for _, container := range pod.Spec.InitContainers {
+			if container.Name == constants.IstioInitContainerName {
+				return nil
+			}
+		}
+
+		// When Istio CNI is enabled, a sidecar.istio.io/interceptionMode annotation is injected to the pod.
+		// There are three interception modes: REDIRECT, TPROXY and NONE.
+		// It only makes sense to adjust the security context of the storage initializer if REDIRECT mode is
+		// observed, because the Istio sidecar would be injected and traffic would be sent to it, but the
+		// sidecar won't be running at PodInitialization phase.
+		// The TPROXY mode can indicate that Istio Ambient is enabled. The Waypoint proxy would already be running and
+		// captured traffic can go through.
+		// The TPROXY mode can also be set by the user. If this is the case, it is not possible to infer the setup.
+		// Lastly, if interception mode is NONE the traffic is not being captured. This is an advanced mode, and
+		// it is not possible to infer the setup.
+		istioInterceptionMode := pod.Annotations[constants.IstioInterceptionModeAnnotation]
+		if istioInterceptionMode != constants.IstioInterceptModeRedirect {
+			return nil
+		}
+
+		// The storage initializer can only run smoothly when running with the same UID as the Istio sidecar.
+		// First, find the name of the Istio sidecar container. This is found in a status annotation injected
+		// by Istio. If there is no Istio sidecar status annotation, assume that the pod does
+		// not have a sidecar and leave untouched the security context.
+		istioStatus, istioStatusOk := pod.Annotations[constants.IstioSidecarStatusAnnotation]
+		if !istioStatusOk {
+			return nil
+		}
+
+		// Decode the Istio status JSON document
+		var istioStatusDecoded interface{}
+		if err := json.Unmarshal([]byte(istioStatus), &istioStatusDecoded); err != nil {
+			return err
+		}
+
+		// Get the Istio sidecar container name.
+		istioSidecarContainerName := ""
+		istioStatusMap := istioStatusDecoded.(map[string]interface{})
+		if istioContainers, istioContainersOk := istioStatusMap["containers"].([]interface{}); istioContainersOk {
+			if len(istioContainers) > 0 {
+				istioSidecarContainerName = istioContainers[0].(string)
+			}
+		}
+
+		// If there is no Istio sidecar, it is not possible to set any UID.
+		if len(istioSidecarContainerName) == 0 {
+			return nil
+		}
+
+		// Find the Istio sidecar container in the pod.
+		var istioSidecarContainer *v1.Container
+		for idx, container := range pod.Spec.Containers {
+			if container.Name == istioSidecarContainerName {
+				istioSidecarContainer = &pod.Spec.Containers[idx]
+				break
+			}
+		}
+
+		// Set the UserID of the storage initializer to the same as the Istio sidecar
+		if istioSidecarContainer != nil {
+			if storageInitializerContainer.SecurityContext == nil {
+				storageInitializerContainer.SecurityContext = &v1.SecurityContext{}
+			}
+			if istioSidecarContainer.SecurityContext == nil || istioSidecarContainer.SecurityContext.RunAsUser == nil {
+				// If the Istio sidecar does not explicitly have a UID set, use 1337 which is the
+				// UID hardcoded in Istio. This would require privileges to run with AnyUID, which should
+				// be OK because, otherwise, the Istio sidecar also would not work correctly.
+				storageInitializerContainer.SecurityContext.RunAsUser = ptr.Int64(constants.DefaultIstioSidecarUID)
+			} else {
+				// If the Istio sidecar has a UID copy it to the storage initializer because this
+				// would be the UID that allows access the network.
+				sidecarUID := *istioSidecarContainer.SecurityContext.RunAsUser
+				storageInitializerContainer.SecurityContext.RunAsUser = ptr.Int64(sidecarUID)
+
+				// Notice that despite in standard Istio the 1337 UID is hardcoded, there exist
+				// other flavors, like Maistra, that allow using arbitrary UIDs on the sidecar.
+				// The need is the same: the storage-initializer needs to run with the UID of
+				// the sidecar to be able to access the network. This is why copying the UID is
+				// preferred over using the default UID of 1337.
+			}
+
+			log.V(1).Info("Storage initializer UID is set", "pod", pod.Name, "uid", storageInitializerContainer.SecurityContext.RunAsUser)
 		}
 	}
-
-	// Add init container to the spec
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When Istio is installed with its CNI plugin, KServe inference services are not capable to start, because networking is not available to the storage-initializer, which is an init-container.

These changes use the approach documented in [Istio CNI docs](https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers) for running the storage initializer using the same UserID as the Istio sidecar. The UID is copied from the sidecar container to cover Istio derivatives, like Maistra.

The downside is that the traffic of the storage initializer won't be captured by Istio and won't benefit from Istio features, although this should be OK for the storage-initializer case.

The modification to the UserID of the storage initializer container is done only when Istio CNI is detected.

The reinvocation policy of the mutating webhook for pods had to be changed to `IfNeeded` since the order of execution of mutating webhooks is unpredictable. The change of the policy is to ensure that the webhook would be called after Istio does the injection of the sidecar, allowing to properly set the UID of the storage initializer when needed.

Fixes #2096 

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Installing Istio with the CNI plugin. See https://istio.io/latest/docs/setup/additional-setup/cni/. Then, deploying KServe with the changes in this PR and validating that the security context of storage initializer is properly configured to use the same UserID as the Istio sidecar.

Also, unit tests were added.

The backwards compatibility validation of the non-CNI case is delegated to existing automated E2E tests.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
Add compatibility for Istio CNI plugin
```
