### PR TITLE
remove unnecessary Istio settings from quick_install.sh

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -78,7 +78,6 @@ spec:
     global:
       proxy:
         autoInject: disabled
-      useMCP: false
 
   meshConfig:
     accessLogFile: /dev/stdout
@@ -99,9 +98,6 @@ spec:
             memory: 200Mi
         podAnnotations:
           cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-        env:
-        - name: PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING
-          value: "false"
 EOF
 
 bin/istioctl manifest apply -f istio-minimal-operator.yaml -y;


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing the `useMCP` and `PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING` as both of these already default to the values they are being set to.

**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue) 

**Feature/Issue validation/testing**:

Checked the minimal Istio profile where the `useMCP` defaults to false (e.g. `istioctl manifest generate --set profile=minimal | grep useMCP`). The `PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING` flag defaults to false in [Istio's source](https://github.com/istio/istio/blob/a8eae20529e2f24a9c07a9f9caf03411d194a035/pilot/pkg/features/experimental.go#L6).
