### PR TITLE
fix: Correct args override behavior in runtime and predictor containers

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -211,7 +211,30 @@ func MergeRuntimeContainers(runtimeContainer *v1.Container, predictorContainer *
 	if mergedContainer.Name == "" {
 		mergedContainer.Name = runtimeContainerName
 	}
+
+	// Only concatenate args when there's no overlap. See discussions in https://github.com/kserve/kserve/pull/3444
+	if len(findIntersection(runtimeContainer.Args, predictorContainer.Args)) == 0 {
+		mergedContainer.Args = append(append([]string{}, runtimeContainer.Args...), predictorContainer.Args...)
+	}
+
 	return &mergedContainer, nil
+}
+
+func findIntersection(arr1, arr2 []string) []string {
+	intersection := make([]string, 0)
+
+	// Traverse each element in arr1
+	for _, num1 := range arr1 {
+		// Check if num1 exists in arr2
+		for _, num2 := range arr2 {
+			if num1 == num2 {
+				intersection = append(intersection, num1)
+				break
+			}
+		}
+	}
+
+	return intersection
 }
 
 // MergePodSpec Merge the predictor PodSpec struct with the runtime PodSpec struct, allowing users

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -46,7 +46,7 @@ import (
 // Constants
 var (
 	SupportedStorageURIPrefixList = []string{"gs://", "s3://", "pvc://", "file://", "https://", "http://", "hdfs://", "webhdfs://", "oci://"}
-	log                           = logf.Log.WithName("CredentialBuilder")
+	log                           = logf.Log.WithName("InferenceServiceUtils")
 )
 
 const (

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -222,18 +222,16 @@ func MergeRuntimeContainers(runtimeContainer *v1.Container, predictorContainer *
 
 func findIntersection(arr1, arr2 []string) []string {
 	intersection := make([]string, 0)
-
 	// Traverse each element in arr1
-	for _, num1 := range arr1 {
-		// Check if num1 exists in arr2
-		for _, num2 := range arr2 {
-			if num1 == num2 {
-				intersection = append(intersection, num1)
+	for _, elem1 := range arr1 {
+		// Check if elem1 exists in arr2
+		for _, elem2 := range arr2 {
+			if elem1 == elem2 {
+				intersection = append(intersection, elem1)
 				break
 			}
 		}
 	}
-
 	return intersection
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -211,10 +211,6 @@ func MergeRuntimeContainers(runtimeContainer *v1.Container, predictorContainer *
 	if mergedContainer.Name == "" {
 		mergedContainer.Name = runtimeContainerName
 	}
-
-	// Strategic merge patch will replace args but more useful behaviour here is to concatenate
-	mergedContainer.Args = append(append([]string{}, runtimeContainer.Args...), predictorContainer.Args...)
-
 	return &mergedContainer, nil
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -727,6 +727,7 @@ func TestMergeRuntimeContainers(t *testing.T) {
 			},
 			containerOverride: &v1.Container{
 				Args: []string{
+					"--test=dummy",
 					"--new-arg=baz",
 				},
 				Env: []v1.EnvVar{
@@ -744,7 +745,6 @@ func TestMergeRuntimeContainers(t *testing.T) {
 				Name:  "kserve-container",
 				Image: "default-image",
 				Args: []string{
-					"--foo=bar",
 					"--test=dummy",
 					"--new-arg=baz",
 				},

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -727,7 +727,6 @@ func TestMergeRuntimeContainers(t *testing.T) {
 			},
 			containerOverride: &v1.Container{
 				Args: []string{
-					"--test=dummy",
 					"--new-arg=baz",
 				},
 				Env: []v1.EnvVar{
@@ -745,6 +744,7 @@ func TestMergeRuntimeContainers(t *testing.T) {
 				Name:  "kserve-container",
 				Image: "default-image",
 				Args: []string{
+					"--foo=bar",
 					"--test=dummy",
 					"--new-arg=baz",
 				},
@@ -762,6 +762,72 @@ func TestMergeRuntimeContainers(t *testing.T) {
 						v1.ResourceCPU:    resource.MustParse("1"),
 						v1.ResourceMemory: resource.MustParse("2Gi"),
 					},
+				},
+			},
+		},
+		"OverlappingContainerArgs": {
+			containerBase: &v1.Container{
+				Name:  "kserve-container",
+				Image: "default-image",
+				Args: []string{
+					"--foo=bar",
+					"--test=dummy",
+				},
+			},
+			containerOverride: &v1.Container{
+				Args: []string{
+					"--foo=bar",
+					"--new=v1",
+				},
+			},
+			expected: &v1.Container{
+				Name:  "kserve-container",
+				Image: "default-image",
+				Args: []string{
+					"--foo=bar",
+					"--new=v1",
+				},
+			},
+		},
+		"EmptyOverrideContainerArgs": {
+			containerBase: &v1.Container{
+				Name:  "kserve-container",
+				Image: "default-image",
+				Args: []string{
+					"--foo=bar",
+					"--test=dummy",
+				},
+			},
+			containerOverride: &v1.Container{
+				Args: []string{},
+			},
+			expected: &v1.Container{
+				Name:  "kserve-container",
+				Image: "default-image",
+				Args: []string{
+					"--foo=bar",
+					"--test=dummy",
+				},
+			},
+		},
+		"EmptyBaseContainerArgs": {
+			containerBase: &v1.Container{
+				Name:  "kserve-container",
+				Image: "default-image",
+				Args:  []string{},
+			},
+			containerOverride: &v1.Container{
+				Args: []string{
+					"--foo=bar",
+					"--test=dummy",
+				},
+			},
+			expected: &v1.Container{
+				Name:  "kserve-container",
+				Image: "default-image",
+				Args: []string{
+					"--foo=bar",
+					"--test=dummy",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes https://github.com/kserve/kserve/issues/3453. The current args from two container specs are being merged in a naive way and cannot handle complex use cases.
1. Key and value are separated to different args, e.g. `--foo bar`  vs `--foo=newBar`
1. Boolean flags, especially when it comes to merging/overriding, e.g. `--bool-flag`
1. Handle duplicates and different ordering of args

The code can be complex if we want to cover these cases.

if there's an overlap, we don't merge them since the merge result will be incorrect and contain duplicates. In addition, instead of overriding individual args, we should simply replace the entire list of args by the list of args defined in `InferenceService`. This PR corrects the behavior.