### PR TITLE
Fix: model id and model dir check order

### DIFF
--- a/charts/kserve-resources/templates/clusterservingruntimes.yaml
+++ b/charts/kserve-resources/templates/clusterservingruntimes.yaml
@@ -359,13 +359,13 @@ spec:
       autoSelect: true
       priority: 1
   protocolVersions:
+    - v1
     - v2
   containers:
     - name: kserve-container
       image: "{{ .Values.kserve.servingruntime.huggingfaceserver.image }}:{{ .Values.kserve.servingruntime.huggingfaceserver.tag }}"
       args:
-        - --model_id={{.Name}}
-        - --model_dir=/mnt/models
+        - --model_name={{ .Values.kserve.servingruntime.modelNamePlaceholder }}
       resources:
         requests:
           cpu: "1"

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -55,7 +55,9 @@ parser.add_argument(
     default="/mnt/models",
     help="A URI pointer to the model binary",
 )
-parser.add_argument("--model_id", required=False, default=None, help="Huggingface model id")
+parser.add_argument(
+    "--model_id", required=False, default=None, help="Huggingface model id"
+)
 parser.add_argument(
     "--model_revision", required=False, default=None, help="Huggingface model revision"
 )

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -52,7 +52,7 @@ parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument(
     "--model_dir",
     required=False,
-    default=None,
+    default="/mnt/models",
     help="A URI pointer to the model binary",
 )
 parser.add_argument("--model_id", required=False, default=None, help="Huggingface model id")
@@ -112,6 +112,7 @@ args, _ = parser.parse_known_args()
 
 def load_model():
     engine_args = None
+    # If --model_id is specified then pass model_id to HF API, otherwise load the model from /mnt/models
     if args.model_id:
         model_id_or_path = cast(str, args.model_id)
     else:

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -55,7 +55,7 @@ parser.add_argument(
     default=None,
     help="A URI pointer to the model binary",
 )
-parser.add_argument("--model_id", required=False, help="Huggingface model id")
+parser.add_argument("--model_id", required=False, default=None, help="Huggingface model id")
 parser.add_argument(
     "--model_revision", required=False, default=None, help="Huggingface model revision"
 )
@@ -112,10 +112,10 @@ args, _ = parser.parse_known_args()
 
 def load_model():
     engine_args = None
-    if args.model_dir:
-        model_id_or_path = Path(Storage.download(args.model_dir))
-    else:
+    if args.model_id:
         model_id_or_path = cast(str, args.model_id)
+    else:
+        model_id_or_path = Path(Storage.download(args.model_dir))
 
     if model_id_or_path is None:
         raise ValueError("You must provide a model_id or model_dir")

--- a/python/lgbserver/lgbserver/__main__.py
+++ b/python/lgbserver/lgbserver/__main__.py
@@ -21,7 +21,6 @@ from lgbserver.model import LightGBMModel
 import kserve
 from kserve.errors import ModelMissingError
 
-DEFAULT_LOCAL_MODEL_DIR = "/tmp/model"
 DEFAULT_NTHREAD = 1
 
 parser = argparse.ArgumentParser(
@@ -49,5 +48,5 @@ if __name__ == "__main__":
         )
         model_repository = LightGBMModelRepository(args.model_dir, args.nthread)
         # LightGBM doesn't support multi-process, so the number of http server workers should be 1.
-        kfserver = kserve.ModelServer(workers=1, registered_models=model_repository)
-        kfserver.start([model] if model.ready else [])
+        server = kserve.ModelServer(workers=1, registered_models=model_repository)
+        server.start([model] if model.ready else [])

--- a/python/pmmlserver/pmmlserver/__main__.py
+++ b/python/pmmlserver/pmmlserver/__main__.py
@@ -19,7 +19,6 @@ from pmmlserver import PmmlModel
 import kserve
 from kserve.errors import WorkersShouldBeLessThanMaxWorkersError
 
-DEFAULT_LOCAL_MODEL_DIR = "/tmp/model"
 
 parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument(

--- a/python/sklearnserver/sklearnserver/__main__.py
+++ b/python/sklearnserver/sklearnserver/__main__.py
@@ -20,8 +20,6 @@ from sklearnserver import SKLearnModel, SKLearnModelRepository
 import kserve
 from kserve.errors import ModelMissingError
 
-DEFAULT_LOCAL_MODEL_DIR = "/tmp/model"
-
 parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 parser.add_argument(
     "--model_dir", required=True, help="A local path to the model binary"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix the condition check order, we should always check if `model_id` is None first as `model_dir` can be always specified.
Default `--model_dir` to `/mnt/models`, so user does not need to add this additional argument on inference service yaml. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


**Special notes for your reviewer**:

1. This depends on https://github.com/kserve/kserve/pull/3679 which should be merged first

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.