### PR TITLE
build: Allow pre-commit to keep changes in reformatted code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
-        args: [--check, --diff, --config, python/pyproject.toml]
+        args: [--config, python/pyproject.toml]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:


### PR DESCRIPTION
Removing the two args `--check, --diff` that prevent `pre-commit` from writing the changes back:

```
  --check                         Don't write the files back, just return the
                                  status. Return code 0 means nothing would
                                  change. Return code 1 means some files would
                                  be reformatted. Return code 123 means there
                                  was an internal error.
  --diff                          Don't write the files back, just output a
                                  diff to indicate what changes Black would've
                                  made. They are printed to stdout so

```

Writing the changes back would be more convenient since developers don't have to run `black` commands locally. They only need to do `git commit ...` once `pre-commit` is installed.