### PR TITLE
fix: Properly close resources and handle errors in agent and storage. Fixes #3323

### DIFF
--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -146,60 +146,72 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 	// Load --> Unload = 0 (cancel first load)
 	// Load --> Unload --> Load = 1 Load (cancel second load?)
 	for modelOp := range ops {
-		switch modelOp.Op {
-		case Add:
-			p.logger.Infof("Downloading model from %s", modelOp.Spec.StorageURI)
-			err := p.Downloader.DownloadModel(modelName, modelOp.Spec)
-			if err != nil {
-				// If there is an error, we will NOT send a request. As such, to know about errors, you will
-				// need to call the error endpoint of the puller
-				p.logger.Errorf("Failed to download model %s with err %v", modelName, err)
-			} else {
-				// Load the model onto the model server
-				resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/load", modelName),
-					"application/json",
-					bytes.NewBufferString("{}"))
+		func() {
+			switch modelOp.Op {
+			case Add:
+				p.logger.Infof("Downloading model from %s", modelOp.Spec.StorageURI)
+				err := p.Downloader.DownloadModel(modelName, modelOp.Spec)
 				if err != nil {
-					// handle error
-					p.logger.Errorf("Failed to Load model %s", modelName)
+					// If there is an error, we will NOT send a request. As such, to know about errors, you will
+					// need to call the error endpoint of the puller
+					p.logger.Errorf("Failed to download model %s with err %v", modelName, err)
 				} else {
-					defer resp.Body.Close()
-					if resp.StatusCode == 200 {
-						p.logger.Infof("Successfully loaded model %s", modelName)
+					// Load the model onto the model server
+					resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/load", modelName),
+						"application/json",
+						bytes.NewBufferString("{}"))
+					if err != nil {
+						// handle error
+						p.logger.Errorf("Failed to Load model %s", modelName)
 					} else {
-						body, err := io.ReadAll(resp.Body)
-						if err == nil {
-							p.logger.Infof("Failed to load model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
+						defer func(Body io.ReadCloser) {
+							newErr := Body.Close()
+							if newErr != nil {
+								p.logger.Error(newErr, "failed to close body")
+							}
+						}(resp.Body)
+						if resp.StatusCode == 200 {
+							p.logger.Infof("Successfully loaded model %s", modelName)
+						} else {
+							body, err := io.ReadAll(resp.Body)
+							if err == nil {
+								p.logger.Infof("Failed to load model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
+							}
+						}
+					}
+				}
+			case Remove:
+				p.logger.Infof("unloading model %s", modelName)
+				// If there is an error, we will NOT do a delete... that could be problematic
+				if err := storage.RemoveDir(filepath.Join(p.Downloader.ModelDir, modelName)); err != nil {
+					p.logger.Error(err, "failing to delete model directory")
+				} else {
+					// unload model from model server
+					resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/unload", modelName),
+						"application/json",
+						bytes.NewBufferString("{}"))
+					if err != nil {
+						// handle error
+						p.logger.Errorf("Failed to Unload model %s", modelName)
+					} else {
+						defer func(Body io.ReadCloser) {
+							newErr := Body.Close()
+							if newErr != nil {
+								p.logger.Error(newErr, "failed to close body")
+							}
+						}(resp.Body)
+						if resp.StatusCode == 200 {
+							p.logger.Infof("Successfully unloaded model %s", modelName)
+						} else {
+							body, err := io.ReadAll(resp.Body)
+							if err == nil {
+								p.logger.Infof("Failed to unload model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
+							}
 						}
 					}
 				}
 			}
-		case Remove:
-			p.logger.Infof("unloading model %s", modelName)
-			// If there is an error, we will NOT do a delete... that could be problematic
-			if err := storage.RemoveDir(filepath.Join(p.Downloader.ModelDir, modelName)); err != nil {
-				p.logger.Error(err, "failing to delete model directory")
-			} else {
-				// unload model from model server
-				resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/unload", modelName),
-					"application/json",
-					bytes.NewBufferString("{}"))
-				if err != nil {
-					// handle error
-					p.logger.Errorf("Failed to Unload model %s", modelName)
-				} else {
-					defer resp.Body.Close()
-					if resp.StatusCode == 200 {
-						p.logger.Infof("Successfully unloaded model %s", modelName)
-					} else {
-						body, err := io.ReadAll(resp.Body)
-						if err == nil {
-							p.logger.Infof("Failed to unload model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
-						}
-					}
-				}
-			}
-		}
-		p.completions <- modelOp
+			p.completions <- modelOp
+		}()
 	}
 }

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -154,7 +154,7 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 				// If there is an error, we will NOT send a request. As such, to know about errors, you will
 				// need to call the error endpoint of the puller
 				p.logger.Errorf("Failed to download model %s with err %v", modelName, err)
-				return
+				break
 			}
 			// Load the model onto the model server
 			resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/load", modelName),
@@ -184,7 +184,7 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 			// If there is an error, we will NOT do a delete... that could be problematic
 			if err := storage.RemoveDir(filepath.Join(p.Downloader.ModelDir, modelName)); err != nil {
 				p.logger.Error(err, "failing to delete model directory")
-				return
+				break
 			}
 			// unload model from model server
 			resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/unload", modelName),

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -165,9 +165,9 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 				p.logger.Errorf("Failed to Load model %s", modelName)
 			} else {
 				defer func(Body io.ReadCloser) {
-					newErr := Body.Close()
-					if newErr != nil {
-						p.logger.Error(newErr, "failed to close body")
+					closeErr := Body.Close()
+					if closeErr != nil {
+						p.logger.Error(closeErr, "failed to close body")
 					}
 				}(resp.Body)
 				if resp.StatusCode == 200 {

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -196,9 +196,9 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 			} else {
 				if resp != nil {
 					defer func(Body io.ReadCloser) {
-						newErr := Body.Close()
-						if newErr != nil {
-							p.logger.Error(newErr, "failed to close body")
+						closeErr := Body.Close()
+						if closeErr != nil {
+							p.logger.Error(closeErr, "failed to close body")
 						}
 					}(resp.Body)
 				}

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -194,12 +194,14 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 				// handle error
 				p.logger.Errorf("Failed to Unload model %s", modelName)
 			} else {
-				defer func(Body io.ReadCloser) {
-					newErr := Body.Close()
-					if newErr != nil {
-						p.logger.Error(newErr, "failed to close body")
-					}
-				}(resp.Body)
+				if resp != nil {
+					defer func(Body io.ReadCloser) {
+						newErr := Body.Close()
+						if newErr != nil {
+							p.logger.Error(newErr, "failed to close body")
+						}
+					}(resp.Body)
+				}
 				if resp.StatusCode == 200 {
 					p.logger.Infof("Successfully unloaded model %s", modelName)
 				} else {

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -154,28 +154,28 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 				// If there is an error, we will NOT send a request. As such, to know about errors, you will
 				// need to call the error endpoint of the puller
 				p.logger.Errorf("Failed to download model %s with err %v", modelName, err)
+				return
+			}
+			// Load the model onto the model server
+			resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/load", modelName),
+				"application/json",
+				bytes.NewBufferString("{}"))
+			if err != nil {
+				// handle error
+				p.logger.Errorf("Failed to Load model %s", modelName)
 			} else {
-				// Load the model onto the model server
-				resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/load", modelName),
-					"application/json",
-					bytes.NewBufferString("{}"))
-				if err != nil {
-					// handle error
-					p.logger.Errorf("Failed to Load model %s", modelName)
+				defer func(Body io.ReadCloser) {
+					newErr := Body.Close()
+					if newErr != nil {
+						p.logger.Error(newErr, "failed to close body")
+					}
+				}(resp.Body)
+				if resp.StatusCode == 200 {
+					p.logger.Infof("Successfully loaded model %s", modelName)
 				} else {
-					defer func(Body io.ReadCloser) {
-						newErr := Body.Close()
-						if newErr != nil {
-							p.logger.Error(newErr, "failed to close body")
-						}
-					}(resp.Body)
-					if resp.StatusCode == 200 {
-						p.logger.Infof("Successfully loaded model %s", modelName)
-					} else {
-						body, err := io.ReadAll(resp.Body)
-						if err == nil {
-							p.logger.Infof("Failed to load model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
-						}
+					body, err := io.ReadAll(resp.Body)
+					if err == nil {
+						p.logger.Infof("Failed to load model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
 					}
 				}
 			}
@@ -184,28 +184,28 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 			// If there is an error, we will NOT do a delete... that could be problematic
 			if err := storage.RemoveDir(filepath.Join(p.Downloader.ModelDir, modelName)); err != nil {
 				p.logger.Error(err, "failing to delete model directory")
+				return
+			}
+			// unload model from model server
+			resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/unload", modelName),
+				"application/json",
+				bytes.NewBufferString("{}"))
+			if err != nil {
+				// handle error
+				p.logger.Errorf("Failed to Unload model %s", modelName)
 			} else {
-				// unload model from model server
-				resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/unload", modelName),
-					"application/json",
-					bytes.NewBufferString("{}"))
-				if err != nil {
-					// handle error
-					p.logger.Errorf("Failed to Unload model %s", modelName)
+				defer func(Body io.ReadCloser) {
+					newErr := Body.Close()
+					if newErr != nil {
+						p.logger.Error(newErr, "failed to close body")
+					}
+				}(resp.Body)
+				if resp.StatusCode == 200 {
+					p.logger.Infof("Successfully unloaded model %s", modelName)
 				} else {
-					defer func(Body io.ReadCloser) {
-						newErr := Body.Close()
-						if newErr != nil {
-							p.logger.Error(newErr, "failed to close body")
-						}
-					}(resp.Body)
-					if resp.StatusCode == 200 {
-						p.logger.Infof("Successfully unloaded model %s", modelName)
-					} else {
-						body, err := io.ReadAll(resp.Body)
-						if err == nil {
-							p.logger.Infof("Failed to unload model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
-						}
+					body, err := io.ReadAll(resp.Body)
+					if err == nil {
+						p.logger.Infof("Failed to unload model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
 					}
 				}
 			}

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -145,73 +145,74 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 	// this is important for handling Load --> Unload requests sent in tandem
 	// Load --> Unload = 0 (cancel first load)
 	// Load --> Unload --> Load = 1 Load (cancel second load?)
-	for modelOp := range ops {
-		func() {
-			switch modelOp.Op {
-			case Add:
-				p.logger.Infof("Downloading model from %s", modelOp.Spec.StorageURI)
-				err := p.Downloader.DownloadModel(modelName, modelOp.Spec)
+	var processOp = func(modelOp *ModelOp) {
+		switch modelOp.Op {
+		case Add:
+			p.logger.Infof("Downloading model from %s", modelOp.Spec.StorageURI)
+			err := p.Downloader.DownloadModel(modelName, modelOp.Spec)
+			if err != nil {
+				// If there is an error, we will NOT send a request. As such, to know about errors, you will
+				// need to call the error endpoint of the puller
+				p.logger.Errorf("Failed to download model %s with err %v", modelName, err)
+			} else {
+				// Load the model onto the model server
+				resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/load", modelName),
+					"application/json",
+					bytes.NewBufferString("{}"))
 				if err != nil {
-					// If there is an error, we will NOT send a request. As such, to know about errors, you will
-					// need to call the error endpoint of the puller
-					p.logger.Errorf("Failed to download model %s with err %v", modelName, err)
+					// handle error
+					p.logger.Errorf("Failed to Load model %s", modelName)
 				} else {
-					// Load the model onto the model server
-					resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/load", modelName),
-						"application/json",
-						bytes.NewBufferString("{}"))
-					if err != nil {
-						// handle error
-						p.logger.Errorf("Failed to Load model %s", modelName)
-					} else {
-						defer func(Body io.ReadCloser) {
-							newErr := Body.Close()
-							if newErr != nil {
-								p.logger.Error(newErr, "failed to close body")
-							}
-						}(resp.Body)
-						if resp.StatusCode == 200 {
-							p.logger.Infof("Successfully loaded model %s", modelName)
-						} else {
-							body, err := io.ReadAll(resp.Body)
-							if err == nil {
-								p.logger.Infof("Failed to load model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
-							}
+					defer func(Body io.ReadCloser) {
+						newErr := Body.Close()
+						if newErr != nil {
+							p.logger.Error(newErr, "failed to close body")
 						}
-					}
-				}
-			case Remove:
-				p.logger.Infof("unloading model %s", modelName)
-				// If there is an error, we will NOT do a delete... that could be problematic
-				if err := storage.RemoveDir(filepath.Join(p.Downloader.ModelDir, modelName)); err != nil {
-					p.logger.Error(err, "failing to delete model directory")
-				} else {
-					// unload model from model server
-					resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/unload", modelName),
-						"application/json",
-						bytes.NewBufferString("{}"))
-					if err != nil {
-						// handle error
-						p.logger.Errorf("Failed to Unload model %s", modelName)
+					}(resp.Body)
+					if resp.StatusCode == 200 {
+						p.logger.Infof("Successfully loaded model %s", modelName)
 					} else {
-						defer func(Body io.ReadCloser) {
-							newErr := Body.Close()
-							if newErr != nil {
-								p.logger.Error(newErr, "failed to close body")
-							}
-						}(resp.Body)
-						if resp.StatusCode == 200 {
-							p.logger.Infof("Successfully unloaded model %s", modelName)
-						} else {
-							body, err := io.ReadAll(resp.Body)
-							if err == nil {
-								p.logger.Infof("Failed to unload model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
-							}
+						body, err := io.ReadAll(resp.Body)
+						if err == nil {
+							p.logger.Infof("Failed to load model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
 						}
 					}
 				}
 			}
-			p.completions <- modelOp
-		}()
+		case Remove:
+			p.logger.Infof("unloading model %s", modelName)
+			// If there is an error, we will NOT do a delete... that could be problematic
+			if err := storage.RemoveDir(filepath.Join(p.Downloader.ModelDir, modelName)); err != nil {
+				p.logger.Error(err, "failing to delete model directory")
+			} else {
+				// unload model from model server
+				resp, err := http.Post(fmt.Sprintf("http://localhost:8080/v2/repository/models/%s/unload", modelName),
+					"application/json",
+					bytes.NewBufferString("{}"))
+				if err != nil {
+					// handle error
+					p.logger.Errorf("Failed to Unload model %s", modelName)
+				} else {
+					defer func(Body io.ReadCloser) {
+						newErr := Body.Close()
+						if newErr != nil {
+							p.logger.Error(newErr, "failed to close body")
+						}
+					}(resp.Body)
+					if resp.StatusCode == 200 {
+						p.logger.Infof("Successfully unloaded model %s", modelName)
+					} else {
+						body, err := io.ReadAll(resp.Body)
+						if err == nil {
+							p.logger.Infof("Failed to unload model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
+						}
+					}
+				}
+			}
+		}
+		p.completions <- modelOp
+	}
+	for modelOp := range ops {
+		processOp(modelOp)
 	}
 }

--- a/pkg/agent/storage/gcs.go
+++ b/pkg/agent/storage/gcs.go
@@ -124,9 +124,9 @@ func (g *GCSObjectDownloader) DownloadFile(client stiface.Client, attrs *gstorag
 		)
 	}
 	defer func(reader stiface.Reader) {
-		newErr := reader.Close()
-		if newErr != nil {
-			log.Error(newErr, "failed to close reader")
+		closeErr := reader.Close()
+		if closeErr != nil {
+			log.Error(closeErr, "failed to close reader")
 		}
 	}(reader)
 	data, err := io.ReadAll(reader)
@@ -151,9 +151,9 @@ func (g *GCSObjectDownloader) WriteToFile(data []byte, attrs *gstorage.ObjectAtt
 		)
 	}
 	defer func(file *os.File) {
-		newErr := file.Close()
-		if newErr != nil {
-			log.Error(newErr, "failed to close file")
+		closeErr := file.Close()
+		if closeErr != nil {
+			log.Error(closeErr, "failed to close file")
 		}
 	}(file)
 	log.Info("Wrote " + attrs.Prefix + " to file " + file.Name())

--- a/pkg/agent/storage/https.go
+++ b/pkg/agent/storage/https.go
@@ -86,9 +86,9 @@ func (h *HTTPSDownloader) Download(client http.Client) error {
 	}
 
 	defer func(Body io.ReadCloser) {
-		newErr := Body.Close()
-		if newErr != nil {
-			log.Error(newErr, "failed to close body")
+		closeErr := Body.Close()
+		if closeErr != nil {
+			log.Error(closeErr, "failed to close body")
 		}
 	}(resp.Body)
 	if resp.StatusCode != 200 {
@@ -186,13 +186,13 @@ func extractZipFiles(reader io.Reader, dest string) error {
 		}
 
 		_, err = io.Copy(file, rc)
-		newErr := file.Close()
-		if newErr != nil {
-			return newErr
+		closeErr := file.Close()
+		if closeErr != nil {
+			return closeErr
 		}
-		newErr = rc.Close()
-		if newErr != nil {
-			return newErr
+		closeErr = rc.Close()
+		if closeErr != nil {
+			return closeErr
 		}
 		if err != nil {
 			return fmt.Errorf("unable to copy file content: %v", err)
@@ -207,9 +207,9 @@ func extractTarFiles(reader io.Reader, dest string) error {
 		return err
 	}
 	defer func(gzr *gzip.Reader) {
-		newErr := gzr.Close()
-		if newErr != nil {
-			log.Error(newErr, "failed to close reader")
+		closeErr := gzr.Close()
+		if closeErr != nil {
+			log.Error(closeErr, "failed to close reader")
 		}
 	}(gzr)
 

--- a/pkg/agent/storage/https.go
+++ b/pkg/agent/storage/https.go
@@ -85,7 +85,12 @@ func (h *HTTPSDownloader) Download(client http.Client) error {
 		return fmt.Errorf("failed to make a request: %v", err)
 	}
 
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		newErr := Body.Close()
+		if newErr != nil {
+			log.Error(newErr, "failed to close body")
+		}
+	}(resp.Body)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("URI: %s returned a %d response code", h.StorageUri, resp.StatusCode)
 	}
@@ -123,7 +128,10 @@ func (h *HTTPSDownloader) extractHeaders() (map[string]string, error) {
 	var headers map[string]string
 	hostname := h.Uri.Hostname()
 	headerJSON := os.Getenv(hostname + HEADER_SUFFIX)
-	json.Unmarshal([]byte(headerJSON), &headers)
+	err := json.Unmarshal([]byte(headerJSON), &headers)
+	if err != nil {
+		log.Error(err, "failed to unmarshal headers")
+	}
 	return headers, nil
 }
 
@@ -172,15 +180,20 @@ func extractZipFiles(reader io.Reader, dest string) error {
 		if err != nil {
 			return err
 		}
-
 		rc, err := zipFile.Open()
 		if err != nil {
 			return fmt.Errorf("unable to open file: %v", err)
 		}
 
 		_, err = io.Copy(file, rc)
-		file.Close()
-		rc.Close()
+		newErr := file.Close()
+		if newErr != nil {
+			log.Error(newErr, "failed to close file")
+		}
+		newErr = rc.Close()
+		if newErr != nil {
+			log.Error(newErr, "failed to close file")
+		}
 		if err != nil {
 			return fmt.Errorf("unable to copy file content: %v", err)
 		}
@@ -193,7 +206,12 @@ func extractTarFiles(reader io.Reader, dest string) error {
 	if err != nil {
 		return err
 	}
-	defer gzr.Close()
+	defer func(gzr *gzip.Reader) {
+		newErr := gzr.Close()
+		if newErr != nil {
+			log.Error(newErr, "failed to close reader")
+		}
+	}(gzr)
 
 	tr := tar.NewReader(gzr)
 

--- a/pkg/agent/storage/https.go
+++ b/pkg/agent/storage/https.go
@@ -188,11 +188,11 @@ func extractZipFiles(reader io.Reader, dest string) error {
 		_, err = io.Copy(file, rc)
 		newErr := file.Close()
 		if newErr != nil {
-			log.Error(newErr, "failed to close file")
+			return newErr
 		}
 		newErr = rc.Close()
 		if newErr != nil {
-			log.Error(newErr, "failed to close file")
+			return newErr
 		}
 		if err != nil {
 			return fmt.Errorf("unable to copy file content: %v", err)

--- a/pkg/agent/storage/s3.go
+++ b/pkg/agent/storage/s3.go
@@ -114,7 +114,12 @@ func (s *S3ObjectDownloader) GetAllObjects(s3Svc s3iface.S3API) ([]s3manager.Bat
 			},
 			Writer: file,
 			After: func() error {
-				defer file.Close()
+				defer func(file *os.File) {
+					newErr := file.Close()
+					if newErr != nil {
+						log.Error(newErr, "failed to close file")
+					}
+				}(file)
 				return nil
 			},
 		}

--- a/pkg/agent/storage/s3.go
+++ b/pkg/agent/storage/s3.go
@@ -115,9 +115,9 @@ func (s *S3ObjectDownloader) GetAllObjects(s3Svc s3iface.S3API) ([]s3manager.Bat
 			Writer: file,
 			After: func() error {
 				defer func(file *os.File) {
-					newErr := file.Close()
-					if newErr != nil {
-						log.Error(newErr, "failed to close file")
+					closeErr := file.Close()
+					if closeErr != nil {
+						log.Error(closeErr, "failed to close file")
 					}
 				}(file)
 				return nil

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -74,9 +74,9 @@ func RemoveDir(dir string) error {
 		return err
 	}
 	defer func(d *os.File) {
-		newErr := d.Close()
-		if newErr != nil {
-			log.Error(newErr, "failed to close file")
+		closeErr := d.Close()
+		if closeErr != nil {
+			log.Error(closeErr, "failed to close file")
 		}
 	}(d)
 	names, err := d.Readdirnames(-1)

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -73,7 +73,12 @@ func RemoveDir(dir string) error {
 	if err != nil {
 		return err
 	}
-	defer d.Close()
+	defer func(d *os.File) {
+		newErr := d.Close()
+		if newErr != nil {
+			log.Error(newErr, "failed to close file")
+		}
+	}(d)
 	names, err := d.Readdirnames(-1)
 	if err != nil {
 		return err

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -83,7 +83,12 @@ func (w *Watcher) Start() {
 		w.logger.Error(err, "Failed to create model dir watcher")
 		panic(err)
 	}
-	defer watcher.Close()
+	defer func(watcher *fsnotify.Watcher) {
+		newErr := watcher.Close()
+		if newErr != nil {
+			w.logger.Error(newErr, "Failed to close watcher")
+		}
+	}(watcher)
 	if err = watcher.Add(w.configDir); err != nil {
 		w.logger.Error(err, "Failed to add watcher config dir")
 	}

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -84,9 +84,9 @@ func (w *Watcher) Start() {
 		panic(err)
 	}
 	defer func(watcher *fsnotify.Watcher) {
-		newErr := watcher.Close()
-		if newErr != nil {
-			w.logger.Error(newErr, "Failed to close watcher")
+		closeErr := watcher.Close()
+		if closeErr != nil {
+			w.logger.Error(closeErr, "Failed to close watcher")
 		}
 	}(watcher)
 	if err = watcher.Add(w.configDir); err != nil {


### PR DESCRIPTION
Fixes https://github.com/kserve/kserve/issues/3323. This PR adds proper closure of resources and error handling for code related to agent and storage to avoid memory leaks and surface potential errors.

There are a few defer statements to release/close resources but they are within for loops, which lead to memory leaks. 