### PR TITLE
Support running model server with arbitary UID

### DIFF
--- a/python/aiffairness.Dockerfile
+++ b/python/aiffairness.Dockerfile
@@ -1,24 +1,28 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
-
-# Install Poetry
-ARG POETRY_HOME=/opt/poetry
-ARG POETRY_VERSION=1.7.1
 
 # Required for building packages for arm64 arch
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -33,18 +37,18 @@ RUN cd aiffairness && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder aiffairness aiffairness
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "aifserver"]

--- a/python/alibiexplainer.Dockerfile
+++ b/python/alibiexplainer.Dockerfile
@@ -1,24 +1,28 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
-
-# Install Poetry
-ARG POETRY_HOME=/opt/poetry
-ARG POETRY_VERSION=1.7.1
 
 # Required for building packages for arm64 arch
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -33,19 +37,19 @@ RUN cd alibiexplainer && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder alibiexplainer alibiexplainer
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "alibiexplainer"]
 

--- a/python/artexplainer.Dockerfile
+++ b/python/artexplainer.Dockerfile
@@ -1,24 +1,28 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
-
-# Install Poetry
-ARG POETRY_HOME=/opt/poetry
-ARG POETRY_VERSION=1.7.1
 
 # Required for building packages for arm64 arch
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -33,18 +37,18 @@ RUN cd artexplainer && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder artexplainer artexplainer
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "artserver"]

--- a/python/custom_model.Dockerfile
+++ b/python/custom_model.Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
 
@@ -11,11 +12,15 @@ ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -30,18 +35,18 @@ RUN cd custom_model && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder custom_model custom_model
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "custom_model.model"]

--- a/python/custom_model_grpc.Dockerfile
+++ b/python/custom_model_grpc.Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
 
@@ -11,11 +12,15 @@ ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -30,18 +35,18 @@ RUN cd custom_model && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder custom_model custom_model
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "custom_model.model_grpc"]

--- a/python/custom_transformer.Dockerfile
+++ b/python/custom_transformer.Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
 
@@ -11,11 +12,15 @@ ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -30,19 +35,19 @@ RUN cd custom_transformer && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder custom_transformer custom_transformer
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "custom_transformer.model"]
 

--- a/python/custom_transformer_grpc.Dockerfile
+++ b/python/custom_transformer_grpc.Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
 
@@ -11,11 +12,15 @@ ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -30,20 +35,20 @@ RUN cd custom_transformer && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder custom_transformer custom_transformer
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "custom_transformer.model_grpc"]
 
 

--- a/python/error_404_isvc.Dockerfile
+++ b/python/error_404_isvc.Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
 
@@ -13,11 +14,15 @@ ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -26,26 +31,26 @@ RUN cd kserve && poetry install --no-interaction --no-cache
 
 RUN echo $(pwd)
 RUN echo $(ls)
-COPY test_resources/graph/error_404_isvc/pyproject.toml test_resources/graph/error_404_isvc/poetry.lock error_404_isvc/
-RUN cd error_404_isvc && poetry install --no-root --no-interaction --no-cache
-COPY test_resources/graph/error_404_isvc error_404_isvc
-RUN cd error_404_isvc && poetry install --no-interaction --no-cache
+COPY test_resources/graph/error_404_isvc/pyproject.toml test_resources/graph/error_404_isvc/poetry.lock test_resources/graph/error_404_isvc/
+RUN cd test_resources/graph/error_404_isvc && poetry install --no-root --no-interaction --no-cache
+COPY test_resources/graph/error_404_isvc test_resources/graph/error_404_isvc
+RUN cd test_resources/graph/error_404_isvc && poetry install --no-interaction --no-cache
 
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder error_404_isvc error_404_isvc
-
 USER 1000
-ENTRYPOINT ["python", "-m", "error_404_isvc.model"]
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
+ENTRYPOINT ["python", "-m", "test_resources.graph.error_404_isvc.model"]

--- a/python/lgb.Dockerfile
+++ b/python/lgb.Dockerfile
@@ -1,24 +1,28 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
-
-# Install Poetry
-ARG POETRY_HOME=/opt/poetry
-ARG POETRY_VERSION=1.7.1
 
 # Required for building packages for arm64 arch
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -33,23 +37,23 @@ RUN cd lgbserver && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder lgbserver lgbserver
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "lgbserver"]

