### PR TITLE
Use add_generation_prompt while creating chat template

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/generative_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/generative_model.py
@@ -387,7 +387,9 @@ class HuggingfaceGenerativeModel(
             prompt=cast(
                 str,
                 self._tokenizer.apply_chat_template(
-                    [m.model_dump() for m in messages], tokenize=False
+                    [m.model_dump() for m in messages],
+                    tokenize=False,
+                    add_generation_prompt=True,
                 ),
             )
         )

--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_completions.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_completions.py
@@ -343,7 +343,9 @@ class OpenAIServingCompletion:
         self,
         messages: Iterable[ChatCompletionRequestMessage,],
     ):
-        return self.tokenizer.apply_chat_template(conversation=messages, tokenize=False)
+        return self.tokenizer.apply_chat_template(
+            conversation=messages, tokenize=False, add_generation_prompt=True
+        )
 
     async def _post_init(self):
         engine_model_config = await self.engine.get_model_config()


### PR DESCRIPTION
**What this PR does / why we need it**:
- add_generation_prompt is useful for chat models which have a special token/tokens before assistant response starts like llama3. 

**Note** : **I'm looking for suggestions** on how to expose this parameter. Ideally this should be a request specific parameter with `True` as default. For that we need to modify the `CreateChatCompletionRequest`. [vLLM does that here](https://github.com/vllm-project/vllm/blob/7cd2ebb0251fd1fd0eec5c93dac674603a22eddd/vllm/entrypoints/openai/protocol.py#L177)

Query:
```bash
curl -H "content-type:application/json" -v localhost:8080/openai/v1/chat/completions -d '{"model": "llama3", "messages": [{"role": "user","content": "Explain transformers from NLP. }], "stream":false,"max_tokens":100}'
```

Response with current change (add_generation_prompt):
```json
{
  "id": "cmpl-01db022c401c4a3da33c6e5fb15e9e39",
  "choices": [
    {
      "finish_reason": "length",
      "index": 0,
      "message": {
        "content": "A fundamental concept in Natural Language Processing (NLP)!\n\nIn NLP, a Transformer is a type of neural network architecture that revolutionized the field by overcoming the limitations of recurrent neural networks (RNNs) in processing sequential data, such as text or speech. The Transformer was introduced in a groundbreaking paper by Vaswani et al. in 2017 and has since become a widely used model in many NLP applications.\n\n**Problems with RNNs:**\n\nRNNs,",
        "tool_calls": null,
        "role": "assistant",
        "function_call": null
      },
      "logprobs": null
    }
  ],
  "created": 1720010426,
  "model": "llama3",
  "system_fingerprint": null,
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 100,
    "prompt_tokens": 18,
    "total_tokens": 118
  }
}
```
Response without add_generation_prompt:
```json
{
  "id": "cmpl-5c6ab0c7237b46608e01b0a8f79e05bd",
  "choices": [
    {
      "finish_reason": "length",
      "index": 0,
      "message": {
        "content": "<|start_header_id|>assistant<|end_header_id|>\n\nTransformers!\n\nIn the field of Natural Language Processing (NLP), Transformers are a type of neural network architecture that has revolutionized the way we approach machine learning tasks. They were introduced in a research paper by Vaswani et al. in 2017 and have since become a widely used and well-established technique.\n\n**What are Transformers?**\n\nTransformers are a type of encoder-decoder model that specializes in processing sequential data, such as texts, speech, or time series",
        "tool_calls": null,
        "role": "assistant",
        "function_call": null
      },
      "logprobs": null
    }
  ],
  "created": 1720010580,
  "model": "llama3",
  "system_fingerprint": null,
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 100,
    "prompt_tokens": 14,
    "total_tokens": 114
  }
}
```

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

- Logs
1. Without `add_generation_prompt`:
```
INFO 07-03 12:43:00 async_llm_engine.py:553] Received request cmpl-5c6ab0c7237b46608e01b0a8f79e05bd-0: 

prompt: '<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nExplain transformers from NLP.<|eot_id|>', 

params: SamplingParams(n=1, best_of=1, ...), 

prompt_token_ids: [128000, 128000, 128006, 882, 128007, 271, 849, 21435, 87970, 505, 452, 12852, 13, 128009], lora_request: None.
```
2. With `add_generation_prompt`:
```
INFO 07-03 12:45:49 async_llm_engine.py:553] Received request cmpl-c09490e9cad845c1b608955956157e6d-0: 

prompt: '<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nExplain transformers from NLP.<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n', 

params: SamplingParams(n=1, best_of=1, ...),

prompt_token_ids: [128000, 128000, 128006, 882, 128007, 271, 849, 21435, 87970, 505, 452, 12852, 13, 128009, 128006, 78191, 128007, 271], lora_request: None.
```
