### PR TITLE
Update cert manager version in quick install script

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -35,7 +35,7 @@ export ISTIO_DIR=istio-${ISTIO_VERSION}
 export KNATIVE_SERVING_VERSION=knative-v1.10.1
 export KNATIVE_ISTIO_VERSION=knative-v1.10.0
 export KSERVE_VERSION=v0.12.0
-export CERT_MANAGER_VERSION=v1.3.0
+export CERT_MANAGER_VERSION=v1.9.0
 export SCRIPT_DIR="$( dirname -- "${BASH_SOURCE[0]}" )"
 
 cleanup(){


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the cert manager version to v1.9.0 in the quick_install.sh script. In the [documentation](https://kserve.github.io/website/master/admin/serverless/serverless/#3-install-cert-manager), we are advised to use v1.9.0, however in the quick_install.sh script, an old version (v1.3.0) of the cert manager is being used.

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)