### PR TITLE
Fix Hugging Face server EncoderModel not returning probabilities by correctly passing --return_probabilities flag  (#3958)

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -275,6 +275,7 @@ def load_model():
                 return_token_type_ids=kwargs.get("return_token_type_ids", None),
                 predictor_config=predictor_config,
                 request_logger=request_logger,
+                return_probabilities=kwargs.get("return_probabilities", False),
             )
     model.load()
     return model

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -28,7 +28,10 @@ from kserve import (
 )
 from kserve.constants import constants
 from ..common.utils import KSERVE_TEST_NAMESPACE, generate, predict_isvc
-from .test_output import huggingface_text_embedding_expected_output
+from .test_output import (
+    huggingface_text_embedding_expected_output,
+    huggingface_sequence_classification_with_probabilities_expected_output,
+)
 
 
 @pytest.mark.llm
@@ -340,6 +343,7 @@ async def test_huggingface_v2_text_embedding(rest_v2_client):
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
+
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
 async def test_huggingface_v2_sequence_classification_with_probabilities(rest_v2_client):
@@ -390,6 +394,6 @@ async def test_huggingface_v2_sequence_classification_with_probabilities(rest_v2
         service_name,
         "./data/bert_sequence_classification_v2.json",
     )
-    assert res.outputs[0].data == ['{0: -2.152204, 1: 2.5094059}']
+    assert res.outputs[0].data == huggingface_sequence_classification_with_probabilities_expected_output
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import ast
 
 import pytest
 from kubernetes import client
@@ -394,6 +395,8 @@ async def test_huggingface_v2_sequence_classification_with_probabilities(rest_v2
         service_name,
         "./data/bert_sequence_classification_v2.json",
     )
-    assert res.outputs[0].data == huggingface_sequence_classification_with_probabilities_expected_output
+
+    parsed_output = [ast.literal_eval(res.outputs[0].data[0])]
+    assert parsed_output == huggingface_sequence_classification_with_probabilities_expected_output
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -339,3 +339,57 @@ async def test_huggingface_v2_text_embedding(rest_v2_client):
     assert res.outputs[0].data == huggingface_text_embedding_expected_output
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+@pytest.mark.llm
+@pytest.mark.asyncio(scope="session")
+async def test_huggingface_v2_sequence_classification_with_probabilities(rest_v2_client):
+    service_name = "hf-bert-sequence-v2"
+    protocol_version = "v2"
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        model=V1beta1ModelSpec(
+            model_format=V1beta1ModelFormat(
+                name="huggingface",
+            ),
+            protocol_version=protocol_version,
+            args=[
+                "--model_id",
+                "textattack/bert-base-uncased-yelp-polarity",
+                "--model_revision",
+                "a4d0a85ea6c1d5bb944dcc12ea5c918863e469a4",
+                "--tokenizer_revision",
+                "a4d0a85ea6c1d5bb944dcc12ea5c918863e469a4",
+                "--backend",
+                "huggingface",
+                "--return_probabilities",
+            ],
+            resources=V1ResourceRequirements(
+                requests={"cpu": "1", "memory": "2Gi"},
+                limits={"cpu": "1", "memory": "4Gi"},
+            ),
+        ),
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND,
+        metadata=client.V1ObjectMeta(
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+    kserve_client.create(isvc)
+    kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+    res = await predict_isvc(
+        rest_v2_client,
+        service_name,
+        "./data/bert_sequence_classification_v2.json",
+    )
+    assert res.outputs[0].data == [[0.0094, 0.9906]]
+
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -347,7 +347,9 @@ async def test_huggingface_v2_text_embedding(rest_v2_client):
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v2_sequence_classification_with_probabilities(rest_v2_client):
+async def test_huggingface_v2_sequence_classification_with_probabilities(
+    rest_v2_client,
+):
     service_name = "hf-bert-sequence-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -397,6 +399,9 @@ async def test_huggingface_v2_sequence_classification_with_probabilities(rest_v2
     )
 
     parsed_output = [ast.literal_eval(res.outputs[0].data[0])]
-    assert parsed_output == huggingface_sequence_classification_with_probabilities_expected_output
+    assert (
+        parsed_output
+        == huggingface_sequence_classification_with_probabilities_expected_output
+    )
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -390,6 +390,6 @@ async def test_huggingface_v2_sequence_classification_with_probabilities(rest_v2
         service_name,
         "./data/bert_sequence_classification_v2.json",
     )
-    assert res.outputs[0].data == [[0.0094, 0.9906]]
+    assert res.outputs[0].data == ['{0: -2.152204, 1: 2.5094059}']
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_output.py
+++ b/test/e2e/predictor/test_output.py
@@ -400,3 +400,10 @@ huggingface_text_embedding_expected_output = [
     approx(0.049627237021923065, abs=1e-6),
     approx(-0.029213037341833115, abs=1e-6),
 ]
+
+huggingface_sequence_classification_with_probabilities_expected_output = [
+    {
+        0: approx(-2.152204, abs=0.000009),
+        1: approx(2.5094059, abs=0.000009),
+    }
+]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes an issue with missing probability distributions in predictions when using the Hugging Face server EncoderModel with `--return_probabilities`.
Ensures `--return_probabilities` is correctly passed, enabling the model to return full probability scores instead of just the predicted class label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3958

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- [x]  Added `test_huggingface_v2_sequence_classification_with_probabilities` in `test_huggingface.py`
- [x]  Verified that existing functionality is unaffected by the change

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed missing probability distributions in Huggingface server EncoderModel when --return_probabilities is specified.
```
