### PR TITLE
Remove GOARCH

### DIFF
--- a/tools/tf2openapi/Dockerfile
+++ b/tools/tf2openapi/Dockerfile
@@ -9,7 +9,7 @@ COPY go.mod  go.mod
 COPY go.sum  go.sum
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o tf2openapi ./tools/tf2openapi/cmd
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o tf2openapi ./tools/tf2openapi/cmd
 
 # Copy tf2openapi into a thin image
 FROM gcr.io/distroless/static:nonroot


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

While running the go build this variable will be set by default to target architecture, we don't need an explicit mention for the architecture. This PR is for removing the same so that this can be consumed easily on any non-amd64 platform easily.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] docker build
- [x] docker run

- Logs
```shell
[root@mkumatag-vm-ai kserve]# docker build -t tf2openapi:latest -f tools/tf2openapi/Dockerfile .
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
[1/2] STEP 1/7: FROM golang:1.21 AS builder
[1/2] STEP 2/7: WORKDIR /go/src/github.com/kserve/kserve
--> Using cache 8e3a6b0063c2d28afb71b93fa1d67109fd27a2a88034f36a20249c89cd286bc9
--> 8e3a6b0063c2
[1/2] STEP 3/7: COPY tools/  tools/
--> 035a20b4a64c
[1/2] STEP 4/7: COPY pkg/    pkg/
--> 0bafaaa08a63
[1/2] STEP 5/7: COPY go.mod  go.mod
--> 425324af6cff
[1/2] STEP 6/7: COPY go.sum  go.sum
--> 6d9245acfd1e
[1/2] STEP 7/7: RUN CGO_ENABLED=0 GOOS=linux go build -a -o tf2openapi ./tools/tf2openapi/cmd
go: downloading github.com/spf13/cobra v1.8.0
go: downloading google.golang.org/protobuf v1.32.0
go: downloading github.com/getkin/kin-openapi v0.120.0
go: downloading github.com/google/go-cmp v0.6.0
go: downloading k8s.io/api v0.28.4
.....
.....
go: downloading go.uber.org/multierr v1.11.0
--> 46748b9e8b33
[2/2] STEP 1/5: FROM gcr.io/distroless/static:nonroot
Trying to pull gcr.io/distroless/static:nonroot...
Getting image source signatures
Copying blob 33e068de2649 done   |
Copying blob be1681d2fb7c done   |
Copying blob 6b16ad2aede1 done   |
Copying blob fe5ca62666f0 done   |
Copying blob b6824ed73363 done   |
Copying blob 7c12895b777b done   |
Copying blob 5664b15f108b done   |
Copying blob 27be814a09eb done   |
Copying blob 4aa0ea1413d3 done   |
Copying blob 9ef7d74bdfdf done   |
Copying blob 9112d77ee5b1 done   |
Copying config f9846c4939 done   |
Writing manifest to image destination
[2/2] STEP 2/5: WORKDIR /
--> d204325041d2
[2/2] STEP 3/5: COPY third_party/ third_party/
--> 7e502e87b818
[2/2] STEP 4/5: COPY --from=builder /go/src/github.com/kserve/kserve/tf2openapi .
--> e384a554115a
[2/2] STEP 5/5: ENTRYPOINT ["/tf2openapi"]
[2/2] COMMIT tf2openapi:latest
--> 2156d4602ce5
Successfully tagged localhost/tf2openapi:latest
2156d4602ce511617e8ed846bfae98cbd163e94ac90ea6a581a1a65dd53eba76
[root@mkumatag-vm-ai kserve]#

[root@mkumatag-vm-ai kserve]# docker run -ti localhost/tf2openapi:latest --help
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
This tool takes TensorFlow SavedModel files as inputs and generates OpenAPI 3.0
			specifications for HTTP prediction requests. The SavedModel files must
			contain signature definitions (SignatureDefs) for models.

Usage:
  tf2openapi [flags]

Flags:
  -h, --help                     help for tf2openapi
  -t, --metagraph_tags strings   All tags identifying desired MetaGraph
  -m, --model_base_path string   Absolute path of SavedModel file
  -n, --name string              Name of model (default "model")
  -o, --output_file string       Absolute path of file to write OpenAPI spec to
  -s, --signature_def string     Serving SignatureDef Key
  -v, --version string           Model version (default "1")
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
