### PR TITLE
docs: Add link to OpenShift Container Platform instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Additionally, we have compiled a list of [presentations and demos](https://kserv
 - **[Quick Installation](https://kserve.github.io/website/master/get_started/)**: Install KServe on your local machine.
 
 #### Kubeflow Installation
-KServe is an important addon component of Kubeflow, please learn more from the [Kubeflow KServe documentation](https://www.kubeflow.org/docs/external-add-ons/kserve/kserve) and follow [KServe with Kubeflow on AWS](https://awslabs.github.io/kubeflow-manifests/main/docs/component-guides/kserve) to learn how to use KServe on AWS.
+KServe is an important addon component of Kubeflow, please learn more from the [Kubeflow KServe documentation](https://www.kubeflow.org/docs/external-add-ons/kserve/kserve). Check out the following guides for running [on AWS](https://awslabs.github.io/kubeflow-manifests/main/docs/component-guides/kserve) or [on OpenShift Container Platform](https://github.com/kserve/kserve/blob/master/docs/OPENSHIFT_GUIDE.md).
 
 ### :flight_departure: [Create your first InferenceService](https://kserve.github.io/website/master/get_started/first_isvc)
 


### PR DESCRIPTION
There's currently only a link for running on AWS. This PR adds a link to OpenShift Container Platform instructions.