### PR TITLE
Add headers to predictor exception logging

### DIFF
--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -345,9 +345,10 @@ class Model(BaseKServeModel):
                 predict_url, timeout=self.timeout, headers=predict_headers, content=data
             )
         except Exception as exc:
+            request_id = predict_headers.get("x-request-id", "unknown-request-id")
             logger.error(
                 f"Could not send a request to predictor at url {predict_url} "
-                f"with headers {predict_headers} "
+                f"for {request_id=} "
                 f"due to exception {exc}"
             )
             raise exc

--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -347,6 +347,7 @@ class Model(BaseKServeModel):
         except Exception as exc:
             logger.error(
                 f"Could not send a request to predictor at url {predict_url} "
+                f"with headers {predict_headers} "
                 f"due to exception {exc}"
             )
             raise exc

--- a/python/kserve/kserve/model.py
+++ b/python/kserve/kserve/model.py
@@ -345,7 +345,7 @@ class Model(BaseKServeModel):
                 predict_url, timeout=self.timeout, headers=predict_headers, content=data
             )
         except Exception as exc:
-            request_id = predict_headers.get("x-request-id", "unknown-request-id")
+            request_id = predict_headers.get("x-request-id", "N.A.")
             logger.error(
                 f"Could not send a request to predictor at url {predict_url} "
                 f"for {request_id=} "


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds the headers to exception logging, which includes request and trace ids. This maybe useful in debugging issues.

**Type of changes**
- [x] New feature (non-breaking change which adds functionality)

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.