### PR TITLE
Add precaution again running v1 endpoints on openai models

### DIFF
--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -364,6 +364,11 @@ class DataPlane:
         """
         # call model locally or remote model workers
         model = self.get_model(model_name)
+        if isinstance(model, OpenAIModel):
+            logger.warning(
+                f"Model {model_name} is of type OpenAIModel. It does not support the explain method."
+                " A request exercised this path and will cause a server crash."
+            )
         if isinstance(model, DeploymentHandle):
             response = await model.remote(request, verb=InferenceVerb.EXPLAIN)
         else:

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -364,9 +364,6 @@ class DataPlane:
         """
         # call model locally or remote model workers
         model = self.get_model(model_name)
-        if isinstance(model, OpenAIModel):
-            error_msg = f"Model {model_name} is of type OpenAIModel. It does not support the explain method."
-            raise InvalidInput(reason=error_msg)
         if isinstance(model, DeploymentHandle):
             response = await model.remote(request, verb=InferenceVerb.EXPLAIN)
         else:

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -30,6 +30,7 @@ from ..model import InferenceVerb, Model
 from ..model_repository import ModelRepository
 from ..utils.utils import create_response_cloudevent, is_structured_cloudevent
 from .infer_type import InferRequest, InferResponse
+from .rest.openai import OpenAIModel
 
 JSON_HEADERS = [
     "application/json",
@@ -333,6 +334,9 @@ class DataPlane:
         """
         # call model locally or remote model workers
         model = self.get_model(model_name)
+        if isinstance(model, OpenAIModel):
+            error_msg = f"Model {model_name} is of type OpenAIModel. It does not support the infer method."
+            raise InvalidInput(reason=error_msg)
         if isinstance(model, DeploymentHandle):
             response = await model.remote(request, headers=headers)
         else:
@@ -360,6 +364,9 @@ class DataPlane:
         """
         # call model locally or remote model workers
         model = self.get_model(model_name)
+        if isinstance(model, OpenAIModel):
+            error_msg = f"Model {model_name} is of type OpenAIModel. It does not support the explain method."
+            raise InvalidInput(reason=error_msg)
         if isinstance(model, DeploymentHandle):
             response = await model.remote(request, verb=InferenceVerb.EXPLAIN)
         else:

--- a/python/kserve/test/test_dataplane.py
+++ b/python/kserve/test/test_dataplane.py
@@ -420,23 +420,6 @@ class TestDataPlaneOpenAI:
         ) -> Union[ChatCompletion, AsyncIterator[ChatCompletionChunk]]:
             pass
 
-    async def test_explain_on_openai_model_raises(self):
-        openai_model = self.DummyOpenAIModel(self.MODEL_NAME)
-        repo = ModelRepository()
-        repo.update(openai_model)
-        dataplane = DataPlane(model_registry=repo)
-
-        with pytest.raises(InvalidInput) as exc:
-            await dataplane.explain(
-                model_name=self.MODEL_NAME,
-                request={},
-            )
-
-        assert (
-            exc.value.reason
-            == "Model TestModel is of type OpenAIModel. It does not support the explain method."
-        )
-
     async def test_infer_on_openai_model_raises(self):
         openai_model = self.DummyOpenAIModel(self.MODEL_NAME)
         repo = ModelRepository()


### PR DESCRIPTION
# What this PR does
Adds error handling for executing V1 endpoints on OpenAI models.

Kserve allows users to send V1 endpoint requests to OpenAI models. This leads to a crash on the server side. We should gracefully fail on these requests.

Before the PR kserve was returning a `500` error to the user. After the PR kserve is returning a `400` error to the user. 

## Logs
500 err before the PR:
```
curl -v \
    -H "Content-Type: application/json" \
    $ENDPOINT \
    -d \
    '{...}'
*   Trying 0.0.0.0:8080...
* Connected to 0.0.0.0 (127.0.0.1) port 8080
> POST /v1/models/local-test-completion:predict HTTP/1.1
> Host: 0.0.0.0:8080
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 329
> 
< HTTP/1.1 500 Internal Server Error
< date: Thu, 16 May 2024 19:37:54 GMT
< server: uvicorn
< content-length: 71
< content-type: application/json
< 
* Connection #0 to host 0.0.0.0 left intact
{"error":"TypeError : 'CompletionsTransformer' object is not callable"}%   
```

400 err after the PR:
```
curl -v \
    -H "Content-Type: application/json" \
    $ENDPOINT \
    -d \
    '{...}'
*   Trying 0.0.0.0:8080...
* Connected to 0.0.0.0 (127.0.0.1) port 8080
> POST /v1/models/local-test-completion:predict HTTP/1.1
> Host: 0.0.0.0:8080
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 329
> 
< HTTP/1.1 400 Bad Request
< date: Thu, 16 May 2024 19:35:56 GMT
< server: uvicorn
< content-length: 97
< content-type: application/json
< 
* Connection #0 to host 0.0.0.0 left intact
{"error":"Model local-test-completion is of type OpenAIModel. It does not support infer method."}%                                                                                                                                                                                         
```

### Future Work
PS1. Ideally server should return a 404.
PS2. The vice versa is still not handled gracefully. Sending an openai request to a non openai model creates a 500.
Happy to address both of the above in follow up PRs.

**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue)

**Re-running failed tests**
- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.