### PR TITLE
Fix localmodel test

### DIFF
--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -462,7 +462,8 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 func (c *LocalModelNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		// Do not reconcile on status change, when a job is created and the status is updated, it may not get the job back in the next reconcile()
+		// Do not reconcile on status change, when a job is created and the status is updated, the next reconcile is triggered immediately and
+		// there is a chance that the job is not returned when we list jobs, causing the same job to be created twice.
 		// Keep AnnotationChangedPredicate because we use it to trigger reconciliation in the test
 		For(&v1alpha1.LocalModelNode{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Owns(&batchv1.Job{}).

--- a/pkg/controller/v1alpha1/localmodelnode/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller_test.go
@@ -381,7 +381,7 @@ var _ = Describe("LocalModelNode controller", func() {
 			// Delete the model folder
 			fsMock.clear()
 
-			// Manually trigger reconcillation
+			// Manually trigger reconciliation
 			patch := client.MergeFrom(localModelNode.DeepCopy())
 			localModelNode.Annotations = map[string]string{"foo": "bar"}
 			Expect(k8sClient.Patch(ctx, localModelNode, patch)).Should(Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make go-lint` and `make py-fmt` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes the following two test failures.

1. This is caused by resource not cleaned up.
https://github.com/kserve/kserve/actions/runs/13458417444/job/37607578015
```
   [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0xc0021eb220>: 
      object is being deleted: localmodelcaches.serving.kserve.io "iris2" already exists
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "object is being deleted: localmodelcaches.serving.kserve.io \"iris2\" already exists",
              Reason: "AlreadyExists",
              Details: {
                  Name: "iris2",
                  Group: "serving.kserve.io",
                  Kind: "localmodelcaches",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 409,
          },
      }
  In [It] at: /home/runner/work/kserve/kserve/pkg/controller/v1alpha1/localmodel/controller_test.go:678 @ 02/21/25 14:07:36.892
```
2. This is caused by job that just created was not returned in the next reconcile which happened immediately. The solution is to disable reconciliation for status change. 
https://github.com/kserve/kserve/actions/runs/13525773064/job/37795820518
```
 • [FAILED] [10.032 seconds]
LocalModelNode controller When creating a local model [It] Should recreate download jobs if the model is missing from local disk
/home/runner/work/kserve/kserve/pkg/controller/v1alpha1/localmodelnode/controller_test.go:287

  Timeline >>
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Agent reconciling LocalModelNode	{"name": "worker2", "node": "worker2"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Downloading models to	{"node": "worker2"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	checking model from spec	{"model": "iris"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Model folder not found	{"model": "iris"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Found jobs	{"model": "iris", "num of jobs": 0}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Found the nodegroup of current node. Using the following PVC name to create download job	{"current node": "worker2", "node group": "gpu", "PVC name": "iris-gpu"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Created job	{"name": "iris-worker2dp4xh", "namespace": "kserve-localmodel-jobs", "model": "iris"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	model downloading status:	{"model": "iris", "node": "worker2", "status": "ModelDownloadPending"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	status updated	{"name": "worker2", "num of models in status": 1}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Agent reconciling LocalModelNode	{"name": "worker2", "node": "worker2"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Downloading models to	{"node": "worker2"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	checking model from spec	{"model": "iris"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Model folder not found	{"model": "iris"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Found jobs	{"model": "iris", "num of jobs": 0}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Found the nodegroup of current node. Using the following PVC name to create download job	{"current node": "worker2", "node group": "gpu", "PVC name": "iris-gpu"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Created job	{"name": "iris-worker2vxmrv", "namespace": "kserve-localmodel-jobs", "model": "iris"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	model downloading status:	{"model": "iris", "node": "worker2", "status": "ModelDownloadPending"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Agent reconciling LocalModelNode	{"name": "worker2", "node": "worker2"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Downloading models to	{"node": "worker2"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	checking model from spec	{"model": "iris"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Model folder not found	{"model": "iris"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	Found jobs	{"model": "iris", "num of jobs": 2}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	model status from latest job	{"model": "iris", "status": "ModelDownloadPending"}
  2025-02-25T16:17:03Z	INFO	v1alpha1LocalModelAgent	model downloading status:	{"model": "iris", "node": "worker2", "status": "ModelDownloadPending"}
  2025-02-25T16:17:13Z	INFO	v1alpha1LocalModelAgent	Agent reconciling LocalModelNode	{"name": "worker2", "node": "worker2"}
  2025-02-25T16:17:13Z	ERROR	v1alpha1LocalModelAgent	Error getting LocalModelNode	{"name": "worker2", "error": "LocalModelNode.serving.kserve.io \"worker2\" not found"}
  github.com/kserve/kserve/pkg/controller/v1alpha1/localmodelnode.(*LocalModelNodeReconciler).Reconcile
  	/home/runner/work/kserve/kserve/pkg/controller/v1alpha1/localmodelnode/controller.go:417
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:118
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:328
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:288
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
  	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:249
  [FAILED] in [It] - /home/runner/work/kserve/kserve/pkg/controller/v1alpha1/localmodelnode/controller_test.go:357 @ 02/25/25 16:17:13.787
  << Timeline
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.