### PR TITLE
Better compatibility with in-place upgrades

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -30,5 +30,7 @@ spec:
           name: https
       - name: manager
         args:
+        # When changing args, also update manager.yaml because the following
+        # list of args will fully override the arguments in manager.yaml.
         - "--metrics-addr=127.0.0.1:8080"
         - "--leader-elect"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,10 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        # When changing arguments, make sure to review the args in manager_auth_proxy_patch.yaml
+        # and update as needed.
+        - "--leader-elect"
         image: ko://github.com/kserve/kserve/cmd/manager
         imagePullPolicy: Always
         name: manager


### PR DESCRIPTION
**What this PR does / why we need it**:

For in-place upgrades the manifests of the new version are applied in a cluster where KServe may already be installed. The old version of the kserve-controller is terminated and the new version is deployed.

The default strategy is Rolling. This has the consequence that during an in-place upgrade, there will be two different versions of kserve-controller running in parallel. Most importantly, the two instances will be running with different configs, which include references to different versions of kserve-agent, kserve-router, storage-initializer, etc. During an in-place upgrade, the new version of the controller will upgrade the deployed models to use the new versions of the images. However, since the old version of kserve-controller is running in parallel, this old version will do rollback. The two instances will conflict with each other, leading to Deployments/KSVCs being changed very quickly which will lead to the cluster spawning pods without control.

Eventually, the cluster will terminate the old version of kserve-controller. However, because of the very, very quick updates to deployments the resources of the cluster can be exhausted leading to instability.

The leader election solves mentioned issues because the new version of the manager won't fully boot until it is capable of getting the lease for being the leader. The manifests enable leader election by default, because `manager_auth_proxy_patch.yaml` is used by default. However, the kustomization.yaml file gives the alternative to use `manager_prometheus_metrics_patch.yaml` and leader election won't be enabled in such case. This is enabling leader election in the manager, by default for all cases. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

I tested manually by modifying the deployment strategy in an existent setup. I observed the expected behavior about the old pod being fully terminated before the new one is created.

**Checklist**:

- [N/A] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [N/A] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.