### PR TITLE
fix: Add missing --timeout flag in batcher

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -66,6 +66,7 @@ var (
 	enableBatcher = flag.Bool("enable-batcher", false, "Enable request batcher")
 	maxBatchSize  = flag.String("max-batchsize", "32", "Max Batch Size")
 	maxLatency    = flag.String("max-latency", "5000", "Max Latency in milliseconds")
+	timeout       = flag.String("timeout", "100", "Batcher timeout in seconds")
 	// probing flags
 	readinessProbeTimeout = flag.Duration("probe-period", -1, "run readiness probe with given timeout")
 	// This creates an abstract socket instead of an actual file.
@@ -110,6 +111,7 @@ type loggerArgs struct {
 type batcherArgs struct {
 	maxBatchSize int
 	maxLatency   int
+	timeout      int
 }
 
 func main() {
@@ -230,9 +232,16 @@ func startBatcher(logger *zap.SugaredLogger) *batcherArgs {
 		os.Exit(1)
 	}
 
+	batcherTimeout, err := strconv.Atoi(*timeout)
+	if err != nil || batcherTimeout <= 0 {
+		logger.Error(errors.New("Invalid batcher timeout"), *timeout)
+		os.Exit(1)
+	}
+
 	return &batcherArgs{
 		maxLatency:   maxLatencyInt,
 		maxBatchSize: maxBatchSizeInt,
+		timeout:      batcherTimeout,
 	}
 }
 
@@ -320,7 +329,7 @@ func buildServer(ctx context.Context, port string, userPort int, loggerArgs *log
 	var composedHandler http.Handler = httpProxy
 
 	if batcherArgs != nil {
-		composedHandler = batcher.New(batcherArgs.maxBatchSize, batcherArgs.maxLatency, composedHandler, logging)
+		composedHandler = batcher.New(batcherArgs.maxBatchSize, batcherArgs.maxLatency, batcherArgs.timeout, composedHandler, logging)
 	}
 	if loggerArgs != nil {
 		composedHandler = kfslogger.New(loggerArgs.logUrl, loggerArgs.sourceUrl, loggerArgs.loggerType,


### PR DESCRIPTION
This flag is currently missing but batch injector is injecting annotation `/batcher-timeout` as well as appending `--timeout` flag to batcher container args.