### PR TITLE
fix: Service existence check should check all spec fields

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -157,8 +157,7 @@ func (r *ServiceReconciler) checkServiceExist(client client.Client) (constants.C
 }
 
 func semanticServiceEquals(desired, existing *corev1.Service) bool {
-	return equality.Semantic.DeepEqual(desired.Spec.Ports, existing.Spec.Ports) &&
-		equality.Semantic.DeepEqual(desired.Spec.Selector, existing.Spec.Selector)
+	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec)
 }
 
 // Reconcile ...


### PR DESCRIPTION
There is an edge case where a service with the same name exists but they have different configurations. The PR adds a more strict check.
