### PR TITLE
Fix:  vllm backend does not work with model_dir for huggingface runtime

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/model.py
+++ b/python/huggingfaceserver/huggingfaceserver/model.py
@@ -99,16 +99,15 @@ class HuggingfaceModel(Model):  # pylint:disable=c-extension-no-member
         return model_cls
 
     def load(self) -> bool:
-        if self.use_vllm and self.device == torch.device("cuda"):   # vllm needs gpu
-            if self.infer_vllm_supported_from_model_architecture(self.model_id) is not None:
-                self.vllm_engine = AsyncLLMEngine.from_engine_args(self.vllm_engine_args)
-                self.ready = True
-                return self.ready
-
         model_id_or_path = self.model_id
         if self.model_dir:
             model_id_or_path = pathlib.Path(Storage.download(self.model_dir))
             # TODO Read the mapping file, index to object name
+        if self.use_vllm and self.device == torch.device("cuda"):   # vllm needs gpu
+            if self.infer_vllm_supported_from_model_architecture(model_id_or_path):
+                self.vllm_engine = AsyncLLMEngine.from_engine_args(self.vllm_engine_args)
+                return True
+
         if not self.task:
             self.task = self.infer_task_from_model_architecture(model_id_or_path)
         # load huggingface tokenizer

--- a/python/huggingfaceserver/huggingfaceserver/model.py
+++ b/python/huggingfaceserver/huggingfaceserver/model.py
@@ -153,7 +153,7 @@ class HuggingfaceModel(Model):  # pylint:disable=c-extension-no-member
                 return_tensors=TensorType.NUMPY,
                 return_token_type_ids=self.return_token_type_ids,
                 padding=True,
-                truncation=True,
+                truncation=True
             )
             context["payload"] = payload
             context["input_ids"] = inputs["input_ids"]
@@ -173,7 +173,7 @@ class HuggingfaceModel(Model):  # pylint:disable=c-extension-no-member
                 return_tensors=TensorType.PYTORCH,
                 return_token_type_ids=self.return_token_type_ids,
                 padding=True,
-                truncation=True,
+                truncation=True
             )
             context["payload"] = payload
             context["input_ids"] = inputs["input_ids"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

```
Traceback (most recent call last):
  File "/prod_venv/lib/python3.10/site-packages/transformers/utils/hub.py", line 385, in cached_file
    resolved_file = hf_hub_download(
  File "/prod_venv/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 118, in _inner_fn
    return fn(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1371, in hf_hub_download
    raise LocalEntryNotFoundError(
huggingface_hub.utils._errors.LocalEntryNotFoundError: An error happened while trying to locate the file on the Hub and we cannot find the requested files in the local cache. Please check your connection and try again or make sure your Internet connection is on.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/huggingfaceserver/huggingfaceserver/__main__.py", line 69, in <module>
    model.load()
  File "/huggingfaceserver/huggingfaceserver/model.py", line 103, in load
    if self.infer_vllm_supported_from_model_architecture(self.model_id) is not None:
  File "/huggingfaceserver/huggingfaceserver/model.py", line 94, in infer_vllm_supported_from_model_architecture
    model_config = AutoConfig.from_pretrained(model_config_path)
  File "/prod_venv/lib/python3.10/site-packages/transformers/models/auto/configuration_auto.py", line 1100, in from_pretrained
    config_dict, unused_kwargs = PretrainedConfig.get_config_dict(pretrained_model_name_or_path, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/transformers/configuration_utils.py", line 634, in get_config_dict
    config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/transformers/configuration_utils.py", line 689, in _get_config_dict
    resolved_config_file = cached_file(
  File "/prod_venv/lib/python3.10/site-packages/transformers/utils/hub.py", line 425, in cached_file
    raise EnvironmentError(
OSError: We couldn't connect to 'https://huggingface.co' to load this file, couldn't find it in the cached files and it looks like None is not the path to a directory containing a file named config.json
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
