### PR TITLE
fix: HPA equality check should include annotations

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -350,6 +350,7 @@ const (
 	CheckResultUpdate  CheckResultType = 1
 	CheckResultExisted CheckResultType = 2
 	CheckResultUnknown CheckResultType = 3
+	CheckResultDelete  CheckResultType = 4
 )
 
 type DeploymentModeType string

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -351,6 +351,7 @@ const (
 	CheckResultExisted CheckResultType = 2
 	CheckResultUnknown CheckResultType = 3
 	CheckResultDelete  CheckResultType = 4
+	CheckResultSkipped CheckResultType = 5
 )
 
 type DeploymentModeType string

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
@@ -83,10 +83,8 @@ func createAutoscaler(client client.Client,
 	componentExt *v1beta1.ComponentExtensionSpec) (Autoscaler, error) {
 	ac := getAutoscalerClass(componentMeta)
 	switch ac {
-	case constants.AutoscalerClassHPA:
+	case constants.AutoscalerClassHPA, constants.AutoscalerClassExternal:
 		return hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt), nil
-	case constants.AutoscalerClassExternal:
-		return &NoOpAutoscaler{}, nil
 	default:
 		return nil, fmt.Errorf("unknown autoscaler class type: %v", ac)
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -149,10 +149,8 @@ func semanticHPAEquals(desired, existing *autoscalingv2.HorizontalPodAutoscaler)
 	var autoscalerClassChanged bool
 	if hasDesiredAutoscalerClass && hasExistingAutoscalerClass {
 		autoscalerClassChanged = desiredAutoscalerClass != existingAutoscalerClass
-	} else {
-		if hasDesiredAutoscalerClass || hasExistingAutoscalerClass {
-			autoscalerClassChanged = true
-		}
+	} else if hasDesiredAutoscalerClass || hasExistingAutoscalerClass {
+		autoscalerClassChanged = true
 	}
 
 	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec) && !autoscalerClassChanged

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -144,8 +144,18 @@ func (r *HPAReconciler) checkHPAExist(client client.Client) (constants.CheckResu
 }
 
 func semanticHPAEquals(desired, existing *autoscalingv2.HorizontalPodAutoscaler) bool {
-	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec) &&
-		equality.Semantic.DeepEqual(desired.ObjectMeta.Annotations, existing.ObjectMeta.Annotations)
+	desiredAutoscalerClass, hasDesiredAutoscalerClass := desired.Annotations[constants.AutoscalerClass]
+	existingAutoscalerClass, hasExistingAutoscalerClass := existing.Annotations[constants.AutoscalerClass]
+	var autoscalerClassChanged bool
+	if hasDesiredAutoscalerClass && hasExistingAutoscalerClass {
+		autoscalerClassChanged = desiredAutoscalerClass != existingAutoscalerClass
+	} else {
+		if hasDesiredAutoscalerClass || hasExistingAutoscalerClass {
+			autoscalerClassChanged = true
+		}
+	}
+
+	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec) && !autoscalerClassChanged
 }
 
 // Reconcile ...

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -144,7 +144,8 @@ func (r *HPAReconciler) checkHPAExist(client client.Client) (constants.CheckResu
 }
 
 func semanticHPAEquals(desired, existing *autoscalingv2.HorizontalPodAutoscaler) bool {
-	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec)
+	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec) &&
+		equality.Semantic.DeepEqual(desired.ObjectMeta.Annotations, existing.ObjectMeta.Annotations)
 }
 
 // Reconcile ...

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -130,7 +130,7 @@ func (r *HPAReconciler) checkHPAExist(client client.Client) (constants.CheckResu
 		Name:      r.HPA.ObjectMeta.Name,
 	}, existingHPA)
 	if err != nil {
-		if apierr.IsNotFound(err) {
+		if apierr.IsNotFound(err) && shouldCreateHPA(r.HPA) {
 			return constants.CheckResultCreate, nil, nil
 		}
 		return constants.CheckResultUnknown, nil, err
@@ -162,6 +162,11 @@ func semanticHPAEquals(desired, existing *autoscalingv2.HorizontalPodAutoscaler)
 func shouldDeleteHPA(desired *autoscalingv2.HorizontalPodAutoscaler) bool {
 	desiredAutoscalerClass, hasDesiredAutoscalerClass := desired.Annotations[constants.AutoscalerClass]
 	return hasDesiredAutoscalerClass && constants.AutoscalerClassType(desiredAutoscalerClass) == constants.AutoscalerClassExternal
+}
+
+func shouldCreateHPA(desired *autoscalingv2.HorizontalPodAutoscaler) bool {
+	desiredAutoscalerClass, hasDesiredAutoscalerClass := desired.Annotations[constants.AutoscalerClass]
+	return hasDesiredAutoscalerClass && constants.AutoscalerClassType(desiredAutoscalerClass) == constants.AutoscalerClassHPA
 }
 
 // Reconcile ...


### PR DESCRIPTION
This PR fixes an issue where:

Correct behavior: If it's a new ISVC with the annotation `serving.kserve.io/autoscalerClass: "external"`, no HPA will be created. 

Incorrect behavior: However, if it's an **_existing_** ISVC where HPA is already created with annotation `serving.kserve.io/autoscalerClass: "hpa"`, our users want to change the annotation to "external" and expect that the existing HPA to be deleted.