### PR TITLE
Fix the 'tokens exceeding model limit' error response in vllm server

### DIFF
--- a/python/huggingfaceserver/tests/test_vllm_model.py
+++ b/python/huggingfaceserver/tests/test_vllm_model.py
@@ -22,7 +22,6 @@ from vllm.config import ModelConfig
 
 from huggingfaceserver.vllm.vllm_completions import OpenAIServingCompletion
 from huggingfaceserver.vllm.vllm_model import VLLMModel
-from kserve.errors import InvalidInput
 from kserve.logging import logger
 from kserve.protocol.rest.openai import ChatCompletionRequest, CompletionRequest
 from kserve.protocol.rest.openai.errors import OpenAIError
@@ -2814,7 +2813,7 @@ class TestOpenAIServingCompletion:
             prompt=prompt,
             max_tokens=opt_model.openai_serving_completion.max_model_len + 1,
         )
-        with pytest.raises(InvalidInput):
+        with pytest.raises(OpenAIError):
             opt_model.openai_serving_completion._validate_input(
                 request,
                 input_text=prompt,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The error returned when total token length exceeds context length is currently returning an InternalServerError (500) when it should return a BadRequest error (400) in VLLM backend with huggingfaceserver predictor. (This is consistent with the error status that vLLM returns)

Example:
Current - InternalServerError (500):
```
{
  "error": {
    "code": "500",
    "message": "This model's maximum context length is 8192 tokens. However, you requested 50014 tokens (14 in the messages, 50000 in the completion). Please reduce the length of the messages or completion.",
    "param": "",
    "type": "OpenAIError"
  }
}
```

Fix - BadRequest error (400):
```
{
  "error": {
    "code": "400",
    "message": "This model's maximum context length is 8192 tokens. However, you requested 50014 tokens (14 in the messages, 50000 in the completion). Please reduce the length of the messages or completion.",
    "param": "",
    "type": "BadRequest"
  }
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Testing the error for Completions and ChatCompletions with and without streaming

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.