### PR TITLE
add DeploymentMode to InferenceService and InferenceGraph status and prevent deploymentMode change

### DIFF
--- a/config/crd/full/serving.kserve.io_inferencegraphs.yaml
+++ b/config/crd/full/serving.kserve.io_inferencegraphs.yaml
@@ -621,6 +621,8 @@ spec:
                   - type
                   type: object
                 type: array
+              deploymentMode:
+                type: string
               observedGeneration:
                 format: int64
                 type: integer

--- a/config/crd/full/serving.kserve.io_inferenceservices.yaml
+++ b/config/crd/full/serving.kserve.io_inferenceservices.yaml
@@ -21422,6 +21422,8 @@ spec:
                       - type
                     type: object
                   type: array
+                deploymentMode:
+                  type: string
                 modelStatus:
                   properties:
                     copies:

--- a/pkg/apis/serving/v1alpha1/inference_graph.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph.go
@@ -320,6 +320,8 @@ type InferenceGraphStatus struct {
 	// Url for the InferenceGraph
 	// +optional
 	URL *apis.URL `json:"url,omitempty"`
+	// InferenceGraph DeploymentMode
+	DeploymentMode string `json:"deploymentMode,omitempty"`
 }
 
 // InferenceGraphList contains a list of InferenceGraph

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -51,6 +51,8 @@ type InferenceServiceStatus struct {
 	Components map[ComponentType]ComponentStatusSpec `json:"components,omitempty"`
 	// Model related statuses
 	ModelStatus ModelStatus `json:"modelStatus,omitempty"`
+	// InferenceService DeploymentMode
+	DeploymentMode string `json:"deploymentMode,omitempty"`
 }
 
 // ComponentStatusSpec describes the state of the component

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -82,8 +82,15 @@ func (v *InferenceServiceValidator) ValidateUpdate(ctx context.Context, oldObj, 
 		validatorLogger.Error(err, "Unable to convert object to InferenceService")
 		return nil, err
 	}
+	oldIsvc, err := convertToInferenceService(oldObj)
+	if err != nil {
+		validatorLogger.Error(err, "Unable to convert object to InferenceService")
+	}
 	validatorLogger.Info("validate update", "name", isvc.Name)
-
+	err = validateDeploymentMode(isvc, oldIsvc)
+	if err != nil {
+		return nil, err
+	}
 	return validateInferenceService(isvc)
 }
 
@@ -431,6 +438,19 @@ func validateCollocationStorageURI(predictorSpec PredictorSpec) error {
 				}
 			}
 			break
+		}
+	}
+	return nil
+}
+
+// validates if the deploymentMode specified in the annotation is not different from the one recorded in the status
+func validateDeploymentMode(newIsvc *InferenceService, oldIsvc *InferenceService) error {
+	statusDeploymentMode := oldIsvc.Status.DeploymentMode
+	if len(statusDeploymentMode) != 0 {
+		annotations := newIsvc.Annotations
+		annotationDeploymentMode, ok := annotations[constants.DeploymentMode]
+		if ok && annotationDeploymentMode != statusDeploymentMode {
+			return fmt.Errorf("update rejected: deploymentMode cannot be changed from '%s' to '%s'", statusDeploymentMode, annotationDeploymentMode)
 		}
 	}
 	return nil

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1343,6 +1343,32 @@ func TestValidateMultiNodeVariables(t *testing.T) {
 	}
 }
 
+func TestDeploymentModeUpdate(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	oldIsvc := makeTestInferenceService()
+	oldIsvc.Status = InferenceServiceStatus{
+		DeploymentMode: "Serverless",
+	}
+	updatedIsvc := oldIsvc.DeepCopy()
+	updatedIsvc.Annotations = map[string]string{
+		constants.DeploymentMode: "RawDeployment",
+	}
+	validator := InferenceServiceValidator{}
+	warnings, err := validator.ValidateUpdate(context.Background(), &oldIsvc, updatedIsvc)
+	// Annotation does not match status, update should be rejected
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).ShouldNot(gomega.Succeed())
+
+	updatedIsvc1 := oldIsvc.DeepCopy()
+	updatedIsvc1.Annotations = map[string]string{
+		constants.DeploymentMode: "Serverless",
+	}
+	warnings, err = validator.ValidateUpdate(context.Background(), &oldIsvc, updatedIsvc1)
+	// Annotation matches status, update is accepted
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+}
+
 func intPtr(i int) *int {
 	return &i
 }

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1354,7 +1354,7 @@ func TestDeploymentModeUpdate(t *testing.T) {
 		constants.DeploymentMode: "RawDeployment",
 	}
 	validator := InferenceServiceValidator{}
