### PR TITLE
Fix make deploy-dev-storage-initializer not working

### DIFF
--- a/hack/storageInitializer_patch_dev.sh
+++ b/hack/storageInitializer_patch_dev.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-set -u
-IMG=$1
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+export IMG=$1
 if [ -z ${IMG} ]; then exit; fi
 cat > config/overlays/dev-image-config/inferenceservice_patch.yaml << EOF
 apiVersion: v1
@@ -18,3 +22,4 @@ data:
         "cpuLimit": "1"
       }
 EOF
+yq eval '.spec.container.image = env(IMG)' config/storagecontainers/default.yaml | kubectl apply -f -


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`make deploy-dev-storage-initializer` no longer functions as expected after introducing `ClusterStorageContainer` CRD. This PR introduces a fix to make it work as expected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
