### PR TITLE
Propagate `trust_remote_code` flag throughout vLLM startup

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -154,7 +154,10 @@ def load_model():
     if (
         (args.backend == Backend.vllm or args.backend == Backend.auto)
         and vllm_available()
-        and infer_vllm_supported_from_model_architecture(model_id_or_path)
+        and infer_vllm_supported_from_model_architecture(
+            model_id_or_path,
+            trust_remote_code=kwargs.get("trust_remote_code", False),
+        )
     ):
         from .vllm.vllm_model import VLLMModel
 
@@ -174,7 +177,9 @@ def load_model():
         }
 
         model_config = AutoConfig.from_pretrained(
-            str(model_id_or_path), revision=kwargs.get("model_revision", None)
+            str(model_id_or_path), 
+            revision=kwargs.get("model_revision", None),
+            trust_remote_code=kwargs.get("trust_remote_code", False),
         )
         if kwargs.get("task", None):
             try:

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -156,7 +156,7 @@ def load_model():
         and vllm_available()
         and infer_vllm_supported_from_model_architecture(
             model_id_or_path,
-            trust_remote_code=kwargs.get("trust_remote_code", False),
+            trust_remote_code=args.trust_remote_code,
         )
     ):
         from .vllm.vllm_model import VLLMModel

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -177,7 +177,7 @@ def load_model():
         }
 
         model_config = AutoConfig.from_pretrained(
-            str(model_id_or_path), 
+            str(model_id_or_path),
             revision=kwargs.get("model_revision", None),
             trust_remote_code=kwargs.get("trust_remote_code", False),
         )

--- a/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
@@ -41,7 +41,9 @@ def infer_vllm_supported_from_model_architecture(
     if not _vllm:
         return False
 
-    model_config = AutoConfig.from_pretrained(model_config_path, trust_remote_code=trust_remote_code)
+    model_config = AutoConfig.from_pretrained(
+        model_config_path, trust_remote_code=trust_remote_code
+    )
     for architecture in model_config.architectures:
         if architecture not in ModelRegistry.get_supported_archs():
             logger.info("not a supported model by vLLM")

--- a/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
@@ -36,11 +36,12 @@ def vllm_available() -> bool:
 
 def infer_vllm_supported_from_model_architecture(
     model_config_path: Union[Path, str],
+    trust_remote_code: bool = False,
 ) -> bool:
     if not _vllm:
         return False
 
-    model_config = AutoConfig.from_pretrained(model_config_path)
+    model_config = AutoConfig.from_pretrained(model_config_path, trust_remote_code=trust_remote_code)
     for architecture in model_config.architectures:
         if architecture not in ModelRegistry.get_supported_archs():
             logger.info("not a supported model by vLLM")


### PR DESCRIPTION
**What this PR does / why we need it**:

This fix propagates the `trust_remote_code` flag throughout the vLLM runtime initialization to allow for custom config files, such as on models like `microsoft/Phi-3-small-128k-instruct`.

**Which issue(s) this PR fixes**:

The `huggingfaceserver` initialization hangs (and errors out) at the `AutoConfig.from_pretrained` calls for local config files that are not intrinsic to the `transformers` library, such as `Phi3SmallConfig` found on `microsoft/Phi-3-small-128k-instruct`. The `trust_remote_code` flag is included in the server initialization, but is not propagated to these calls correctly.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.