### PR TITLE
Add a CI_USE_ISVC_HOST for testing with the ISVC hostname

### DIFF
--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -115,7 +115,7 @@ def predict_ig(ig_name, input_json, protocol_version="v1",
             version=version,
         )
 
-        cluster_ip, host = get_isvc_endpoint(ig)
+        cluster_ip, host, _ = get_isvc_endpoint(ig)
         headers = {"Host": host}
         url = f"http://{cluster_ip}"
 
@@ -150,7 +150,7 @@ def explain_response(service_name, input_json):
     )
     # temporary sleep until this is fixed https://github.com/kserve/kserve/issues/604
     time.sleep(10)
-    cluster_ip, host = get_isvc_endpoint(isvc)
+    cluster_ip, host, _ = get_isvc_endpoint(isvc)
     url = "http://{}/v1/models/{}:explain".format(cluster_ip, service_name)
     headers = {"Host": host}
     with open(input_json) as json_file:
@@ -212,7 +212,7 @@ def predict_grpc(service_name, payload, parameters=None, version=constants.KSERV
         namespace=KSERVE_TEST_NAMESPACE,
         version=version,
     )
-    cluster_ip, host = get_isvc_endpoint(isvc)
+    cluster_ip, host, _ = get_isvc_endpoint(isvc)
     if ":" not in cluster_ip:
         cluster_ip = cluster_ip + ":80"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the possibility to run E2E tests using the hostname specified in the `status.url` field of the InferenceServices, rather than using the ClusterIP of the Istio Ingress gateway.

This behavior is enabled by, first, setting the `CI_USE_ISVC_HOST=1` environment variable and, then invoking pytest. Thus, the original behavior of using Istio IngressGateway ClusterIP is the default one.

Perhaps, right now this is not relevant for KServe CI. In the [opendatahub fork](https://github.com/opendatahub-io/kserve) we run the E2E suite in a production-like environment and, thus, we prefer to test without workarounds. We contribute back these small changes in case other people from the community can benefit from this.

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

These changes are present in the following pull request of the opendatahub fork: opendatahub-io/kserve#147. In the checks, you can see that there are checks named _ci/prow/e2e-fast_ and _ci/prow/e2e-slow_ that make use of this and are passing.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
NONE
```
