### PR TITLE
Support OpenAIModel in ModelRepository

### DIFF
--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -44,7 +44,7 @@ PREDICTOR_V2_URL_FORMAT = "{0}://{1}/v2/models/{2}/infer"
 EXPLAINER_V2_URL_FORMAT = "{0}://{1}/v2/models/{2}/explain"
 
 
-class BaseKserveModel(ABC):
+class BaseKServeModel(ABC):
     """
     A base class to inherit all of the kserve models from.
 

--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -104,7 +104,7 @@ class PredictorConfig:
         self.predictor_request_timeout_seconds = predictor_request_timeout_seconds
 
 
-class Model(BaseKserveModel):
+class Model(BaseKServeModel):
     def __init__(self, name: str, predictor_config: Optional[PredictorConfig] = None):
         """KServe Model Public Interface
 

--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from abc import ABC
 import inspect
 import time
 from enum import Enum
 from typing import Dict, List, Union, Optional, AsyncIterator, Any
-
 import grpc
 import httpx
 import orjson
@@ -42,6 +42,24 @@ PREDICTOR_URL_FORMAT = "{0}://{1}/v1/models/{2}:predict"
 EXPLAINER_URL_FORMAT = "{0}://{1}/v1/models/{2}:explain"
 PREDICTOR_V2_URL_FORMAT = "{0}://{1}/v2/models/{2}/infer"
 EXPLAINER_V2_URL_FORMAT = "{0}://{1}/v2/models/{2}/explain"
+
+
+class BaseKserveModel(ABC):
+    """
+    A base class to inherit all of the kserve models from.
+
+    This class implements the expectations of model repository and model server.
+    """
+
+    def __init__(self, name: str):
+        """
+        Adds the required attributes
+
+        Args:
+            name: The name of the model.
+        """
+        self.name = name
+        self.ready = False
 
 
 class InferenceVerb(Enum):
@@ -86,7 +104,7 @@ class PredictorConfig:
         self.predictor_request_timeout_seconds = predictor_request_timeout_seconds
 
 
-class Model:
+class Model(BaseKserveModel):
     def __init__(self, name: str, predictor_config: Optional[PredictorConfig] = None):
         """KServe Model Public Interface
 
@@ -96,8 +114,8 @@ class Model:
             name: The name of the model.
             predictor_config: The configurations for http call to the predictor.
         """
