### PR TITLE
Add logging request feature for vLLM backend

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -164,7 +164,7 @@ def load_model():
         args.model = args.model_id or args.model_dir
         args.revision = args.model_revision
         engine_args = build_vllm_engine_args(args)
-        model = VLLMModel(args.model_name, engine_args)
+        model = VLLMModel(args.model_name, engine_args, max_log_len=args.max_log_len)
 
     else:
         kwargs = vars(args)

--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -18,6 +18,7 @@ from typing import cast
 
 import torch
 import kserve
+from huggingfaceserver.request_logger import RequestLogger
 from kserve import logging
 from kserve.logging import logger
 from kserve.model import PredictorConfig
@@ -113,7 +114,18 @@ parser.add_argument(
     action="store_true",
     help="Return all probabilities",
 )
-
+parser.add_argument(
+    "--disable_log_requests", action="store_true", help="Disable logging requests"
+)
+parser.add_argument(
+    "--max_log_len",
+    "--max-log-len",
+    type=int,
+    default=None,
+    help="Max number of prompt characters or prompt "
+    "ID numbers being printed in log."
+    "\n\nDefault: Unlimited",
+)
 parser = maybe_add_vllm_cli_parser(parser)
 
 default_dtype = "float16" if torch.cuda.is_available() else "float32"
@@ -124,7 +136,8 @@ if not vllm_available():
         required=False,
         default="auto",
         choices=dtype_choices,
-        help=f"data type to load the weights in. One of {dtype_choices}. Defaults to float16 for GPU and float32 for CPU systems",
+        help=f"data type to load the weights in. One of {dtype_choices}. "
+        f"Defaults to float16 for GPU and float32 for CPU systems",
     )
 
 args, _ = parser.parse_known_args()
@@ -145,6 +158,11 @@ def load_model():
     else:
         model_id_or_path = Path(Storage.download(args.model_dir))
 
+    if args.disable_log_requests:
+        request_logger = None
+    else:
+        request_logger = RequestLogger(max_log_len=args.max_log_len)
+
     if model_id_or_path is None:
         raise ValueError("You must provide a model_id or model_dir")
 
@@ -164,7 +182,7 @@ def load_model():
         args.model = args.model_id or args.model_dir
         args.revision = args.model_revision
         engine_args = build_vllm_engine_args(args)
-        model = VLLMModel(args.model_name, engine_args, max_log_len=args.max_log_len)
+        model = VLLMModel(args.model_name, engine_args, request_logger=request_logger)
 
     else:
         kwargs = vars(args)
@@ -214,6 +232,7 @@ def load_model():
                 max_length=kwargs["max_length"],
                 dtype=dtype,
                 trust_remote_code=kwargs["trust_remote_code"],
+                request_logger=request_logger,
             )
         else:
             # Convert dtype from string to torch dtype. Default to float32
@@ -242,6 +261,7 @@ def load_model():
                 tensor_input_names=kwargs.get("tensor_input_names", None),
                 return_token_type_ids=kwargs.get("return_token_type_ids", None),
                 predictor_config=predictor_config,
+                request_logger=request_logger,
             )
     model.load()
     return model

--- a/python/huggingfaceserver/huggingfaceserver/generative_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/generative_model.py
@@ -58,6 +58,7 @@ from transformers import (
     set_seed,
 )
 from kserve.metrics import LLMStats
