### PR TITLE
Set default for SamplingParams.max_tokens in OpenAI requests if unset

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_completions.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_completions.py
@@ -153,7 +153,10 @@ class OpenAIServingCompletion:
             )
 
             for i, prompt_inputs in enumerate(prompts):
-                sampling_params = to_sampling_params(request, default_max_tokens=self.max_model_len - len(prompt_inputs[0]))
+                sampling_params = to_sampling_params(
+                    request,
+                    default_max_tokens=self.max_model_len - len(prompt_inputs[0]),
+                )
                 self._log_inputs(request_id, prompt_inputs, sampling_params)
                 generators.append(
                     self.engine.generate(

--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_completions.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_completions.py
@@ -55,8 +55,12 @@ from kserve.protocol.rest.openai.errors import OpenAIError, create_error_respons
 from kserve.protocol.rest.openai import ChatCompletionRequestMessage, CompletionRequest
 
 
-def to_sampling_params(request: CreateCompletionRequest):
-    echo_without_generation = request.echo and request.max_tokens == 0
+def to_sampling_params(request: CreateCompletionRequest, default_max_tokens: int):
+    # Based on the same fix as https://github.com/vllm-project/vllm/pull/6954
+    max_tokens = request.max_tokens
+    if max_tokens is None:
+        max_tokens = default_max_tokens
+    echo_without_generation = request.echo and max_tokens == 0
 
     logits_processors = None
     if request.logit_bias:
@@ -82,7 +86,7 @@ def to_sampling_params(request: CreateCompletionRequest):
         seed=request.seed,
         stop=request.stop,
         logprobs=request.logprobs,
-        max_tokens=request.max_tokens if not echo_without_generation else 1,
+        max_tokens=max_tokens if not echo_without_generation else 1,
         logits_processors=logits_processors,
         prompt_logprobs=request.logprobs if request.echo else None,
     )
@@ -138,7 +142,6 @@ class OpenAIServingCompletion:
         # Schedule the request and get the result generator.
         generators = []
         try:
-            sampling_params = to_sampling_params(request)
             prompts = list(
                 self._tokenize_prompt_input_or_inputs(
                     request,
@@ -150,6 +153,7 @@ class OpenAIServingCompletion:
             )
 
             for i, prompt_inputs in enumerate(prompts):
+                sampling_params = to_sampling_params(request, default_max_tokens=self.max_model_len - len(prompt_inputs[0]))
                 self._log_inputs(request_id, prompt_inputs, sampling_params)
                 generators.append(
                     self.engine.generate(

--- a/python/huggingfaceserver/tests/test_vllm_model.py
+++ b/python/huggingfaceserver/tests/test_vllm_model.py
@@ -304,6 +304,65 @@ class TestChatCompletions:
         )
         assert compare_response_to_expected(response, expected) is True
 
+    async def test_vllm_chat_completion_facebook_opt_model_should_set_correct_max_tokens(
+        self, vllm_opt_model
+    ):
+        opt_model, mock_vllm_engine = vllm_opt_model
+        request_id = "cmpl-d771287a234c44498e345f0a429d6691"
+
+        max_tokens_arg = None
+        async def mock_generate(*args, **kwargs) -> AsyncIterator[RequestOutput]:
+            nonlocal max_tokens_arg
+            # sampling_params is the second argument to generate()
+            max_tokens_arg = args[1].max_tokens
+            for cmpl_chunk in opt_chat_cmpl_chunks:
+                cmpl_chunk.request_id = args[2]
+                yield cmpl_chunk
+
+        mock_vllm_engine.generate = mock_generate
+
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a friendly chatbot who always responds in the style of a pirate",
+            },
+            {
+                "role": "user",
+                "content": "How many helicopters can a human eat in one sitting?",
+            },
+        ]
+
+        # max_tokens unset
+        params = CreateChatCompletionRequest(
+            model="opt-125m",
+            messages=messages,
+            stream=False,
+            chat_template="{% for message in messages %}"
+            "{{ message.content }}{{ eos_token }}"
+            "{% endfor %}",
+        )
+        request = ChatCompletionRequest(
+            request_id=request_id, params=params, context={}
+        )
+        await opt_model.create_chat_completion(request)
+        assert max_tokens_arg is not None
+
+        # max_tokens set
+        params = CreateChatCompletionRequest(
+            model="opt-125m",
+            messages=messages,
+            stream=False,
+            max_tokens=15,
+            chat_template="{% for message in messages %}"
+            "{{ message.content }}{{ eos_token }}"
+            "{% endfor %}",
+        )
+        request = ChatCompletionRequest(
+            request_id=request_id, params=params, context={}
+        )
+        await opt_model.create_chat_completion(request)
+        assert max_tokens_arg == 15
+
     async def test_vllm_chat_completion_facebook_opt_model_with_max_token_stream(
         self, vllm_opt_model
     ):

--- a/python/huggingfaceserver/tests/test_vllm_model.py
+++ b/python/huggingfaceserver/tests/test_vllm_model.py
@@ -309,8 +309,8 @@ class TestChatCompletions:
     ):
         opt_model, mock_vllm_engine = vllm_opt_model
         request_id = "cmpl-d771287a234c44498e345f0a429d6691"
-
         max_tokens_arg = None
+
         async def mock_generate(*args, **kwargs) -> AsyncIterator[RequestOutput]:
             nonlocal max_tokens_arg
             # sampling_params is the second argument to generate()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR basically does the same as https://github.com/vllm-project/vllm/pull/6954. The issue is `vllm/engine/output_processor/multi_step.py` requires `SamplingParams.max_tokens` to be set. And so, the vLLM engine crashes when `--num-scheduler-steps > 1` and `max_tokens` is undefined.

So this PR sets a default for `max_tokens` if it is not set by the client.

**Which issue(s) this PR fixes**:
Fixes #3971 

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Added `test_vllm_chat_completion_facebook_opt_model_should_set_correct_max_tokens` in `test_vllm_model.py`

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

**Release note**:
```release-note
Set default for SamplingParams.max_tokens in OpenAI requests if unset
```
