### PR TITLE
Support datetime object serialization in v1/v2 response

### DIFF
--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -1049,6 +1049,8 @@ class InferOutput:
             raise InferenceError("input_tensor must be a numpy array")
 
         dtype = from_np_dtype(output_tensor.dtype)
+        if np.issubdtype(output_tensor.dtype, np.datetime64):
+            output_tensor = output_tensor.astype(np.object_)
         if self._datatype != dtype:
             raise InferenceError(
                 "got unexpected datatype {} from numpy array, expected {}".format(

--- a/python/kserve/kserve/protocol/rest/v1_endpoints.py
+++ b/python/kserve/kserve/protocol/rest/v1_endpoints.py
@@ -16,7 +16,7 @@ from typing import Optional, Union, Dict, List, AsyncIterator
 
 from fastapi import Request, Response, FastAPI, APIRouter
 from starlette.responses import StreamingResponse
-from fastapi.responses import JSONResponse
+from fastapi.responses import ORJSONResponse
 
 from kserve.errors import ModelNotReady
 from ..dataplane import DataPlane
@@ -96,7 +96,7 @@ class V1Endpoints:
             return Response(content=response, headers=response_headers)
         if isinstance(response, AsyncIterator):
             return StreamingResponse(content=response)
-        return JSONResponse(content=response, headers=response_headers)
+        return ORJSONResponse(content=response, headers=response_headers)
 
     async def explain(self, model_name: str, request: Request) -> Union[Response, Dict]:
         """Explain handler.
@@ -131,9 +131,9 @@ class V1Endpoints:
         response_headers.update(res_headers)
         response_headers.pop("content-length", None)
 
-        if not isinstance(response, dict):
-            return Response(content=response, headers=response_headers)
-        return response
+        if isinstance(response, dict):
+            return ORJSONResponse(content=response, headers=response_headers)
+        return Response(content=response, headers=response_headers)
 
 
 def register_v1_endpoints(

--- a/python/kserve/kserve/utils/numpy_codec.py
+++ b/python/kserve/kserve/utils/numpy_codec.py
@@ -59,6 +59,10 @@ def from_np_dtype(np_dtype):
         return "FP32"
     elif np_dtype == np.float64:
         return "FP64"
-    elif np_dtype == np.object_ or np_dtype.type == np.bytes_:
+    elif (
+        np_dtype == np.object_
+        or np_dtype.type == np.bytes_
+        or np.issubdtype(np_dtype, np.datetime64)
+    ):
         return "BYTES"
     return None


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Serializes datetime to Iso datetime format with tz info.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4096

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support datetime object serialization in v1/v2 response
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.