### PR TITLE
Make the modelcar injection idempotent

### DIFF
--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -121,7 +121,9 @@ func GetContainerSpecForStorageUri(storageUri string, client client.Client) (*v1
 
 // InjectModelcar injects a sidecar with the full model included to the Pod.
 // This so called "modelcar" is then directly accessed from the user container
-// via the proc filesystem (possible when `shareProcessNamespace` is enabled in the Pod spec)
+// via the proc filesystem (possible when `shareProcessNamespace` is enabled in the Pod spec).
+// This method is idempotent so can be called multiple times like it happens when the
+// webhook is configured with `reinvocationPolicy: IfNeeded`
 func (mi *StorageInitializerInjector) InjectModelcar(pod *v1.Pod) error {
 	srcURI, ok := pod.ObjectMeta.Annotations[constants.StorageInitializerSourceUriInternalAnnotationKey]
 	if !ok {
@@ -134,12 +136,7 @@ func (mi *StorageInitializerInjector) InjectModelcar(pod *v1.Pod) error {
 	}
 
 	// Add an emptyDir Volume to Pod
-	pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-		Name: StorageInitializerVolumeName,
-		VolumeSource: v1.VolumeSource{
-			EmptyDir: &v1.EmptyDirVolumeSource{},
-		},
-	})
+	addEmptyDirVolumeIfNotPresent(pod, StorageInitializerVolumeName)
 
 	// Extract image reference for modelcar from URI
 	image := strings.TrimPrefix(srcURI, OciURIPrefix)
@@ -155,14 +152,10 @@ func (mi *StorageInitializerInjector) InjectModelcar(pod *v1.Pod) error {
 	addOrReplaceEnv(userContainer, ModelInitModeEnv, "async")
 
 	// Mount volume initialized by the modelcar container to the user container and transformer (if exists)
-	modelMount := v1.VolumeMount{
-		Name:      StorageInitializerVolumeName,
-		MountPath: getParentDirectory(constants.DefaultModelLocalMountPath),
-		ReadOnly:  false,
-	}
-	userContainer.VolumeMounts = append(userContainer.VolumeMounts, modelMount)
+	modelParentDir := getParentDirectory(constants.DefaultModelLocalMountPath)
+	addVolumeMountIfNotPresent(userContainer, StorageInitializerVolumeName, modelParentDir)
 	if transformerContainer != nil {
-		transformerContainer.VolumeMounts = append(transformerContainer.VolumeMounts, modelMount)
+		addVolumeMountIfNotPresent(transformerContainer, StorageInitializerVolumeName, modelParentDir)
 	}
 
 	// If configured, run as the given user. There might be certain installations
@@ -175,9 +168,11 @@ func (mi *StorageInitializerInjector) InjectModelcar(pod *v1.Pod) error {
 	}
 
 	// Create the modelcar that is used as a sidecar in Pod and add it to the end
-	// of the containers
-	modelContainer := mi.createModelContainer(image, constants.DefaultModelLocalMountPath)
-	pod.Spec.Containers = append(pod.Spec.Containers, *modelContainer)
+	// of the containers (but only if not already have been added)
+	if getContainerWithName(pod, ModelcarContainerName) == nil {
+		modelContainer := mi.createModelContainer(image, constants.DefaultModelLocalMountPath)
+		pod.Spec.Containers = append(pod.Spec.Containers, *modelContainer)
+	}
 
 	// Enable process namespace sharing so that the modelcar's root filesystem
 	// can be reached by the user container
@@ -689,7 +684,39 @@ func (mi *StorageInitializerInjector) createModelContainer(image string, modelPa
 	return modelContainer
 }
 
-// GetParentDirectory returns the parent directory of the given path,
+// addEmptyDirVolumeIfNotPresent adds an emptyDir volume only if not present in the
+// list. pod and pod.Spec must not be nil
+func addEmptyDirVolumeIfNotPresent(pod *v1.Pod, name string) {
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == name {
+			return
+		}
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+		Name: name,
+		VolumeSource: v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{},
+		},
+	})
+}
+
+// addVolumeMountIfNotPresent adds a volume mount to a given container but only if no volumemoun
+// with this name has been already added. container must not be nil
+func addVolumeMountIfNotPresent(container *v1.Container, mountName string, mountPath string) {
+	for _, v := range container.VolumeMounts {
+		if v.Name == mountName {
+			return
+		}
+	}
+	modelMount := v1.VolumeMount{
+		Name:      mountName,
+		MountPath: mountPath,
+		ReadOnly:  false,
+	}
+	container.VolumeMounts = append(container.VolumeMounts, modelMount)
+}
+
+// getParentDirectory returns the parent directory of the given path,
 // or "/" if the path is a top-level directory.
 func getParentDirectory(path string) string {
 	// Get the parent directory

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -2788,6 +2789,28 @@ func checkVolumeMounts(t *testing.T, pod *v1.Pod, containerNames []string) {
 		assert.Len(t, volumeMounts, 1)
 		assert.Equal(t, volumeMounts[0].MountPath, getParentDirectory(constants.DefaultModelLocalMountPath))
 	}
+}
+
+func TestModelcarIdempotency(t *testing.T) {
+	t.Run("Test that calling the modelcar injector twice results with the same input pod, the injected pod is the same", func(t *testing.T) {
+		podReference := createTestPodForModelcarWithTransformer()
+		pod := createTestPodForModelcarWithTransformer()
+
+		injector := &StorageInitializerInjector{config: &StorageInitializerConfig{}}
+
+		// Inject modelcar twice
+		err := injector.InjectModelcar(pod)
+		assert.Nil(t, err)
+		err = injector.InjectModelcar(pod)
+		assert.Nil(t, err)
+
+		// Reference modelcar
+		err = injector.InjectModelcar(podReference)
+		assert.Nil(t, err)
+
+		// It should not make a difference if the modelcar is injected once or twice
+		assert.True(t, reflect.DeepEqual(podReference, pod))
+	})
 }
 
 func TestStorageInitializerInjectorWithModelcarConfig(t *testing.T) {


### PR DESCRIPTION
Due to changes in https://github.com/kserve/kserve/commit/39b8a6748732349f72d0701076c85e66d630755f which added `reinvocationPolicy: IfNeeded` to the WebHook configuration, the injection function can (and will be) called multiple times, and needs to be idempotent (which is a good thing anyway).

This commit fixes the array field handling and adds volumes, volume mounts, and containers only if they are still needed to be added.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

It fixes an issue with model car injection when using `reinvocationPolicy: IfNeeded` in the webhook configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3506 

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Unit test that checks via `reflect.DeepEquals` that running the inject code twice results in the same pod

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [X] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation? --> no change needed

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issue with modelcar injection
```