### PR TITLE
Rename max_length parameter to max_model_len to be in sync with vLLM

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -133,13 +133,6 @@ if not vllm_available():
         choices=dtype_choices,
         help=f"data type to load the weights in. One of {dtype_choices}. Defaults to float16 for GPU and float32 for CPU systems",
     )
-    # vLLM uses max-model-len as paramter to denote max tokens. Register the same for HuggingFace (if vllm not available)
-    parser.add_argument(
-        "--max-model-len",
-        required=False,
-        type=int,
-        help="max number of tokens the model can process/tokenize. If not mentioned, uses model's max position encodings",
-    )
 
 
 args, _ = parser.parse_known_args()

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -70,6 +70,13 @@ parser.add_argument(
     help="Huggingface tokenizer revision",
 )
 parser.add_argument(
+    "--max_length",
+    dest="max_model_len",
+    type=int,
+    required=False,
+    help="max sequence length for the tokenizer. will be deprecated in favour of --max-model-length",
+)
+parser.add_argument(
     "--disable_lower_case",
     action="store_true",
     help="do not use lower case for the tokenizer",

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -74,7 +74,13 @@ parser.add_argument(
     dest="max_model_len",
     type=int,
     required=False,
-    help="max sequence length for the tokenizer. will be deprecated in favour of --max-model-len",
+    help="max sequence length for the tokenizer. will be deprecated in favour of --max_model_len",
+)
+parser.add_argument(
+    "--max_model_len",
+    type=int,
+    required=False,
+    help="max number of tokens the model can process/tokenize. If not mentioned, uses model's max position encodings",
 )
 parser.add_argument(
     "--disable_lower_case",

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -74,7 +74,7 @@ parser.add_argument(
     dest="max_model_len",
     type=int,
     required=False,
-    help="max sequence length for the tokenizer. will be deprecated in favour of --max-model-length",
+    help="max sequence length for the tokenizer. will be deprecated in favour of --max-model-len",
 )
 parser.add_argument(
     "--disable_lower_case",

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -70,12 +70,6 @@ parser.add_argument(
     help="Huggingface tokenizer revision",
 )
 parser.add_argument(
-    "--max_length",
-    type=int,
-    required=False,
-    help="max sequence length for the tokenizer",
-)
-parser.add_argument(
     "--disable_lower_case",
     action="store_true",
     help="do not use lower case for the tokenizer",
@@ -126,6 +120,14 @@ if not vllm_available():
         choices=dtype_choices,
         help=f"data type to load the weights in. One of {dtype_choices}. Defaults to float16 for GPU and float32 for CPU systems",
     )
+    # vLLM uses max-model-len as paramter to denote max tokens. Register the same for HuggingFace (if vllm not available)
+    parser.add_argument(
+        "--max-model-len",
+        required=False,
+        type=int,
+        help="max number of tokens the model can process/tokenize. If not mentioned, uses model's max position encodings",
+    )
+
 
 args, _ = parser.parse_known_args()
 
@@ -211,7 +213,7 @@ def load_model():
                 model_revision=kwargs.get("model_revision", None),
                 tokenizer_revision=kwargs.get("tokenizer_revision", None),
                 do_lower_case=not kwargs.get("disable_lower_case", False),
-                max_length=kwargs["max_length"],
+                max_length=kwargs["max_model_len"],
                 dtype=dtype,
                 trust_remote_code=kwargs["trust_remote_code"],
             )
@@ -236,7 +238,7 @@ def load_model():
                 tokenizer_revision=kwargs.get("tokenizer_revision", None),
                 do_lower_case=not kwargs.get("disable_lower_case", False),
                 add_special_tokens=not kwargs.get("disable_special_tokens", False),
-                max_length=kwargs["max_length"],
+                max_length=kwargs["max_model_len"],
                 dtype=dtype,
                 trust_remote_code=kwargs["trust_remote_code"],
                 tensor_input_names=kwargs.get("tensor_input_names", None),

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -48,7 +48,7 @@ def test_huggingface_openai_chat_completions():
                 "27dcfa74d334bc871f3234de431e71c6eeba5dd6",
                 "--backend",
                 "huggingface",
-                "--max-model-len",
+                "--max_model_len",
                 "512",
             ],
             resources=V1ResourceRequirements(
@@ -251,7 +251,7 @@ def test_huggingface_openai_text_2_text():
                 "t5-small",
                 "--backend",
                 "huggingface",
-                "--max-model-len",
+                "--max_model_len",
                 "512",
             ],
             resources=V1ResourceRequirements(

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -48,7 +48,7 @@ def test_huggingface_openai_chat_completions():
                 "27dcfa74d334bc871f3234de431e71c6eeba5dd6",
                 "--backend",
                 "huggingface",
-                "--max_length",
+                "--max-model-len",
                 "512",
             ],
             resources=V1ResourceRequirements(
@@ -251,7 +251,7 @@ def test_huggingface_openai_text_2_text():
                 "t5-small",
                 "--backend",
                 "huggingface",
-                "--max_length",
+                "--max-model-len",
                 "512",
             ],
             resources=V1ResourceRequirements(


### PR DESCRIPTION
**What this PR does / why we need it**:
vLLM uses parameter called `max-model-len` to denote the max length allowed for tokenisation and processing. We have similar parameter for HF case but under a diff name called `max_length`. Rename that to use the same parameter for both backends for consistency.
Now we're adding `--max_model_len` which would essentially write to `args.max_model_len`. We'll slowly move away from `--max_length` .



**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

```release-note
Add `--max_model_len` to huggingface runtime and deprecate `--max_length`
```