### PR TITLE
Explicitly specify pad token id when generating tokens 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ CUSTOM_MODEL_IMG ?= custom-model
 CUSTOM_MODEL_GRPC_IMG ?= custom-model-grpc
 CUSTOM_TRANSFORMER_IMG ?= image-transformer
 CUSTOM_TRANSFORMER_GRPC_IMG ?= custom-image-transformer-grpc
+HUGGINGFACE_SERVER_IMG ?= huggingfaceserver
 AIF_IMG ?= aiffairness
 ART_IMG ?= art-explainer
 STORAGE_INIT_IMG ?= storage-initializer
@@ -107,6 +108,9 @@ deploy-dev-pmml : docker-push-pmml
 
 deploy-dev-paddle: docker-push-paddle
 	./hack/serving_runtime_image_patch.sh "kserve-paddleserver.yaml" "${KO_DOCKER_REPO}/${PADDLE_IMG}"
+
+deploy-dev-huggingface: docker-push-huggingface
+	./hack/serving_runtime_image_patch.sh "kserve-huggingfaceserver.yaml" "${KO_DOCKER_REPO}/${HUGGINGFACE_SERVER_IMG}"
 
 deploy-dev-storageInitializer: docker-push-storageInitializer
 	./hack/storageInitializer_patch_dev.sh ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG}
@@ -308,6 +312,12 @@ docker-build-error-node-404:
 
 docker-push-error-node-404: docker-build-error-node-404
 	docker push ${KO_DOCKER_REPO}/${ERROR_404_ISVC_IMG}
+
+docker-build-huggingface:
+	cd python && docker buildx build -t ${KO_DOCKER_REPO}/${HUGGINGFACE_SERVER_IMG} -f huggingface_server.Dockerfile .
+
+docker-push-huggingface: docker-build-huggingface
+	docker push ${KO_DOCKER_REPO}/${HUGGINGFACE_SERVER_IMG}
 
 test-qpext:
 	cd qpext && go test -v ./... -cover

--- a/python/huggingfaceserver/huggingfaceserver/test_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/test_model.py
@@ -353,15 +353,11 @@ def test_input_padding_with_pad_token_not_specified():
     # openai-gpt model does not specify the pad token, so the fallback pad token should be added.
     assert model.tokenizer.pad_token == "[PAD]"
     assert model.tokenizer.pad_token_id is not None
-    request_one = "My name is Lewis and I like to"
-    request_two = "My name is Teven and I am"
+    request_one = "my name is merve and my favorite color is blue."
+    request_two = "my name is teven and i am"
     response = asyncio.run(model({"instances": [request_one, request_two]}, headers={}))
-    assert response == {
-        "predictions": [
-            "my name is lewis and i like to think of myself as a'good'man. i'm",
-            'my name is teven and i am a member of the royal family. " \n " i\'m',
-        ]
-    }
+    assert request_one in response["predictions"][0]
+    assert request_two in response["predictions"][1]
 
 
 if __name__ == "__main__":

--- a/python/huggingfaceserver/huggingfaceserver/test_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/test_model.py
@@ -338,9 +338,14 @@ async def test_input_truncation(bert_base_yelp_polarity: HuggingfaceEncoderModel
 
 
 def test_input_padding_with_pad_token_not_specified():
-    model = HuggingfaceModel("openai-gpt",
-                             {"model_id": "openai-community/openai-gpt",
-                              "task": MLTask.text_generation.value})
+    model = HuggingfaceModel(
+        "openai-gpt",
+        {
+            "model_id": "openai-community/openai-gpt",
+            "task": MLTask.text_generation.value,
+            "disable_special_tokens": True,
+        },
+    )
     model.load()
 
     # inputs with different lengths will throw an error
@@ -348,11 +353,15 @@ def test_input_padding_with_pad_token_not_specified():
     # openai-gpt model does not specify the pad token, so the fallback pad token should be added.
     assert model.tokenizer.pad_token == "[PAD]"
     assert model.tokenizer.pad_token_id is not None
-    request_one = "Once upon a time,"
+    request_one = "My name is Lewis and I like to"
     request_two = "My name is Teven and I am"
     response = asyncio.run(model({"instances": [request_one, request_two]}, headers={}))
-    assert response == {'predictions': ['once upon a time, i was a man of the world. \n " i\'m',
-                                        'my name is teven and i am a member of the royal family. " \n " i\'m']}
+    assert response == {
+        "predictions": [
+            "my name is lewis and i like to think of myself as a'good'man. i'm",
+            'my name is teven and i am a member of the royal family. " \n " i\'m',
+        ]
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We have added a [fallback pad token if it is not already present in the tokenizer](https://github.com/kserve/kserve/blob/11e0ab2ca4d852ec154156fad4f9d220c8768d78/python/huggingfaceserver/huggingfaceserver/model.py#L130-L131) as part of the PR #3459. But it does not explicitly specifies pad_token_id when invoking generate method which leads to huggingface using eos_token_id as the pad_token_id. The log from huggingface server is show below. To avoid this we should explicitly specify the pad_token_id
```
Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3536

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Explicitly specify pad token id when generating tokens
```
