### PR TITLE
Fixup max_length for HF and model info for vLLM

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -153,7 +153,7 @@ def load_model():
     ):
         from .vllm.vllm_model import VLLMModel
 
-        args.model = args.model_dir or args.model_id
+        args.model = args.model_id or args.model_dir
         args.revision = args.model_revision
         engine_args = build_vllm_engine_args(args)
         model = VLLMModel(args.model_name, engine_args)

--- a/python/huggingfaceserver/huggingfaceserver/encoder_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/encoder_model.py
@@ -121,7 +121,7 @@ class HuggingfaceEncoderModel(Model):  # pylint:disable=c-extension-no-member
     def load(self) -> bool:
         model_id_or_path = self.model_id_or_path
         if self.max_length is None:
-            self.max_length = self.model_config.max_length
+            self.max_length = self.model_config.max_position_embeddings
 
         # device_map = "auto" enables model parallelism but all model architcture dont support it.
         # For pre-check we initialize the model class without weights to check the `_no_split_modules`

--- a/python/huggingfaceserver/huggingfaceserver/encoder_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/encoder_model.py
@@ -45,6 +45,7 @@ from .task import (
     get_model_class_for_task,
     infer_task_from_model_architecture,
 )
+from .utils import _get_and_verify_max_len
 
 
 class HuggingfaceEncoderModel(Model):  # pylint:disable=c-extension-no-member
@@ -120,8 +121,8 @@ class HuggingfaceEncoderModel(Model):  # pylint:disable=c-extension-no-member
 
     def load(self) -> bool:
         model_id_or_path = self.model_id_or_path
-        if self.max_length is None:
-            self.max_length = self.model_config.max_position_embeddings
+
+        self.max_length = _get_and_verify_max_len(self.model_config, self.max_length)
 
         # device_map = "auto" enables model parallelism but all model architcture dont support it.
         # For pre-check we initialize the model class without weights to check the `_no_split_modules`

--- a/python/huggingfaceserver/huggingfaceserver/generative_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/generative_model.py
@@ -402,7 +402,9 @@ class HuggingfaceGenerativeModel(
             inputs = self._tokenizer(
                 prompts, padding=True, return_tensors=TensorType.PYTORCH
             ).to(self._device)
-        num_input_tokens = len(inputs["input_ids"][0]) # inputs["input_ids"] is of shape (batch_size, sequence_length) aka (1,num_input_tokens)
+        num_input_tokens = len(
+            inputs["input_ids"][0]
+        )  # inputs["input_ids"] is of shape (batch_size, sequence_length) aka (1,num_input_tokens)
         if params.max_tokens is None:
             params.max_tokens = self.max_length - num_input_tokens
         if num_input_tokens + params.max_tokens > self.max_length:

--- a/python/huggingfaceserver/huggingfaceserver/generative_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/generative_model.py
@@ -402,9 +402,7 @@ class HuggingfaceGenerativeModel(
             inputs = self._tokenizer(
                 prompts, padding=True, return_tensors=TensorType.PYTORCH
             ).to(self._device)
-        num_input_tokens = len(
-            inputs["input_ids"][0]
-        )  # inputs["input_ids"] is of shape (batch_size, sequence_length) aka (1,num_input_tokens)
+        num_input_tokens = len(inputs["input_ids"])
         if params.max_tokens is None:
             params.max_tokens = self.max_length - num_input_tokens
         if num_input_tokens + params.max_tokens > self.max_length:

--- a/python/huggingfaceserver/huggingfaceserver/generative_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/generative_model.py
@@ -179,7 +179,7 @@ class HuggingfaceGenerativeModel(
         model_id_or_path = self.model_id_or_path
 
         if self.max_length is None:
-            self.max_length = self.model_config.max_length
+            self.max_length = self.model_config.max_position_embeddings
 
         # device_map = "auto" enables model parallelism but all model architcture dont support it.
         # For pre-check we initialize the model class without weights to check the `_no_split_modules`

--- a/python/huggingfaceserver/huggingfaceserver/test_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/test_model.py
@@ -257,12 +257,13 @@ async def test_bloom_completion(bloom_model: HuggingfaceGenerativeModel):
         prompt="Hello, my dog is cute",
         stream=False,
         echo=True,
+        max_tokens=100,  # bloom doesn't have any field specifying context length. Our implementation would default to 2048. Testing with something longer than HF's default max_length of 20
     )
     request = CompletionRequest(params=params)
     response = await bloom_model.create_completion(request)
     assert (
         response.choices[0].text
-        == "Hello, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute"
+        == "Hello, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey,' == 'Hello, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute"
     )
 
 

--- a/python/huggingfaceserver/huggingfaceserver/test_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/test_model.py
@@ -257,13 +257,29 @@ async def test_bloom_completion(bloom_model: HuggingfaceGenerativeModel):
         prompt="Hello, my dog is cute",
         stream=False,
         echo=True,
+    )
+    request = CompletionRequest(params=params)
+    response = await bloom_model.create_completion(request)
+    assert (
+        response.choices[0].text
+        == "Hello, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bloom_completion_max_tokens(bloom_model: HuggingfaceGenerativeModel):
+    params = CreateCompletionRequest(
+        model="bloom-560m",
+        prompt="Hello, my dog is cute",
+        stream=False,
+        echo=True,
         max_tokens=100,  # bloom doesn't have any field specifying context length. Our implementation would default to 2048. Testing with something longer than HF's default max_length of 20
     )
     request = CompletionRequest(params=params)
     response = await bloom_model.create_completion(request)
     assert (
         response.choices[0].text
-        == "Hello, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey,' == 'Hello, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute"
+        == "Hello, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey, my dog is cute.\n- Hey,"
     )
 
 
@@ -296,15 +312,13 @@ async def test_bloom_chat_completion(bloom_model: HuggingfaceGenerativeModel):
         },
     ]
     params = CreateChatCompletionRequest(
-        model="bloom-560m",
-        messages=messages,
-        stream=False,
+        model="bloom-560m", messages=messages, stream=False, max_tokens=20
     )
     request = ChatCompletionRequest(params=params)
     response = await bloom_model.create_chat_completion(request)
     assert (
         response.choices[0].message.content
-        == "The first thing you need to do is to get a good idea of what you are looking for"
+        == "The first thing you need to do is to get a good idea of what you are looking for."
     )
 
 
