### PR TITLE
Reduce E2Es dependency on CI environment (2)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,6 +34,7 @@ env:
   PMML_IMG: "pmmlserver"
   PADDLE_IMG: "paddleserver"
   CUSTOM_MODEL_GRPC_IMG: "custom-model-grpc"
+  CUSTOM_MODEL_GRPC_IMG_TAG: "kserve/custom-model-grpc:${{ github.sha }}"
   HUGGINGFACE_IMG: "huggingfaceserver"
   # Explainer images
   ART_IMG: "art-explainer"

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -71,10 +71,10 @@ async def predict_isvc(
         namespace=KSERVE_TEST_NAMESPACE,
         version=version,
     )
-    cluster_ip, host, path = get_isvc_endpoint(isvc)
+    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc)
     if model_name is None:
         model_name = service_name
-    base_url = f"http://{cluster_ip}{path}"
+    base_url = f"{scheme}://{cluster_ip}{path}"
     return await predict(
         client,
         base_url,
@@ -167,8 +167,8 @@ async def predict_ig(
         namespace=KSERVE_TEST_NAMESPACE,
         version=version,
     )
-    cluster_ip, host, _ = get_isvc_endpoint(ig)
-    url = f"http://{cluster_ip}"
+    scheme, cluster_ip, host, _ = get_isvc_endpoint(ig)
+    url = f"{scheme}://{cluster_ip}"
     return await predict(client, url, host, input_path, is_graph=True)
 
 
@@ -191,8 +191,8 @@ async def explain_response(client, service_name, input_path) -> Dict:
         namespace=KSERVE_TEST_NAMESPACE,
         version=constants.KSERVE_V1BETA1_VERSION,
     )
-    cluster_ip, host, path = get_isvc_endpoint(isvc)
-    url = f"http://{cluster_ip}{path}"
+    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc)
+    url = f"{scheme}://{cluster_ip}{path}"
     headers = {"Host": host}
     with open(input_path) as json_file:
         data = json.load(json_file)
@@ -257,7 +257,7 @@ async def predict_grpc(
         namespace=KSERVE_TEST_NAMESPACE,
         version=version,
     )
-    _, host, _ = get_isvc_endpoint(isvc)
+    _, _, host, _ = get_isvc_endpoint(isvc)
 
     if model_name is None:
         model_name = service_name
