### PR TITLE
Enable Server-Side Apply for Kustomize Overlays in Test Environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ deploy: manifests
 	cd config/default && if [ ${KSERVE_ENABLE_SELF_SIGNED_CA} != false ]; then \
 	echo > ../certmanager/certificate.yaml; \
 	else git checkout HEAD -- ../certmanager/certificate.yaml; fi;
-	kubectl apply -k config/default
+	kubectl apply --server-side=true -k config/default
 	if [ ${KSERVE_ENABLE_SELF_SIGNED_CA} != false ]; then ./hack/self-signed-ca.sh; fi;
 	kubectl wait --for=condition=ready pod -l control-plane=kserve-controller-manager -n kserve --timeout=300s
-	kubectl apply -k config/clusterresources
+	kubectl apply  --server-side=true  -k config/clusterresources
 	git checkout HEAD -- config/certmanager/certificate.yaml
 
 
@@ -87,11 +87,11 @@ deploy-dev: manifests
 	cd config/default && if [ ${KSERVE_ENABLE_SELF_SIGNED_CA} != false ]; then \
 	echo > ../certmanager/certificate.yaml; \
 	else git checkout HEAD -- ../certmanager/certificate.yaml; fi;
-	kubectl apply -k config/overlays/development
+	kubectl apply --server-side=true -k config/overlays/development
 	if [ ${KSERVE_ENABLE_SELF_SIGNED_CA} != false ]; then ./hack/self-signed-ca.sh; fi;
 	# TODO: Add runtimes as part of default deployment
 	kubectl wait --for=condition=ready pod -l control-plane=kserve-controller-manager -n kserve --timeout=300s
-	kubectl apply -k config/clusterresources
+	kubectl apply --server-side=true -k config/clusterresources
 	git checkout HEAD -- config/certmanager/certificate.yaml
 
 deploy-dev-sklearn: docker-push-sklearn
@@ -114,13 +114,13 @@ deploy-dev-huggingface: docker-push-huggingface
 
 deploy-dev-storageInitializer: docker-push-storageInitializer
 	./hack/storageInitializer_patch_dev.sh ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG}
-	kubectl apply -k config/overlays/dev-image-config
+	kubectl apply --server-side=true -k config/overlays/dev-image-config
 
 deploy-ci: manifests
-	kubectl apply -k config/overlays/test
+	kubectl apply --server-side=true -k config/overlays/test
 	# TODO: Add runtimes as part of default deployment
 	kubectl wait --for=condition=ready pod -l control-plane=kserve-controller-manager -n kserve --timeout=300s
-	kubectl apply -k config/overlays/test/clusterresources
+	kubectl apply --server-side=true -k config/overlays/test/clusterresources
 
 deploy-helm: manifests
 	helm install kserve-crd charts/kserve-crd/ --wait --timeout 180s

--- a/hack/kserve_migration/kserve_migration.sh
+++ b/hack/kserve_migration/kserve_migration.sh
@@ -121,7 +121,7 @@ ksvc_count=${#ksvc_names[@]}
         yq 'del(.metadata.managedFields)' -i "${ISVC_CONFIG_DIR}/${isvc_names[$i]}.yaml"
         yq 'del(.status)' -i "${ISVC_CONFIG_DIR}/${isvc_names[$i]}.yaml"
         sed -i -- 's/kubeflow.org/kserve.io/g' ${ISVC_CONFIG_DIR}/${isvc_names[$i]}.yaml
-        kubectl apply -f "${ISVC_CONFIG_DIR}/${isvc_names[$i]}.yaml"
+        kubectl apply --server-side=true -f "${ISVC_CONFIG_DIR}/${isvc_names[$i]}.yaml"
     done
 )
 sleep 300

--- a/hack/serving_runtime_image_patch.sh
+++ b/hack/serving_runtime_image_patch.sh
@@ -23,4 +23,4 @@ set -o pipefail
 export SERVING_RUNTIME_FILE_NAME=$1
 export IMG=$2
 if [ -z "$IMG" ] || [ -z "$SERVING_RUNTIME_FILE_NAME" ]; then exit; fi
-yq eval '.spec.containers[0].image = env(IMG)' config/runtimes/"$SERVING_RUNTIME_FILE_NAME" | kubectl apply -f -
+yq eval '.spec.containers[0].image = env(IMG)' config/runtimes/"$SERVING_RUNTIME_FILE_NAME" | kubectl apply --server-side=true -f -


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
With [this PR](https://github.com/kserve/kserve/pull/3871), the inference service CRD size will be increased from 672k to 757k 
~~~
ls -alh /tmp/isvc_old.yaml 
-rw-r--r-- 1 jooho jooho 672K Aug 20 07:08 /tmp/isvc_old.yaml 

ls -alh /tmp/isvc_new.yaml 
-rw-r--r-- 1 jooho jooho 757K Aug 20 07:05 /tmp/isvc_new.yaml 
~~~
e2e test ci failed to create  the new CRD with the following error msg:
~~~
The CustomResourceDefinition "inferenceservices.serving.kserve.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes 
~~~

When `kubectl apply` used, the whole specification is added to the annotation `last-applied-configuration`

This PR addresses an issue encountered during the e2e tests, which is related to the problem described in [kserve/kserve#3487](https://github.com/kserve/kserve/issues/3487). The changes aim to prevent similar issues from affecting future test runs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kserve crd needs to be installed with server side apply
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.