### PR TITLE
Allow KServe to have its own local gateways for Serverless mode

### DIFF
--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -27,9 +27,9 @@ $ helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.13.0
 | kserve.controller.gateway.domainTemplate | string | `"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"` |  |
 | kserve.controller.gateway.ingressGateway.className | string | `"istio"` |  |
 | kserve.controller.gateway.ingressGateway.gateway | string | `"knative-serving/knative-ingress-gateway"` |  |
-| kserve.controller.gateway.ingressGateway.gatewayService | string | `"istio-ingressgateway.istio-system.svc.cluster.local"` |  |
 | kserve.controller.gateway.localGateway.gateway | string | `"knative-serving/knative-local-gateway"` |  |
 | kserve.controller.gateway.localGateway.gatewayService | string | `"knative-local-gateway.istio-system.svc.cluster.local"` |  |
+| kserve.controller.gateway.localGateway.knativeGatewayService | string | `""` |  |
 | kserve.controller.gateway.urlScheme | string | `"http"` |  |
 | kserve.controller.image | string | `"kserve/kserve-controller"` |  |
 | kserve.controller.nodeSelector | object | `{}` |  |

--- a/charts/kserve-resources/templates/configmap.yaml
+++ b/charts/kserve-resources/templates/configmap.yaml
@@ -181,7 +181,6 @@ data:
      ingress: |-
        {
            "ingressGateway" : "knative-serving/knative-ingress-gateway",
-           "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
            "localGateway" : "knative-serving/knative-local-gateway",
            "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
            "ingressDomain"  : "example.com",
@@ -199,9 +198,15 @@ data:
            # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
            "ingressGateway" : "knative-serving/knative-ingress-gateway",
 
-           # ingressService specifies the hostname of the ingress service.
+           # knativeLocalGatewayService specifies the hostname of the Knative's local gateway service.
+           # The default KServe configurations are re-using the Istio local gateways for Knative. In this case, this
+           # knativeLocalGatewayService field can be left unset. When unset, the value of "localGatewayService" will be used.
+           # However, sometimes it may be better to have local gateways specifically for KServe (e.g. when enabling strict mTLS in Istio).
+           # Under such setups where KServe is needed to have its own local gateways, the values of the "localGateway" and
+           # "localGatewayService" should point to the KServe local gateways. Then, this knativeLocalGatewayService field
+           # should point to the Knative's local gateway service.
            # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
+           "knativeLocalGatewayService": "",
 
            # localGateway specifies the gateway which handles the network traffic within the cluster.
            # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
@@ -495,7 +500,7 @@ data:
   ingress: |-
     {
         "ingressGateway" : "{{ .Values.kserve.controller.gateway.ingressGateway.gateway }}",
-        "ingressService" : "{{ .Values.kserve.controller.gateway.ingressGateway.gatewayService }}",
+        "knativeLocalGatewayService" : "{{ .Values.kserve.controller.gateway.localGateway.knativeGatewayService }}",
         "localGateway" : "{{ .Values.kserve.controller.gateway.localGateway.gateway }}",
         "localGatewayService" : "{{ .Values.kserve.controller.gateway.localGateway.gatewayService }}",
         "ingressClassName" : "{{ .Values.kserve.controller.gateway.ingressGateway.className }}",

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -43,9 +43,9 @@ kserve:
       localGateway:
         gateway: knative-serving/knative-local-gateway
         gatewayService: knative-local-gateway.istio-system.svc.cluster.local
+        knativeGatewayService: ""
       ingressGateway:
         gateway: knative-serving/knative-ingress-gateway
-        gatewayService: istio-ingressgateway.istio-system.svc.cluster.local
         className: istio
     nodeSelector: {}
     tolerations: []

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -192,7 +192,6 @@ data:
      ingress: |-
        {
            "ingressGateway" : "knative-serving/knative-ingress-gateway",
-           "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
            "localGateway" : "knative-serving/knative-local-gateway",
            "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
            "ingressDomain"  : "example.com",
@@ -210,9 +209,15 @@ data:
            # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
            "ingressGateway" : "knative-serving/knative-ingress-gateway",
      
-           # ingressService specifies the hostname of the ingress service.
+           # knativeLocalGatewayService specifies the hostname of the Knative's local gateway service.
+           # The default KServe configurations are re-using the Istio local gateways for Knative. In this case, this
+           # knativeLocalGatewayService field can be left unset. When unset, the value of "localGatewayService" will be used.
+           # However, sometimes it may be better to have local gateways specifically for KServe (e.g. when enabling strict mTLS in Istio).
+           # Under such setups where KServe is needed to have its own local gateways, the values of the "localGateway" and
+           # "localGatewayService" should point to the KServe local gateways. Then, this knativeLocalGatewayService field
+           # should point to the Knative's local gateway service.
            # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
+           "knativeLocalGatewayService": "",
      
            # localGateway specifies the gateway which handles the network traffic within the cluster.
            # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
@@ -494,7 +499,6 @@ data:
   ingress: |-
     {
         "ingressGateway" : "knative-serving/knative-ingress-gateway",
-        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
         "localGateway" : "knative-serving/knative-local-gateway",
         "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
         "ingressDomain"  : "example.com",

--- a/config/overlays/test/configmap/inferenceservice-disable-istio.yaml
+++ b/config/overlays/test/configmap/inferenceservice-disable-istio.yaml
@@ -7,7 +7,6 @@ data:
   ingress: |-
     {
        "ingressGateway" : "knative-serving/knative-ingress-gateway",
-       "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
        "localGateway" : "knative-serving/knative-local-gateway",
        "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
        "ingressDomain"  : "example.com",

--- a/config/overlays/test/configmap/inferenceservice-ingress.yaml
+++ b/config/overlays/test/configmap/inferenceservice-ingress.yaml
@@ -7,7 +7,6 @@ data:
   ingress: |-
     {
         "ingressGateway" : "knative-serving/knative-ingress-gateway",
-        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
         "localGateway": "knative-serving/knative-local-gateway",
         "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
         "ingressClassName" : "istio",

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -32,7 +32,6 @@ data:
   ingress: |-
     {
         "ingressGateway" : "knative-serving/knative-ingress-gateway",
-        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
         "localGateway": "knative-serving/knative-local-gateway",
         "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
         "ingressClassName" : "istio",

--- a/hack/violation_exceptions.list
+++ b/hack/violation_exceptions.list
@@ -30,7 +30,6 @@ API rule violation: names_match,github.com/kserve/kserve/pkg/apis/serving/v1beta
 API rule violation: names_match,github.com/kserve/kserve/pkg/apis/serving/v1beta1,ExplainerConfig,ContainerImage
 API rule violation: names_match,github.com/kserve/kserve/pkg/apis/serving/v1beta1,ExplainerExtensionSpec,StorageURI
 API rule violation: names_match,github.com/kserve/kserve/pkg/apis/serving/v1beta1,ExplainersConfig,ARTExplainer
-API rule violation: names_match,github.com/kserve/kserve/pkg/apis/serving/v1beta1,IngressConfig,IngressServiceName
 API rule violation: names_match,github.com/kserve/kserve/pkg/apis/serving/v1beta1,IngressConfig,LocalGatewayServiceName
 API rule violation: names_match,github.com/kserve/kserve/pkg/apis/serving/v1beta1,ModelStatus,ModelCopies
 API rule violation: names_match,github.com/kserve/kserve/pkg/apis/serving/v1beta1,ModelStatus,ModelRevisionStates

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -65,18 +65,18 @@ type InferenceServicesConfig struct {
 
 // +kubebuilder:object:generate=false
 type IngressConfig struct {
-	IngressGateway           string    `json:"ingressGateway,omitempty"`
-	IngressServiceName       string    `json:"ingressService,omitempty"`
-	LocalGateway             string    `json:"localGateway,omitempty"`
-	LocalGatewayServiceName  string    `json:"localGatewayService,omitempty"`
-	IngressDomain            string    `json:"ingressDomain,omitempty"`
-	IngressClassName         *string   `json:"ingressClassName,omitempty"`
-	AdditionalIngressDomains *[]string `json:"additionalIngressDomains,omitempty"`
-	DomainTemplate           string    `json:"domainTemplate,omitempty"`
-	UrlScheme                string    `json:"urlScheme,omitempty"`
-	DisableIstioVirtualHost  bool      `json:"disableIstioVirtualHost,omitempty"`
-	PathTemplate             string    `json:"pathTemplate,omitempty"`
-	DisableIngressCreation   bool      `json:"disableIngressCreation,omitempty"`
+	IngressGateway             string    `json:"ingressGateway,omitempty"`
+	KnativeLocalGatewayService string    `json:"knativeLocalGatewayService,omitempty"`
+	LocalGateway               string    `json:"localGateway,omitempty"`
+	LocalGatewayServiceName    string    `json:"localGatewayService,omitempty"`
+	IngressDomain              string    `json:"ingressDomain,omitempty"`
+	IngressClassName           *string   `json:"ingressClassName,omitempty"`
+	AdditionalIngressDomains   *[]string `json:"additionalIngressDomains,omitempty"`
+	DomainTemplate             string    `json:"domainTemplate,omitempty"`
+	UrlScheme                  string    `json:"urlScheme,omitempty"`
+	DisableIstioVirtualHost    bool      `json:"disableIstioVirtualHost,omitempty"`
+	PathTemplate               string    `json:"pathTemplate,omitempty"`
+	DisableIngressCreation     bool      `json:"disableIngressCreation,omitempty"`
 }
 
 // +kubebuilder:object:generate=false
@@ -112,8 +112,8 @@ func NewIngressConfig(clientset kubernetes.Interface) (*IngressConfig, error) {
 			return nil, fmt.Errorf("unable to parse ingress config json: %w", err)
 		}
 
-		if ingressConfig.IngressGateway == "" || ingressConfig.IngressServiceName == "" {
-			return nil, fmt.Errorf("invalid ingress config - ingressGateway and ingressService are required")
+		if ingressConfig.IngressGateway == "" {
+			return nil, fmt.Errorf("invalid ingress config - ingressGateway is required")
 		}
 		if ingressConfig.PathTemplate != "" {
 			// TODO: ensure that the generated path is valid, that is:
@@ -127,6 +127,10 @@ func NewIngressConfig(clientset kubernetes.Interface) (*IngressConfig, error) {
 			if ingressConfig.IngressDomain == "" {
 				return nil, fmt.Errorf("invalid ingress config - ingressDomain is required if pathTemplate is given")
 			}
+		}
+
+		if len(ingressConfig.KnativeLocalGatewayService) == 0 {
+			ingressConfig.KnativeLocalGatewayService = ingressConfig.LocalGatewayServiceName
 		}
 	}
 

--- a/pkg/apis/serving/v1beta1/configmap_test.go
+++ b/pkg/apis/serving/v1beta1/configmap_test.go
@@ -28,23 +28,23 @@ import (
 )
 
 var (
-	KnativeIngressGateway = "knative-serving/knative-ingress-gateway"
-	IngressService        = "test-destination"
-	KnativeLocalGateway   = "knative-serving/knative-local-gateway"
-	LocalGatewayService   = "knative-local-gateway.istio-system.svc.cluster.local"
-	UrlScheme             = "https"
-	IngressDomain         = "example.com"
-	AdditionalDomain      = "additional-example.com"
-	AdditionalDomainExtra = "additional-example-extra.com"
-	IngressConfigData     = fmt.Sprintf(`{
+	KnativeIngressGateway      = "knative-serving/knative-ingress-gateway"
+	KnativeLocalGatewayService = "test-destination"
+	KnativeLocalGateway        = "knative-serving/knative-local-gateway"
+	LocalGatewayService        = "knative-local-gateway.istio-system.svc.cluster.local"
+	UrlScheme                  = "https"
+	IngressDomain              = "example.com"
+	AdditionalDomain           = "additional-example.com"
+	AdditionalDomainExtra      = "additional-example-extra.com"
+	IngressConfigData          = fmt.Sprintf(`{
 		"ingressGateway" : "%s",
-		"ingressService" : "%s",
+		"knativeLocalGatewayService" : "%s",
 		"localGateway" : "%s",
 		"localGatewayService" : "%s",
 		"ingressDomain": "%s",
 		"urlScheme": "https",
         "additionalIngressDomains": ["%s","%s"]
-	}`, KnativeIngressGateway, IngressService, KnativeLocalGateway, LocalGatewayService, IngressDomain,
+	}`, KnativeIngressGateway, KnativeLocalGatewayService, KnativeLocalGateway, LocalGatewayService, IngressDomain,
 		AdditionalDomain, AdditionalDomainExtra)
 )
 
@@ -71,12 +71,34 @@ func TestNewIngressConfig(t *testing.T) {
 	g.Expect(ingressCfg).ShouldNot(gomega.BeNil())
 
 	g.Expect(ingressCfg.IngressGateway).To(gomega.Equal(KnativeIngressGateway))
-	g.Expect(ingressCfg.IngressServiceName).To(gomega.Equal(IngressService))
+	g.Expect(ingressCfg.KnativeLocalGatewayService).To(gomega.Equal(KnativeLocalGatewayService))
 	g.Expect(ingressCfg.LocalGateway).To(gomega.Equal(KnativeLocalGateway))
 	g.Expect(ingressCfg.LocalGatewayServiceName).To(gomega.Equal(LocalGatewayService))
 	g.Expect(ingressCfg.UrlScheme).To(gomega.Equal(UrlScheme))
 	g.Expect(ingressCfg.IngressDomain).To(gomega.Equal(IngressDomain))
 	g.Expect(*ingressCfg.AdditionalIngressDomains).To(gomega.Equal([]string{AdditionalDomain, AdditionalDomainExtra}))
+}
+
+func TestNewIngressConfigDefaultKnativeService(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	clientset := fakeclientset.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
+		Data: map[string]string{
+			IngressConfigKeyName: fmt.Sprintf(`{
+				"ingressGateway" : "%s",
+				"localGateway" : "%s",
+				"localGatewayService" : "%s",
+				"ingressDomain": "%s",
+				"urlScheme": "https",
+        		"additionalIngressDomains": ["%s","%s"]
+			}`, KnativeIngressGateway, KnativeLocalGateway, LocalGatewayService, IngressDomain,
+				AdditionalDomain, AdditionalDomainExtra),
+		},
+	})
+	ingressCfg, err := NewIngressConfig(clientset)
+	g.Expect(err).Should(gomega.BeNil())
+	g.Expect(ingressCfg).ShouldNot(gomega.BeNil())
+	g.Expect(ingressCfg.KnativeLocalGatewayService).To(gomega.Equal(LocalGatewayService))
 }
 
 func TestNewDeployConfig(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/openapi_generated.go
+++ b/pkg/apis/serving/v1beta1/openapi_generated.go
@@ -4936,7 +4936,7 @@ func schema_pkg_apis_serving_v1beta1_IngressConfig(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
-					"ingressService": {
+					"knativeLocalGatewayService": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/pkg/apis/serving/v1beta1/swagger.json
+++ b/pkg/apis/serving/v1beta1/swagger.json
@@ -2732,7 +2732,7 @@
         "ingressGateway": {
           "type": "string"
         },
-        "ingressService": {
+        "knativeLocalGatewayService": {
           "type": "string"
         },
         "localGateway": {

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -76,7 +76,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}`,
 			"ingress": `{
 				"ingressGateway": "knative-serving/knative-ingress-gateway",
-				"ingressService": "test-destination",
 				"localGateway": "knative-serving/knative-local-gateway",
 				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
 			}`,
@@ -1778,7 +1777,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					copiedConfigs[key] = `{
 						"disableIstioVirtualHost": true,
 						"ingressGateway": "knative-serving/knative-ingress-gateway",
-						"ingressService": "test-destination",
 						"localGateway": "knative-serving/knative-local-gateway",
 						"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
 					}`

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -74,7 +74,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}`,
 			"ingress": `{
 				"ingressGateway": "knative-serving/knative-ingress-gateway",
-				"ingressService": "test-destination",
 				"localGateway": "knative-serving/knative-local-gateway",
 				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
 			}`,
@@ -1275,7 +1274,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
             }`,
 			"ingress": `{
                "ingressGateway": "knative-serving/knative-ingress-gateway",
-               "ingressService": "test-destination",
                "localGateway": "knative-serving/knative-local-gateway",
                "localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
                "ingressDomain": "example.com"
@@ -1707,7 +1705,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
             }`,
 			"ingress": `{
                "ingressGateway": "knative-serving/knative-ingress-gateway",
-               "ingressService": "test-destination",
                "localGateway": "knative-serving/knative-local-gateway",
                "localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
                "ingressDomain": "example.com",

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -401,7 +401,7 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 			Match: createHTTPMatchRequest(constants.ExplainPrefix(), serviceHost,
 				network.GetServiceHostname(isvc.Name, isvc.Namespace), additionalHosts, isInternal, config),
 			Route: []*istiov1beta1.HTTPRouteDestination{
-				createHTTPRouteDestination(config.LocalGatewayServiceName),
+				createHTTPRouteDestination(config.KnativeLocalGatewayService),
 			},
 			Headers: &istiov1beta1.Headers{
 				Request: &istiov1beta1.Headers_HeaderOperations{
@@ -418,7 +418,7 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 		Match: createHTTPMatchRequest("", serviceHost,
 			network.GetServiceHostname(isvc.Name, isvc.Namespace), additionalHosts, isInternal, config),
 		Route: []*istiov1beta1.HTTPRouteDestination{
-			createHTTPRouteDestination(config.LocalGatewayServiceName),
+			createHTTPRouteDestination(config.KnativeLocalGatewayService),
 		},
 		Headers: &istiov1beta1.Headers{
 			Request: &istiov1beta1.Headers_HeaderOperations{
@@ -481,7 +481,7 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 				Uri: "/",
 			},
 			Route: []*istiov1beta1.HTTPRouteDestination{
-				createHTTPRouteDestination(config.LocalGatewayServiceName),
+				createHTTPRouteDestination(config.KnativeLocalGatewayService),
 			},
 			Headers: &istiov1beta1.Headers{
 				Request: &istiov1beta1.Headers_HeaderOperations{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -42,6 +42,7 @@ func TestCreateVirtualService(t *testing.T) {
 	annotations := map[string]string{"test": "test"}
 	isvcAnnotations := map[string]string{"test": "test", "kubectl.kubernetes.io/last-applied-configuration": "test"}
 	labels := map[string]string{"test": "test"}
+	knativeLocalGatewayService := "someIngressServiceName"
 	domain := "example.com"
 	additionalDomain := "my-additional-domain.com"
 	additionalSecondDomain := "my-second-additional-domain.com"
@@ -83,10 +84,10 @@ func TestCreateVirtualService(t *testing.T) {
 	}, {
 		name: "predictor missing url",
 		ingressConfig: &v1beta1.IngressConfig{
-			IngressGateway:          constants.KnativeIngressGateway,
-			IngressServiceName:      "someIngressServiceName",
-			LocalGateway:            constants.KnativeLocalGateway,
-			LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+			IngressGateway:             constants.KnativeIngressGateway,
+			KnativeLocalGatewayService: knativeLocalGatewayService,
+			LocalGateway:               constants.KnativeLocalGateway,
+			LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 		},
 		useDefault: false,
 		componentStatus: &v1beta1.InferenceServiceStatus{
@@ -98,10 +99,10 @@ func TestCreateVirtualService(t *testing.T) {
 	}, {
 		name: "found predictor status",
 		ingressConfig: &v1beta1.IngressConfig{
-			IngressGateway:          constants.KnativeIngressGateway,
-			IngressServiceName:      "someIngressServiceName",
-			LocalGateway:            constants.KnativeLocalGateway,
-			LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+			IngressGateway:             constants.KnativeIngressGateway,
+			KnativeLocalGatewayService: knativeLocalGatewayService,
+			LocalGateway:               constants.KnativeLocalGateway,
+			LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 		},
 		useDefault: false,
 		componentStatus: &v1beta1.InferenceServiceStatus{
@@ -138,7 +139,7 @@ func TestCreateVirtualService(t *testing.T) {
 						Match: predictorRouteMatch,
 						Route: []*istiov1beta1.HTTPRouteDestination{
 							{
-								Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+								Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 								Weight:      100,
 							},
 						},
@@ -153,10 +154,10 @@ func TestCreateVirtualService(t *testing.T) {
 	}, {
 		name: "local cluster predictor",
 		ingressConfig: &v1beta1.IngressConfig{
-			IngressGateway:          constants.KnativeIngressGateway,
-			IngressServiceName:      "someIngressServiceName",
-			LocalGateway:            constants.KnativeLocalGateway,
-			LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+			IngressGateway:             constants.KnativeIngressGateway,
+			KnativeLocalGatewayService: knativeLocalGatewayService,
+			LocalGateway:               constants.KnativeLocalGateway,
+			LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 		},
 		useDefault: false,
 		componentStatus: &v1beta1.InferenceServiceStatus{
@@ -202,7 +203,7 @@ func TestCreateVirtualService(t *testing.T) {
 						},
 						Route: []*istiov1beta1.HTTPRouteDestination{
 							{
-								Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+								Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 								Weight:      100,
 							},
 						},
@@ -218,10 +219,10 @@ func TestCreateVirtualService(t *testing.T) {
 		{
 			name: "nil transformer status fails with status unknown",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -245,10 +246,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "found transformer and predictor status",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -301,7 +302,7 @@ func TestCreateVirtualService(t *testing.T) {
 							Match: predictorRouteMatch,
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},
@@ -317,10 +318,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "found transformer and predictor status",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -373,7 +374,7 @@ func TestCreateVirtualService(t *testing.T) {
 							Match: predictorRouteMatch,
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},
@@ -389,10 +390,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "nil explainer status fails with status unknown",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -416,10 +417,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "found explainer and predictor status",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -499,7 +500,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},
@@ -513,7 +514,7 @@ func TestCreateVirtualService(t *testing.T) {
 							Match: predictorRouteMatch,
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},
@@ -529,14 +530,14 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "found predictor status with path template",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
-				UrlScheme:               "http",
-				IngressDomain:           "my-domain.com",
-				PathTemplate:            "/serving/{{ .Namespace }}/{{ .Name }}",
-				DisableIstioVirtualHost: false,
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
+				UrlScheme:                  "http",
+				IngressDomain:              "my-domain.com",
+				PathTemplate:               "/serving/{{ .Namespace }}/{{ .Name }}",
+				DisableIstioVirtualHost:    false,
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -590,7 +591,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},
@@ -632,7 +633,7 @@ func TestCreateVirtualService(t *testing.T) {
 								Uri: "/",
 							},
 							Route: []*istiov1beta1.HTTPRouteDestination{
-								createHTTPRouteDestination("knative-local-gateway.istio-system.svc.cluster.local"),
+								createHTTPRouteDestination(knativeLocalGatewayService),
 							},
 							Headers: &istiov1beta1.Headers{
 								Request: &istiov1beta1.Headers_HeaderOperations{
@@ -648,15 +649,15 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "found predictor status with the additional ingress domains",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:           constants.KnativeIngressGateway,
-				IngressServiceName:       "someIngressServiceName",
-				LocalGateway:             constants.KnativeLocalGateway,
-				LocalGatewayServiceName:  "knative-local-gateway.istio-system.svc.cluster.local",
-				UrlScheme:                "http",
-				IngressDomain:            "my-domain.com",
-				AdditionalIngressDomains: &[]string{additionalDomain, additionalSecondDomain},
-				PathTemplate:             "/serving/{{ .Namespace }}/{{ .Name }}",
-				DisableIstioVirtualHost:  false,
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
+				UrlScheme:                  "http",
+				IngressDomain:              "my-domain.com",
+				AdditionalIngressDomains:   &[]string{additionalDomain, additionalSecondDomain},
+				PathTemplate:               "/serving/{{ .Namespace }}/{{ .Name }}",
+				DisableIstioVirtualHost:    false,
 			},
 			domainList: &[]string{"my-domain-1.com", "example.com"},
 			useDefault: false,
@@ -728,7 +729,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},
@@ -770,7 +771,7 @@ func TestCreateVirtualService(t *testing.T) {
 								Uri: "/",
 							},
 							Route: []*istiov1beta1.HTTPRouteDestination{
-								createHTTPRouteDestination("knative-local-gateway.istio-system.svc.cluster.local"),
+								createHTTPRouteDestination(knativeLocalGatewayService),
 							},
 							Headers: &istiov1beta1.Headers{
 								Request: &istiov1beta1.Headers_HeaderOperations{
@@ -786,10 +787,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "found predictor status with default suffix",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: true,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -826,7 +827,7 @@ func TestCreateVirtualService(t *testing.T) {
 							Match: predictorRouteMatch,
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},
@@ -841,10 +842,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "found transformer and predictor status with default suffix",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: true,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -897,7 +898,7 @@ func TestCreateVirtualService(t *testing.T) {
 							Match: predictorRouteMatch,
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},
@@ -913,10 +914,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "transformer is not ready",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: true,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -963,10 +964,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "nil explainer status fails with status unknown",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -990,10 +991,10 @@ func TestCreateVirtualService(t *testing.T) {
 		}, {
 			name: "explainer is not ready",
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -1053,10 +1054,10 @@ func TestCreateVirtualService(t *testing.T) {
 				},
 			},
 			ingressConfig: &v1beta1.IngressConfig{
-				IngressGateway:          constants.KnativeIngressGateway,
-				IngressServiceName:      "someIngressServiceName",
-				LocalGateway:            constants.KnativeLocalGateway,
-				LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
+				IngressGateway:             constants.KnativeIngressGateway,
+				KnativeLocalGatewayService: knativeLocalGatewayService,
+				LocalGateway:               constants.KnativeLocalGateway,
+				LocalGatewayServiceName:    "knative-local-gateway.istio-system.svc.cluster.local",
 			},
 			useDefault: false,
 			componentStatus: &v1beta1.InferenceServiceStatus{
@@ -1104,7 +1105,7 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 							Route: []*istiov1beta1.HTTPRouteDestination{
 								{
-									Destination: &istiov1beta1.Destination{Host: constants.LocalGatewayHost, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
+									Destination: &istiov1beta1.Destination{Host: knativeLocalGatewayService, Port: &istiov1beta1.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
 								},
 							},

--- a/pkg/controller/v1beta1/inferenceservice/suite_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/suite_test.go
@@ -105,7 +105,6 @@ var _ = BeforeSuite(func() {
 	deployConfig := &v1beta1.DeployConfig{DefaultDeploymentMode: "Serverless"}
 	ingressConfig := &v1beta1.IngressConfig{
 		IngressGateway:          constants.KnativeIngressGateway,
-		IngressServiceName:      "someIngressServiceName",
 		LocalGateway:            constants.KnativeLocalGateway,
 		LocalGatewayServiceName: "knative-local-gateway.istio-system.svc.cluster.local",
 		DisableIstioVirtualHost: false,

--- a/python/kserve/docs/V1beta1IngressConfig.md
+++ b/python/kserve/docs/V1beta1IngressConfig.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **ingress_class_name** | **str** |  | [optional] 
 **ingress_domain** | **str** |  | [optional] 
 **ingress_gateway** | **str** |  | [optional] 
-**ingress_service** | **str** |  | [optional] 
+**knative_local_gateway_service** | **str** |  | [optional] 
 **local_gateway** | **str** |  | [optional] 
 **local_gateway_service** | **str** |  | [optional] 
 **path_template** | **str** |  | [optional] 

--- a/python/kserve/kserve/models/v1beta1_ingress_config.py
+++ b/python/kserve/kserve/models/v1beta1_ingress_config.py
@@ -54,7 +54,7 @@ class V1beta1IngressConfig(object):
         'ingress_class_name': 'str',
         'ingress_domain': 'str',
         'ingress_gateway': 'str',
-        'ingress_service': 'str',
+        'knative_local_gateway_service': 'str',
         'local_gateway': 'str',
         'local_gateway_service': 'str',
         'path_template': 'str',
@@ -69,14 +69,14 @@ class V1beta1IngressConfig(object):
         'ingress_class_name': 'ingressClassName',
         'ingress_domain': 'ingressDomain',
         'ingress_gateway': 'ingressGateway',
-        'ingress_service': 'ingressService',
+        'knative_local_gateway_service': 'knativeLocalGatewayService',
         'local_gateway': 'localGateway',
         'local_gateway_service': 'localGatewayService',
         'path_template': 'pathTemplate',
         'url_scheme': 'urlScheme'
     }
 
-    def __init__(self, additional_ingress_domains=None, disable_ingress_creation=None, disable_istio_virtual_host=None, domain_template=None, ingress_class_name=None, ingress_domain=None, ingress_gateway=None, ingress_service=None, local_gateway=None, local_gateway_service=None, path_template=None, url_scheme=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, additional_ingress_domains=None, disable_ingress_creation=None, disable_istio_virtual_host=None, domain_template=None, ingress_class_name=None, ingress_domain=None, ingress_gateway=None, knative_local_gateway_service=None, local_gateway=None, local_gateway_service=None, path_template=None, url_scheme=None, local_vars_configuration=None):  # noqa: E501
         """V1beta1IngressConfig - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -89,7 +89,7 @@ class V1beta1IngressConfig(object):
         self._ingress_class_name = None
         self._ingress_domain = None
         self._ingress_gateway = None
-        self._ingress_service = None
+        self._knative_local_gateway_service = None
         self._local_gateway = None
         self._local_gateway_service = None
         self._path_template = None
@@ -110,8 +110,8 @@ class V1beta1IngressConfig(object):
             self.ingress_domain = ingress_domain
         if ingress_gateway is not None:
             self.ingress_gateway = ingress_gateway
-        if ingress_service is not None:
-            self.ingress_service = ingress_service
+        if knative_local_gateway_service is not None:
+            self.knative_local_gateway_service = knative_local_gateway_service
         if local_gateway is not None:
             self.local_gateway = local_gateway
         if local_gateway_service is not None:
@@ -269,25 +269,25 @@ class V1beta1IngressConfig(object):
         self._ingress_gateway = ingress_gateway
 
     @property
-    def ingress_service(self):
-        """Gets the ingress_service of this V1beta1IngressConfig.  # noqa: E501
+    def knative_local_gateway_service(self):
+        """Gets the knative_local_gateway_service of this V1beta1IngressConfig.  # noqa: E501
 
 
-        :return: The ingress_service of this V1beta1IngressConfig.  # noqa: E501
+        :return: The knative_local_gateway_service of this V1beta1IngressConfig.  # noqa: E501
         :rtype: str
         """
-        return self._ingress_service
+        return self._knative_local_gateway_service
 
-    @ingress_service.setter
-    def ingress_service(self, ingress_service):
-        """Sets the ingress_service of this V1beta1IngressConfig.
+    @knative_local_gateway_service.setter
+    def knative_local_gateway_service(self, knative_local_gateway_service):
+        """Sets the knative_local_gateway_service of this V1beta1IngressConfig.
 
 
-        :param ingress_service: The ingress_service of this V1beta1IngressConfig.  # noqa: E501
+        :param knative_local_gateway_service: The knative_local_gateway_service of this V1beta1IngressConfig.  # noqa: E501
         :type: str
         """
 
-        self._ingress_service = ingress_service
+        self._knative_local_gateway_service = knative_local_gateway_service
 
     @property
     def local_gateway(self):

--- a/python/kserve/test/test_v1beta1_ingress_config.py
+++ b/python/kserve/test/test_v1beta1_ingress_config.py
@@ -50,7 +50,7 @@ class TestV1beta1IngressConfig(unittest.TestCase):
         optional params are included"""
         # model = kserve.models.v1beta1_ingress_config.V1beta1IngressConfig()  # noqa: E501
         if include_optional:
-            return V1beta1IngressConfig(ingress_gateway="0", ingress_service="0")
+            return V1beta1IngressConfig(ingress_gateway="0")
         else:
             return V1beta1IngressConfig()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

These changes introduce the possibility to configure KServe with its own Istio local gateway, to partially decouple KServe from the Knative local gateway.

Typically, it is OK to re-use the already configured Knative local gateway for KServe uses (as long as configs do not conflict). However, there are cases where having a dedicated local gateway for KServe is beneficial. Just to give some examples:
* To have the ability to use strict mTLS in Istio
* To reduce some pressure on the Knative local gateway by having a dedicated gateway deployment (it still would hit Knative gateway, but only once, rather than twice)
* To be able to configure TLS on cluster-local hostnames (Knative support is still experimental)

To have a dedicated Gateway in KServe, similar configurations to Knative are need to be done. At the very least, and if not having a dedicated gateway deployment, a v1/Service and an Istio Gateway resource need to be created for KServe. Such resources would need to be configured in _localGateway_ and _localGatewayService_. KServe still needs to rely on Knative routing for the KSVCs it creates. Thus, after handling an incoming request and resolving its target, it needs to be forwarded to be handled by Knative. This is the reason for introducing a new `knativeLocalGatewayService` in the ConfigMap.

The removed `ingressService` seems to be unused. Apparently, it became unused when the v1alpha2 API of the InferenceServices was deprecated and removed.

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

**TODO**

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow KServe to have its own local gateways for Serverless mode
```

