### PR TITLE
ci: Bump minikube version to work with newer K8s version

### DIFF
--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Setup Minikube
       uses: medyagh/setup-minikube@latest
       with:
-        minikube-version: '1.31.1'
+        minikube-version: '1.32.0'
         kubernetes-version: 'v1.27.4'
         driver: 'none'
         network-plugin: 'cni'


### PR DESCRIPTION
This warning is on CI builds due to unsupported combination between Minikube and K8s versions and CI sometimes has issue to set up minikube + K8s. Example: https://github.com/kserve/kserve/actions/runs/8145181761/job/22261191715?pr=3443

```
/home/runner/bin/minikube start --cni calico --driver none --kubernetes-version v1.27.4 --network-plugin cni --wait all --wait-timeout=6m0s
* minikube v1.31.1 on Ubuntu 22.04
! Specified Kubernetes version 1.27.4 is newer than the newest supported version: v1.27.3. Use `minikube config defaults kubernetes-version` for details.
```

Upgrading minikube could potentially help alleviate this issue from happening frequently.