### PR TITLE
Fix azure workload identity federation by excluding azure client secret

### DIFF
--- a/pkg/credentials/azure/azure_secret.go
+++ b/pkg/credentials/azure/azure_secret.go
@@ -54,6 +54,7 @@ func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
 		if _, ok := secret.Data[legacyDataKey]; ok {
 			dataKey = legacyDataKey
 		}
+		//Leave out the AzureClientSecret env var if not defined as Data in the secret
 		if _, ok := secret.Data[dataKey]; !(!ok && dataKey == AzureClientSecret) {
 			envs = append(envs, v1.EnvVar{
 				Name: k,

--- a/pkg/credentials/azure/azure_secret.go
+++ b/pkg/credentials/azure/azure_secret.go
@@ -54,17 +54,19 @@ func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
 		if _, ok := secret.Data[legacyDataKey]; ok {
 			dataKey = legacyDataKey
 		}
-		envs = append(envs, v1.EnvVar{
-			Name: k,
-			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: secret.Name,
+		if _, ok := secret.Data[dataKey]; !(!ok && dataKey == AzureClientSecret) {
+			envs = append(envs, v1.EnvVar{
+				Name: k,
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: secret.Name,
+						},
+						Key: dataKey,
 					},
-					Key: dataKey,
 				},
-			},
-		})
+			})
+		}
 	}
 
 	return envs

--- a/pkg/credentials/azure/azure_secret_test.go
+++ b/pkg/credentials/azure/azure_secret_test.go
@@ -29,10 +29,16 @@ func TestAzureSecret(t *testing.T) {
 		secret   *v1.Secret
 		expected []v1.EnvVar
 	}{
-		"AzureSecretEnvs": {
+		"AzureSecretEnvsWithClientSecret": {
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "azcreds",
+				},
+				Data: map[string][]byte{
+					AzureSubscriptionId: []byte("AzureSubscriptionId"),
+					AzureTenantId:       []byte("AzureTenantId"),
+					AzureClientId:       []byte("AzureClientId"),
+					AzureClientSecret:   []byte("AzureClientSecret"),
 				},
 			},
 			expected: []v1.EnvVar{
@@ -77,6 +83,53 @@ func TestAzureSecret(t *testing.T) {
 								Name: "azcreds",
 							},
 							Key: AzureClientSecret,
+						},
+					},
+				},
+			},
+		},
+		"AzureSecretEnvsWithoutClientSecret": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "azcreds",
+				},
+				Data: map[string][]byte{
+					AzureSubscriptionId: []byte("AzureSubscriptionId"),
+					AzureTenantId:       []byte("AzureTenantId"),
+					AzureClientId:       []byte("AzureClientId"),
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name: AzureSubscriptionId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureSubscriptionId,
+						},
+					},
+				},
+				{
+					Name: AzureTenantId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureTenantId,
+						},
+					},
+				},
+				{
+					Name: AzureClientId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureClientId,
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
According to this [readme](https://github.com/kserve/kserve/tree/master/docs/samples/storage/azure#create-a-k8s-secret) it states that an `AZURE_CLIENT_SECRET` is not required and allows for managed identity federation. When I leave out this field in the secret, the storage initializer init container cannot start due to the missing field `AZURE_CLIENT_SECRET`. The `AZURE_CLIENT_SECRET` is always added as an env variable, even if not filled in. 

This PR modifies the env variable injection so that  `AZURE_CLIENT_SECRET` is only injected when filled in.

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- [x] unit test
- [x] Deployed forked image on azure cluster to verify


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation? (not needed)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix azure workload identity federation for the storage initializer by excluding azure client secret
```
