### PR TITLE
Change `certificate` to `ca_bundle` in json style of s3 storageSecret 

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -117,7 +117,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
                 ("AWS_ACCESS_KEY_ID", "access_key_id"),
                 ("AWS_SECRET_ACCESS_KEY", "secret_access_key"),
                 ("AWS_DEFAULT_REGION", "region"),
-                ("AWS_CA_BUNDLE", "certificate_path"),
+                ("AWS_CA_BUNDLE", "ca_bundle"),
                 ("S3_VERIFY_SSL", "verify_ssl"),
                 ("awsAnonymousCredential", "anonymous"),
             ):

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -117,7 +117,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
                 ("AWS_ACCESS_KEY_ID", "access_key_id"),
                 ("AWS_SECRET_ACCESS_KEY", "secret_access_key"),
                 ("AWS_DEFAULT_REGION", "region"),
-                ("AWS_CA_BUNDLE", "certificate"),
+                ("AWS_CA_BUNDLE", "certificate_path"),
                 ("S3_VERIFY_SSL", "verify_ssl"),
                 ("awsAnonymousCredential", "anonymous"),
             ):

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -251,7 +251,7 @@ def test_update_with_storage_spec_s3(monkeypatch):
         "region": "us-east-2",
         "secret_access_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "type": "s3",
-        "certificate_path": "/path/to/cabundle.crt",
+        "ca_bundle": "/path/to/cabundle.crt",
         "verify_ssl": "false",
         "anonymous": "True",
     }
@@ -263,7 +263,7 @@ def test_update_with_storage_spec_s3(monkeypatch):
     assert os.getenv("AWS_ACCESS_KEY_ID") == storage_config["access_key_id"]
     assert os.getenv("AWS_SECRET_ACCESS_KEY") == storage_config["secret_access_key"]
     assert os.getenv("AWS_DEFAULT_REGION") == storage_config["region"]
-    assert os.getenv("AWS_CA_BUNDLE") == storage_config["certificate_path"]
+    assert os.getenv("AWS_CA_BUNDLE") == storage_config["ca_bundle"]
     assert os.getenv("S3_VERIFY_SSL") == storage_config["verify_ssl"]
     assert os.getenv("awsAnonymousCredential") == storage_config["anonymous"]
 

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -251,7 +251,7 @@ def test_update_with_storage_spec_s3(monkeypatch):
         "region": "us-east-2",
         "secret_access_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "type": "s3",
-        "certificate": "/path/to/ca.bundle",
+        "certificate_path": "/path/to/cabundle.crt",
         "verify_ssl": "false",
         "anonymous": "True",
     }
@@ -263,7 +263,7 @@ def test_update_with_storage_spec_s3(monkeypatch):
     assert os.getenv("AWS_ACCESS_KEY_ID") == storage_config["access_key_id"]
     assert os.getenv("AWS_SECRET_ACCESS_KEY") == storage_config["secret_access_key"]
     assert os.getenv("AWS_DEFAULT_REGION") == storage_config["region"]
-    assert os.getenv("AWS_CA_BUNDLE") == storage_config["certificate"]
+    assert os.getenv("AWS_CA_BUNDLE") == storage_config["certificate_path"]
     assert os.getenv("S3_VERIFY_SSL") == storage_config["verify_ssl"]
     assert os.getenv("awsAnonymousCredential") == storage_config["anonymous"]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kserve/kserve/issues/3462

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

The `certifcate` in kserve was useless until this PR(https://github.com/kserve/kserve/pull/3250) merged. Even after the merge, `certificate` can not be used solely so changing the field does not impact anything.

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
