### PR TITLE
Fix triton health check

### DIFF
--- a/python/kserve/kserve/inference_client.py
+++ b/python/kserve/kserve/inference_client.py
@@ -102,7 +102,7 @@ class InferenceGRPCClient:
         url: str,
         verbose: bool = False,
         use_ssl: bool = False,
-        root_certificates: str = "/Users/jdong183/CABundle.pem",
+        root_certificates: str = None,
         private_key: str = None,
         certificate_chain: str = None,
         creds: grpc.ChannelCredentials = None,
@@ -401,7 +401,7 @@ class InferenceRESTClient:
             http2=self._config.http2,
             timeout=self._config.timeout,
             auth=self._config.auth,
-            verify=False,
+            verify=self._config.verify,
         )
 
     def _construct_url(

--- a/python/kserve/kserve/inference_client.py
+++ b/python/kserve/kserve/inference_client.py
@@ -679,7 +679,10 @@ class InferenceRESTClient:
         # Raise for other status codes
         if not response.is_success:
             raise self._construct_http_status_error(response)
-        return response.json().get("ready")
+        if response.headers.get("Content-Type") == "application/json":
+            return response.json().get("ready")
+        # v2 protocol returns 200 with empty body if model is ready
+        return True
 
     async def close(self):
         """

--- a/python/kserve/kserve/inference_client.py
+++ b/python/kserve/kserve/inference_client.py
@@ -102,7 +102,7 @@ class InferenceGRPCClient:
         url: str,
         verbose: bool = False,
         use_ssl: bool = False,
-        root_certificates: str = None,
+        root_certificates: str = "/Users/jdong183/CABundle.pem",
         private_key: str = None,
         certificate_chain: str = None,
         creds: grpc.ChannelCredentials = None,
@@ -401,7 +401,7 @@ class InferenceRESTClient:
             http2=self._config.http2,
             timeout=self._config.timeout,
             auth=self._config.auth,
-            verify=self._config.verify,
+            verify=False,
         )
 
     def _construct_url(

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -302,7 +302,9 @@ class DataPlane:
                     return is_ready
                 except HTTPError as exc:
                     logger.debug(
-                        f"predictor not ready, HTTP exception for {exc.request.url} - {exc}"
+                        "check predictor readiness - HTTP exception for %s - %s",
+                        exc.request.url,
+                        exc,
                     )
                     return False
 

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -21,6 +21,7 @@ import cloudevents.exceptions as ce
 import orjson
 from cloudevents.http import CloudEvent, from_http
 from cloudevents.sdk.converters.util import has_binary_headers
+from grpc import RpcError
 from httpx import HTTPError
 
 from ..constants import constants
@@ -284,8 +285,12 @@ class DataPlane:
                 self.predictor_config.predictor_protocol
                 == PredictorProtocol.GRPC_V2.value
             ):
-                is_ready = await self.grpc_client.is_model_ready(model_name=model_name)
-                return is_ready
+                try:
+                    is_ready = await self.grpc_client.is_model_ready(model_name=model_name)
+                    return is_ready
+                except RpcError:
+                    # Logged in the grpc client
+                    return False
             else:
                 try:
                     is_ready = await self.rest_client.is_model_ready(

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -263,11 +263,15 @@ class DataPlane:
                 )
         return True
 
-    async def model_ready(self, model_name: str) -> bool:
+    async def model_ready(
+        self, model_name: str, disable_predictor_health_check: bool = False
+    ) -> bool:
         """Check if a model is ready.
 
         Args:
             model_name (str): name of the model
+            disable_predictor_health_check (bool): Flag to disable predictor health
+            check for infer/predict requests.
 
         Returns:
             bool: True if the model is ready, False otherwise.
@@ -280,7 +284,11 @@ class DataPlane:
 
         # If predictor host is present, then it means this is a transformer,
         # We should also check the predictor model's health if predictor health check is enabled.
-        if self.predictor_config and self.predictor_config.predictor_health_check:
+        if (
+            not disable_predictor_health_check
+            and self.predictor_config
+            and self.predictor_config.predictor_health_check
+        ):
             if (
                 self.predictor_config.predictor_protocol
                 == PredictorProtocol.GRPC_V2.value

--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -286,7 +286,9 @@ class DataPlane:
                 == PredictorProtocol.GRPC_V2.value
             ):
                 try:
-                    is_ready = await self.grpc_client.is_model_ready(model_name=model_name)
+                    is_ready = await self.grpc_client.is_model_ready(
+                        model_name=model_name
+                    )
                     return is_ready
                 except RpcError:
                     # Logged in the grpc client
@@ -299,7 +301,9 @@ class DataPlane:
                     )
                     return is_ready
                 except HTTPError as exc:
