### PR TITLE
fix: HuggingFace predictor should not be recognized as multi-model server

### DIFF
--- a/pkg/apis/serving/v1beta1/predictor.go
+++ b/pkg/apis/serving/v1beta1/predictor.go
@@ -116,6 +116,7 @@ func (s *PredictorSpec) GetImplementations() []ComponentImplementation {
 		s.PMML,
 		s.LightGBM,
 		s.Paddle,
+		s.HuggingFace,
 		s.Model,
 	})
 	// This struct is not a pointer, so it will never be nil; include if containers are specified

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -64,7 +64,13 @@ func IsMMSPredictor(predictor *v1beta1api.PredictorSpec) bool {
 		}
 		return false
 	} else {
-		return predictor.GetImplementation().GetStorageUri() == nil && predictor.GetImplementation().GetStorageSpec() == nil
+		impl := predictor.GetImplementation()
+		res := impl.GetStorageUri() == nil && impl.GetStorageSpec() == nil
+		// HuggingFace supports model ID without storage initializer, but it should not be a multi-model server.
+		if predictor.HuggingFace != nil {
+			return false
+		}
+		return res
 	}
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -67,7 +67,7 @@ func IsMMSPredictor(predictor *v1beta1api.PredictorSpec) bool {
 		impl := predictor.GetImplementation()
 		res := impl.GetStorageUri() == nil && impl.GetStorageSpec() == nil
 		// HuggingFace supports model ID without storage initializer, but it should not be a multi-model server.
-		if predictor.HuggingFace != nil {
+		if predictor.HuggingFace != nil || (predictor.Model != nil && predictor.Model.ModelFormat.Name == "huggingface") {
 			return false
 		}
 		return res

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -99,6 +99,20 @@ func TestIsMMSPredictor(t *testing.T) {
 			},
 			expected: false,
 		},
+		"HuggingFaceModel": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hg-model",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						HuggingFace: &HuggingFaceRuntimeSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{RuntimeVersion: proto.String("latest")}},
+					},
+				},
+			},
+			expected: false,
+		},
 		"CustomSpec": {
 			isvc: InferenceService{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Otherwise, the the model agent is always injected to the HuggingFace runtime.