### PR TITLE
fix conflict isvc name for keda e2e

### DIFF
--- a/test/e2e/predictor/test_autoscaling.py
+++ b/test/e2e/predictor/test_autoscaling.py
@@ -439,7 +439,7 @@ async def test_sklearn_keda_scale_new_spec_external(rest_v1_client, network_laye
     """
     Test KEDA autoscaling with new InferenceService (auto_scaling) spec
     """
-    service_name = "isvc-sklearn-keda-scale-new-spec"
+    service_name = "isvc-sklearn-keda-scale-new-spec-2"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         max_replicas=5,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make go-lint` and `make py-fmt` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
2 Keda e2e tests use the same isvc name and it impacts to e2e test. So I just add another name for the test-case.

```
FAILED predictor/test_autoscaling.py::test_sklearn_keda_scale_new_spec_external - RuntimeError: Exception when calling CustomObjectsApi->create_namespaced_custom_object:                 (409)
Reason: Conflict
HTTP response headers: HTTPHeaderDict({'Audit-Id': '4992c914-a1fc-433f-8212-9b7fde5475be', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': 'a3d4b9da-f1a1-4d86-b080-3bd9c2370a23', 'X-Kubernetes-Pf-Prioritylevel-Uid': '72545cec-789d-4726-bbd7-b6b1e0f8a551', 'Date': 'Wed, 12 Mar 2025 02:12:01 GMT', 'Content-Length': '339'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"object is being deleted: inferenceservices.serving.kserve.io \"isvc-sklearn-keda-scale-new-spec\" already exists","reason":"AlreadyExists","details":{"name":"isvc-sklearn-keda-scale-new-spec","group":"serving.kserve.io","kind":"inferenceservices"},"code":409}
============= 1 failed, 16 passed, 5 warnings in 429.31s (0:07:09) =============
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.