-	warnings, err := validator.ValidateUpdate(context.Background(), &oldIsvc, updatedIsvc)
+	warnings, err := validator.ValidateUpdate(t.Context(), &oldIsvc, updatedIsvc)
 	// Annotation does not match status, update should be rejected
 	g.Expect(warnings).Should(gomega.BeEmpty())
 	g.Expect(err).ShouldNot(gomega.Succeed())
@@ -1363,7 +1363,7 @@ func TestDeploymentModeUpdate(t *testing.T) {
 	updatedIsvc1.Annotations = map[string]string{
 		constants.DeploymentMode: "Serverless",
 	}
-	warnings, err = validator.ValidateUpdate(context.Background(), &oldIsvc, updatedIsvc1)
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvc, updatedIsvc1)
 	// Annotation matches status, update is accepted
 	g.Expect(warnings).Should(gomega.BeEmpty())
 	g.Expect(err).Should(gomega.Succeed())

--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -184,7 +184,7 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return reconcile.Result{}, errors.Wrapf(err, "fails to create DeployConfig")
 	}
 
-	deploymentMode := isvcutils.GetDeploymentMode(graph.ObjectMeta.Annotations, deployConfig)
+	deploymentMode := isvcutils.GetDeploymentMode(graph.Status.DeploymentMode, graph.ObjectMeta.Annotations, deployConfig)
 	r.Log.Info("Inference graph deployment ", "deployment mode ", deploymentMode)
 	if deploymentMode == constants.RawDeployment {
 		// Create inference graph resources such as deployment, service, hpa in raw deployment mode

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -144,7 +144,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return reconcile.Result{}, errors.Wrapf(err, "fails to create DeployConfig")
 	}
 
-	deploymentMode := isvcutils.GetDeploymentMode(annotations, deployConfig)
+	deploymentMode := isvcutils.GetDeploymentMode(isvc.Status.DeploymentMode, annotations, deployConfig)
 	r.Log.Info("Inference service deployment mode ", "deployment mode ", deploymentMode)
 
 	if deploymentMode == constants.ModelMeshDeployment {
@@ -302,10 +302,11 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return ctrl.Result{}, nil
 }
 
