### PR TITLE
Fix  InferenceService state when Predictor pod in CrashLoopBackOff 

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status_test.go
@@ -360,6 +360,7 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 		statusSpec               ComponentStatusSpec
 		podList                  *v1.PodList
 		rawDeployment            bool
+		serviceStatus            *knservingv1.ServiceStatus
 		expectedRevisionStates   *ModelRevisionStates
 		expectedTransitionStatus TransitionStatus
 		expectedFailureInfo      *FailureInfo
@@ -400,6 +401,16 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				Items:    []v1.Pod{},
 			},
 			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: "",
 				TargetModelState: Pending,
@@ -466,6 +477,16 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				},
 			},
 			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: "",
 				TargetModelState: Pending,
@@ -538,6 +559,16 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				},
 			},
 			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: "",
 				TargetModelState: FailedToLoad,
@@ -619,6 +650,16 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				},
 			},
 			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: "",
 				TargetModelState: FailedToLoad,
@@ -695,6 +736,16 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				},
 			},
 			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: "",
 				TargetModelState: FailedToLoad,
@@ -776,6 +827,16 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				},
 			},
 			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "Unknown",
+						},
+					},
+				},
+			},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: "",
 				TargetModelState: FailedToLoad,
@@ -850,6 +911,98 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				},
 			},
 			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
+			expectedRevisionStates: &ModelRevisionStates{
+				ActiveModelState: "",
+				TargetModelState: Loading,
+			},
+			expectedTransitionStatus: InProgress,
+			expectedFailureInfo:      nil,
+		},
+		"storage initializer in running state but knative has errors": {
+			isvcStatus: &InferenceServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: v1.ConditionFalse,
+						},
+					},
+				},
+				Address: &duckv1.Addressable{},
+				URL:     &apis.URL{},
+				Components: map[ComponentType]ComponentStatusSpec{
+					PredictorComponent: {
+						LatestRolledoutRevision: "test-predictor-default-0001",
+					},
+				},
+				ModelStatus: ModelStatus{},
+			},
+			statusSpec: ComponentStatusSpec{
+				LatestReadyRevision:       "",
+				LatestCreatedRevision:     "",
+				PreviousRolledoutRevision: "",
+				LatestRolledoutRevision:   "",
+				Traffic:                   nil,
+				URL:                       nil,
+				RestURL:                   nil,
+				GrpcURL:                   nil,
+				Address:                   nil,
+			},
+			podList: &v1.PodList{
+				TypeMeta: metav1.TypeMeta{},
+				ListMeta: metav1.ListMeta{},
+				Items: []v1.Pod{
+					{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: constants.StorageInitializerContainerName,
+						},
+						Spec: v1.PodSpec{},
+						Status: v1.PodStatus{
+							InitContainerStatuses: []v1.ContainerStatus{
+								{
+									Name: constants.StorageInitializerContainerName,
+									State: v1.ContainerState{
+										Running: &v1.ContainerStateRunning{
+											StartedAt: metav1.Time{},
+										},
+									},
+									LastTerminationState: v1.ContainerState{},
+									Ready:                false,
+									RestartCount:         0,
+									Image:                "",
+									ImageID:              "",
+									ContainerID:          "",
+									Started:              proto.Bool(true),
+								},
+							},
+						},
+					},
+				},
+			},
+			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:    "Ready",
+							Status:  "True",
+							Reason:  "RevisionFailed",
+							Message: "For testing",
+						},
+					},
+				},
+			},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: "",
 				TargetModelState: Loading,
@@ -917,6 +1070,16 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				},
 			},
 			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: Loaded,
 				TargetModelState: Loaded,
@@ -984,6 +1147,7 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 				},
 			},
 			rawDeployment: true,
+			serviceStatus: &knservingv1.ServiceStatus{},
 			expectedRevisionStates: &ModelRevisionStates{
 				ActiveModelState: Loaded,
 				TargetModelState: Loaded,
@@ -1049,7 +1213,17 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 					},
 				},
 			},
-			rawDeployment:            false,
+			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
 			expectedRevisionStates:   nil,
 			expectedTransitionStatus: "",
 			expectedFailureInfo:      nil,
@@ -1112,7 +1286,17 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 					},
 				},
 			},
-			rawDeployment:            false,
+			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
 			expectedRevisionStates:   nil,
 			expectedTransitionStatus: "",
 			expectedFailureInfo:      nil,
@@ -1121,7 +1305,7 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			scenario.isvcStatus.PropagateModelStatus(scenario.statusSpec, scenario.podList, scenario.rawDeployment)
+			scenario.isvcStatus.PropagateModelStatus(scenario.statusSpec, scenario.podList, scenario.rawDeployment, scenario.serviceStatus)
 
 			g.Expect(scenario.isvcStatus.ModelStatus.ModelRevisionStates).To(gomega.Equal(scenario.expectedRevisionStates))
 			g.Expect(scenario.isvcStatus.ModelStatus.TransitionStatus).To(gomega.Equal(scenario.expectedTransitionStatus))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When deploying a model with an error (e.g. a nonexistent model path) the ISVC modelStatus was stuck in Pending / InProgress. This happened because the Predictor's reconcile function was catching the failing pod's storage initializer container in the running state and never rechecked in order to catch the container in the terminated state. This PR will requeue the Predictor's reconcile function if the storage initializer container is caught in the running state and there was a previous error ( a hint that something may be wrong even if our current status is running). 
The ideal scenario is that we now catch the storage initializer in the terminated state and update the modelStatus to FailedToLoad  / BlockedByFailedLoad. However, the PR also adds a secondary check for serverless deployment so that if we miss the terminated state and the deployment has scaled down to 0, we can retrieve the error status from knative. 

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

Fixes #1859

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Added a unit test to cover the case where we need to use the knative error information to update the ISVC modelStatus
- [ ] Live test:
1. Deployed a model via ODH UI and waited for it to scale to 1
2. Edited the model config to point to a nonexistent model path 
![model_config](https://github.com/user-attachments/assets/ba582e60-11f3-4398-a6b1-f86d9c63a342)
3. After the deployment has scaled to 0, double checked that the final ISVC modelStatus was FailedToLoad  / BlockedByFailedLoad.
![ISVC_final_modelStatus](https://github.com/user-attachments/assets/9d32e482-a8fd-4a1f-8f85-5a24fefaf708)

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.