### PR TITLE
Allow rerunning failed workflows by comment

### DIFF
--- a/.github/workflows/re-run-actions.yml
+++ b/.github/workflows/re-run-actions.yml
@@ -1,0 +1,16 @@
+name: Re-Run PR tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_pr_tests:
+    name: rerun_pr_tests
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: estroz/rerun-actions@main
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        comment_id: ${{ github.event.comment.id }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

### Re-running failed tests
The following commands are supported by this action:

`/rerun-all` - rerun all failed workflows.
`/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

### Some notes:

The PR either must have an `ok-to-test` label present on the PR, or the user who writes a command must be an organization member, or repo owner, contributor, or collaborator.
Typically `ok-to-test` can/should only be applied by repo reviewers/approvers to prevent spam and abuse.

**Reference:** https://github.com/estroz/rerun-actions 

**Fixes** #3631 


**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


```release-note
NONE
```
