### PR TITLE
Add well-known label to InferenceGraphs

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -30,15 +30,15 @@ import (
 )
 
 // KServe Constants
-var (
+const (
 	KServeName                       = "kserve"
 	KServeAPIGroupName               = "serving.kserve.io"
 	KnativeAutoscalingAPIGroupName   = "autoscaling.knative.dev"
 	KnativeServingAPIGroupNamePrefix = "serving.knative"
 	KnativeServingAPIGroupName       = KnativeServingAPIGroupNamePrefix + ".dev"
-	KServeNamespace                  = getEnvOrDefault("POD_NAMESPACE", "kserve")
-	KServeDefaultVersion             = "v0.5.0"
 )
+
+var KServeNamespace = getEnvOrDefault("POD_NAMESPACE", "kserve")
 
 // InferenceService Constants
 var (
@@ -331,6 +331,7 @@ const (
 	KServiceComponentLabel = "component"
 	KServiceModelLabel     = "model"
 	KServiceEndpointLabel  = "endpoint"
+	KServeWorkloadKind     = KServeAPIGroupName + "/kind"
 )
 
 // Labels for TrainedModel

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -128,6 +128,7 @@ var _ = Describe("Inference Graph controller test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"serving.kserve.io/inferencegraph": graphName,
+									constants.KServeWorkloadKind:       "InferenceGraph",
 								},
 								Annotations: map[string]string{
 									"autoscaling.knative.dev/min-scale": "1",
@@ -265,6 +266,7 @@ var _ = Describe("Inference Graph controller test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"serving.kserve.io/inferencegraph": graphName,
+									constants.KServeWorkloadKind:       "InferenceGraph",
 								},
 								Annotations: map[string]string{
 									"autoscaling.knative.dev/min-scale": "1",
@@ -416,6 +418,7 @@ var _ = Describe("Inference Graph controller test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"serving.kserve.io/inferencegraph": graphName,
+									constants.KServeWorkloadKind:       "InferenceGraph",
 								},
 								Annotations: map[string]string{
 									"autoscaling.knative.dev/min-scale": "1",
@@ -743,6 +746,7 @@ var _ = Describe("Inference Graph controller test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"serving.kserve.io/inferencegraph": graphName,
+									constants.KServeWorkloadKind:       "InferenceGraph",
 								},
 								Annotations: map[string]string{
 									"autoscaling.knative.dev/min-scale": "1",

--- a/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
+++ b/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
@@ -167,6 +167,7 @@ func createKnativeService(componentMeta metav1.ObjectMeta, graph *v1alpha1.Infer
 		return !utils.Includes(constants.RevisionTemplateLabelDisallowedList, key)
 	})
 	labels[constants.InferenceGraphLabel] = componentMeta.Name
+	labels[constants.KServeWorkloadKind] = "InferenceGraph"
 	service := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        componentMeta.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:

We require to add an `AuthorizationPolicy` to the resulting pods of InferenceGraph (serverless mode). In Istio, Workload Selectors require a <key, value> pair. Apparently, there is no support to match only on the presence of a label key (it needs to be both <key,value>). See https://istio.io/latest/docs/reference/config/type/workload-selector/#WorkloadSelector.

Thus, to correctly apply AuthorizationPolicies, this is adding the `serving.kserve.io/kind: InferenceGraph` label to pods that belong to InferenceGraph.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Deploying an InferenceGraph in Serverless mode. Verify that the new label is present in the resulting pods.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [N/A] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add well-known label to InferenceGraphs
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.