-        self.name = name
-        self.ready = False
+        super().__init__(name)
+
         # The predictor config member fields are kept for backwards compatibility as they could be set outside
         self.protocol = (
             predictor_config.predictor_protocol

--- a/python/kserve/kserve/model_repository.py
+++ b/python/kserve/kserve/model_repository.py
@@ -55,7 +55,9 @@ class ModelRepository:
         model = self.get_model(name)
         if not model:
             return False
-        if isinstance(model, Union[Model, OpenAIModel]):
+        if isinstance(model, Model):
+            return model.ready
+        if isinstance(model, OpenAIModel):
             return model.ready
         else:
             # For Ray Serve, the models are guaranteed to be ready after deploying the model.

--- a/python/kserve/kserve/model_repository.py
+++ b/python/kserve/kserve/model_repository.py
@@ -43,7 +43,9 @@ class ModelRepository:
     def set_models_dir(self, models_dir):  # used for unit tests
         self.models_dir = models_dir
 
-    def get_model(self, name: str) -> Optional[Union[Model, OpenAIModel, DeploymentHandle]]:
+    def get_model(
+        self, name: str
+    ) -> Optional[Union[Model, OpenAIModel, DeploymentHandle]]:
         return self.models.get(name, None)
 
     def get_models(self) -> Dict[str, Union[Model, OpenAIModel, DeploymentHandle]]:

--- a/python/kserve/kserve/model_repository.py
+++ b/python/kserve/kserve/model_repository.py
@@ -57,11 +57,13 @@ class ModelRepository:
             return False
         if isinstance(model, Model):
             return model.ready
+
         if isinstance(model, OpenAIModel):
+            # Duplicating this logic until we merge all the models in an abstract class
             return model.ready
-        else:
-            # For Ray Serve, the models are guaranteed to be ready after deploying the model.
-            return True
+
+        # For Ray Serve, the models are guaranteed to be ready after deploying the model.
+        return True
 
     def update(self, model: Union[Model, OpenAIModel]):
         self.models[model.name] = model

--- a/python/kserve/kserve/model_repository.py
+++ b/python/kserve/kserve/model_repository.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import Dict, Optional, Union
-from .model import BaseKserveModel
+from .model import BaseKServeModel
 from ray.serve.handle import DeploymentHandle
 import os
 
@@ -30,7 +30,7 @@ class ModelRepository:
     """
 
     def __init__(self, models_dir: str = MODEL_MOUNT_DIRS):
-        self.models: Dict[str, Union[BaseKserveModel, DeploymentHandle]] = {}
+        self.models: Dict[str, Union[BaseKServeModel, DeploymentHandle]] = {}
         self.models_dir = models_dir
 
     def load_models(self):
@@ -44,23 +44,23 @@ class ModelRepository:
 
     def get_model(
         self, name: str
-    ) -> Optional[Union[BaseKserveModel, DeploymentHandle]]:
+    ) -> Optional[Union[BaseKServeModel, DeploymentHandle]]:
         return self.models.get(name, None)
 
-    def get_models(self) -> Dict[str, Union[BaseKserveModel, DeploymentHandle]]:
+    def get_models(self) -> Dict[str, Union[BaseKServeModel, DeploymentHandle]]:
         return self.models
 
     def is_model_ready(self, name: str):
         model = self.get_model(name)
         if not model:
             return False
-        if isinstance(model, BaseKserveModel):
+        if isinstance(model, BaseKServeModel):
             return model.ready
         else:
             # For Ray Serve, the models are guaranteed to be ready after deploying the model.
             return True
 
-    def update(self, model: BaseKserveModel):
+    def update(self, model: BaseKServeModel):
         self.models[model.name] = model
 
     def update_handle(self, name: str, model_handle: DeploymentHandle):

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -27,7 +27,7 @@ from ray.serve.api import Deployment
 from ray.serve.handle import DeploymentHandle
 
 from .logging import KSERVE_LOG_CONFIG, logger
-from .model import BaseKserveModel
+from .model import BaseKServeModel
 from .model_repository import ModelRepository
 from .protocol.dataplane import DataPlane
 from .protocol.grpc.server import GRPCServer
@@ -219,7 +219,7 @@ class ModelServer:
         self._custom_exception_handler = None
 
     def start(
-        self, models: Union[List[BaseKserveModel], Dict[str, Deployment]]
+        self, models: Union[List[BaseKServeModel], Dict[str, Deployment]]
     ) -> None:
         """Start the model server with a set of registered models.
 
@@ -228,12 +228,12 @@ class ModelServer:
         """
         if isinstance(models, list):
             for model in models:
-                if isinstance(model, BaseKserveModel):
+                if isinstance(model, BaseKServeModel):
                     self.register_model(model)
                     # pass whether to log request latency into the model
                     model.enable_latency_logging = self.enable_latency_logging
                 else:
-                    raise RuntimeError("Model type should be 'BaseKserveModel'")
+                    raise RuntimeError("Model type should be 'BaseKServeModel'")
         elif isinstance(models, dict):
             if all([isinstance(v, Deployment) for v in models.values()]):
                 # TODO: make this port number a variable
@@ -369,7 +369,7 @@ class ModelServer:
         self.registered_models.update_handle(name, model_handle)
         logger.info("Registering model handle: %s", name)
 
-    def register_model(self, model: BaseKserveModel):
+    def register_model(self, model: BaseKServeModel):
         """Register a model to the model server.
 
         Args:

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -153,6 +153,7 @@ parser.add_argument(
 )
 args, _ = parser.parse_known_args()
 
+BaseModelType = Union[Model, OpenAIModel]
 
 class ModelServer:
     def __init__(
@@ -227,7 +228,7 @@ class ModelServer:
         """
         if isinstance(models, list):
             for model in models:
-                if isinstance(model, Union[Model, OpenAIModel]):
+                if isinstance(model, BaseModelType):
                     self.register_model(model)
                     # pass whether to log request latency into the model
                     model.enable_latency_logging = self.enable_latency_logging

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -155,6 +155,7 @@ args, _ = parser.parse_known_args()
 
 BaseModelType = Union[Model, OpenAIModel]
 
+
 class ModelServer:
     def __init__(
         self,

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -27,13 +27,12 @@ from ray.serve.api import Deployment
 from ray.serve.handle import DeploymentHandle
 
 from .logging import KSERVE_LOG_CONFIG, logger
-from .model import Model
+from .model import BaseKserveModel
 from .model_repository import ModelRepository
 from .protocol.dataplane import DataPlane
 from .protocol.grpc.server import GRPCServer
 from .protocol.model_repository_extension import ModelRepositoryExtension
 from .protocol.rest.server import UvicornServer
-from .protocol.rest.openai import OpenAIModel
 from .utils import utils
 
 DEFAULT_HTTP_PORT = 8080
@@ -153,8 +152,6 @@ parser.add_argument(
 )
 args, _ = parser.parse_known_args()
 
-BaseModelType = Union[Model, OpenAIModel]
-
 
 class ModelServer:
     def __init__(
@@ -221,7 +218,7 @@ class ModelServer:
         self.access_log_format = access_log_format
         self._custom_exception_handler = None
 
-    def start(self, models: Union[List[Model], Dict[str, Deployment]]) -> None:
+    def start(self, models: Union[List[BaseKserveModel], Dict[str, Deployment]]) -> None:
         """Start the model server with a set of registered models.
 
         Args:
@@ -229,12 +226,12 @@ class ModelServer:
         """
         if isinstance(models, list):
             for model in models:
-                if isinstance(model, BaseModelType):
+                if isinstance(model, BaseKserveModel):
                     self.register_model(model)
                     # pass whether to log request latency into the model
                     model.enable_latency_logging = self.enable_latency_logging
                 else:
-                    raise RuntimeError("Model type should be 'Model'")
+                    raise RuntimeError("Model type should be 'BaseKserveModel'")
         elif isinstance(models, dict):
             if all([isinstance(v, Deployment) for v in models.values()]):
                 # TODO: make this port number a variable
@@ -370,7 +367,7 @@ class ModelServer:
         self.registered_models.update_handle(name, model_handle)
         logger.info("Registering model handle: %s", name)
 
-    def register_model(self, model: Model):
+    def register_model(self, model: BaseKserveModel):
         """Register a model to the model server.
 
         Args:

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -218,7 +218,9 @@ class ModelServer:
         self.access_log_format = access_log_format
         self._custom_exception_handler = None
 
-    def start(self, models: Union[List[BaseKserveModel], Dict[str, Deployment]]) -> None:
+    def start(
+        self, models: Union[List[BaseKserveModel], Dict[str, Deployment]]
+    ) -> None:
         """Start the model server with a set of registered models.
 
         Args:

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -33,6 +33,7 @@ from .protocol.dataplane import DataPlane
 from .protocol.grpc.server import GRPCServer
 from .protocol.model_repository_extension import ModelRepositoryExtension
 from .protocol.rest.server import UvicornServer
+from .protocol.rest.openai import OpenAIModel
 from .utils import utils
 
 DEFAULT_HTTP_PORT = 8080
@@ -226,7 +227,7 @@ class ModelServer:
         """
         if isinstance(models, list):
             for model in models:
-                if isinstance(model, Model):
+                if isinstance(model, Union[Model, OpenAIModel]):
                     self.register_model(model)
                     # pass whether to log request latency into the model
                     model.enable_latency_logging = self.enable_latency_logging

--- a/python/kserve/kserve/protocol/rest/openai/openai_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import AsyncIterator, Callable, Iterable, Union, cast
 
 from openai.types import Completion, CompletionChoice, CompletionCreateParams

--- a/python/kserve/kserve/protocol/rest/openai/openai_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_model.py
@@ -58,6 +58,16 @@ class OpenAIModel(ABC):
     these endpoints.
     """
 
+    def __init__(self, name: str):
+        """
+        Adds the attributes required by the ModelRepository
+
+        Args:
+            name: The name of the model.
+        """
+        self.name = name
+        self.ready = True
+
     @abstractmethod
     async def create_completion(
         self, params: CompletionCreateParams

--- a/python/kserve/kserve/protocol/rest/openai/openai_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_model.py
@@ -38,6 +38,7 @@ from openai.types.completion_create_params import (
 from pydantic import BaseModel
 
 from ....errors import InvalidInput
+from ....model import BaseKserveModel
 
 
 class ChatPrompt(BaseModel):
@@ -49,7 +50,7 @@ class ChatCompletionMessage(BaseChatCompletionMessage):
     role: str
 
 
-class OpenAIModel(ABC):
+class OpenAIModel(BaseKserveModel):
     """
     An abstract model with methods for implementing OpenAI's completions (v1/completions)
     and chat completions (v1/chat/completions) endpoints.
@@ -59,13 +60,10 @@ class OpenAIModel(ABC):
     """
 
     def __init__(self, name: str):
-        """
-        Adds the attributes required by the ModelRepository
+        super().__init__(name)
 
-        Args:
-            name: The name of the model.
-        """
-        self.name = name
+        # We don't support the `load()` method on OpenAIModel yet
+        # Assume the model is ready
         self.ready = True
 
     @abstractmethod

--- a/python/kserve/kserve/protocol/rest/openai/openai_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_model.py
@@ -38,7 +38,7 @@ from openai.types.completion_create_params import (
 from pydantic import BaseModel
 
 from ....errors import InvalidInput
-from ....model import BaseKserveModel
+from ....model import BaseKServeModel
 
 
 class ChatPrompt(BaseModel):
@@ -50,7 +50,7 @@ class ChatCompletionMessage(BaseChatCompletionMessage):
     role: str
 
 
-class OpenAIModel(BaseKserveModel):
+class OpenAIModel(BaseKServeModel):
     """
     An abstract model with methods for implementing OpenAI's completions (v1/completions)
     and chat completions (v1/chat/completions) endpoints.

--- a/python/kserve/test/test_model_repository.py
+++ b/python/kserve/test/test_model_repository.py
@@ -19,6 +19,7 @@ from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.chat import CompletionCreateParams as ChatCompletionCreateParams
 from typing import AsyncIterator, Union
 
+
 class DummyOpenAIModel(OpenAIModel):
     async def create_completion(
         self, params: CompletionCreateParams
@@ -30,6 +31,7 @@ class DummyOpenAIModel(OpenAIModel):
     ) -> Union[ChatCompletion, AsyncIterator[ChatCompletionChunk]]:
         pass
 
+
 def test_adding_kserve_model():
     repo = ModelRepository()
     repo.update(Model(name="kserve-model"))
@@ -39,6 +41,7 @@ def test_adding_kserve_model():
     assert actual is not None
     assert isinstance(actual, Model)
     assert actual.name == "kserve-model"
+
 
 def test_adding_openai_model():
     repo = ModelRepository()
@@ -50,10 +53,12 @@ def test_adding_openai_model():
     assert isinstance(actual, OpenAIModel)
     assert actual.name == "openai-model"
 
+
 def test_is_model_ready_inexsistent_model():
     repo = ModelRepository()
     actual = repo.is_model_ready("none-model")
     assert actual is False
+
 
 def test_is_model_ready_kserve_model():
     repo = ModelRepository()
@@ -66,6 +71,7 @@ def test_is_model_ready_kserve_model():
     model.load()
     actual = repo.is_model_ready("kserve-model")
     assert actual is True
+
 
 def test_is_model_ready_openai_model():
     repo = ModelRepository()

--- a/python/kserve/test/test_model_repository.py
+++ b/python/kserve/test/test_model_repository.py
@@ -1,0 +1,76 @@
+# Copyright 2024 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kserve import ModelRepository, Model
+from kserve.protocol.rest.openai import OpenAIModel
+from openai.types import Completion, CompletionCreateParams
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat import CompletionCreateParams as ChatCompletionCreateParams
+from typing import AsyncIterator, Union
+
+class DummyOpenAIModel(OpenAIModel):
+    async def create_completion(
+        self, params: CompletionCreateParams
+    ) -> Union[Completion, AsyncIterator[Completion]]:
+        pass
+
+    async def create_chat_completion(
+        self, params: ChatCompletionCreateParams
+    ) -> Union[ChatCompletion, AsyncIterator[ChatCompletionChunk]]:
+        pass
+
+def test_adding_kserve_model():
+    repo = ModelRepository()
+    repo.update(Model(name="kserve-model"))
+
+    actual = repo.get_model("kserve-model")
+
+    assert actual is not None
+    assert isinstance(actual, Model)
+    assert actual.name == "kserve-model"
+
+def test_adding_openai_model():
+    repo = ModelRepository()
+    repo.update(DummyOpenAIModel(name="openai-model"))
+
+    actual = repo.get_model("openai-model")
+
+    assert actual is not None
+    assert isinstance(actual, OpenAIModel)
+    assert actual.name == "openai-model"
+
+def test_is_model_ready_inexsistent_model():
+    repo = ModelRepository()
+    actual = repo.is_model_ready("none-model")
+    assert actual is False
+
+def test_is_model_ready_kserve_model():
+    repo = ModelRepository()
+    model = Model(name="kserve-model")
+    repo.update(model)
+
+    actual = repo.is_model_ready("kserve-model")
+    assert actual is False
+
+    model.load()
+    actual = repo.is_model_ready("kserve-model")
+    assert actual is True
+
+def test_is_model_ready_openai_model():
+    repo = ModelRepository()
+    model = DummyOpenAIModel(name="openai-model")
+    repo.update(model)
+
+    actual = repo.is_model_ready("openai-model")
+    assert actual is True

--- a/python/kserve/test/test_model_server.py
+++ b/python/kserve/test/test_model_server.py
@@ -1,0 +1,25 @@
+# Copyright 2024 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from kserve import ModelServer
+
+
+def test_model_server_start_no_models():
+    server = ModelServer()
+
+    with pytest.raises(RuntimeError) as exc:
+        server.start(models=None)
+
+    assert exc.value.args[0] == "Unknown model collection types"

--- a/python/kserve/test/test_model_server.py
+++ b/python/kserve/test/test_model_server.py
@@ -15,6 +15,7 @@
 import pytest
 from kserve import ModelServer
 
+UNKNOWN_MODEL_TYPE_ERR_MESSAGE = "Unknown model collection types"
 
 def test_model_server_start_no_models():
     server = ModelServer()
@@ -22,4 +23,4 @@ def test_model_server_start_no_models():
     with pytest.raises(RuntimeError) as exc:
         server.start(models=None)
 
-    assert exc.value.args[0] == "Unknown model collection types"
+    assert exc.value.args[0] == UNKNOWN_MODEL_TYPE_ERR_MESSAGE

--- a/python/kserve/test/test_model_server.py
+++ b/python/kserve/test/test_model_server.py
@@ -17,6 +17,7 @@ from kserve import ModelServer
 
 UNKNOWN_MODEL_TYPE_ERR_MESSAGE = "Unknown model collection types"
 
+
 def test_model_server_start_no_models():
     server = ModelServer()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `OpenAIModel` support to `ModelRepository`.

In https://github.com/kserve/kserve/pull/3477 we introduced openai endpoints to kserve. These endpoints are registered [when there are any models](https://github.com/kserve/kserve/blob/master/python/kserve/kserve/protocol/rest/openai/config.py#L48-L51) of type `OpenAIModel` in the `ModelRepository`. In order to take advantage of the openai endpoints, ModelRepository should support `OpenAIModel` type.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

`cd python/kserve && make test`