### PR TITLE
Feature: vLLM completion extra guided decoding params

### DIFF
--- a/python/kserve/kserve/protocol/rest/openai/openai_chat_adapter_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_chat_adapter_model.py
@@ -83,6 +83,12 @@ class OpenAIChatAdapterModel(OpenAIGenerativeModel):
             top_p=request.top_p,
             user=request.user,
             logprobs=request.top_logprobs,
+            guided_json=request.guided_json,
+            guided_regex=request.guided_regex,
+            guided_choice=request.guided_choice,
+            guided_grammar=request.guided_grammar,
+            guided_decoding_backend=request.guided_decoding_backend,
+            guided_whitespace_pattern=request.guided_whitespace_pattern,
         )
 
     @classmethod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
  
KServe supports vLLM backend, but some of the powerful vLLM-specific features are unavailable. vLLM completion uses an API protocol that slightly differs from the one [used by KServe and provided by OpenAI](https://github.com/kserve/kserve/blob/master/python/kserve/kserve/protocol/rest/openai/types/openapi.py), introducing [new parameters](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters-for-completions-api). Some of these params include guided decoding for completion and chat completion, allowing models to provide outputs in a guided manner, e.g. provide the most suitable option in a passed list as an output ([example](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#extra-parameters)).

The main purpose of this PR is to extend 2 OpenAI API classes, `CreateCompletionRequest` and `CreateChatCompletionRequest`, with the new guided vLLM-specific extra parameters, while maintaining the compatibility with OpenAI-provided classes. This solution can further be used to introduce remaining vLLM-specific extra params.
  
Notes:
1. The mentioned params can be passed as json arguments in an HTTP request to the model endpoint, and are specified as is (e.g. as `"guided_choice": ...`, not as  `"extra_body": {"guided_choice": ...}`.
2. The PR would require [documentation update](https://kserve.github.io/website/latest/modelserving/v1beta1/llm/vllm/#vllm-runtime).
---  
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] This change requires a documentation update
- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

The simplest way is to start huggingface server locally (if a GPU is available):

```sh
cd python/huggingfaceserver/
poetry shell && poetry install
pip install vllm
python -m huggingfaceserver --model_id=Qwen/Qwen2.5-0.5B-Instruct --model_name='debug-model' --max_model_len=128   # or a simpler model
curl -v http://0.0.0.0:8080/openai/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "debug-model",
        "guided_choice": ["positive", "negative"],
        "messages": [
            {"role": "user", "content": "Classify this sentiment: vLLM is wonderful!"}
        ]
    }'
```

Also these tests test new functionality (both are available through github actions):

- [x] [Test A](https://github.com/kserve/kserve/commit/4cda25f0f8ec04009cf336f384ada3c2ce96b829#diff-6997a3a976acff1ff07a3c60e6b9c150226a885841faa27699bde4447595426fR2986)
- [x] [Test B](https://github.com/kserve/kserve/commit/4cda25f0f8ec04009cf336f384ada3c2ce96b829#diff-6997a3a976acff1ff07a3c60e6b9c150226a885841faa27699bde4447595426fR2986)


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
ADD guided decoding params to vLLM completion
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.