### PR TITLE
Extract openai predict logic into smaller methods

### DIFF
--- a/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
@@ -254,15 +254,19 @@ class OpenAIProxyModel(OpenAIModel):
             )
             return it
         else:
-            response = await self._http_client.send(req)
-            response.raise_for_status()
-            if self.skip_upstream_validation:
-                obj = response.json()
-                completion = Completion.model_construct(**obj)
-            else:
-                completion = Completion.model_validate_json(response.content)
+            completion = await self.predict_completion(req)
             self.postprocess_completion(completion, request)
             return completion
+
+    async def predict_completion(self, req: httpx.Request) -> Completion:
+        response = await self._http_client.send(req)
+        response.raise_for_status()
+        if self.skip_upstream_validation:
+            obj = response.json()
+            completion = Completion.model_construct(**obj)
+        else:
+            completion = Completion.model_validate_json(response.content)
+        return completion
 
     @error_handler
     async def create_chat_completion(
@@ -280,12 +284,16 @@ class OpenAIProxyModel(OpenAIModel):
             )
             return it
         else:
-            response = await self._http_client.send(req)
-            response.raise_for_status()
-            if self.skip_upstream_validation:
-                obj = response.json()
-                chat_completion = ChatCompletion.model_construct(**obj)
-            else:
-                chat_completion = ChatCompletion.model_validate_json(response.content)
+            chat_completion = await self.predict_chat_completion(req)
             self.postprocess_chat_completion(chat_completion, request)
             return chat_completion
+
+    async def predict_chat_completion(self, req: httpx.Request) -> ChatCompletion:
+        response = await self._http_client.send(req)
+        response.raise_for_status()
+        if self.skip_upstream_validation:
+            obj = response.json()
+            chat_completion = ChatCompletion.model_construct(**obj)
+        else:
+            chat_completion = ChatCompletion.model_validate_json(response.content)
+        return chat_completion

--- a/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
@@ -289,7 +289,9 @@ class OpenAIProxyModel(OpenAIModel):
             self.postprocess_chat_completion(chat_completion, request)
             return chat_completion
 
-    async def generate_chat_completion(self, request: ChatCompletionRequest) -> ChatCompletion:
+    async def generate_chat_completion(
+        self, request: ChatCompletionRequest
+    ) -> ChatCompletion:
         req = self._build_request(self._chat_completions_endpoint, request)
         response = await self._http_client.send(req)
         response.raise_for_status()

--- a/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
@@ -243,8 +243,8 @@ class OpenAIProxyModel(OpenAIModel):
         self, request: CompletionRequest
     ) -> Union[Completion, AsyncIterator[Completion]]:
         self.preprocess_completion_request(request)
-        req = self._build_request(self._completions_endpoint, request)
         if request.params.stream:
+            req = self._build_request(self._completions_endpoint, request)
             r = await self._http_client.send(req, stream=True)
             r.raise_for_status()
             it = AsyncMappingIterator(
@@ -254,11 +254,12 @@ class OpenAIProxyModel(OpenAIModel):
             )
             return it
         else:
-            completion = await self.predict_completion(req)
+            completion = await self.generate_completion(request)
             self.postprocess_completion(completion, request)
             return completion
 
-    async def predict_completion(self, req: httpx.Request) -> Completion:
+    async def generate_completion(self, request: CompletionRequest) -> Completion:
+        req = self._build_request(self._completions_endpoint, request)
         response = await self._http_client.send(req)
         response.raise_for_status()
         if self.skip_upstream_validation:
@@ -273,8 +274,8 @@ class OpenAIProxyModel(OpenAIModel):
         self, request: ChatCompletionRequest
     ) -> Union[ChatCompletion, AsyncIterator[ChatCompletionChunk]]:
         self.preprocess_chat_completion_request(request)
-        req = self._build_request(self._chat_completions_endpoint, request)
         if request.params.stream:
+            req = self._build_request(self._chat_completions_endpoint, request)
             r = await self._http_client.send(req, stream=True)
             r.raise_for_status()
             it = AsyncMappingIterator(
@@ -284,11 +285,12 @@ class OpenAIProxyModel(OpenAIModel):
             )
             return it
         else:
-            chat_completion = await self.predict_chat_completion(req)
+            chat_completion = await self.generate_chat_completion(request)
             self.postprocess_chat_completion(chat_completion, request)
             return chat_completion
 
-    async def predict_chat_completion(self, req: httpx.Request) -> ChatCompletion:
+    async def generate_chat_completion(self, request: ChatCompletionRequest) -> ChatCompletion:
+        req = self._build_request(self._chat_completions_endpoint, request)
         response = await self._http_client.send(req)
         response.raise_for_status()
         if self.skip_upstream_validation:


### PR DESCRIPTION
## What does this PR do?
This PR is purely a refactor. It does not change the logic. It puts the the prediction code into smaller methods.
## Why do we want it?
1. Having fine grained methods yields a better user experience since the child classes have greater flexibility on what logic they want to override.
1. The internal implementation is now closer to the `pre-process / predict / post-process` pattern, the users are already accustomed to from v1 endpoints.
## Example Usage
In the V1 endpoints, we override the [predict logic](https://github.com/kserve/kserve/blob/master/python/kserve/kserve/model.py#L398) to wrap it with custom latency measurements and exception handling. It looks like below:

```python
async def predict(self, payload: dict, headers: dict[str, str] = None) -> dict:
  with self.latency_tracker.report_predict(tag1=my_tag_1, tag2=my_tag2):
    try:
      return await super().predict(payload, headers)
    except Exception as exc:
      # log, inc counters etc.
      raise exc
```

With the current implementation of OpenAIProxyModel, we have to override the whole `create_completion` method to apply this pattern. It is better to be able to override only the prediction logic and measure that.

**Feature/Issue validation/testing**: `make test`

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.