+from .request_logger import RequestLogger
 
 from .stop_sequence_stopping_criteria import StopSequenceStoppingCriteria
 from .task import (
@@ -151,6 +152,7 @@ class HuggingfaceGenerativeModel(
         tokenizer_revision: Optional[str] = None,
         trust_remote_code: bool = False,
         system_fingerprint: Optional[str] = None,
+        request_logger: Optional[RequestLogger] = None,
     ):
         super().__init__(name)
         self.model_config = model_config
@@ -164,6 +166,7 @@ class HuggingfaceGenerativeModel(
         self.trust_remote_code = trust_remote_code
         self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self._request_queue = queue.Queue()
+        self.request_logger = request_logger
 
         if model_config:
             self.model_config = model_config
@@ -396,6 +399,7 @@ class HuggingfaceGenerativeModel(
     async def create_completion(
         self, request: CompletionRequest
     ) -> Union[Completion, AsyncIterator[Completion]]:
+        self._log_request(request)
         params = request.params
         if params.prompt is None:
             raise ValueError("prompt is required")
@@ -492,4 +496,18 @@ class HuggingfaceGenerativeModel(
                     completion_tokens=stats.num_generation_tokens,
                     total_tokens=stats.num_prompt_tokens + stats.num_generation_tokens,
                 ),
+            )
+
+    def _log_request(self, request: CompletionRequest) -> None:
+        is_prompt_token = isinstance(request.params.prompt, list) and (
+            isinstance(request.params.prompt[0], int)
+            or isinstance(request.params.prompt[0], list)
+            and isinstance(request.params.prompt[0][0], int)
+        )
+        if self.request_logger:
+            self.request_logger.log_inputs(
+                request_id=request.request_id,
+                prompt=request.params.prompt if not is_prompt_token else None,
+                prompt_token_ids=request.params.prompt if is_prompt_token else None,
+                params=request.params.model_dump(exclude={"prompt"}),
             )

--- a/python/huggingfaceserver/huggingfaceserver/request_logger.py
+++ b/python/huggingfaceserver/huggingfaceserver/request_logger.py
@@ -1,0 +1,60 @@
+# Copyright 2024 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, List, Union, Any
+
+from kserve.logging import trace_logger
+
+
+class RequestLogger:
+
+    def __init__(self, *, max_log_len: Optional[int]) -> None:
+        super().__init__()
+
+        self.max_log_len = max_log_len
+
+    def log_inputs(
+        self,
+        request_id: str,
+        prompt: Optional[Union[str, List[str]]] = None,
+        prompt_token_ids: Optional[List[int]] = None,
+        params: Optional[Any] = None,
+        lora_request: Optional[Any] = None,
+        prompt_adapter_request: Optional[Any] = None,
+    ) -> None:
+        max_log_len = self.max_log_len
+        if max_log_len is not None:
+            if prompt is not None:
+                if isinstance(prompt, list):
+                    for i, p in enumerate(prompt):
+                        prompt[i] = p[:max_log_len]
+                prompt = prompt[:max_log_len]
+
+            if prompt_token_ids is not None:
+                if isinstance(prompt_token_ids, list):
+                    for i, p in enumerate(prompt_token_ids):
+                        prompt_token_ids[i] = p[:max_log_len]
+                prompt_token_ids = prompt_token_ids[:max_log_len]
+
+        trace_logger.info(
+            "Received request %s: prompt: %r, "
+            "params: %s, prompt_token_ids: %s, "
+            "lora_request: %s, prompt_adapter_request: %s.",
+            request_id,
+            prompt,
+            params,
+            prompt_token_ids,
+            lora_request,
+            prompt_adapter_request,
+        )

--- a/python/huggingfaceserver/huggingfaceserver/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/utils.py
@@ -14,11 +14,12 @@
 
 from transformers import PretrainedConfig
 from typing import Optional
+
 from kserve.logging import logger
 
-"This implementation is based on vLLM's _get_and_verify_max_len https://github.com/vllm-project/vllm/blob/a377f0bd5e1fa0ca069e3dbf28f4de5af64d0bb1/vllm/config.py#L1160"
 
-
+# "This implementation is based on vLLM's _get_and_verify_max_len "
+# "https://github.com/vllm-project/vllm/blob/a377f0bd5e1fa0ca069e3dbf28f4de5af64d0bb1/vllm/config.py#L1160"
 def _get_and_verify_max_len(
     hf_config: PretrainedConfig,
     max_model_len: Optional[int],

--- a/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
@@ -54,14 +54,6 @@ def infer_vllm_supported_from_model_architecture(
 def maybe_add_vllm_cli_parser(parser: ArgumentParser) -> ArgumentParser:
     if not _vllm:
         return parser
-    parser.add_argument(
-        "--max-log-len",
-        type=int,
-        default=None,
-        help="Max number of prompt characters or prompt "
-        "ID numbers being printed in log."
-        "\n\nDefault: Unlimited",
-    )
     return AsyncEngineArgs.add_cli_args(parser)
 
 

--- a/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/utils.py
@@ -54,6 +54,14 @@ def infer_vllm_supported_from_model_architecture(
 def maybe_add_vllm_cli_parser(parser: ArgumentParser) -> ArgumentParser:
     if not _vllm:
         return parser
+    parser.add_argument(
+        "--max-log-len",
+        type=int,
+        default=None,
+        help="Max number of prompt characters or prompt "
+        "ID numbers being printed in log."
+        "\n\nDefault: Unlimited",
+    )
     return AsyncEngineArgs.add_cli_args(parser)
 
 

--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
@@ -42,14 +42,11 @@ class VLLMModel(Model, OpenAIChatAdapterModel):  # pylint:disable=c-extension-no
         model_name: str,
         engine_args: AsyncEngineArgs = None,
         predictor_config: Optional[PredictorConfig] = None,
-        max_log_len: Optional[int] = None,
+        request_logger: Optional[RequestLogger] = None,
     ):
         super().__init__(model_name, predictor_config)
         self.vllm_engine_args = engine_args
-        if self.vllm_engine_args.disable_log_requests:
-            self.request_logger = None
-        else:
-            self.request_logger = RequestLogger(max_log_len=max_log_len)
+        self.request_logger = request_logger
 
     def load(self) -> bool:
         if torch.cuda.is_available():

--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
@@ -15,6 +15,8 @@
 from typing import AsyncIterator, Iterable, Optional, Union
 
 import torch
+from vllm.entrypoints.logger import RequestLogger
+
 from kserve import Model
 from kserve.model import PredictorConfig
 from kserve.protocol.rest.openai import (
@@ -40,15 +42,22 @@ class VLLMModel(Model, OpenAIChatAdapterModel):  # pylint:disable=c-extension-no
         model_name: str,
         engine_args: AsyncEngineArgs = None,
         predictor_config: Optional[PredictorConfig] = None,
+        max_log_len: Optional[int] = None,
     ):
         super().__init__(model_name, predictor_config)
         self.vllm_engine_args = engine_args
+        if self.vllm_engine_args.disable_log_requests:
+            self.request_logger = None
+        else:
+            self.request_logger = RequestLogger(max_log_len=max_log_len)
 
     def load(self) -> bool:
         if torch.cuda.is_available():
             self.vllm_engine_args.tensor_parallel_size = torch.cuda.device_count()
         self.vllm_engine = AsyncLLMEngine.from_engine_args(self.vllm_engine_args)
-        self.openai_serving_completion = OpenAIServingCompletion(self.vllm_engine)
+        self.openai_serving_completion = OpenAIServingCompletion(
+            self.vllm_engine, self.request_logger
+        )
         self.ready = True
         return self.ready
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3848

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Test A
```
$ /home/ubuntu/go/src/github.com/kserve/kserve/.venv/bin/python -m huggingfaceserver --model_id=facebook/opt-125m --model_name=opt-125m --max_length=512 --dtype=float32 

INFO 08-09 14:44:23 config.py:1417] Upcasting torch.float16 to torch.float32.
INFO 08-09 14:44:23 llm_engine.py:176] Initializing an LLM engine (v0.5.3.post1) with config: model='facebook/opt-125m', speculative_config=None, tokenizer='facebook/opt-125m', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float32, max_seq_len=2048, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, quantization_param_path=None, device_config=cpu, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None), seed=0, served_model_name=facebook/opt-125m, use_v2_block_manager=False, enable_prefix_caching=False)
WARNING 08-09 14:44:23 cpu_executor.py:136] CUDA graph is not supported on CPU, fallback to the eager mode.
WARNING 08-09 14:44:23 cpu_executor.py:163] Environment variable VLLM_CPU_KVCACHE_SPACE (GB) for CPU backend is not set, using 4 by default.
INFO 08-09 14:44:23 selector.py:117] Cannot use _Backend.FLASH_ATTN backend on CPU.
INFO 08-09 14:44:23 selector.py:66] Using Torch SDPA backend.
INFO 08-09 14:44:25 selector.py:117] Cannot use _Backend.FLASH_ATTN backend on CPU.
INFO 08-09 14:44:25 selector.py:66] Using Torch SDPA backend.
INFO 08-09 14:44:26 weight_utils.py:223] Using model weights format ['*.bin']
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.32it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.32it/s]

INFO 08-09 14:44:27 cpu_executor.py:76] # CPU blocks: 3640
2024-08-09 14:44:29.077 18580 kserve INFO [model_server.py:register_model():389] Registering model: opt-125m
2024-08-09 14:44:29.077 18580 kserve INFO [model_server.py:start():314] Setting max asyncio worker threads as 12
2024-08-09 14:44:29.078 18580 kserve INFO [model_server.py:_serve_rest():247] Starting uvicorn with 1 workers
2024-08-09 14:44:29.141 uvicorn.error INFO:     Started server process [18580]
2024-08-09 14:44:29.141 uvicorn.error INFO:     Waiting for application startup.
2024-08-09 14:44:29.157 18580 kserve INFO [server.py:start():68] Starting gRPC server on [::]:8081
2024-08-09 14:44:29.157 uvicorn.error INFO:     Application startup complete.
2024-08-09 14:44:29.158 uvicorn.error INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)

INFO 08-09 14:44:50 logger.py:36] Received request cmpl-7cf8f64b9cd44a5287eaee721b3be812: prompt: 'Hi, I love my cat', params: SamplingParams(n=1, best_of=1, presence_penalty=0, frequency_penalty=0, repetition_penalty=1.0, temperature=1, top_p=1, top_k=-1, min_p=0.0, seed=None, use_beam_search=False, length_penalty=1.0, early_stopping=False, stop=[], stop_token_ids=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None), prompt_token_ids: [2, 30086, 6, 38, 657, 127, 4758], lora_request: None, prompt_adapter_request: None.

INFO 08-09 14:44:50 async_llm_engine.py:173] Added request cmpl-7cf8f64b9cd44a5287eaee721b3be812-0.
2024-08-09 14:44:50.496 uvicorn.access INFO:     127.0.0.1:41516 18580 - "POST /openai/v1/completions HTTP/1.1" 200 OK
INFO 08-09 14:44:50 metrics.py:396] Avg prompt throughput: 0.3 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.
INFO 08-09 14:44:50 async_llm_engine.py:140] Finished request cmpl-7cf8f64b9cd44a5287eaee721b3be812-0.
```





**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.