### PR TITLE
build: Remove misleading logs from minimal-crdgen.sh

### DIFF
--- a/hack/minimal-crdgen.sh
+++ b/hack/minimal-crdgen.sh
@@ -4,10 +4,9 @@ set -eu -o pipefail
 cd "$(dirname "$0")/.."
 
 find config/crd/full -name 'serving.kserve.io*.yaml' | while read -r file; do
-  echo "Patching ${file}"
   # create minimal
   minimal="config/crd/minimal/$(basename "$file")"
-  echo "Creating ${minimal}"
+  echo "Creating minimal CRD: ${minimal}"
   cp "$file" "$minimal"
   go run ./cmd/crd-gen removecrdvalidation "$minimal"
 done

--- a/hack/minimal-crdgen.sh
+++ b/hack/minimal-crdgen.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.."
 find config/crd/full -name 'serving.kserve.io*.yaml' | while read -r file; do
   # create minimal
   minimal="config/crd/minimal/$(basename "$file")"
-  echo "Creating minimal CRD: ${minimal}"
+  echo "Creating minimal CRD file: ${minimal}"
   cp "$file" "$minimal"
   go run ./cmd/crd-gen removecrdvalidation "$minimal"
 done


### PR DESCRIPTION
The current logs are misleading which may look like both the minimal and full CRDs are applied to the cluster twice:

```
./hack/minimal-crdgen.sh
Patching config/crd/full/serving.kserve.io_servingruntimes.yaml
Creating config/crd/minimal/serving.kserve.io_servingruntimes.yaml
```

The PR makes it less confusing.

/cc @yuzisun 

