### PR TITLE
Fix dup metrics aggr port

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -153,3 +153,19 @@ func AppendEnvVarIfNotExists(slice []v1.EnvVar, elems ...v1.EnvVar) []v1.EnvVar 
 	}
 	return slice
 }
+
+func AppendPortIfNotExists(slice []v1.ContainerPort, elems ...v1.ContainerPort) []v1.ContainerPort {
+	for _, elem := range elems {
+		isElemExists := false
+		for _, item := range slice {
+			if item.Name == elem.Name {
+				isElemExists = true
+				break
+			}
+		}
+		if isElemExists == false {
+			slice = append(slice, elem)
+		}
+	}
+	return slice
+}

--- a/pkg/webhook/admission/pod/metrics_aggregate_injector.go
+++ b/pkg/webhook/admission/pod/metrics_aggregate_injector.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	"strconv"
 )
@@ -70,7 +71,7 @@ func setMetricAggregationEnvVarsAndPorts(pod *v1.Pod) {
 			// Set the port that queue-proxy will use to expose the aggregate metrics.
 			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: constants.QueueProxyAggregatePrometheusMetricsPortEnvVarKey, Value: strconv.Itoa(constants.QueueProxyAggregatePrometheusMetricsPort)})
 
-			pod.Spec.Containers[i].Ports = append(pod.Spec.Containers[i].Ports, v1.ContainerPort{
+			pod.Spec.Containers[i].Ports = utils.AppendPortIfNotExists(pod.Spec.Containers[i].Ports, v1.ContainerPort{
 				Name:          constants.AggregateMetricsPortName,
 				ContainerPort: int32(constants.QueueProxyAggregatePrometheusMetricsPort),
 				Protocol:      "TCP",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix the issue for duplicated metrics port when the webhook is invoked for multiple times. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