--- a/python/paddle.Dockerfile
+++ b/python/paddle.Dockerfile
@@ -1,24 +1,28 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
-
-# Install Poetry
-ARG POETRY_HOME=/opt/poetry
-ARG POETRY_VERSION=1.7.1
 
 # Required for building packages for arm64 arch
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -33,23 +37,23 @@ RUN cd paddleserver && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libgomp1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder paddleserver paddleserver
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "paddleserver"]

--- a/python/pmml.Dockerfile
+++ b/python/pmml.Dockerfile
@@ -1,7 +1,8 @@
 ARG PYTHON_VERSION=3.9
 ARG JAVA_VERSION=11
 ARG BASE_IMAGE=openjdk:${JAVA_VERSION}-slim
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
 
@@ -19,11 +20,15 @@ ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python${PYTHON_VERSION} -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python${PYTHON_VERSION} -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -38,7 +43,8 @@ RUN cd pmmlserver && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 ARG PYTHON_VERSION
 # Install python
@@ -49,14 +55,13 @@ RUN apt-get update && \
 
 # Activate virtual env
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder pmmlserver pmmlserver
-
 USER 1000
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python3", "-m", "pmmlserver"]

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -1,24 +1,32 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
-
-# Install Poetry
-ARG POETRY_HOME=/opt/poetry
-ARG POETRY_VERSION=1.7.1
 
 # Required for building packages for arm64 arch
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -30,21 +38,20 @@ RUN cd sklearnserver && poetry install --no-root --no-interaction --no-cache
 COPY sklearnserver sklearnserver
 RUN cd sklearnserver && poetry install --no-interaction --no-cache
 
-
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder sklearnserver sklearnserver
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "sklearnserver"]

--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -1,24 +1,28 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
-
-# Install Poetry
-ARG POETRY_HOME=/opt/poetry
-ARG POETRY_VERSION=1.7.1
 
 # Required for building packages for arm64 arch
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache --extras "storage"
@@ -38,22 +42,21 @@ RUN pip install --no-cache-dir krbcontext==0.10 hdfs~=2.6.0 requests-kerberos==0
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
 
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY ./storage-initializer /storage-initializer
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
-RUN chmod +x /storage-initializer/scripts/initializer-entrypoint
-RUN mkdir /work
-WORKDIR /work
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+COPY ./storage-initializer storage-initializer
+
+RUN chmod +x storage-initializer/scripts/initializer-entrypoint
 
 USER 1000
-ENTRYPOINT ["/storage-initializer/scripts/initializer-entrypoint"]
+ENTRYPOINT ["storage-initializer/scripts/initializer-entrypoint"]

--- a/python/success_200_isvc.Dockerfile
+++ b/python/success_200_isvc.Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
 
@@ -13,11 +14,15 @@ ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -26,26 +31,26 @@ RUN cd kserve && poetry install --no-interaction --no-cache
 
 RUN echo $(pwd)
 RUN echo $(ls)
-COPY test_resources/graph/success_200_isvc/pyproject.toml test_resources/graph/success_200_isvc/poetry.lock success_200_isvc/
-RUN cd success_200_isvc && poetry install --no-root --no-interaction --no-cache
-COPY test_resources/graph/success_200_isvc success_200_isvc
-RUN cd success_200_isvc && poetry install --no-interaction --no-cache
+COPY test_resources/graph/success_200_isvc/pyproject.toml test_resources/graph/success_200_isvc/poetry.lock test_resources/graph/success_200_isvc/
+RUN cd test_resources/graph/success_200_isvc && poetry install --no-root --no-interaction --no-cache
+COPY test_resources/graph/success_200_isvc test_resources/graph/success_200_isvc
+RUN cd test_resources/graph/success_200_isvc && poetry install --no-interaction --no-cache
 
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
-
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder success_200_isvc success_200_isvc
-
 USER 1000
