### PR TITLE
Fix logprobs for vLLM

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_completions.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_completions.py
@@ -294,7 +294,9 @@ class OpenAIServingCompletion:
                     output_text = prompt_text
                 elif request.echo and request.max_tokens > 0:
                     token_ids = prompt_token_ids + output.token_ids
-                    top_logprobs = prompt_logprobs + output.logprobs
+                    top_logprobs = output.logprobs or prompt_logprobs
+                    if output.logprobs and prompt_logprobs:
+                        top_logprobs = prompt_logprobs + output.logprobs
                     output_text = prompt_text + output.text
                 else:
                     token_ids = output.token_ids
@@ -402,16 +404,16 @@ class OpenAIServingCompletion:
             step_top_logprobs = top_logprobs[i]
             if step_top_logprobs is not None:
                 token_logprob = step_top_logprobs[token_id].logprob
+                token = step_top_logprobs[token_id].decoded_token
+                logprobs.tokens.append(token)
+                last_token_len = len(token)
             else:
                 token_logprob = None
-            token = step_top_logprobs[token_id].decoded_token
-            logprobs.tokens.append(token)
             logprobs.token_logprobs.append(token_logprob)
             if len(logprobs.text_offset) == 0:
                 logprobs.text_offset.append(initial_text_offset)
             else:
                 logprobs.text_offset.append(logprobs.text_offset[-1] + last_token_len)
-            last_token_len = len(token)
 
             if num_output_top_logprobs:
                 logprobs.top_logprobs.append(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
- Fixes #3739

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Test A - With logprobs and echo True
```bash
$ curl -v -H "content-type: application/json" http://localhost:8080/openai/v1/completions -d '{"model": "opt-125m", "prompt": "translate this to german", "echo": true, "logprobs": 1}'

*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /openai/v1/completions HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.81.0
> Accept: */*
> content-type: application/json
> Content-Length: 88
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< date: Thu, 13 Jun 2024 11:22:32 GMT
< server: uvicorn
< content-length: 2130
< content-type: application/json
< 
{"id":"cmpl-5c92df9e085945e888cfaa7a7bd1e50e","choices":[{"finish_reason":"length","index":0,"logprobs":{"text_offset":[0,5,9,14,17,19,24,25,27,34,38,48,53,58,63,65,70,72,73,77,79,82,83],"token_logprobs":[null,-11.66795825958252,-3.775797128677368,-2.9433515071868896,-2.451396942138672,-5.648609638214111,-0.32780468463897705,-1.728607416152954,-4.922608375549316,-7.971958637237549,-2.743764877319336,-4.614389419555664,-4.869665622711182,-2.094351291656494,-2.8680009841918945,-2.635239601135254,-0.14527273178100586,-11.590120315551758,-3.0626769065856934,-10.316385269165039,-4.29969596862793,-5.206110000610352,-0.8678125143051147],"tokens":["trans","late"," this"," to"," g","erman","\n","In"," Europe"," you"," pronounce"," your"," name"," with"," g","erman","op",","," gal","ef","lex",","],"top_logprobs":[null,{"trans":-11.66795825958252,"I":-1.4278717041015625},{"late":-3.775797128677368,"gender":-2.200160264968872},{" this":-2.9433515071868896,"\n":-1.592982530593872},{" to":-2.451396942138672," into":-2.0535802841186523},{" g":-5.648609638214111,":":-1.9646825790405273},{"erman":-0.32780468463897705},{"\n":-1.728607416152954},{"In":-4.922608375549316,"I":-2.300739049911499},{" Europe":-7.971958637237549," German":-1.2194041013717651},{" you":-2.743764877319336,",":-1.3225795030593872},{" pronounce":-4.614389419555664," can":-1.11029052734375},{" your":-4.869665622711182," it":-0.8181374669075012},{" name":-2.094351291656494},{" with":-2.8680009841918945," as":-1.9227696657180786},{" g":-2.635239601135254," a":-1.0428322553634644},{"erman":-0.14527273178100586},{"op":-11.590120315551758,".":-1.4955559968948364},{",":-3.0626769065856934,".":-2.163510799407959},{" gal":-10.316385269165039," so":-2.2866501808166504},{"ef":-4.29969596862793,"er":-2.7384908199310303},{"lex":-5.206110000610352,",":-2.5782179832458496},{",":-0.8678125143051147}]},"text":"translate this to german\nIn Europe you pronounce your name with germanop, galeflex,"}],"created":1718277753,"model":"opt-125m","system_fingerprint":null,"object":"text_completion","usage":{"completion_tokens":16,"prompt_tokens":7,"total_tokens":23}}
```
- [x] Test B - Without logprobs and echo True
```bash
$ curl -v -H "content-type: application/json" http://localhost:8080/openai/v1/completions -d '{"model": "opt-125m", "prompt": "translate this to german", "echo": true}'

*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /openai/v1/completions HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.81.0
> Accept: */*
> content-type: application/json
> Content-Length: 73
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< date: Thu, 13 Jun 2024 11:23:44 GMT
< server: uvicorn
< content-length: 380
< content-type: application/json
< 
* Connection #0 to host localhost left intact
{"id":"cmpl-60b612557a0a4957b1cd390376821dd2","choices":[{"finish_reason":"length","index":0,"logprobs":null,"text":"translate this to german words\nTranslate into german languages = both parent words. Just like \""}],"created":1718277825,"model":"opt-125m","system_fingerprint":null,"object":"text_completion","usage":{"completion_tokens":16,"prompt_tokens":7,"total_tokens":23}}
```

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix logprobs for vLLM backend
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.