-                    logger.debug(f"predictor not ready, HTTP exception for {exc.request.url} - {exc}")
+                    logger.debug(
+                        f"predictor not ready, HTTP exception for {exc.request.url} - {exc}"
+                    )
                     return False
 
         return await self._model_registry.is_model_ready(model_name)

--- a/python/kserve/kserve/protocol/rest/v1_endpoints.py
+++ b/python/kserve/kserve/protocol/rest/v1_endpoints.py
@@ -70,7 +70,8 @@ class V1Endpoints:
         Returns:
             Dict|Response: Model inference response.
         """
-        model_ready = await self.dataplane.model_ready(model_name)
+        # Disable predictor health check
+        model_ready = await self.dataplane.model_ready(model_name, True)
 
         if not model_ready:
             raise ModelNotReady(model_name)
@@ -108,7 +109,8 @@ class V1Endpoints:
         Returns:
             Dict: Explainer output.
         """
-        model_ready = await self.dataplane.model_ready(model_name)
+        # Disable predictor health check
+        model_ready = await self.dataplane.model_ready(model_name, True)
 
         if not model_ready:
             raise ModelNotReady(model_name)

--- a/python/kserve/kserve/protocol/rest/v2_endpoints.py
+++ b/python/kserve/kserve/protocol/rest/v2_endpoints.py
@@ -151,7 +151,8 @@ class V2Endpoints:
         if model_version:
             raise NotImplementedError("Model versioning not supported yet.")
 
-        model_ready = await self.dataplane.model_ready(model_name)
+        # Disable predictor health check
+        model_ready = await self.dataplane.model_ready(model_name, True)
 
         if not model_ready:
             raise ModelNotReady(model_name)

--- a/python/kserve/test/test_dataplane.py
+++ b/python/kserve/test/test_dataplane.py
@@ -689,9 +689,7 @@ class TestDataplaneTransformer:
     async def test_model_readiness_v2(self, httpx_mock):
         # scenario: getting a 2xx response from predictor
         predictor_host = "ready.host"
-        httpx_mock.add_response(
-            url=re.compile(f"http://{predictor_host}/v2/*"), json={"ready": True}
-        )
+        httpx_mock.add_response(url=re.compile(f"http://{predictor_host}/v2/*"))
         dataplane = DataPlane(
             model_registry=ModelRepository(),
             predictor_config=PredictorConfig(

--- a/python/kserve/test/test_dataplane.py
+++ b/python/kserve/test/test_dataplane.py
@@ -765,7 +765,8 @@ class TestDataplaneTransformer:
         not_ready_model = DummyModel("NotReadyModel")
         dataplane._model_registry.update(not_ready_model)
         httpx_mock.add_exception(
-            url=re.compile(f"http://{predictor_host}/v2/*"), exception=httpx.ConnectError("All connection attempts failed")
+            url=re.compile(f"http://{predictor_host}/v2/*"),
+            exception=httpx.ConnectError("All connection attempts failed"),
         )
         assert (await dataplane.model_ready(not_ready_model.name)) is False
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make go-lint` and `make py-fmt` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes the following issues:
1. Triton model health endpoint returns 200 with no response content, but kserve parses the response as json, causing 500 #4267 
2. When the transformer cannot connect to the predictor, it returns 500 instead of 503. #4262
3. Removed predictor health check for infer/predict requests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4267 #4262

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.