### PR TITLE
Fix snyk scan null error

### DIFF
--- a/.github/workflows/scheduled-image-scan.yml
+++ b/.github/workflows/scheduled-image-scan.yml
@@ -43,13 +43,14 @@ jobs:
             --sarif-file-output=./application/${{ matrix.image.name }}/docker.snyk.sarif
           sarif: false
 
-      # Replace any "undefined" security severity values with 0. The undefined value is used in the case
+      # Replace any "undefined" or "null" security severity values with 0. The undefined value is used in the case
       # of license-related findings, which do not indicate a security vulnerability.
       # See https://github.com/github/codeql-action/issues/2187 for more context.
       # This can be removed once https://github.com/snyk/cli/pull/5409 is merged.
       - name: Replace security-severity undefined for license-related findings
         run: |
           sudo sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' ./application/${{ matrix.image.name }}/docker.snyk.sarif
+          sudo sed -i 's/"security-severity": "null"/"security-severity": "0"/g' ./application/${{ matrix.image.name }}/docker.snyk.sarif
 
       - name: Upload sarif file to Github Code Scanning
         if: always()
@@ -88,13 +89,14 @@ jobs:
             --sarif-file-output=./application/${{ matrix.image.name }}/docker.snyk.sarif
           sarif: false
 
-      # Replace any "undefined" security severity values with 0. The undefined value is used in the case
+      # Replace any "undefined" or "null" security severity values with 0. The undefined value is used in the case
       # of license-related findings, which do not indicate a security vulnerability.
       # See https://github.com/github/codeql-action/issues/2187 for more context.
       # This can be removed once https://github.com/snyk/cli/pull/5409 is merged.
       - name: Replace security-severity undefined for license-related findings
         run: |
           sudo sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' ./application/${{ matrix.image.name }}/docker.snyk.sarif
+          sudo sed -i 's/"security-severity": "null"/"security-severity": "0"/g' ./application/${{ matrix.image.name }}/docker.snyk.sarif
 
       - name: Upload sarif file to Github Code Scanning
         if: always()
@@ -129,13 +131,14 @@ jobs:
             --sarif-file-output=./application/${{ matrix.image.name }}/docker.snyk.sarif
           sarif: false
 
-      # Replace any "undefined" security severity values with 0. The undefined value is used in the case
+      # Replace any "undefined" or "null" security severity values with 0. The undefined value is used in the case
       # of license-related findings, which do not indicate a security vulnerability.
       # See https://github.com/github/codeql-action/issues/2187 for more context.
       # This can be removed once https://github.com/snyk/cli/pull/5409 is merged.
       - name: Replace security-severity undefined for license-related findings
         run: |
           sudo sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' ./application/${{ matrix.image.name }}/docker.snyk.sarif
+          sudo sed -i 's/"security-severity": "null"/"security-severity": "0"/g' ./application/${{ matrix.image.name }}/docker.snyk.sarif
 
       - name: Upload sarif file to Github Code Scanning
         if: always()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Snyk scan is still failing due to invalid value in the sarif file. This PR replaces the invalid null value with "0".
![Screenshot from 2024-10-07 12-46-48](https://github.com/user-attachments/assets/5bc066c2-9564-47e9-92d5-e7cc4f8f4f68)


**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Tested in my fork repo
![Screenshot from 2024-10-07 12-47-43](https://github.com/user-attachments/assets/d5d2f8b9-e39d-45e1-a240-05bca8042cd5)



**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.