-func (r *InferenceServiceReconciler) updateStatus(ctx context.Context, desiredService *v1beta1.InferenceService,
-	deploymentMode constants.DeploymentModeType,
-) error {
-	existingService := &v1beta1.InferenceService{}
+func (r *InferenceServiceReconciler) updateStatus(ctx context.Context, desiredService *v1beta1.InferenceService, deploymentMode constants.DeploymentModeType) error {
+	// set the DeploymentMode used for the InferenceService in the status
+	desiredService.Status.DeploymentMode = string(deploymentMode)
+
+	existingService := &v1beta1api.InferenceService{}
 	namespacedName := types.NamespacedName{Name: desiredService.Name, Namespace: desiredService.Namespace}
 	if err := r.Get(ctx, namespacedName, existingService); err != nil {
 		return err

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -306,7 +306,7 @@ func (r *InferenceServiceReconciler) updateStatus(ctx context.Context, desiredSe
 	// set the DeploymentMode used for the InferenceService in the status
 	desiredService.Status.DeploymentMode = string(deploymentMode)
 
-	existingService := &v1beta1api.InferenceService{}
+	existingService := &v1beta1.InferenceService{}
 	namespacedName := types.NamespacedName{Name: desiredService.Name, Namespace: desiredService.Namespace}
 	if err := r.Get(ctx, namespacedName, existingService); err != nil {
 		return err

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"time"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/components"
+	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kserve/kserve/pkg/utils"
@@ -567,6 +570,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -1117,6 +1121,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -1645,6 +1650,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -2021,6 +2027,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -2590,6 +2597,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -3425,6 +3433,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -4369,6 +4378,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -5053,6 +5063,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -5938,6 +5949,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -6974,6 +6986,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
@@ -7858,6 +7871,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					TransitionStatus:    "InProgress",
 					ModelRevisionStates: &v1beta1.ModelRevisionStates{TargetModelState: "Pending"},
 				},
+				DeploymentMode: string(constants.RawDeployment),
 			}
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -22,9 +22,10 @@ import (
 	"time"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
-	"github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/components"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/components"
 
 	"github.com/kserve/kserve/pkg/utils"
 

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -21,11 +21,8 @@ import (
 	"fmt"
 	"time"
 
-	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
-	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/components"
 	"github.com/kserve/kserve/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -173,12 +173,20 @@ case 2: serving.kserve.org/deploymentMode is set
 	        if the mode is "RawDeployment", "Serverless" or "ModelMesh", return it.
 			else return config.deploy.defaultDeploymentMode
 */
-func GetDeploymentMode(annotations map[string]string, deployConfig *v1beta1.DeployConfig) constants.DeploymentModeType {
+func GetDeploymentMode(statusDeploymentMode string, annotations map[string]string, deployConfig *v1beta1.DeployConfig) constants.DeploymentModeType {
+	// First priority is the deploymentMode recorded in the status
+	if len(statusDeploymentMode) != 0 {
+		return constants.DeploymentModeType(statusDeploymentMode)
+	}
+
+	// Second priority, if the status doesn't have the deploymentMode recorded, is explicit annotations
 	deploymentMode, ok := annotations[constants.DeploymentMode]
 	if ok && (deploymentMode == string(constants.RawDeployment) || deploymentMode ==
 		string(constants.Serverless) || deploymentMode == string(constants.ModelMeshDeployment)) {
 		return constants.DeploymentModeType(deploymentMode)
 	}
+
+	// Finally, if an InferenceService is being created and does not explicitly specify a DeploymentMode
 	return constants.DeploymentModeType(deployConfig.DefaultDeploymentMode)
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -1297,7 +1297,7 @@ func TestGetDeploymentMode(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			deploymentMode := GetDeploymentMode(scenario.annotations, scenario.deployConfig)
+			deploymentMode := GetDeploymentMode("", scenario.annotations, scenario.deployConfig)
 			if !g.Expect(deploymentMode).To(gomega.Equal(scenario.expected)) {
 				t.Errorf("got %v, want %v", deploymentMode, scenario.expected)
 			}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -646,6 +646,13 @@ func schema_pkg_apis_serving_v1alpha1_InferenceGraphStatus(ref common.ReferenceC
 							Ref:         ref("knative.dev/pkg/apis.URL"),
 						},
 					},
+					"deploymentMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InferenceGraph DeploymentMode",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -1821,7 +1828,6 @@ func schema_pkg_apis_serving_v1alpha1_SupportedModelFormat(ref common.ReferenceC
 						},
 					},
 				},
-				
 			},
 		},
 	}
@@ -4441,7 +4447,6 @@ func schema_pkg_apis_serving_v1beta1_ExplainerExtensionSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5485,7 +5490,6 @@ func schema_pkg_apis_serving_v1beta1_HuggingFaceRuntimeSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5722,6 +5726,13 @@ func schema_pkg_apis_serving_v1beta1_InferenceServiceStatus(ref common.Reference
 							Description: "Model related statuses",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kserve/kserve/pkg/apis/serving/v1beta1.ModelStatus"),
+						},
+					},
+					"deploymentMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InferenceService DeploymentMode",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -6224,7 +6235,6 @@ func schema_pkg_apis_serving_v1beta1_LightGBMSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -6480,7 +6490,6 @@ func schema_pkg_apis_serving_v1beta1_ModelFormat(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 	}
@@ -7238,7 +7247,6 @@ func schema_pkg_apis_serving_v1beta1_ONNXRuntimeSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -7594,7 +7602,6 @@ func schema_pkg_apis_serving_v1beta1_PMMLSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -7919,7 +7926,6 @@ func schema_pkg_apis_serving_v1beta1_PaddleServerSpec(ref common.ReferenceCallba
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -8786,7 +8792,6 @@ func schema_pkg_apis_serving_v1beta1_PredictorExtensionSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -9817,7 +9822,6 @@ func schema_pkg_apis_serving_v1beta1_SKLearnSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -10231,7 +10235,6 @@ func schema_pkg_apis_serving_v1beta1_TFServingSpec(ref common.ReferenceCallback)
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -10557,7 +10560,6 @@ func schema_pkg_apis_serving_v1beta1_TorchServeSpec(ref common.ReferenceCallback
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -11450,7 +11452,6 @@ func schema_pkg_apis_serving_v1beta1_TritonSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -12244,7 +12245,6 @@ func schema_pkg_apis_serving_v1beta1_XGBoostSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1828,6 +1828,7 @@ func schema_pkg_apis_serving_v1alpha1_SupportedModelFormat(ref common.ReferenceC
 						},
 					},
 				},
+				
 			},
 		},
 	}