@@ -293,13 +293,14 @@ async def predict_modelmesh(
 
 
 def get_isvc_endpoint(isvc):
+    scheme = urlparse(isvc["status"]["url"]).scheme
     host = urlparse(isvc["status"]["url"]).netloc
     path = urlparse(isvc["status"]["url"]).path
     if os.environ.get("CI_USE_ISVC_HOST") == "1":
         cluster_ip = host
     else:
         cluster_ip = get_cluster_ip()
-    return cluster_ip, host, path
+    return scheme, cluster_ip, host, path
 
 
 def generate(
@@ -319,13 +320,13 @@ def generate(
             namespace=KSERVE_TEST_NAMESPACE,
             version=version,
         )
-        cluster_ip, host, path = get_isvc_endpoint(isvc)
+        scheme, cluster_ip, host, path = get_isvc_endpoint(isvc)
         headers = {"Host": host, "Content-Type": "application/json"}
 
         if chat_completions:
-            url = f"http://{cluster_ip}{path}/openai/v1/chat/completions"
+            url = f"{scheme}://{cluster_ip}{path}/openai/v1/chat/completions"
         else:
-            url = f"http://{cluster_ip}{path}/openai/v1/completions"
+            url = f"{scheme}://{cluster_ip}{path}/openai/v1/completions"
         logger.info("Sending Header = %s", headers)
         logger.info("Sending url = %s", url)
         logger.info("Sending request data: %s", data)

--- a/test/e2e/custom/test_custom_model_grpc.py
+++ b/test/e2e/custom/test_custom_model_grpc.py
@@ -44,7 +44,7 @@ async def test_custom_model_grpc():
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("CUSTOM_MODEL_GRPC_IMG_TAG"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},
@@ -106,7 +106,7 @@ async def test_predictor_grpc_with_transformer_grpc():
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("CUSTOM_MODEL_GRPC_IMG_TAG"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},
@@ -186,7 +186,7 @@ async def test_predictor_grpc_with_transformer_http(rest_v2_client):
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("CUSTOM_MODEL_GRPC_IMG_TAG"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},

--- a/test/e2e/custom/test_ray.py
+++ b/test/e2e/custom/test_ray.py
@@ -37,7 +37,7 @@ async def test_custom_model_http_ray(rest_v1_client):
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("CUSTOM_MODEL_GRPC_IMG_TAG"),
                 # Override the entrypoint to run the model using ray
                 command=["python", "-m", "custom_model.model_remote"],
                 resources=V1ResourceRequirements(

--- a/test/e2e/predictor/test_grpc.py
+++ b/test/e2e/predictor/test_grpc.py
@@ -75,7 +75,7 @@ async def test_custom_model_grpc():
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("CUSTOM_MODEL_GRPC_IMG_TAG"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},

--- a/test/e2e/predictor/test_raw_deployment.py
+++ b/test/e2e/predictor/test_raw_deployment.py
@@ -131,7 +131,7 @@ async def test_isvc_with_multiple_container_port():
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("CUSTOM_MODEL_GRPC_IMG_TAG"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},

--- a/test/e2e/predictor/test_response_headers.py
+++ b/test/e2e/predictor/test_response_headers.py
@@ -30,7 +30,7 @@ def test_predictor_headers_v1():
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("CUSTOM_MODEL_GRPC_IMG_TAG"),
                 # Override the entrypoint to run the custom model rest server
                 command=["python", "-m", "custom_model.model"],
                 resources=V1ResourceRequirements(
@@ -80,13 +80,13 @@ def test_predictor_headers_v1():
         namespace=KSERVE_TEST_NAMESPACE,
         version=constants.KSERVE_V1BETA1_VERSION,
     )
-    cluster_ip, host, path = get_isvc_endpoint(isvc)
+    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc)
     headers = {"Host": host, "Content-Type": "application/json"}
 
     if model_name is None:
         model_name = service_name
 
-    url = f"http://{cluster_ip}{path}/v1/models/{model_name}:predict"
+    url = f"{scheme}://{cluster_ip}{path}/v1/models/{model_name}:predict"
 
     time.sleep(10)
     with open(input_json) as json_file:
@@ -116,7 +116,7 @@ def test_predictor_headers_v2():
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image=os.environ.get("CUSTOM_MODEL_GRPC_IMG_TAG"),
                 # Override the entrypoint to run the custom model rest server
                 command=["python", "-m", "custom_model.model"],
                 resources=V1ResourceRequirements(
@@ -165,13 +165,13 @@ def test_predictor_headers_v2():
         namespace=KSERVE_TEST_NAMESPACE,
         version=constants.KSERVE_V1BETA1_VERSION,
     )
-    cluster_ip, host, path = get_isvc_endpoint(isvc)
+    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc)
     headers = {"Host": host, "Content-Type": "application/json"}
 
     if model_name is None:
         model_name = service_name
 
-    url = f"http://{cluster_ip}{path}/v2/models/{model_name}/infer"
+    url = f"{scheme}://{cluster_ip}{path}/v2/models/{model_name}/infer"
 
     time.sleep(10)
     with open(input_json) as json_file:


### PR DESCRIPTION
Follow-up of #3435 

**What this PR does / why we need it**:

Some code of the E2Es assume the environment is GitHub, because it is referring to GitHub-specific variables. This PR focuses on the `kserve/custom-model-grpc` container image, so that no Python code of the E2Es using this image is referencing the `github_sha` variable.

Also, a small improvement on the `get_isvc_endpoint` utility function is done to use the schema in the endpoint specified in the status of the InferenceService, rather than hard-coding to plain-text HTTP. This adds compatibility for CI environments where KServe ConfigMap has been configured with `urlScheme: https` for the Ingress.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
