### PR TITLE
ci: publish helm chart to ghcr

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -11,18 +11,40 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   upload-helm-charts:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package helm charts
         run: for dir in ./*/; do helm package $dir; done
         working-directory: ${{ env.HELM_CHARTS_PATH }}
+
+      - name: Push Charts to GHCR
+        working-directory: ${{ env.HELM_CHARTS_PATH }}
+        run: |
+          for pkg in *.tgz; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts
+          done
 
       - name: Rename helm chart archives
         run: for filename in *.tgz; do mv "$filename" "helm-chart-$filename"; done

--- a/charts/kserve-crd/README.md
+++ b/charts/kserve-crd/README.md
@@ -1,0 +1,7 @@
+# kserve-crd
+
+## Using this chart
+
+```console
+helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version 0.11.2
+```

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -1,0 +1,15 @@
+# kserve
+
+## Using this chart
+
+First install the `kserve-crd` chart
+
+```console
+helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version 0.11.2
+```
+
+Then install this chart
+
+```console
+helm install kserve oci://ghcr.io/kserve/charts/kserve --version 0.11.2
+```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR extends the CI to push the helm charts to GHCR so that users can easily install KServe using them.
Examples of the charts published from this PR can be seen here:
https://github.com/davidspek/kserve/pkgs/container/charts%2Fkserve
https://github.com/davidspek/kserve/pkgs/container/charts%2Fkserve-crd

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ci: publish helm charts to GHCR
```
