### PR TITLE
Do not set security context on the storage initializer from user container

### DIFF
--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -168,6 +168,10 @@ $ helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.14.0-rc1
 | kserve.servingruntime.xgbserver.tag | string | `"v0.14.0-rc1"` |  |
 | kserve.storage.caBundleConfigMapName | string | `""` | Mounted CA bundle config map name for storage initializer. |
 | kserve.storage.caBundleVolumeMountPath | string | `"/etc/ssl/custom-certs"` | Mounted path for CA bundle config map. |
+| kserve.storage.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| kserve.storage.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| kserve.storage.containerSecurityContext.privileged | bool | `false` |  |
+| kserve.storage.containerSecurityContext.runAsNonRoot | bool | `true` |  |
 | kserve.storage.cpuModelcar | string | `"10m"` | Model sidecar cpu requirement. |
 | kserve.storage.enableModelcar | bool | `false` | Flag for enabling model sidecar feature. |
 | kserve.storage.image | string | `"kserve/storage-initializer"` |  |

--- a/charts/kserve-resources/templates/clusterstoragecontainer.yaml
+++ b/charts/kserve-resources/templates/clusterstoragecontainer.yaml
@@ -13,6 +13,10 @@ spec:
       limits:
         memory: 1Gi
         cpu: "1"
+    securityContext:
+      {{- with .Values.kserve.storage.containerSecurityContext}}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
   supportedUriFormats:
     - prefix: gs://
     - prefix: s3://

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -10,6 +10,15 @@ kserve:
   storage:
     image: kserve/storage-initializer
     tag: *defaultVersion
+
+    # security context for the default storage container
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      privileged: false
+      runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
  
     # -- Flag for enabling model sidecar feature.
     enableModelcar: false

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -354,7 +354,6 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 		storageInitializerImage = mi.config.Image
 	}
 
-	securityContext := userContainer.SecurityContext.DeepCopy()
 	// Add an init container to run provisioning logic to the PodSpec
 	initContainer := &v1.Container{
 		Name:  StorageInitializerContainerName,
@@ -375,7 +374,6 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 				v1.ResourceMemory: resource.MustParse(mi.config.MemoryRequest),
 			},
 		},
-		SecurityContext: securityContext,
 	}
 
 	// Add a mount the shared volume on the kserve-container, update the PodSpec

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -2623,6 +2623,9 @@ func TestGetStorageContainerSpec(t *testing.T) {
 						v1.ResourceMemory: resource.MustParse("200Mi"),
 					},
 				},
+				SecurityContext: &v1.SecurityContext{
+					RunAsNonRoot: ptr.Bool(true),
+				},
 			},
 			SupportedUriFormats: []v1alpha1.SupportedUriFormat{{Prefix: "custom://"}},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Curently the `securityContext` of the storage initializer container comes from `kserve-container` which comes from servingRuntimes. This was added in https://github.com/kserve/kserve/pull/613 when we didn't have `ClusterStorageContainer` yet. Now people can set `securityContext` from `ClusterStorageContainer` .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

* Updated unit tests
* Do a helm dry run and check the output
`helm install kserve-resources ./kserve-resources -n kserve --dry-run > output`
```
# Source: kserve/templates/clusterstoragecontainer.yaml
apiVersion: "serving.kserve.io/v1alpha1"
kind: ClusterStorageContainer
metadata:
  name: default
spec:
  container:
    name: storage-initializer
    image: "kserve/storage-initializer:v0.14.0-rc1"
    resources:
      requests:
        memory: 100Mi
        cpu: 100m
      limits:
        memory: 1Gi
        cpu: "1"
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      privileged: false
      runAsNonRoot: true
```
- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.