### PR TITLE
Reduce E2Es dependency on CI environment

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  IMAGE_TRANSFORMER_IMG: "kserve/image-transformer:${{ github.sha }}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/test/e2e/custom/test_custom_model_grpc.py
+++ b/test/e2e/custom/test_custom_model_grpc.py
@@ -202,8 +202,7 @@ def test_predictor_grpc_with_transformer_http():
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/image-transformer:"
-                      + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("IMAGE_TRANSFORMER_IMG"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"}),

--- a/test/e2e/predictor/test_triton.py
+++ b/test/e2e/predictor/test_triton.py
@@ -91,8 +91,7 @@ def test_triton_runtime_with_transformer():
     transformer = V1beta1TransformerSpec(
         min_replicas=1,
         containers=[V1Container(
-                      image='kserve/image-transformer:'
-                            + os.environ.get("GITHUB_SHA"),
+                      image=os.environ.get("IMAGE_TRANSFORMER_IMG"),
                       name='kserve-container',
                       resources=V1ResourceRequirements(
                           requests={'cpu': '10m', 'memory': '128Mi'},

--- a/test/e2e/transformer/test_collocation.py
+++ b/test/e2e/transformer/test_collocation.py
@@ -59,7 +59,7 @@ def test_transformer_collocation():
             ),
             V1Container(
                 name=TRANSFORMER_CONTAINER,
-                image='kserve/image-transformer:' + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("IMAGE_TRANSFORMER_IMG"),
                 args=[f"--model_name={model_name}", "--http_port=8080", "--grpc_port=8081",
                       "--predictor_host=localhost:8085"],
                 ports=[
@@ -124,7 +124,7 @@ def test_raw_transformer_collocation():
             ),
             V1Container(
                 name=TRANSFORMER_CONTAINER,
-                image='kserve/image-transformer:' + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("IMAGE_TRANSFORMER_IMG"),
                 args=[f"--model_name={model_name}", "--http_port=8080", "--grpc_port=8081",
                       "--predictor_host=localhost:8085"],
                 ports=[

--- a/test/e2e/transformer/test_raw_transformer.py
+++ b/test/e2e/transformer/test_raw_transformer.py
@@ -47,8 +47,7 @@ def test_transformer():
     transformer = V1beta1TransformerSpec(
         min_replicas=1,
         containers=[V1Container(
-            image='kserve/image-transformer:'
-                  + os.environ.get("GITHUB_SHA"),
+            image=os.environ.get("IMAGE_TRANSFORMER_IMG"),
             name='kserve-container',
             resources=V1ResourceRequirements(
                 requests={"cpu": "50m", "memory": "128Mi"},

--- a/test/e2e/transformer/test_transformer.py
+++ b/test/e2e/transformer/test_transformer.py
@@ -46,8 +46,7 @@ def test_transformer():
     transformer = V1beta1TransformerSpec(
         min_replicas=1,
         containers=[V1Container(
-                      image='kserve/image-transformer:'
-                            + os.environ.get("GITHUB_SHA"),
+                      image=os.environ.get("IMAGE_TRANSFORMER_IMG"),
                       name='kserve-container',
                       resources=V1ResourceRequirements(
                           requests={'cpu': '10m', 'memory': '128Mi'},


### PR DESCRIPTION
**What this PR does / why we need it**:

Some code of the E2Es assume the environment is GitHub, because it is referring to GitHub-specific variables.

This PR focuses on references to the `kserve/image-transformer` image. This image is built in the CI flow and made available to the runner, so that a pull from an external registry is not needed.

The references to this image are changed to an environment variable that is more agnostic to the runner, in an effort to make E2Es more compatible in other environments. The e2e-test.yml is modified to declare the new variable.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
