### PR TITLE
Add predictor healthcheck to OpenAIProxyModel

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
@@ -20,7 +20,6 @@ from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.entrypoints.logger import RequestLogger
 
 from kserve import Model
-from kserve.errors import ModelNotReady
 from kserve.model import PredictorConfig
 from kserve.protocol.rest.openai import (
     ChatCompletionRequestMessage,

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -14,28 +14,26 @@
 
 import time
 from importlib import metadata
-from typing import Dict, Optional, Tuple, Union, cast
 from inspect import iscoroutinefunction
+from typing import Dict, Optional, Tuple, Union, cast
 
 import cloudevents.exceptions as ce
 import orjson
-
 from cloudevents.http import CloudEvent, from_http
 from cloudevents.sdk.converters.util import has_binary_headers
 
-from ..inference_client import RESTConfig
-from .rest.v2_datamodels import InferenceRequest
 from ..constants import constants
 from ..constants.constants import INFERENCE_CONTENT_LENGTH_HEADER, PredictorProtocol
 from ..errors import InvalidInput, ModelNotFound
+from ..inference_client import RESTConfig
 from ..logging import logger
-from ..model import PredictorConfig
-from ..model import InferenceVerb, BaseKServeModel, InferenceModel
+from ..model import BaseKServeModel, InferenceModel, InferenceVerb, PredictorConfig
 from ..model_repository import ModelRepository
 from ..utils.inference_client_factory import InferenceClientFactory
 from ..utils.utils import create_response_cloudevent, is_structured_cloudevent
 from .infer_type import InferRequest, InferResponse
 from .rest.openai import OpenAICompletionModel
+from .rest.v2_datamodels import InferenceRequest
 
 JSON_HEADERS = [
     "application/json",

--- a/python/kserve/kserve/protocol/rest/openai/dataplane.py
+++ b/python/kserve/kserve/protocol/rest/openai/dataplane.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import AsyncIterator, Union, List
+from typing import AsyncIterator, List, Union
 
 from fastapi import Response
-from starlette.datastructures import Headers
-
 from kserve.protocol.rest.openai.types.openapi import CreateChatCompletionRequest
 from kserve.protocol.rest.openai.types.openapi import (
     CreateChatCompletionResponse as ChatCompletion,
@@ -32,15 +30,16 @@ from kserve.protocol.rest.openai.types.openapi import CreateEmbeddingRequest
 from kserve.protocol.rest.openai.types.openapi import (
     CreateEmbeddingResponse as Embedding,
 )
+from starlette.datastructures import Headers
 
 from ...dataplane import DataPlane
 from .openai_model import (
     ChatCompletionRequest,
     CompletionRequest,
     EmbeddingRequest,
-    OpenAIModel,
     OpenAICompletionModel,
     OpenAIEmbeddingModel,
+    OpenAIModel,
 )
 
 

--- a/python/kserve/kserve/protocol/rest/openai/endpoints.py
+++ b/python/kserve/kserve/protocol/rest/openai/endpoints.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import os
+import time
 from collections.abc import AsyncIterable
 from typing import AsyncGenerator
-import time
 
 from fastapi import APIRouter, FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
@@ -197,7 +197,12 @@ class OpenAIEndpoints:
         )
 
     async def health(self, model_name: str):
-        await self.dataplane.model_ready(model_name)
+        try:
+            model_ready = await self.dataplane.model_ready(model_name)
+        except Exception as e:
+            raise ModelNotReady(model_name) from e
+        if not model_ready:
+            raise ModelNotReady(model_name)
 
 
 def register_openai_endpoints(app: FastAPI, dataplane: OpenAIDataPlane):

--- a/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
@@ -302,7 +302,7 @@ class OpenAIProxyModel(OpenAICompletionModel):
         else:
             chat_completion = ChatCompletion.model_validate_json(response.content)
         return chat_completion
-    
+
     async def healthy(self) -> bool:
         """
         Check the health of this model. By default returns `self.ready`.

--- a/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
@@ -310,12 +310,9 @@ class OpenAIProxyModel(OpenAICompletionModel):
         Returns:
             True if healthy, false otherwise
         """
-        print("OpenAiProxyModel.healthy")
         req = self._http_client.build_request(
             "GET",
             self._health_endpoint,
         )
-        print(req.__dict__)
         response = await self._http_client.send(req)
-        print(response.__dict__)
         return response.status_code == httpx.codes.OK

--- a/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
@@ -106,7 +106,7 @@ class OpenAIProxyModel(OpenAICompletionModel):
             e.g. `http://my-backend:9000`
         http_client (httpx.AsyncClient|None):
             An optional instance of httpx.AsyncClient to use for sending requests to the upstream server.
-        health_endpoint: The defualt /health endpoint is for TGI and vllm, use /openai/v1/models/{model_name}
+        health_endpoint: The default /health endpoint is for TGI and vLLM, use /openai/v1/models/{model_name}
             for KServe OpenAI protocol.
     """
 

--- a/python/kserve/test/test_openai_completion.py
+++ b/python/kserve/test/test_openai_completion.py
@@ -562,4 +562,3 @@ class TestOpenAIProxyModelCompletion:
         async with mocked_openai_proxy_model(handler) as model:
             result = await model.healthy()
             assert result is False
-

--- a/python/kserve/test/test_openai_completion.py
+++ b/python/kserve/test/test_openai_completion.py
@@ -536,7 +536,6 @@ class TestOpenAIProxyModelCompletion:
         self
     ):
         def handler(request):
-            print(request.url.path)
             if request.url.path == "/health":
                 return httpx.Response(
                     200,
@@ -553,7 +552,6 @@ class TestOpenAIProxyModelCompletion:
         self
     ):
         def handler(request):
-            print("path", request.url.path)
             if request.url.path == "/health":
                 return httpx.Response(
                     503,

--- a/python/kserve/test/test_openai_completion.py
+++ b/python/kserve/test/test_openai_completion.py
@@ -532,9 +532,7 @@ class TestOpenAIProxyModelCompletion:
             ).assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_healthcheck_success(
-        self
-    ):
+    async def test_healthcheck_success(self):
         def handler(request):
             if request.url.path == "/health":
                 return httpx.Response(
@@ -543,14 +541,13 @@ class TestOpenAIProxyModelCompletion:
             return httpx.Response(
                 503,
             )
+
         async with mocked_openai_proxy_model(handler) as model:
             result = await model.healthy()
             assert result is True
 
     @pytest.mark.asyncio
-    async def test_healthcheck_failure(
-        self
-    ):
+    async def test_healthcheck_failure(self):
         def handler(request):
             if request.url.path == "/health":
                 return httpx.Response(
@@ -559,6 +556,7 @@ class TestOpenAIProxyModelCompletion:
             return httpx.Response(
                 200,
             )
+
         async with mocked_openai_proxy_model(handler) as model:
             result = await model.healthy()
             assert result is False


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR addes predictor healthcheck to OpenAIProxy Model so the inference service health endpoint can reflect the  status of the transformer. Before this PR, we could not detect predictor failures though the health endpoint if the service has a transformer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Added a unit test `pytest test_openai_completion.py`
- [x] Tested it locally with a local TGI container.
```
huggingface-cli download openai-community/gpt2
volume=/Users/jdong183/data
docker run --shm-size 1g -p 8081:80 -v $volume:/data ghcr.io/huggingface/text-generation-inference --model-id /data/gpt2 --trust-remote-code

# Run a main.py that passes params to OpenAIProxyModel
 python __main__.py   --model_name llama-2-70b \
  --predictor_host localhost:8081 \
  --predictor_use_ssl=false \
  --ca_bundle CABundle.pem \
  --skip_upstream_validation=true
  --enable_predictor_health_check

With TGI running, curl localhost:8080/openai/v1/models/llama-2-70b -> 200 OK
With TGI shutdown, we got "GET /openai/v1/models/llama-2-70b HTTP/1.1" 503 Service Unavailable
```


- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.