### PR TITLE
huggingfaceserver: allow transformers updates within the  major version

### DIFF
--- a/python/huggingfaceserver/pyproject.toml
+++ b/python/huggingfaceserver/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
 kserve = { path = "../kserve", extras = ["storage"], develop = true }
-transformers = "~4.40.2"
+transformers = "^4.40.2"
 accelerate = "~0.30.0"
 torch = "~2.3.0"
 vllm = { version = "^0.4.3", optional = true }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR relaxes the restriction for the transformers package so that we can install latest versions allowing minor and patch upgrades. This is required in order to be able to use the server with latest models on huggingface (e.g. [gemma2](https://huggingface.co/google/gemma-2-27b-it) which requires `v4.42.3`).
Changing the requirement from using a tilde (~) to a caret (^) will allow us to use latest minor and patch versions of transformers.
Assuming that minor and patch releases have full backwards compatibility this will not cause any issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3782 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Relax requirements for transformers in huggingfaceserver allowing minor and patch version upgrades 
```