-ENTRYPOINT ["python", "-m", "success_200_isvc.model"]
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
+ENTRYPOINT ["python", "-m", "test_resources.graph.success_200_isvc.model"]

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -1,24 +1,28 @@
 ARG PYTHON_VERSION=3.9
 ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bullseye
-ARG VENV_PATH=/prod_venv
+ARG VENV_PATH=venv
+ARG WORK_DIR=/model-server
 
 FROM ${BASE_IMAGE} as builder
-
-# Install Poetry
-ARG POETRY_HOME=/opt/poetry
-ARG POETRY_VERSION=1.7.1
 
 # Required for building packages for arm64 arch
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.7.1
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"
 
-# Activate virtual env
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
+RUN chmod -R g=u ${WORK_DIR}
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
 ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="${WORK_DIR}/${VENV_PATH}"
+RUN python3 -m venv ${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 COPY kserve/pyproject.toml kserve/poetry.lock kserve/
 RUN cd kserve && poetry install --no-root --no-interaction --no-cache
@@ -33,24 +37,24 @@ RUN cd xgbserver && poetry install --no-interaction --no-cache
 
 FROM ${BASE_IMAGE} as prod
 
-COPY third_party third_party
+ARG WORK_DIR
+WORKDIR ${WORK_DIR}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libgomp1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Activate virtual env
-ARG VENV_PATH
-ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
 RUN useradd kserve -m -u 1000 -d /home/kserve
-
-COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
-COPY --from=builder kserve kserve
-COPY --from=builder xgbserver xgbserver
-
 USER 1000
+
+# To activate virtual env we have to set VIRTUAL_ENV environment variable
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${WORK_DIR}/${VENV_PATH}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+COPY third_party third_party
+COPY --from=builder --chown=kserve:0 ${WORK_DIR} .
+
 ENTRYPOINT ["python", "-m", "xgbserver"]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Sets file's group to the root group and give the group the same permissions as the users. This is the recommendation of OpenShift (https://docs.openshift.com/container-platform/4.13/openshift_images/create-images.html#use-uid_create-images) to run under arbitrary user ids (but with those users also being member of the "root" group).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3041 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

```
kserve@sklearn-iris2-predictor-00001-deployment-6885c5658d-5szd4:/model-server$ id
uid=1000(kserve) gid=1000(kserve) groups=1000(kserve)

kserve@sklearn-iris2-predictor-00001-deployment-6885c5658d-5szd4:/$ ls -ld /model-server
drwxr-xr-x 1 root root 4096 Jan  2 07:25 /model-server

kserve@sklearn-iris2-predictor-00001-deployment-6885c5658d-5szd4:/model-server$ ls -l
total 28
drwxr-xr-x 1 kserve root 4096 Dec 27 06:25 kserve
drwxr-xr-x 1 kserve root 4096 Dec 27 06:25 sklearnserver
drwxr-xr-x 3 root   root 4096 Mar 29  2023 third_party
drwxr-xr-x 1 kserve root 4096 Jan  2 07:24 venv

kserve@sklearn-iris2-predictor-00001-deployment-6885c5658d-5szd4:/model-server$ ls -l kserve
total 348
-rw-rw-r-- 1 kserve root    269 Dec 27 06:25 Makefile
-rw-rw-r-- 1 kserve root     36 Mar 29  2023 OWNERS
-rw-rw-r-- 1 kserve root   6521 Nov 20 18:08 README.md
drwxrwxr-x 2 kserve root   4096 Nov 20 18:08 docs
-rw-rw-r-- 1 kserve root   1827 Nov 20 18:08 git_push.sh
drwxrwxr-x 1 kserve root   4096 Jan  2 07:12 kserve
-rw-rw-r-- 1 kserve root 302343 Dec 27 06:25 poetry.lock
-rw-rw-r-- 1 kserve root   2971 Dec 27 06:25 pyproject.toml
-rw-rw-r-- 1 kserve root     28 Nov 20 18:08 setup.cfg
drwxrwxr-x 4 kserve root   4096 Dec 22 08:19 test
-rw-rw-r-- 1 kserve root    111 Nov 20 18:08 test-requirements.txt
-rw-rw-r-- 1 kserve root    148 Nov 20 18:08 tox.ini
```

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support running model server with arbitary UID
```
