### PR TITLE
fix: add trainedmodels custom resource to kubeflow-kserve clusterroles

### DIFF
--- a/config/overlays/kubeflow/cluster-role.yaml
+++ b/config/overlays/kubeflow/cluster-role.yaml
@@ -21,6 +21,7 @@ rules:
 - apiGroups:
   - serving.kserve.io
   resources:
+  - inferencegraphs
   - inferenceservices
   - servingruntimes
   - trainedmodels
@@ -64,6 +65,7 @@ rules:
 - apiGroups:
   - serving.kserve.io
   resources:
+  - inferencegraphs
   - inferenceservices
   - servingruntimes
   - trainedmodels

--- a/config/overlays/kubeflow/cluster-role.yaml
+++ b/config/overlays/kubeflow/cluster-role.yaml
@@ -23,6 +23,7 @@ rules:
   resources:
   - inferenceservices
   - servingruntimes
+  - trainedmodels
   verbs:
   - get
   - list
@@ -65,6 +66,7 @@ rules:
   resources:
   - inferenceservices
   - servingruntimes
+  - trainedmodels
   verbs:
   - get
   - list


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In this PR I added the `trainedmodels` custom resource to the `kubeflow-kserve-edit` and `kubeflow-kserve-view` cluster roles so that users can create/view TrainedModel type resources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4224

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] I have multi-user Kubeflow 1.9.1 instance deployed with version 0.13.0 of KServe on an openstack-based private cloud
 - [ ] Created a new user profile, and a notebook
 - [ ] Applied the following InferenceService manifest
 ```
kind: "InferenceService"
metadata:
  name: "triton-mms"
  annotations:
    sidecar.istio.io/inject: "false"
spec:
  predictor:
    triton:
      args:
      - --log-verbose=1
      env:
      - name: OMP_NUM_THREADS
        value: "1"  
      resources:
        limits:
          cpu: "1"
          memory: 2Gi
        requests:
          cpu: "1"
          memory: 2Gi(base)
```
- [ ] Created a TrainedModel type resource
```
apiVersion: "serving.kserve.io/v1alpha1"
kind: "TrainedModel"
metadata:
  name: "cifar10"
spec:
  inferenceService: triton-mms
  model:
    framework: pytorch
    storageUri: gs://kfserving-examples/models/torchscript/cifar10
    memory: "1Gi" 
```
- [ ] kubectl get trainedmodels - logs below
- [ ] Applied another TrainedModel type resource - logs below
```
apiVersion: "serving.kserve.io/v1alpha1"
kind: "TrainedModel"
metadata:
  name: "simple-string"
spec:
  inferenceService: triton-mms
  model:
    framework: tensorflow 
    storageUri: gs://kfserving-examples/models/triton/simple_string
```
- [ ] kubectl get trainedmodels - logs below

- Logs

```
(base) jovyan@check-0:~$ kubectl get trainedmodels
NAME      URL                                                              READY   AGE
cifar10   https://triton-mms.<MYURL>/v2/models/cifar10/infer   True    30s

(base) jovyan@check-0:~$ kubectl apply -f Kubeflow/model2.yaml 
trainedmodel.serving.kserve.io/simple-string created

(base) jovyan@check-0:~$ kubectl get trainedmodels
NAME            URL                                                                    READY   AGE
cifar10         https://triton-mms.<MYURL>/v2/models/cifar10/infer         True    30s
simple-string   https://triton-mms.<MYURL>/v2/models/simple-string/infer   True    2s
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.