@@ -324,6 +338,7 @@ async def test_bloom_chat_completion_streaming(bloom_model: HuggingfaceGenerativ
         model="bloom-560m",
         messages=messages,
         stream=True,
+        max_tokens=20,
     )
     request = ChatCompletionRequest(params=params)
     response = await bloom_model.create_chat_completion(request)
@@ -332,7 +347,7 @@ async def test_bloom_chat_completion_streaming(bloom_model: HuggingfaceGenerativ
         output += chunk.choices[0].delta.content
     assert (
         output
-        == "The first thing you need to do is to get a good idea of what you are looking for"
+        == "The first thing you need to do is to get a good idea of what you are looking for."
     )
 
 

--- a/python/huggingfaceserver/huggingfaceserver/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/utils.py
@@ -1,0 +1,111 @@
+from transformers import PretrainedConfig
+from typing import Optional
+from kserve.logging import logger
+
+"This implementation is based on vLLM's _get_and_verify_max_len https://github.com/vllm-project/vllm/blob/a377f0bd5e1fa0ca069e3dbf28f4de5af64d0bb1/vllm/config.py#L1160"
+
+
+def _get_and_verify_max_len(
+    hf_config: PretrainedConfig,
+    max_model_len: Optional[int],
+    disable_sliding_window: bool = False,
+    sliding_window_len: Optional[int] = None,
+) -> int:
+    """Get and verify the model's maximum length."""
+    derived_max_model_len = float("inf")
+    possible_keys = [
+        # OPT
+        "max_position_embeddings",
+        # GPT-2
+        "n_positions",
+        # MPT
+        "max_seq_len",
+        # ChatGLM2
+        "seq_length",
+        # Command-R
+        "model_max_length",
+        # Others
+        "max_sequence_length",
+        "max_seq_length",
+        "seq_len",
+    ]
+    # Choose the smallest "max_length" from the possible keys.
+    max_len_key = None
+    for key in possible_keys:
+        max_len = getattr(hf_config, key, None)
+        if max_len is not None:
+            max_len_key = key if max_len < derived_max_model_len else max_len_key
+            derived_max_model_len = min(derived_max_model_len, max_len)
+
+    # If sliding window is manually disabled, max_length should be less
+    # than the sliding window length in the model config.
+    if disable_sliding_window and sliding_window_len is not None:
+        max_len_key = (
+            "sliding_window"
+            if sliding_window_len < derived_max_model_len
+            else max_len_key
+        )
+        derived_max_model_len = min(derived_max_model_len, sliding_window_len)
+
+    # If none of the keys were found in the config, use a default and
+    # log a warning.
+    if derived_max_model_len == float("inf"):
+        if max_model_len is not None:
+            # If max_model_len is specified, we use it.
+            return max_model_len
+
+        default_max_len = 2048
+        logger.warning(
+            "The model's config.json does not contain any of the following "
+            "keys to determine the original maximum length of the model: "
+            "%s. Assuming the model's maximum length is %d.",
+            possible_keys,
+            default_max_len,
+        )
+        derived_max_model_len = default_max_len
+
+    rope_scaling = getattr(hf_config, "rope_scaling", None)
+    if rope_scaling is not None and rope_scaling["type"] != "su":
+        if disable_sliding_window:
+            # TODO(robertgshaw): Find a model that supports rope_scaling
+            # with sliding window to see if this case should be allowed.
+            raise NotImplementedError(
+                "Disabling sliding window is not supported for models "
+                "with rope_scaling. Please raise an issue so we can "
+                "investigate."
+            )
+        assert "factor" in rope_scaling
+        scaling_factor = rope_scaling["factor"]
+        if rope_scaling["type"] == "yarn":
+            derived_max_model_len = rope_scaling["original_max_position_embeddings"]
+        derived_max_model_len *= scaling_factor
+
+    # If the user specified a max length, make sure it is smaller than the
+    # derived length from the HF model config.
+    if max_model_len is None:
+        max_model_len = int(derived_max_model_len)
+    elif max_model_len > derived_max_model_len:
+        # Some models might have a separate key for specifying model_max_length
+        # that will be bigger than derived_max_model_len. We compare user input
+        # with model_max_length and allow this override when it's smaller.
+        model_max_length = getattr(hf_config, "model_max_length", None)
+        if model_max_length is not None and max_model_len <= model_max_length:
+            if disable_sliding_window:
+                # TODO(robertgshaw): Find a model that has model_max_length
+                # with sliding window to see if this case should be allowed.
+                raise NotImplementedError(
+                    "Disabling sliding window is not supported for models "
+                    "model_max_length in the config. Please raise an issue "
+                    "so we can investigate."
+                )
+            pass
+        else:
+            raise ValueError(
+                f"User-specified max_model_len ({max_model_len}) is greater "
+                "than the derived max_model_len "
+                f"({max_len_key}={derived_max_model_len} or model_max_length="
+                f"{model_max_length} in model's config.json). This may lead "
+                "to incorrect model outputs or CUDA errors. Make sure the "
+                "value is correct and within the model context size."
+            )
+    return int(max_model_len)

--- a/python/huggingfaceserver/huggingfaceserver/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2024 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from transformers import PretrainedConfig
 from typing import Optional
 from kserve.logging import logger
@@ -67,8 +81,6 @@ def _get_and_verify_max_len(
     rope_scaling = getattr(hf_config, "rope_scaling", None)
     if rope_scaling is not None and rope_scaling["type"] != "su":
         if disable_sliding_window:
-            # TODO(robertgshaw): Find a model that supports rope_scaling
-            # with sliding window to see if this case should be allowed.
             raise NotImplementedError(
                 "Disabling sliding window is not supported for models "
                 "with rope_scaling. Please raise an issue so we can "

--- a/test/e2e/data/opt_125m_input_generate.json
+++ b/test/e2e/data/opt_125m_input_generate.json
@@ -10,5 +10,6 @@
         "content": "What are we having for dinner?"
       }
     ],
-    "temperature": 0
+    "temperature": 0,
+    "max_tokens": 20
 }

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -76,7 +76,7 @@ def test_huggingface_openai_chat_completions():
     res = generate(service_name, "./data/opt_125m_input_generate.json")
     assert (
         res["choices"][0]["message"]["content"]
-        == "I'm not sure if this is a good idea, but I'm not sure if I should"
+        == "I'm not sure if this is a good idea, but I'm not sure if I should be"
     )
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)


### PR DESCRIPTION
**What this PR does / why we need it**:

1. As of now, if you pass any model_id param to create vLLM model, it fails because the args.model is being set to `/mnt/model`, the default value of `args.model_dir`. So for creating `args.model`, let `args.model_id` take precedence over `args.model_dir`.
2. By default while initialising and loading models, we're setting `self.max_length` (that denotes max num of tokens that can be processed) to [`self.model_config.max_length`](https://huggingface.co/docs/transformers/en/main_classes/configuration#transformers.PretrainedConfig.max_length) which is a parameter read from generation_config.json, that defaults to 20. But a lot of models like [mistral](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2/blob/main/generation_config.json), [gemma](https://huggingface.co/google/gemma-2b-it/blob/main/generation_config.json) don't have that parameter (llama has). So let's rely on `self.max_position_embeddings` for the same?


**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue)



**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
