### PR TITLE
For vllm users, our parser should be able to support both - and _

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -50,7 +50,12 @@ def list_of_strings(arg):
     return arg.split(",")
 
 
-parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
+try:
+    from vllm.utils import FlexibleArgumentParser
+
+    parser = FlexibleArgumentParser(parents=[kserve.model_server.parser])
+except ImportError:
+    parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
 
 parser.add_argument(
     "--model_dir",


### PR DESCRIPTION


**What this PR does / why we need it**:
In huggingfaceserver, we do not support "_" but vLLM does support it. This is inconsistent and may cause performance effect: for example, if we have a typo "--use_v2_block_manager" then, this is unset and many other optimization parameters would be unset, which would cause unexpected formance.


- [x] New feature (non-breaking change which adds functionality)



