### PR TITLE
Fix LocalModelCache controller reconciles deleted resource

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -513,7 +513,8 @@ jobs:
     needs:
       [
         kserve-image-build,
-        predictor-runtime-build
+        predictor-runtime-build,
+        explainer-runtime-build
       ]
     steps:
       - name: Checkout

--- a/pkg/controller/v1alpha1/localmodel/controller.go
+++ b/pkg/controller/v1alpha1/localmodel/controller.go
@@ -115,7 +115,7 @@ func (c *LocalModelReconciler) deleteModelFromNodes(ctx context.Context, localMo
 }
 
 // Creates a PV and set the localModel as its controller
-func (c *LocalModelReconciler) createPV(ctx context.Context, spec v1.PersistentVolume, localModel *v1alpha1.ClusterLocalModel) error {
+func (c *LocalModelReconciler) createPV(ctx context.Context, spec v1.PersistentVolume, localModel *v1alpha1.LocalModelCache) error {
 	persistentVolumes := c.Clientset.CoreV1().PersistentVolumes()
 	if _, err := persistentVolumes.Get(ctx, spec.Name, metav1.GetOptions{}); err != nil {
 		if !apierr.IsNotFound(err) {
@@ -136,7 +136,7 @@ func (c *LocalModelReconciler) createPV(ctx context.Context, spec v1.PersistentV
 }
 
 // Creates a PVC and sets the localModel as its controller
-func (c *LocalModelReconciler) createPVC(ctx context.Context, spec v1.PersistentVolumeClaim, namespace string, localModel *v1alpha1.ClusterLocalModel) error {
+func (c *LocalModelReconciler) createPVC(ctx context.Context, spec v1.PersistentVolumeClaim, namespace string, localModel *v1alpha1.LocalModelCache) error {
 	persistentVolumeClaims := c.Clientset.CoreV1().PersistentVolumeClaims(namespace)
 	if _, err := persistentVolumeClaims.Get(ctx, spec.Name, metav1.GetOptions{}); err != nil {
 		if !apierr.IsNotFound(err) {
@@ -241,11 +241,8 @@ func (c *LocalModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	localModel := &v1alpha1api.LocalModelCache{}
 	if err := c.Get(ctx, req.NamespacedName, localModel); err != nil {
-		if apierr.IsNotFound(err) {
-			// Ignore not-found errors, we can get them on deleted requests.
-			return reconcile.Result{}, nil
-		}
-		return reconcile.Result{}, err
+		// Ignore not-found errors, we can get them on deleted requests.
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
 	nodeGroup := &v1alpha1api.LocalModelNodeGroup{}

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -211,33 +211,6 @@ var _ = Describe("CachedModel controller", func() {
 			// Now let's test deletion
 			Expect(k8sClient.Delete(ctx, cachedModel)).Should(Succeed())
 
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, modelLookupKey, cachedModel)
-				if err != nil {
-					return false
-				}
-				if cachedModel.Status.ModelCopies == nil {
-					return false
-				}
-				// TODO: Uncomment this after fixing the deletion logic. NodeDeleting stauts is not set during deletion
-				// if cachedModel.Status.NodeStatus[nodeName] != v1alpha1.NodeDeleting {
-				// 	return false
-				// }
-				return true
-			}, timeout, time.Millisecond).Should(BeTrue(), "Node status should be deleting")
-
-			// Todo: Job is not used for deletion anymore ?
-			// Deletion job should be created
-			// deletionJob := &batchv1.Job{}
-			// Eventually(func() bool {
-			// 	err := k8sClient.Get(ctx, types.NamespacedName{Name: "iris-node-1-delete", Namespace: modelCacheNamespace}, deletionJob)
-			// 	return err == nil
-			// }, timeout, interval).Should(BeTrue())
-
-			// Let's we update deletion job status to be successful and check if the cr is deleted.
-			// deletionJob.Status.Succeeded = 1
-			// Expect(k8sClient.Status().Update(ctx, deletionJob)).Should(Succeed())
-
 			newLocalModel := &v1alpha1.LocalModelCache{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, modelLookupKey, newLocalModel)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- Fixes LocalModeCachel controller reconciles deleted resource.
![Screenshot from 2024-12-09 14-40-05](https://github.com/user-attachments/assets/b2883bcc-48f6-4aef-959b-3e894c793f53)

- ~Fixes flaky localmodel test~ (Addressed in #4105)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.