### PR TITLE
Prevent the PassthroughCluster for clients/workloads in the service mesh

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -231,6 +231,7 @@ const (
 
 var (
 	LocalGatewayHost = "knative-local-gateway.istio-system.svc." + network.GetClusterDomainName()
+	IstioMeshGateway = "mesh"
 )
 
 // InferenceService Component enums

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -316,6 +316,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: istiov1beta1.VirtualService{
 					Gateways: []string{
 						constants.KnativeLocalGateway,
+						constants.IstioMeshGateway,
 						constants.KnativeIngressGateway,
 					},
 					Hosts: []string{
@@ -326,7 +327,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
 								{
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 									Authority: &istiov1beta1.StringMatch{
 										MatchType: &istiov1beta1.StringMatch_Regex{
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceKey.Name, serviceKey.Namespace)),

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -289,7 +289,7 @@ func createHTTPMatchRequest(prefix, targetHost, internalHost string, additionalH
 					Regex: constants.HostRegExp(internalHost),
 				},
 			},
-			Gateways: []string{config.LocalGateway},
+			Gateways: []string{config.LocalGateway, constants.IstioMeshGateway},
 		},
 	}
 	if !isInternal {
@@ -431,6 +431,7 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 
 	gateways := []string{
 		config.LocalGateway,
+		constants.IstioMeshGateway,
 	}
 	if !isInternal {
 		hosts = append(hosts, serviceHost)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -57,7 +57,7 @@ func TestCreateVirtualService(t *testing.T) {
 					Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 				},
 			},
-			Gateways: []string{constants.KnativeLocalGateway},
+			Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 		},
 		{
 			Authority: &istiov1beta1.StringMatch{
@@ -132,7 +132,7 @@ func TestCreateVirtualService(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 			Spec: istiov1beta1.VirtualService{
 				Hosts:    []string{serviceInternalHostName, serviceHostName},
-				Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+				Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 				Http: []*istiov1beta1.HTTPRoute{
 					{
 						Match: predictorRouteMatch,
@@ -187,7 +187,7 @@ func TestCreateVirtualService(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 			Spec: istiov1beta1.VirtualService{
 				Hosts:    []string{serviceInternalHostName},
-				Gateways: []string{constants.KnativeLocalGateway},
+				Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 				Http: []*istiov1beta1.HTTPRoute{
 					{
 						Match: []*istiov1beta1.HTTPMatchRequest{
@@ -197,7 +197,7 @@ func TestCreateVirtualService(t *testing.T) {
 										Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 									},
 								},
-								Gateways: []string{constants.KnativeLocalGateway},
+								Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 							},
 						},
 						Route: []*istiov1beta1.HTTPRouteDestination{
@@ -295,7 +295,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: predictorRouteMatch,
@@ -367,7 +367,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: predictorRouteMatch,
@@ -466,7 +466,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
@@ -481,7 +481,7 @@ func TestCreateVirtualService(t *testing.T) {
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 										},
 									},
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 								},
 								{
 									Uri: &istiov1beta1.StringMatch{
@@ -567,7 +567,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName, "my-domain.com"},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
@@ -577,7 +577,7 @@ func TestCreateVirtualService(t *testing.T) {
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 										},
 									},
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 								},
 								{
 									Authority: &istiov1beta1.StringMatch{
@@ -689,7 +689,7 @@ func TestCreateVirtualService(t *testing.T) {
 				Spec: istiov1beta1.VirtualService{
 					Hosts: []string{serviceInternalHostName, serviceHostName, "my-domain.com",
 						"my-model.test.my-additional-domain.com", "my-model.test.my-second-additional-domain.com"},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
@@ -699,7 +699,7 @@ func TestCreateVirtualService(t *testing.T) {
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 										},
 									},
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 								},
 								{
 									Authority: &istiov1beta1.StringMatch{
@@ -820,7 +820,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: predictorRouteMatch,
@@ -891,7 +891,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: predictorRouteMatch,
@@ -1089,7 +1089,7 @@ func TestCreateVirtualService(t *testing.T) {
 				}},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName},
-					Gateways: []string{constants.KnativeLocalGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
@@ -1099,7 +1099,7 @@ func TestCreateVirtualService(t *testing.T) {
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 										},
 									},
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 								},
 							},
 							Route: []*istiov1beta1.HTTPRouteDestination{


### PR DESCRIPTION
# What this PR does / why we need it

## Background
The KServe Ingress VirtualServices are created with configurations targeting only the Gateways. Although this works, the omission of the Istio sidecars has the following downsides for client/workloads that belong to the Istio mesh (i.e. have an Istio sidecar):

* Requests to InferenceServices will be treated as going to external services (i.e. not part of the mesh), because the sidecars are unaware of the routing rules.
* In consequence, the requests will be hanlded as with any external (non-mesh) workload: the ingress gateway will first receive the request and will forward it to itself doing the URL rewrite to the relevant `-predictor`, `-explainer` or `-transformer` hostname. Such forwarding can be avoided (for mesh-workloads) and the rewrite can be performed by the sidecars with the right VirtualService configuration.

This can be verified in the metrics that [Istio emits](https://istio.io/latest/docs/reference/config/metrics/). For example, the `istio_requests_total` metric would be emitted like this (some labels omitted for brevity):

```
istio_requests_total{
 destination_canonical_revision="latest",
 destination_canonical_service="unknown",
 destination_cluster="unknown",
 destination_principal="unknown",
 destination_service="sklearn-v2-iris.kserve-test.svc.cluster.local",
 destination_service_name="PassthroughCluster",
 destination_service_namespace="unknown",
 destination_workload="unknown",
 destination_workload_namespace="unknown",
 [...]}
```

Specifically, the `destination_service_name="PassthroughCluster"` reveals that the requests are being hanlded as leaving the service mesh, despite the client-workload has a sidecar. Such requests would be blocked if Istio would be configured with `REGISTRY_ONLY`.
* Learn more about the PassthroughCluster in [this Istio blog post](https://istio.io/v1.13/blog/2019/monitoring-external-service-traffic/#what-are-blackhole-and-passthrough-clusters), and about REGISTRY_ONLY [in Istio docs](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-control/#change-to-the-blocking-by-default-policy).

When using the [Kiali project](https://kiali.io/), its graph will reveal that observability is potentially lost. For example, the following image shows that the `curl-inside-mesh` workload has a sidecar and all its requests are going to the PassthroghCluster, despite everything is in the mesh.

![image](https://github.com/kserve/kserve/assets/23639005/6f64e684-c215-47cd-a307-70b54070d007)


## Fix

This is adding the missing configurations in the KServe-created VirtualService, so that Istio sidecars are aware of the KServe services/hostnames and workloads with an Istio sidecar will correctly handle the requests as mesh-internal traffic. Also, there is the added benefit that the URL rewrite will be done in the sidecar, rather than delaying/deferring the rewrite to the Gateway and this saves one request forwarding (potentially, slightly better performance).

With the fixed configs, the following is an example of a metric that will be emitted by Istio:

```
istio_requests_total{
 destination_app="unknown",
 destination_canonical_revision="data-science-smcp",
 destination_canonical_service="istio-ingressgateway",
 destination_cluster="Kubernetes",
 destination_principal="unknown",
 destination_service="knative-local-gateway.istio-system.svc.cluster.local",
 destination_service_name="knative-local-gateway",
 destination_service_namespace="istio-system",
 destination_version="unknown",
 destination_workload="istio-ingressgateway",
 destination_workload_namespace="istio-system",
 [...]}
```

Such metric no longer involves the PassthroughCluster, which should be understood as Istio handling the requests as mesh-internal. Furthermore, if mTLS is enabled in Istio, the metrics will also have _principal_ labels populated (requests are authenticated); e.g:

```
istio_requests_total{
 [...]
 destination_principal="spiffe://cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account",
 source_principal="spiffe://cluster.local/ns/kserve-workloads/sa/default"}
```

...and this gives the advantage of being able to use Istio security features, if needed (like AuthorizationPolicies). Also, better observability may also be possible. For example, the Kiali graph would now be like this:

![image](https://github.com/kserve/kserve/assets/23639005/829cff1a-3984-4844-b451-30269eb3e59e)


**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Feature/Issue validation/testing

* Relevant unit tests were adapted.
* Manual validation with Istio metrics was performed, as mentioned previously.


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?
