### PR TITLE
Fix Raw Logger E2E

### DIFF
--- a/test/e2e/logger/test_raw_logger.py
+++ b/test/e2e/logger/test_raw_logger.py
@@ -49,7 +49,8 @@ def test_kserve_logger():
     isvc = V1beta1InferenceService(api_version=constants.KSERVE_V1BETA1,
                                    kind=constants.KSERVE_KIND,
                                    metadata=client.V1ObjectMeta(
-                                        name=msg_dumper, namespace=KSERVE_TEST_NAMESPACE),
+                                        name=msg_dumper, namespace=KSERVE_TEST_NAMESPACE,
+                                        annotations=annotations),
                                    spec=V1beta1InferenceServiceSpec(predictor=predictor))
 
     kserve_client.create(isvc)
@@ -60,7 +61,7 @@ def test_kserve_logger():
         min_replicas=1,
         logger=V1beta1LoggerSpec(
             mode="all",
-            url="http://"+msg_dumper+"."+KSERVE_TEST_NAMESPACE+".svc.cluster.local"
+            url="http://"+msg_dumper+"-predictor."+KSERVE_TEST_NAMESPACE+".svc.cluster.local"
         ),
         sklearn=V1beta1SKLearnSpec(
             storage_uri='gs://kfserving-examples/models/sklearn/1.0/model',


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a small fix to the test_raw_logger.py/test_kserve_logger E2E test.

This E2E test was creating a `message-dumper-raw` that was dependent on a Serverless setup, leading to the E2E to fail on an environment where Istio nor KNative are available.

The fix is to add the right annotation to `message-dumper-raw` to deploy it in Raw mode, and adjust the logger URL of the `isvc-logger-raw` to point to the Kubernetes Service, rather than the KNative service.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
