### PR TITLE
add tags to rest server timing logs to differentiate cpu and wall time

### DIFF
--- a/python/kserve/kserve/protocol/rest/server.py
+++ b/python/kserve/kserve/protocol/rest/server.py
@@ -52,7 +52,7 @@ async def metrics_handler(request: Request) -> Response:
 
 class PrintTimings(TimingClient):
     def timing(self, metric_name, timing, tags):
-        trace_logger.info(f"{metric_name}: {timing}")
+        trace_logger.info(f"{metric_name}: {timing} {tags}")
 
 
 class _NoSignalUvicornServer(uvicorn.Server):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The current logging of timings ([here](https://github.com/kserve/kserve/blob/2376eeb3256034fcaa5ee8f494c014576a2b4f5e/python/kserve/kserve/protocol/rest/server.py#L55)) produces one log entry for wall time and another for cpu time (via [timing-asgi](https://github.com/steinnes/timing-asgi/blob/2a0dd6535b740481f4354831a37b92b47a70d4c2/timing_asgi/middleware.py#L61-L66)). As it doesn't use the tags provided by timing-asgi, the entries look the same, and cannot be parsed automatically (e.g. into a [log-based metric](https://cloud.google.com/logging/docs/logs-based-metrics)).

```
2024-09-23 06:52:11.122 kserve.trace kserve.io.kserve.protocol.rest.v1_endpoints.predict: 1.287339210510254
2024-09-23 06:52:11.122 kserve.trace kserve.io.kserve.protocol.rest.v1_endpoints.predict: 14.015691999999717
```

This PR simply adds the tags to the log message, which makes it possible to automatically pull values for either cpu or wall time from the log messages.

```
2024-09-24 06:45:36.529 kserve.trace kserve.io.kserve.protocol.rest.v1_endpoints.predict: 6.345419406890869 ['http_status:200', 'http_method:POST', 'time:wall']
2024-09-24 06:45:36.530 kserve.trace kserve.io.kserve.protocol.rest.v1_endpoints.predict: 10.888566999999998 ['http_status:200', 'http_method:POST', 'time:cpu']
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

So far only built a docker image with update python package and run in an InferenceService to produce the logs. Will continue to set up kserve development environment when I have time.

- Logs

```
2024-09-24 06:45:36.529 kserve.trace kserve.io.kserve.protocol.rest.v1_endpoints.predict: 6.345419406890869 ['http_status:200', 'http_method:POST', 'time:wall']
2024-09-24 06:45:36.530 kserve.trace kserve.io.kserve.protocol.rest.v1_endpoints.predict: 10.888566999999998 ['http_status:200', 'http_method:POST', 'time:cpu']
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

No changes to image versions.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
The REST server timing-asgi logs are changed to include the provided tags, include `time:cpu` or `time:wall` to provide more information about the timings.
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.