### PR TITLE
Storage Initializer support single digit azure DNS zone ID

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -39,11 +39,11 @@ _HDFS_PREFIX = "hdfs://"
 _WEBHDFS_PREFIX = "webhdfs://"
 _AZURE_BLOB_RE = [
     "https://(.+?).blob.core.windows.net/(.+)",
-    "https://(.+?).z[0-9]{2}.blob.storage.azure.net/(.+)",
+    "https://(.+?).z[0-9]{1,2}.blob.storage.azure.net/(.+)",
 ]
 _AZURE_FILE_RE = [
     "https://(.+?).file.core.windows.net/(.+)",
-    "https://(.+?).z[0-9]{2}.file.storage.azure.net/(.+)",
+    "https://(.+?).z[0-9]{1,2}.file.storage.azure.net/(.+)",
 ]
 _LOCAL_PREFIX = "file://"
 _URI_RE = "https?://(.+)/(.+)"

--- a/python/kserve/kserve/storage/test/test_storage.py
+++ b/python/kserve/kserve/storage/test/test_storage.py
@@ -265,6 +265,7 @@ def test_download_azure_blob_called_with_matching_uri(mock_download_azure_blob):
     azure_blob_uris = [
         "https://accountname.blob.core.windows.net/container/some/blob/",
         "https://accountname.z20.blob.storage.azure.net/container/some/blob/",
+        "https://accountname.z2.blob.storage.azure.net/container/some/blob/",
     ]
 
     for uri in azure_blob_uris:
@@ -281,6 +282,7 @@ def test_download_azure_file_share_called_with_matching_uri(
     azure_file_uris = [
         "https://accountname.file.core.windows.net/container/some/blob",
         "https://accountname.z20.file.storage.azure.net/container/some/blob",
+        "https://accountname.z2.file.storage.azure.net/container/some/blob/",
     ]
 
     for uri in azure_file_uris:

--- a/python/kserve/kserve/storage/test/test_storage.py
+++ b/python/kserve/kserve/storage/test/test_storage.py
@@ -282,7 +282,7 @@ def test_download_azure_file_share_called_with_matching_uri(
     azure_file_uris = [
         "https://accountname.file.core.windows.net/container/some/blob",
         "https://accountname.z20.file.storage.azure.net/container/some/blob",
-        "https://accountname.z2.file.storage.azure.net/container/some/blob/",
+        "https://accountname.z2.file.storage.azure.net/container/some/blob",
     ]
 
     for uri in azure_file_uris:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- allows regex matching for single digit DNS zone ID as well

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4069 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.