### PR TITLE
Fix Pydantic 2 warnings

### DIFF
--- a/python/kserve/kserve/protocol/rest/v2_datamodels.py
+++ b/python/kserve/kserve/protocol/rest/v2_datamodels.py
@@ -232,9 +232,7 @@ class InferenceRequest(BaseModel):
     outputs: Optional[List[RequestOutput]] = None
 
     if is_pydantic_2:
-        model_config = ConfigDict(
-            json_loads=orjson.loads, json_schema_extra=inference_request_schema_extra
-        )
+        model_config = ConfigDict(json_schema_extra=inference_request_schema_extra)
 
     else:
 
@@ -312,9 +310,7 @@ class GenerateRequest(BaseModel):
     parameters: Optional[Parameters] = None
 
     if is_pydantic_2:
-        model_config = ConfigDict(
-            json_loads=orjson.loads, json_schema_extra=generate_request_schema_extra
-        )
+        model_config = ConfigDict(json_schema_extra=generate_request_schema_extra)
     else:
 
         class Config:
@@ -341,9 +337,7 @@ class Token(BaseModel):
     text: str
 
     if is_pydantic_2:
-        model_config = ConfigDict(
-            json_loads=orjson.loads, json_schema_extra=token_schema_extra
-        )
+        model_config = ConfigDict(json_schema_extra=token_schema_extra)
     else:
 
         class Config:
@@ -374,7 +368,6 @@ class Details(BaseModel):
 
     if is_pydantic_2:
         model_config = ConfigDict(
-            json_loads=orjson.loads,
             json_schema_extra=details_schema_extra,
         )
     else:
@@ -405,7 +398,6 @@ class StreamingDetails(BaseModel):
 
     if is_pydantic_2:
         model_config = ConfigDict(
-            json_loads=orjson.loads,
             json_schema_extra=streaming_details_schema_extra,
         )
     else:
@@ -453,7 +445,8 @@ class GenerateResponse(BaseModel):
 
     if is_pydantic_2:
         model_config = ConfigDict(
-            json_loads=orjson.loads, json_schema_extra=generate_response_schema_extra
+            protected_namespaces=(),
+            json_schema_extra=generate_response_schema_extra,
         )
     else:
 
@@ -498,7 +491,7 @@ class GenerateStreamingResponse(BaseModel):
 
     if is_pydantic_2:
         model_config = ConfigDict(
-            json_loads=orjson.loads,
+            protected_namespaces=(),
             json_schema_extra=generate_streaming_response_schema_extra,
         )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently Pydantic 2 is emitting two errors.

```
Field "model_name" has conflict with protected namespace "model_".
```

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Currently these warnings are being emitted by Pydantic.
```
kserve/venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:322
  /Users/cmaddalozzo/Code/kserve/python/kserve/venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:322: UserWarning: Valid config keys have changed in V2:
  * 'json_loads' has been removed
    warnings.warn(message, UserWarning)

kserve/venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:151
  /Users/cmaddalozzo/Code/kserve/python/kserve/venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_name" has conflict with protected namespace "model_".

  You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
    warnings.warn(

kserve/venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:151
  /Users/cmaddalozzo/Code/kserve/python/kserve/venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_version" has conflict with protected namespace "model_".

  You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
    warnings.warn(
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
