### PR TITLE
Fix:vLLM Model Supported check throwing circular dependency

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -239,6 +239,6 @@ if __name__ == "__main__":
         kserve.ModelServer().start([model] if model.ready else [])
     except Exception as e:
         import sys
-        
-        logger.debug(f"Failed to start model server: {e}")
+
+        logger.error(f"Failed to start model server: {e}")
         sys.exit(1)

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -234,11 +234,11 @@ def load_model():
 
 
 if __name__ == "__main__":
-    # try:
-    model = load_model()
-    kserve.ModelServer().start([model] if model.ready else [])
-# except Exception as e:
-#     import sys
-#     print(e)
-#     logger.debug(f"Failed to start model server: {e}")
-#     sys.exit(1)
+    try:
+        model = load_model()
+        kserve.ModelServer().start([model] if model.ready else [])
+    except Exception as e:
+        import sys
+        
+        logger.debug(f"Failed to start model server: {e}")
+        sys.exit(1)

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -145,7 +145,7 @@ def load_model():
     if (
         (args.backend == Backend.vllm or args.backend == Backend.auto)
         and vllm_available()
-        and infer_vllm_supported_from_model_architecture(model_id_or_path) is not None
+        and infer_vllm_supported_from_model_architecture(model_id_or_path)
     ):
         from .vllm.vllm_model import VLLMModel
 
@@ -234,11 +234,11 @@ def load_model():
 
 
 if __name__ == "__main__":
-    try:
-        model = load_model()
-        kserve.ModelServer().start([model] if model.ready else [])
-    except Exception as e:
-        import sys
-
-        logger.error(f"Failed to start model server: {e}")
-        sys.exit(1)
+    # try:
+    model = load_model()
+    kserve.ModelServer().start([model] if model.ready else [])
+# except Exception as e:
+#     import sys
+#     print(e)
+#     logger.debug(f"Failed to start model server: {e}")
+#     sys.exit(1)

--- a/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
@@ -44,6 +44,7 @@ def infer_vllm_supported_from_model_architecture(
 
     if architecture not in ModelRegistry.get_supported_archs():
         logger.info("not a supported model by vLLM")
+        return False
     return True
 
 

--- a/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 from argparse import ArgumentParser
-from typing import Any, Optional, Type, Union
+from typing import Any, Union
 from pathlib import Path
 
 from kserve.logging import logger
-from torch import nn
 
 try:
     from vllm.engine.arg_utils import AsyncEngineArgs
@@ -37,15 +36,15 @@ def vllm_available() -> bool:
 
 def infer_vllm_supported_from_model_architecture(
     model_config_path: Union[Path, str],
-) -> Optional[Type[nn.Module]]:
+) -> bool:
     if not _vllm:
-        return None
+        return False
     model_config = AutoConfig.from_pretrained(model_config_path)
     architecture = model_config.architectures[0]
-    model_cls = ModelRegistry.load_model_cls(architecture)
-    if model_cls is None:
+
+    if architecture not in ModelRegistry.get_supported_archs():
         logger.info("not a supported model by vLLM")
-    return model_cls
+    return True
 
 
 def maybe_add_vllm_cli_parser(parser: ArgumentParser) -> ArgumentParser:

--- a/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
@@ -39,7 +39,7 @@ def infer_vllm_supported_from_model_architecture(
 ) -> bool:
     if not _vllm:
         return False
-    
+
     model_config = AutoConfig.from_pretrained(model_config_path)
     for architecture in model_config.architectures:
         if architecture not in ModelRegistry.get_supported_archs():

--- a/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
@@ -39,12 +39,12 @@ def infer_vllm_supported_from_model_architecture(
 ) -> bool:
     if not _vllm:
         return False
+    
     model_config = AutoConfig.from_pretrained(model_config_path)
-    architecture = model_config.architectures[0]
-
-    if architecture not in ModelRegistry.get_supported_archs():
-        logger.info("not a supported model by vLLM")
-        return False
+    for architecture in model_config.architectures:
+        if architecture not in ModelRegistry.get_supported_archs():
+            logger.info("not a supported model by vLLM")
+            return False
     return True
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
After vLLM update to version 4.2
The load of Llama Arch was causing a circular dependency error.

This PR fixes that issue

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests you ran to verify your changes and the relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Ran sanity checks on Llama, Mistral, and Gemma arch Models

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.