### PR TITLE
Fix Huggingface server stopping criteria

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/generative_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/generative_model.py
@@ -414,7 +414,10 @@ class HuggingfaceGenerativeModel(
                 for seq in stop
             ]
             stop_sequence_stopping_criteria = StopSequenceStoppingCriteria(
-                input_length=inputs["input_ids"].shape[-1],
+                # Encoder-decoder models do not include input tokens in output
+                input_length=(
+                    0 if self.is_encoder_decoder else inputs["input_ids"].shape[-1]
+                ),
                 stop_sequences=stop_sequences,
             )
             stopping_criteria = StoppingCriteriaList([stop_sequence_stopping_criteria])

--- a/python/huggingfaceserver/huggingfaceserver/generative_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/generative_model.py
@@ -435,6 +435,7 @@ class HuggingfaceGenerativeModel(
                 request=request,
                 generate_queue=response_queue,
                 system_fingerprint=self.system_fingerprint,
+                stop_sequence_stopping_criteria=stop_sequence_stopping_criteria,
             )
         else:
             outputs = await response_queue.get()

--- a/python/huggingfaceserver/huggingfaceserver/test_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/test_model.py
@@ -109,6 +109,19 @@ async def test_t5(t5_model: HuggingfaceGenerativeModel):
 
 
 @pytest.mark.asyncio
+async def test_t5_stopping_criteria(t5_model: HuggingfaceGenerativeModel):
+    params = CreateCompletionRequest(
+        model="t5-small",
+        prompt="translate from English to German: we are making words",
+        stop=["setzen "],
+        stream=False,
+    )
+    request = CompletionRequest(params=params)
+    response = await t5_model.create_completion(request)
+    assert response.choices[0].text == "wir setzen"
+
+
+@pytest.mark.asyncio
 async def test_t5_bad_params(t5_model: HuggingfaceGenerativeModel):
     params = CreateCompletionRequest(
         model="t5-small",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes two issues:
1. Stopping criteria was not working properly for encoder-decoder models as it was not accounting for the fact that they do not include input tokens in the generated output
2. Streamed responses were not getting the `finish_reason` set properly do to the stopping criteria not being passed into the streamer object

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.