### PR TITLE
Ensure root model directory exists and add protection for jobs created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ deploy-dev: manifests
 	if [ ${KSERVE_ENABLE_SELF_SIGNED_CA} != false ]; then ./hack/self-signed-ca.sh; fi;
 	# TODO: Add runtimes as part of default deployment
 	kubectl wait --for=condition=ready pod -l control-plane=kserve-controller-manager -n kserve --timeout=300s
-	kubectl apply --server-side=true -k config/clusterresources
+	kubectl apply --server-side=true --force-conflicts -k config/clusterresources
 	git checkout HEAD -- config/certmanager/certificate.yaml
 
 deploy-dev-sklearn: docker-push-sklearn

--- a/pkg/controller/v1alpha1/localmodel/controller.go
+++ b/pkg/controller/v1alpha1/localmodel/controller.go
@@ -228,6 +228,7 @@ func (c *LocalModelReconciler) ReconcileForIsvcs(ctx context.Context, localModel
 	return nil
 }
 
+// Reconcile
 // Step 1 - Checks if the CR is in the deletion process. Deletion completes when all LocalModelNodes have been updated
 // Step 2 - Adds this model to LocalModelNode resources in the node group
 // Step 3 - Creates PV & PVC for model download

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -123,13 +123,14 @@ func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode
 		return nil, err
 	}
 	jobs := c.Clientset.BatchV1().Jobs(jobNamespace)
-	job, err = jobs.Create(ctx, job, metav1.CreateOptions{})
-	c.Log.Info("Creating job", "name", job.Name, "namespace", job.Namespace)
+	createdJob, err := jobs.Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {
 		c.Log.Error(err, "Failed to create job.", "name", job.Name)
 		return nil, err
 	}
-	return job, err
+	c.Log.Info("Created job", "name", createdJob.Name, "namespace", createdJob.Namespace,
+		"model", modelInfo.ModelName)
+	return createdJob, err
 }
 
 // Fetches container spec for model download container, use the default KServe image if not found
@@ -163,7 +164,7 @@ func (c *LocalModelNodeReconciler) getContainerSpecForStorageUri(ctx context.Con
 	return defaultContainer, nil
 }
 
