### PR TITLE
Fix azure blob storage access key env not mounted

### DIFF
--- a/pkg/credentials/azure/azure_secret.go
+++ b/pkg/credentials/azure/azure_secret.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	LegacyAzureEnvKeys        = []string{LegacyAzureSubscriptionId, LegacyAzureTenantId, LegacyAzureClientId, LegacyAzureClientSecret}
-	AzureEnvKeys              = []string{AzureSubscriptionId, AzureTenantId, AzureClientId, AzureClientSecret}
+	AzureEnvKeys              = []string{AzureSubscriptionId, AzureTenantId, AzureClientId, AzureClientSecret, AzureStorageAccessKey}
 	legacyAzureEnvKeyMappings = map[string]string{
 		AzureSubscriptionId: LegacyAzureSubscriptionId,
 		AzureTenantId:       LegacyAzureTenantId,
@@ -54,8 +54,8 @@ func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
 		if _, ok := secret.Data[legacyDataKey]; ok {
 			dataKey = legacyDataKey
 		}
-		// Leave out the AzureClientSecret env var if not defined as Data in the secret
-		if _, ok := secret.Data[dataKey]; !(!ok && dataKey == AzureClientSecret) {
+		// Leave out the AzureClientSecret or AzureStorageAccessKey env var if not defined as Data in the secret
+		if _, ok := secret.Data[dataKey]; !(!ok && (dataKey == AzureClientSecret || dataKey == AzureStorageAccessKey)) {
 			envs = append(envs, v1.EnvVar{
 				Name: k,
 				ValueFrom: &v1.EnvVarSource{

--- a/pkg/credentials/azure/azure_secret_test.go
+++ b/pkg/credentials/azure/azure_secret_test.go
@@ -88,7 +88,255 @@ func TestAzureSecret(t *testing.T) {
 				},
 			},
 		},
+		"AzureSecretEnvsWithStorageAccessKey": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "azcreds",
+				},
+				Data: map[string][]byte{
+					AzureSubscriptionId:   []byte("AzureSubscriptionId"),
+					AzureTenantId:         []byte("AzureTenantId"),
+					AzureClientId:         []byte("AzureClientId"),
+					AzureStorageAccessKey: []byte("AzureStorageAccessKey"),
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name: AzureSubscriptionId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureSubscriptionId,
+						},
+					},
+				},
+				{
+					Name: AzureTenantId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureTenantId,
+						},
+					},
+				},
+				{
+					Name: AzureClientId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureClientId,
+						},
+					},
+				},
+				{
+					Name: AzureStorageAccessKey,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureStorageAccessKey,
+						},
+					},
+				},
+			},
+		},
+		"AzureSecretEnvsWithClientSecretAndStorageAccessKey": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "azcreds",
+				},
+				Data: map[string][]byte{
+					AzureSubscriptionId:   []byte("AzureSubscriptionId"),
+					AzureTenantId:         []byte("AzureTenantId"),
+					AzureClientId:         []byte("AzureClientId"),
+					AzureClientSecret:     []byte("AzureClientSecret"),
+					AzureStorageAccessKey: []byte("AzureStorageAccessKey"),
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name: AzureSubscriptionId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureSubscriptionId,
+						},
+					},
+				},
+				{
+					Name: AzureTenantId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureTenantId,
+						},
+					},
+				},
+				{
+					Name: AzureClientId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureClientId,
+						},
+					},
+				},
+				{
+					Name: AzureClientSecret,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureClientSecret,
+						},
+					},
+				},
+				{
+					Name: AzureStorageAccessKey,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureStorageAccessKey,
+						},
+					},
+				},
+			},
+		},
 		"AzureSecretEnvsWithoutClientSecret": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "azcreds",
+				},
+				Data: map[string][]byte{
+					AzureSubscriptionId:   []byte("AzureSubscriptionId"),
+					AzureTenantId:         []byte("AzureTenantId"),
+					AzureClientId:         []byte("AzureClientId"),
+					AzureStorageAccessKey: []byte("AzureStorageAccessKey"),
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name: AzureSubscriptionId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureSubscriptionId,
+						},
+					},
+				},
+				{
+					Name: AzureTenantId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureTenantId,
+						},
+					},
+				},
+				{
+					Name: AzureClientId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureClientId,
+						},
+					},
+				},
+				{
+					Name: AzureStorageAccessKey,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureStorageAccessKey,
+						},
+					},
+				},
+			},
+		},
+		"AzureSecretEnvsWithoutStorageAccessKey": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "azcreds",
+				},
+				Data: map[string][]byte{
+					AzureSubscriptionId: []byte("AzureSubscriptionId"),
+					AzureTenantId:       []byte("AzureTenantId"),
+					AzureClientId:       []byte("AzureClientId"),
+					AzureClientSecret:   []byte("AzureClientSecret"),
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name: AzureSubscriptionId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureSubscriptionId,
+						},
+					},
+				},
+				{
+					Name: AzureTenantId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureTenantId,
+						},
+					},
+				},
+				{
+					Name: AzureClientId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureClientId,
+						},
+					},
+				},
+				{
+					Name: AzureClientSecret,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "azcreds",
+							},
+							Key: AzureClientSecret,
+						},
+					},
+				},
+			},
+		},
+		"AzureSecretEnvsWithoutClientSecretAndStorageAccessKey": {
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "azcreds",

--- a/pkg/credentials/service_account_credentials_test.go
+++ b/pkg/credentials/service_account_credentials_test.go
@@ -807,10 +807,11 @@ func TestAzureCredentialBuilder(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			"AZURE_SUBSCRIPTION_ID": {},
-			"AZURE_TENANT_ID":       {},
-			"AZURE_CLIENT_ID":       {},
-			"AZURE_CLIENT_SECRET":   {},
+			"AZURE_SUBSCRIPTION_ID":    {},
+			"AZURE_TENANT_ID":          {},
+			"AZURE_CLIENT_ID":          {},
+			"AZURE_CLIENT_SECRET":      {},
+      "AZURE_STORAGE_ACCESS_KEY": {},
 		},
 	}
 
@@ -884,6 +885,17 @@ func TestAzureCredentialBuilder(t *testing.T) {
 															Name: "az-custom-secret",
 														},
 														Key: azure.AzureClientSecret,
+													},
+												},
+											},
+											{
+												Name: azure.AzureStorageAccessKey,
+												ValueFrom: &v1.EnvVarSource{
+													SecretKeyRef: &v1.SecretKeySelector{
+														LocalObjectReference: v1.LocalObjectReference{
+															Name: "az-custom-secret",
+														},
+														Key: azure.AzureStorageAccessKey,
 													},
 												},
 											},

--- a/pkg/credentials/service_account_credentials_test.go
+++ b/pkg/credentials/service_account_credentials_test.go
@@ -811,7 +811,7 @@ func TestAzureCredentialBuilder(t *testing.T) {
 			"AZURE_TENANT_ID":          {},
 			"AZURE_CLIENT_ID":          {},
 			"AZURE_CLIENT_SECRET":      {},
-      "AZURE_STORAGE_ACCESS_KEY": {},
+			"AZURE_STORAGE_ACCESS_KEY": {},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4063 
- adds optional `AZURE_STORAGE_ACCESS_KEY` to azure credential env mounting

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.