### PR TITLE
Install packages needed for vllm model load

### DIFF
--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -36,9 +36,7 @@ RUN pip3 install vllm==${VLLM_VERSION}
 
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 as prod
 
-RUN apt-get update -y && apt-get install build-essential gcc python3-dev -y
-
-RUN apt-get update -y && apt-get install python3.10-venv -y && apt-get clean && \
+RUN apt-get update -y && apt-get install python3.10-venv build-essential gcc python3-dev -y && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY third_party third_party

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -36,6 +36,8 @@ RUN pip3 install vllm==${VLLM_VERSION}
 
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 as prod
 
+RUN apt-get update -y && apt-get install build-essential gcc python3-dev -y
+
 RUN apt-get update -y && apt-get install python3.10-venv -y && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Models from the Mixtral family load fail due the need for a specific cuda kernel. 

Fixes the below error 
vllm issue reference https://github.com/vllm-project/vllm/issues/2997

```
2024-07-17 17:14:33,710 ERROR worker.py:406 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::RayWorkerWrapper.execute_method() (pid=814, ip=172.17.0.2, actor_id=85d031a1ac73b20b6c5282f001000000, repr=<vllm.executor.ray_utils.RayWorkerWrapper object at 0x77c0580cbfd0>)
  File "/prod_venv/lib/python3.10/site-packages/vllm/worker/worker_base.py", line 149, in execute_method
    raise e
  File "/prod_venv/lib/python3.10/site-packages/vllm/worker/worker_base.py", line 140, in execute_method
    return executor(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/vllm/worker/worker.py", line 154, in determine_num_available_blocks
    self.model_runner.profile_run()
  File "/prod_venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 809, in profile_run
    self.execute_model(seqs, kv_caches)
  File "/prod_venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 728, in execute_model
    hidden_states = model_executable(**execute_model_kwargs)
  File "/prod_venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/vllm/model_executor/models/mixtral.py", line 491, in forward
    hidden_states = self.model(input_ids, positions, kv_caches,
  File "/prod_venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/vllm/model_executor/models/mixtral.py", line 424, in forward
    hidden_states, residual = layer(positions, hidden_states,
  File "/prod_venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/vllm/model_executor/models/mixtral.py", line 380, in forward
    hidden_states = self.block_sparse_moe(hidden_states)
  File "/prod_venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    return forward_call(*args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/vllm/model_executor/models/mixtral.py", line 227, in forward
    final_hidden_states = fused_moe(hidden_states,
  File "/prod_venv/lib/python3.10/site-packages/vllm/model_executor/layers/fused_moe/fused_moe.py", line 511, in fused_moe
    return fused_experts(hidden_states,
  File "/prod_venv/lib/python3.10/site-packages/vllm/model_executor/layers/fused_moe/fused_moe.py", line 423, in fused_experts
    invoke_fused_moe_kernel(hidden_states,
  File "/prod_venv/lib/python3.10/site-packages/vllm/model_executor/layers/fused_moe/fused_moe.py", line 246, in invoke_fused_moe_kernel
    fused_moe_kernel[grid](
  File "/prod_venv/lib/python3.10/site-packages/triton/runtime/jit.py", line 167, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
  File "/prod_venv/lib/python3.10/site-packages/triton/runtime/jit.py", line 363, in run
    device = driver.get_current_device()
  File "/prod_venv/lib/python3.10/site-packages/triton/runtime/driver.py", line 209, in __getattr__
    self._initialize_obj()
  File "/prod_venv/lib/python3.10/site-packages/triton/runtime/driver.py", line 206, in _initialize_obj
    self._obj = self._init_fn()
  File "/prod_venv/lib/python3.10/site-packages/triton/runtime/driver.py", line 239, in initialize_driver
    return CudaDriver()
  File "/prod_venv/lib/python3.10/site-packages/triton/runtime/driver.py", line 102, in __init__
    self.utils = CudaUtils()
  File "/prod_venv/lib/python3.10/site-packages/triton/runtime/driver.py", line 49, in __init__
    so = _build("cuda_utils", src_path, tmpdir)
  File "/prod_venv/lib/python3.10/site-packages/triton/common/build.py", line 83, in _build
    raise RuntimeError("Failed to find C compiler. Please specify via CC environment variable.")
RuntimeError: Failed to find C compiler. Please specify via CC environment variable.

```

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Sanity tests conducted

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.