-func (c *LocalModelNodeReconciler) getLatestJob(ctx context.Context, modelName string, nodeName string, excludeSucceeded bool) (*batchv1.Job, error) {
+func (c *LocalModelNodeReconciler) getLatestJob(ctx context.Context, modelName string, nodeName string) (*batchv1.Job, int, error) {
 	jobList := &batchv1.JobList{}
 	labelSelector := map[string]string{
 		"model": modelName,
@@ -172,21 +173,18 @@ func (c *LocalModelNodeReconciler) getLatestJob(ctx context.Context, modelName s
 	if err := c.Client.List(ctx, jobList, client.InNamespace(jobNamespace), client.MatchingLabels(labelSelector)); err != nil {
 		if errors.IsNotFound(err) {
 			c.Log.Info("Job not found", "model", modelName)
-			return nil, nil
+			return nil, 0, nil
 		}
-		return nil, err
+		return nil, 0, err
 	}
 	c.Log.Info("Found jobs", "model", modelName, "num of jobs", len(jobList.Items))
 	var latestJob *batchv1.Job
 	for i, job := range jobList.Items {
-		if excludeSucceeded && job.Status.Succeeded > 0 {
-			continue
-		}
 		if latestJob == nil || job.CreationTimestamp.After(latestJob.CreationTimestamp.Time) {
 			latestJob = &jobList.Items[i]
 		}
 	}
-	return latestJob, nil
+	return latestJob, len(jobList.Items), nil
 }
 
 func getModelStatusFromJobStatus(jobStatus batchv1.JobStatus) v1alpha1api.ModelStatus {
@@ -224,7 +222,7 @@ func (c *LocalModelNodeReconciler) downloadModels(ctx context.Context, localMode
 					continue
 				}
 			}
-			job, err = c.getLatestJob(ctx, modelInfo.ModelName, nodeName, false)
+			job, _, err = c.getLatestJob(ctx, modelInfo.ModelName, nodeName)
 			if err != nil {
 				c.Log.Error(err, "Failed to getLatestJob", "model", modelInfo.ModelName, "node", nodeName)
 				return err
@@ -238,10 +236,13 @@ func (c *LocalModelNodeReconciler) downloadModels(ctx context.Context, localMode
 					return err
 				}
 			}
+			newStatus[modelInfo.ModelName] = getModelStatusFromJobStatus(job.Status)
+			c.Log.Info("model downloading status:", "model", modelInfo.ModelName,
+				"node", localModelNode.ObjectMeta.Name, "status", newStatus[modelInfo.ModelName])
 		} else {
 			// Folder does not exist
 			c.Log.Info("Model folder not found", "model", modelInfo.ModelName)
-			job, err = c.getLatestJob(ctx, modelInfo.ModelName, nodeName, true)
+			job, jobCount, err := c.getLatestJob(ctx, modelInfo.ModelName, nodeName)
 			if err != nil {
 				c.Log.Error(err, "Failed to getLatestJob", "model", modelInfo.ModelName, "node", nodeName)
 				return err
@@ -252,19 +253,18 @@ func (c *LocalModelNodeReconciler) downloadModels(ctx context.Context, localMode
 			// Recreate job if it has been terminated because the model is missing locally
 			// If the job has failed, we do not retry here because there are retries on the job.
 			// To retry the download, users can manually fix the issue and delete the failed job.
-			if job == nil || job.Status.Succeeded > 0 {
-				c.Log.Info("Download model", "model", modelInfo.ModelName)
+			// Add the job count check for protection to ensure not creating more than 2 jobs including the previous one.
+			if job == nil || (job.Status.Succeeded > 0 && jobCount <= 2) {
 				job, err = c.launchJob(ctx, *localModelNode, modelInfo)
 				if err != nil {
-					c.Log.Error(err, "Failed to create Job", "model", modelInfo.ModelName, "node", nodeName)
+					c.Log.Error(err, "Failed to create job", "model", modelInfo.ModelName, "node", nodeName)
 					return err
 				}
 			}
+			newStatus[modelInfo.ModelName] = getModelStatusFromJobStatus(job.Status)
+			c.Log.Info("model downloading status:", "model", modelInfo.ModelName,
+				"node", localModelNode.ObjectMeta.Name, "status", newStatus[modelInfo.ModelName])
 		}
-		newStatus[modelInfo.ModelName] = getModelStatusFromJobStatus(job.Status)
-
-		c.Log.Info("Downloading models:", "model", modelInfo.ModelName,
-			"node", localModelNode.ObjectMeta.Name, "status", newStatus[modelInfo.ModelName])
 	}
 
 	// Skip update if no changes to status
@@ -286,10 +286,6 @@ func (c *LocalModelNodeReconciler) downloadModels(ctx context.Context, localMode
 func (c *LocalModelNodeReconciler) deleteModels(localModelNode v1alpha1api.LocalModelNode) error {
 	// 1. Scan model dir and get a list of existing folders representing downloaded models
 	foldersToRemove := map[string]struct{}{}
-	if err := fsHelper.ensureModelRootFolderExists(); err != nil {
-		c.Log.Error(err, "Failed to ensure model root folder exists")
-		return err
-	}
 	entries, err := fsHelper.getModelFolders()
 	if err != nil {
 		c.Log.Error(err, "Failed to list model folder")
@@ -365,6 +361,11 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// fsHelper is a global variable to allow mocking in tests
 	if fsHelper == nil {
 		fsHelper = NewFileSystemHelper(modelsRootFolder)
+		// TODO we need a way to ensure that the local path on persistent volume is the same as the local path of the node agent DaemonSet.
+		err := fsHelper.ensureModelRootFolderExists()
+		if err != nil {
+			panic("Failed to ensure model root folder exists")
+		}
 	}
 
 	// Create Jobs to download models if the model is not present locally.

--- a/pkg/controller/v1alpha1/localmodelnode/file_utils.go
+++ b/pkg/controller/v1alpha1/localmodelnode/file_utils.go
@@ -39,12 +39,12 @@ func NewFileSystemHelper(modelsRootFolder string) *FileSystemHelper {
 }
 
 // should be used only in this struct
-func (f *FileSystemHelper) getModelFolderPrivate(modelName string) string {
-	return filepath.Join(f.modelsRootFolder, modelName)
+func getModelFolder(rootFolderName string, modelName string) string {
+	return filepath.Join(rootFolderName, modelName)
 }
 
 func (f *FileSystemHelper) removeModel(modelName string) error {
-	path := f.getModelFolderPrivate(modelName)
+	path := getModelFolder(f.modelsRootFolder, modelName)
 	return os.RemoveAll(path)
 }
 
@@ -53,7 +53,7 @@ func (f *FileSystemHelper) getModelFolders() ([]os.DirEntry, error) {
 }
 
 func (f *FileSystemHelper) hasModelFolder(modelName string) (bool, error) {
-	folder := f.getModelFolderPrivate(modelName)
+	folder := getModelFolder(f.modelsRootFolder, modelName)
 	_, err := os.ReadDir(folder)
 	if err == nil {
 		return true, nil


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix bug when local path of the PV and the node agent does not match, the download job is succeeded but the model folder check fails. This results in keeping creating the download jobs as the model folder check fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4151 

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] When PV local path matches the path of the node agent daemonset
- [X] Update local path of the node agent daemonset to not match the local path on PV

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.