### PR TITLE
Force symlink for ModelCar

### DIFF
--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -696,7 +696,7 @@ func (mi *StorageInitializerInjector) createModelContainer(image string, modelPa
 			"sh",
 			"-c",
 			// $$$$ gets escaped by YAML to $$, which is the current PID
-			fmt.Sprintf("ln -s /proc/$$$$/root/models %s && sleep infinity", modelPath),
+			fmt.Sprintf("ln -sf /proc/$$$$/root/models %s && sleep infinity", modelPath),
 		},
 		Resources: corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make go-lint` and `make py-fmt` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When the single-node cluster is rebooted, the containers are not recreated from scratch, so the model is already present in the Pods filesystem, the original command fails (`ln: /mnt/models: File exists`), and the model server container keeps restarting (CrashloopBackoff).
Adding `-f` forces creation of the symlink by the ModelCar containers, overwriting them if already exist.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] [This change requires a documentation update](https://github.com/kserve/website/blob/20eea7151cf7ab66fe98fa2fae641300998b87a9/docs/modelserving/storage/oci.md?plain=1#L129)

**Feature/Issue validation/testing**:

- Create InferenceService with a model in OCI, wait until the Deployment starts (Raw Deployment mode)
- Reboot the node
- See if the Deployment becomes ready or keeps restarting (CrashloopBackoff)

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] ~~Have you added unit/e2e tests that prove your fix is effective or that this feature works?~~ Not applicable?
- [ ] ~~Has code been commented, particularly in hard-to-understand areas?~~ Not applicable?
- [ ] Have you made corresponding changes to the documentation? https://github.com/kserve/website/pull/448

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.