@@ -4447,6 +4448,7 @@ func schema_pkg_apis_serving_v1beta1_ExplainerExtensionSpec(ref common.Reference
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -5490,6 +5492,7 @@ func schema_pkg_apis_serving_v1beta1_HuggingFaceRuntimeSpec(ref common.Reference
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -6235,6 +6238,7 @@ func schema_pkg_apis_serving_v1beta1_LightGBMSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -6490,6 +6494,7 @@ func schema_pkg_apis_serving_v1beta1_ModelFormat(ref common.ReferenceCallback) c
 						},
 					},
 				},
+				
 			},
 		},
 	}
@@ -7247,6 +7252,7 @@ func schema_pkg_apis_serving_v1beta1_ONNXRuntimeSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -7602,6 +7608,7 @@ func schema_pkg_apis_serving_v1beta1_PMMLSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -7926,6 +7933,7 @@ func schema_pkg_apis_serving_v1beta1_PaddleServerSpec(ref common.ReferenceCallba
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -8792,6 +8800,7 @@ func schema_pkg_apis_serving_v1beta1_PredictorExtensionSpec(ref common.Reference
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -9822,6 +9831,7 @@ func schema_pkg_apis_serving_v1beta1_SKLearnSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -10235,6 +10245,7 @@ func schema_pkg_apis_serving_v1beta1_TFServingSpec(ref common.ReferenceCallback)
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -10560,6 +10571,7 @@ func schema_pkg_apis_serving_v1beta1_TorchServeSpec(ref common.ReferenceCallback
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -11452,6 +11464,7 @@ func schema_pkg_apis_serving_v1beta1_TritonSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{
@@ -12245,6 +12258,7 @@ func schema_pkg_apis_serving_v1beta1_XGBoostSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
+				
 			},
 		},
 		Dependencies: []string{

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -293,6 +293,10 @@
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
         },
+        "deploymentMode": {
+          "description": "InferenceGraph DeploymentMode",
+          "type": "string"
+        },
         "observedGeneration": {
           "description": "ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.",
           "type": "integer",
@@ -3153,6 +3157,10 @@
           },
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
+        },
+        "deploymentMode": {
+          "description": "InferenceService DeploymentMode",
+          "type": "string"
         },
         "modelStatus": {
           "description": "Model related statuses",

--- a/python/kserve/docs/V1alpha1InferenceGraphStatus.md
+++ b/python/kserve/docs/V1alpha1InferenceGraphStatus.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **annotations** | **dict(str, str)** | Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards. | [optional] 
 **conditions** | [**list[KnativeCondition]**](KnativeCondition.md) | Conditions the latest available observations of a resource&#39;s current state. | [optional] 
+**deployment_mode** | **str** | InferenceGraph DeploymentMode | [optional] 
 **observed_generation** | **int** | ObservedGeneration is the &#39;Generation&#39; of the Service that was last processed by the controller. | [optional] 
 **url** | [**KnativeURL**](KnativeURL.md) |  | [optional] 
 

--- a/python/kserve/docs/V1beta1InferenceServiceStatus.md
+++ b/python/kserve/docs/V1beta1InferenceServiceStatus.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **annotations** | **dict(str, str)** | Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards. | [optional] 
 **components** | [**dict(str, V1beta1ComponentStatusSpec)**](V1beta1ComponentStatusSpec.md) | Statuses for the components of the InferenceService | [optional] 
 **conditions** | [**list[KnativeCondition]**](KnativeCondition.md) | Conditions the latest available observations of a resource&#39;s current state. | [optional] 
+**deployment_mode** | **str** | InferenceService DeploymentMode | [optional] 
 **model_status** | [**V1beta1ModelStatus**](V1beta1ModelStatus.md) |  | [optional] 
 **observed_generation** | **int** | ObservedGeneration is the &#39;Generation&#39; of the Service that was last processed by the controller. | [optional] 
 **url** | [**KnativeURL**](KnativeURL.md) |  | [optional] 

--- a/python/kserve/kserve/models/v1alpha1_inference_graph_status.py
+++ b/python/kserve/kserve/models/v1alpha1_inference_graph_status.py
@@ -49,6 +49,7 @@ class V1alpha1InferenceGraphStatus(object):
     openapi_types = {
         'annotations': 'dict(str, str)',
         'conditions': 'list[KnativeCondition]',
+        'deployment_mode': 'str',
         'observed_generation': 'int',
         'url': 'KnativeURL'
     }
@@ -56,11 +57,12 @@ class V1alpha1InferenceGraphStatus(object):
     attribute_map = {
         'annotations': 'annotations',
         'conditions': 'conditions',
+        'deployment_mode': 'deploymentMode',
         'observed_generation': 'observedGeneration',
         'url': 'url'
     }
 
-    def __init__(self, annotations=None, conditions=None, observed_generation=None, url=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, annotations=None, conditions=None, deployment_mode=None, observed_generation=None, url=None, local_vars_configuration=None):  # noqa: E501
         """V1alpha1InferenceGraphStatus - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -68,6 +70,7 @@ class V1alpha1InferenceGraphStatus(object):
 
         self._annotations = None
         self._conditions = None
+        self._deployment_mode = None
         self._observed_generation = None
         self._url = None
         self.discriminator = None
@@ -76,6 +79,8 @@ class V1alpha1InferenceGraphStatus(object):
             self.annotations = annotations
         if conditions is not None:
             self.conditions = conditions
+        if deployment_mode is not None:
+            self.deployment_mode = deployment_mode
         if observed_generation is not None:
             self.observed_generation = observed_generation
         if url is not None:
@@ -126,6 +131,29 @@ class V1alpha1InferenceGraphStatus(object):
         """
 
         self._conditions = conditions
+
+    @property
+    def deployment_mode(self):
+        """Gets the deployment_mode of this V1alpha1InferenceGraphStatus.  # noqa: E501
+
+        InferenceGraph DeploymentMode  # noqa: E501
+
+        :return: The deployment_mode of this V1alpha1InferenceGraphStatus.  # noqa: E501
+        :rtype: str
+        """
+        return self._deployment_mode
+
+    @deployment_mode.setter
+    def deployment_mode(self, deployment_mode):
+        """Sets the deployment_mode of this V1alpha1InferenceGraphStatus.
+
+        InferenceGraph DeploymentMode  # noqa: E501
+
+        :param deployment_mode: The deployment_mode of this V1alpha1InferenceGraphStatus.  # noqa: E501
+        :type: str
+        """
+
+        self._deployment_mode = deployment_mode
 
     @property
     def observed_generation(self):

--- a/python/kserve/kserve/models/v1beta1_inference_service_status.py
+++ b/python/kserve/kserve/models/v1beta1_inference_service_status.py
@@ -51,6 +51,7 @@ class V1beta1InferenceServiceStatus(object):
         'annotations': 'dict(str, str)',
         'components': 'dict(str, V1beta1ComponentStatusSpec)',
         'conditions': 'list[KnativeCondition]',
+        'deployment_mode': 'str',
         'model_status': 'V1beta1ModelStatus',
         'observed_generation': 'int',
         'url': 'KnativeURL'
@@ -61,12 +62,13 @@ class V1beta1InferenceServiceStatus(object):
         'annotations': 'annotations',
         'components': 'components',
         'conditions': 'conditions',
+        'deployment_mode': 'deploymentMode',
         'model_status': 'modelStatus',
         'observed_generation': 'observedGeneration',
         'url': 'url'
     }
 
-    def __init__(self, address=None, annotations=None, components=None, conditions=None, model_status=None, observed_generation=None, url=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, address=None, annotations=None, components=None, conditions=None, deployment_mode=None, model_status=None, observed_generation=None, url=None, local_vars_configuration=None):  # noqa: E501
         """V1beta1InferenceServiceStatus - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -76,6 +78,7 @@ class V1beta1InferenceServiceStatus(object):
         self._annotations = None
         self._components = None
         self._conditions = None
+        self._deployment_mode = None
         self._model_status = None
         self._observed_generation = None
         self._url = None
@@ -89,6 +92,8 @@ class V1beta1InferenceServiceStatus(object):
             self.components = components
         if conditions is not None:
             self.conditions = conditions
+        if deployment_mode is not None:
+            self.deployment_mode = deployment_mode
         if model_status is not None:
             self.model_status = model_status
         if observed_generation is not None:
@@ -185,6 +190,29 @@ class V1beta1InferenceServiceStatus(object):
         """
 
         self._conditions = conditions
+
+    @property
+    def deployment_mode(self):
+        """Gets the deployment_mode of this V1beta1InferenceServiceStatus.  # noqa: E501
+
+        InferenceService DeploymentMode  # noqa: E501
+
+        :return: The deployment_mode of this V1beta1InferenceServiceStatus.  # noqa: E501
+        :rtype: str
+        """
+        return self._deployment_mode
+
+    @deployment_mode.setter
+    def deployment_mode(self, deployment_mode):
+        """Sets the deployment_mode of this V1beta1InferenceServiceStatus.
+
+        InferenceService DeploymentMode  # noqa: E501
+
+        :param deployment_mode: The deployment_mode of this V1beta1InferenceServiceStatus.  # noqa: E501
+        :type: str
+        """
+
+        self._deployment_mode = deployment_mode
 
     @property
     def model_status(self):

--- a/python/kserve/test/__init__.py
+++ b/python/kserve/test/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/python/kserve/test/__init__.py
+++ b/python/kserve/test/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+

--- a/test/crds/serving.kserve.io_inferenceservices.yaml
+++ b/test/crds/serving.kserve.io_inferenceservices.yaml
@@ -5399,6 +5399,8 @@ spec:
                   - type
                   type: object
                 type: array
+              deploymentMode:
+                type: string
               observedGeneration:
                 format: int64
                 type: integer
@@ -26834,6 +26836,8 @@ spec:
                   - type
                   type: object
                 type: array
+              deploymentMode:
+                type: string
               modelStatus:
                 properties:
                   copies:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4191 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

***Original Behavior***
- set `defaultDeploymentMode : Serverless`
- Deploy
```
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "sklearn-v2-iris-basic"
  annotations:
    serving.knative.openshift.io/enablePassthrough: 'true'
    sidecar.istio.io/inject: 'true'
    sidecar.istio.io/rewriteAppHTTPProbers: 'true'
spec:
  predictor:
    model:
      modelFormat:
        name: sklearn
      protocolVersion: v2
      runtime: kserve-sklearnserver
      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
```
- verify successful deployment of isvc with Serverless mode (3/3 containers)
- change `defaultDeploymentMode : RawDeployment`
- restart `kserve-controller-manager`
- check that the InferenceService now has 2 deployments (one for serverless mode, one for rawdeployment mode) 

***New Behavior***
- set `defaultDeploymentMode : Serverless`
- Deploy
```
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "sklearn-v2-iris-basic"
  annotations:
    serving.knative.openshift.io/enablePassthrough: 'true'
    sidecar.istio.io/inject: 'true'
    sidecar.istio.io/rewriteAppHTTPProbers: 'true'
spec:
  predictor:
    model:
      modelFormat:
        name: sklearn
      protocolVersion: v2
      runtime: kserve-sklearnserver
      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
```
- verify successful deployment of isvc with Serverless mode (3/3 containers)
- verify `isvc.Status.deploymentMode = Serverless`
- change `defaultDeploymentMode : RawDeployment`
- restart `kserve-controller-manager`
- verify that `isvc.Status.deploymentMode = Serverless` continues to be true
- check that the InferenceService still only has 1 deployment, corresponding to Serverless mode. 



**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
added deploymentMode to inferenceservice and inferencegraph status
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.