### PR TITLE
Stop and resume a model by adding a new annotation [Serverless] 

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service.go
+++ b/pkg/apis/serving/v1beta1/inference_service.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	"strings"
+
+	"github.com/kserve/kserve/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -135,4 +138,16 @@ type InferenceServiceList struct {
 
 func init() {
 	SchemeBuilder.Register(&InferenceService{}, &InferenceServiceList{})
+}
+
+func (isvc *InferenceService) GetForceStopRuntime() bool {
+	forceStopRuntime := false
+	if isvc == nil || isvc.Annotations == nil {
+		return forceStopRuntime
+	}
+	if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
+		forceStopRuntime = strings.EqualFold(val, "true")
+	}
+
+	return forceStopRuntime
 }

--- a/pkg/apis/serving/v1beta1/inference_service.go
+++ b/pkg/apis/serving/v1beta1/inference_service.go
@@ -19,8 +19,9 @@ package v1beta1
 import (
 	"strings"
 
-	"github.com/kserve/kserve/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 // InferenceServiceSpec is the top level type for this resource

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -124,6 +124,8 @@ const (
 	RoutesReady apis.ConditionType = "RoutesReady"
 	// LatestDeploymentReady is set when underlying configurations for all components have reported readiness.
 	LatestDeploymentReady apis.ConditionType = "LatestDeploymentReady"
+	// Stopped is set when the inference service has been stopped and all related objects are deleted
+	Stopped apis.ConditionType = "Stopped"
 )
 
 type ModelStatus struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -94,7 +94,7 @@ var (
 	TargetUtilizationPercentage                 = KServeAPIGroupName + "/targetUtilizationPercentage"
 	MinScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/min-scale"
 	MaxScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/max-scale"
-	StopResumeAnnotationKey                     = KServeAPIGroupName + "/stop"
+	StopAnnotationKey                           = KServeAPIGroupName + "/stop"
 	RollOutDurationAnnotationKey                = KnativeServingAPIGroupName + "/rollout-duration"
 	KnativeOpenshiftEnablePassthroughKey        = "serving.knative.openshift.io/enablePassthrough"
 	EnableMetricAggregation                     = KServeAPIGroupName + "/enable-metric-aggregation"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -94,6 +94,7 @@ var (
 	TargetUtilizationPercentage                 = KServeAPIGroupName + "/targetUtilizationPercentage"
 	MinScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/min-scale"
 	MaxScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/max-scale"
+	StopResumeAnnotationKey                     = KServeAPIGroupName + "/stop"
 	RollOutDurationAnnotationKey                = KnativeServingAPIGroupName + "/rollout-duration"
 	KnativeOpenshiftEnablePassthroughKey        = "serving.knative.openshift.io/enablePassthrough"
 	EnableMetricAggregation                     = KServeAPIGroupName + "/enable-metric-aggregation"

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -195,7 +195,7 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 		}
 
 		forceStopRuntime := "false"
-		if val, exist := isvc.Annotations[constants.StopResumeAnnotationKey]; exist {
+		if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
 			forceStopRuntime = val
 		}
 

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -200,7 +200,13 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 		}
 
 		if strings.EqualFold(forceStopRuntime, "true") {
-			// Clear all statuses if the ISVC is stopped
+			// Exit early if we have already set the status to stopped
+			existing_stopped_condition := isvc.Status.GetCondition(v1beta1.Stopped)
+			if existing_stopped_condition != nil && existing_stopped_condition.Status == corev1.ConditionTrue {
+				return ctrl.Result{}, nil
+			}
+
+			// Clear all statuses
 			p.Log.Info("Clearing ISVC status")
 			isvc.Status = v1beta1.InferenceServiceStatus{}
 

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -204,18 +204,11 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 			// Clear all statuses
 			isvc.Status = v1beta1.InferenceServiceStatus{}
 
-			// Set the ready condition to false via the ready condition's dependencies PredictorReady and IngressReady
 			predictor_ready_condition := &apis.Condition{
 				Type:   v1beta1.PredictorReady,
 				Status: corev1.ConditionFalse,
 			}
 			isvc.Status.SetCondition(v1beta1.PredictorReady, predictor_ready_condition)
-
-			ingress_ready_condition := &apis.Condition{
-				Type:   v1beta1.IngressReady,
-				Status: corev1.ConditionFalse,
-			}
-			isvc.Status.SetCondition(v1beta1.IngressReady, ingress_ready_condition)
 
 			// Add the stopped condition
 			stopped_condition := &apis.Condition{

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -201,9 +201,15 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 				return ctrl.Result{}, nil
 			}
 
+			deployMode := isvc.Status.DeploymentMode
+
 			// Clear all statuses
 			isvc.Status = v1beta1.InferenceServiceStatus{}
 
+			// Preserve the deployment mode value
+			isvc.Status.DeploymentMode = deployMode
+
+			// Set the ready condition
 			predictor_ready_condition := &apis.Condition{
 				Type:   v1beta1.PredictorReady,
 				Status: corev1.ConditionFalse,

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -204,10 +204,9 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 			}
 
 			// Clear all statuses
-			p.Log.Info("Clearing ISVC status")
 			isvc.Status = v1beta1.InferenceServiceStatus{}
 
-			// Set the ready conditions to false
+			// Set the ready condition to false via the ready condition's dependencies PredictorReady and IngressReady
 			predictor_ready_condition := &apis.Condition{
 				Type:   v1beta1.PredictorReady,
 				Status: corev1.ConditionFalse,

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -192,6 +193,32 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 		if kstatus, err = p.reconcileKnativeDeployment(ctx, isvc, &objectMeta, &podSpec); err != nil {
 			return ctrl.Result{}, err
 		}
+
+		forceStopRuntime := "false"
+		if val, exist := isvc.Annotations[constants.StopResumeAnnotationKey]; exist {
+			forceStopRuntime = val
+		}
+
+		if strings.EqualFold(forceStopRuntime, "true") {
+			// Clear all statuses if the ISVC is stopped
+			p.Log.Info("Clearing ISVC status")
+			isvc.Status = v1beta1.InferenceServiceStatus{}
+
+			// Add the stopped condition
+			stopped_condition := &apis.Condition{
+				Type:   v1beta1.Stopped,
+				Status: corev1.ConditionTrue,
+			}
+			isvc.Status.SetCondition(v1beta1.Stopped, stopped_condition)
+
+			return ctrl.Result{}, nil
+		} else {
+			resume_condition := &apis.Condition{
+				Type:   v1beta1.Stopped,
+				Status: corev1.ConditionFalse,
+			}
+			isvc.Status.SetCondition(v1beta1.Stopped, resume_condition)
+		}
 	}
 
 	statusSpec := isvc.Status.Components[v1beta1.PredictorComponent]
@@ -204,6 +231,7 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "fails to list inferenceservice pods by label")
 	}
+
 	if isvc.Status.PropagateModelStatus(statusSpec, predictorPods, rawDeployment, kstatus) {
 		return ctrl.Result{}, nil
 	} else {

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -220,14 +220,9 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return reconcile.Result{}, err
 	}
 
-	forceStopRuntime := false
-	if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
-		forceStopRuntime = strings.EqualFold(val, "true")
-	}
-
 	reconcilers := []components.Component{}
 	if deploymentMode != constants.ModelMeshDeployment {
-		reconcilers = append(reconcilers, components.NewPredictor(r.Client, r.Clientset, r.Scheme, isvcConfig, deploymentMode, forceStopRuntime))
+		reconcilers = append(reconcilers, components.NewPredictor(r.Client, r.Clientset, r.Scheme, isvcConfig, deploymentMode))
 	}
 	if isvc.Spec.Transformer != nil {
 		reconcilers = append(reconcilers, components.NewTransformer(r.Client, r.Clientset, r.Scheme, isvcConfig, deploymentMode))
@@ -259,7 +254,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if isvc.Spec.Explainer != nil {
 			componentList = append(componentList, v1beta1.ExplainerComponent)
 		}
-		if !forceStopRuntime {
+		if !isvc.GetForceStopRuntime() {
 			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.RoutesReady)
 			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.LatestDeploymentReady)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -220,9 +220,14 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return reconcile.Result{}, err
 	}
 
+	forceStopRuntime := false
+	if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
+		forceStopRuntime = strings.EqualFold(val, "true")
+	}
+
 	reconcilers := []components.Component{}
 	if deploymentMode != constants.ModelMeshDeployment {
-		reconcilers = append(reconcilers, components.NewPredictor(r.Client, r.Clientset, r.Scheme, isvcConfig, deploymentMode))
+		reconcilers = append(reconcilers, components.NewPredictor(r.Client, r.Clientset, r.Scheme, isvcConfig, deploymentMode, forceStopRuntime))
 	}
 	if isvc.Spec.Transformer != nil {
 		reconcilers = append(reconcilers, components.NewTransformer(r.Client, r.Clientset, r.Scheme, isvcConfig, deploymentMode))
@@ -254,8 +259,10 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if isvc.Spec.Explainer != nil {
 			componentList = append(componentList, v1beta1.ExplainerComponent)
 		}
-		isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.RoutesReady)
-		isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.LatestDeploymentReady)
+		if !forceStopRuntime {
+			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.RoutesReady)
+			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.LatestDeploymentReady)
+		}
 	}
 	// Reconcile ingress
 	ingressConfig, err := v1beta1.NewIngressConfig(isvcConfigMap)

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -580,7 +580,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			// Define InferenceService
 			isvc := defaultIsvc(serviceKey.Namespace, serviceKey.Name, storageUri)
 			isvc.Annotations = map[string]string{}
-			isvc.Annotations[constants.StopResumeAnnotationKey] = "false"
+			isvc.Annotations[constants.StopAnnotationKey] = "false"
 			Expect(k8sClient.Create(context.TODO(), isvc)).NotTo(HaveOccurred())
 			defer k8sClient.Delete(ctx, isvc)
 			time.Sleep(10 * time.Second)
@@ -619,7 +619,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			// Define InferenceService
 			isvc := defaultIsvc(serviceKey.Namespace, serviceKey.Name, storageUri)
 			isvc.Annotations = map[string]string{}
-			isvc.Annotations[constants.StopResumeAnnotationKey] = "true"
+			isvc.Annotations[constants.StopAnnotationKey] = "true"
 			Expect(k8sClient.Create(context.TODO(), isvc)).NotTo(HaveOccurred())
 			defer k8sClient.Delete(ctx, isvc)
 

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -808,6 +808,15 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout).
 				Should(BeTrue())
 
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
+				if err != nil {
+					return false
+				}
+				readyCond := actualIsvc.Status.GetCondition(v1beta1.PredictorReady)
+				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+			}, timeout, interval).Should(BeTrue(), "InferenceService should be ready before updating the annotation")
+
 			// Stop the inference service
 			updatedIsvc := actualIsvc.DeepCopy()
 			updatedIsvc.Annotations[constants.StopAnnotationKey] = "true"

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -629,10 +629,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Name:      constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace,
 			}
-			Eventually(func() bool {
+			Consistently(func() bool {
 				err := k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
 				return apierr.IsNotFound(err)
-			}, time.Second*30).Should(BeTrue(), "The ksvc should not be created")
+			}, timeout).Should(BeTrue(), "The ksvc should not be created")
 
 			// Check that the ISVC status reflects that it is stopped
 			updatedIsvc := &v1beta1.InferenceService{}
@@ -679,7 +679,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			isvc.Annotations[constants.StopAnnotationKey] = "false"
 			Expect(k8sClient.Create(context.TODO(), isvc)).NotTo(HaveOccurred())
 			defer k8sClient.Delete(ctx, isvc)
-			time.Sleep(20 * time.Second)
 
 			// Knative service
 			actualService := &knservingv1.Service{}
@@ -687,7 +686,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Name:      constants.PredictorServiceName(serviceKey.Name),
 				Namespace: serviceKey.Namespace,
 			}
-			Consistently(func() error {
+			Eventually(func() error {
 				err := k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
 				return err
 			}, timeout).
@@ -703,7 +702,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			updatedIsvc := actualIsvc.DeepCopy()
 			updatedIsvc.Annotations[constants.StopAnnotationKey] = "true"
 			Expect(k8sClient.Update(ctx, updatedIsvc)).NotTo(HaveOccurred())
-			time.Sleep(10 * time.Second)
 
 			// Check that the KSVC was deleted
 			Eventually(func() bool {

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -559,7 +559,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			return configMap
 		}
 
-		It("Should keep the knative service when the annotation is set to false", func() {
+		It("Should keep the knative service/virtualService/service when the annotation is set to false", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -673,7 +673,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue(), "The ingress should be ready")
 		})
 
-		It("Should delete the knative service when the annotation is set to true", func() {
+		It("Should delete the knative service/virtualService/service when the annotation is set to true", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -745,7 +745,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
 		})
 
-		It("Should delete the knative service when the annotation is updated to true on an existing ISVC", func() {
+		It("Should delete the knative service/virtualService/service when the annotation is updated to true on an existing ISVC", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -890,7 +890,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
 		})
 
-		It("Should create the knative service when the annotation is updated to false on an existing ISVC that is stopped", func() {
+		It("Should create the knative service/virtualService/service when the annotation is updated to false on an existing ISVC that is stopped", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -294,10 +294,14 @@ func (ir *IngressReconciler) reconcileVirtualService(ctx context.Context, isvc *
 	} else {
 		// Delete the virtualservice
 		if getExistingErr == nil {
-			log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated VirtualService")
-			if err := ir.client.Delete(ctx, existing); err != nil {
-				return err
+			// Make sure that we only delete virtual services owned by the isvc
+			if existing.OwnerReferences[0].UID == isvc.UID {
+				log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated VirtualService")
+				if err := ir.client.Delete(ctx, existing); err != nil {
+					return err
+				}
 			}
+
 		} else if !apierr.IsNotFound(getExistingErr) {
 			return getExistingErr
 		}
@@ -364,9 +368,12 @@ func (ir *IngressReconciler) reconcileExternalService(ctx context.Context, isvc 
 	} else {
 		// Delete the service
 		if getExistingErr == nil {
-			log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated Service")
-			if err := ir.client.Delete(ctx, existing); err != nil {
-				return err
+			// Make sure that we only delete services owned by the isvc
+			if existing.OwnerReferences[0].UID == isvc.UID {
+				log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated Service")
+				if err := ir.client.Delete(ctx, existing); err != nil {
+					return err
+				}
 			}
 		} else if !apierr.IsNotFound(getExistingErr) {
 			return getExistingErr

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -112,7 +112,6 @@ func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infere
 	}
 
 	if serviceHost == "" || serviceUrl == "" {
-		log.Info("Service host or url is empty")
 		return nil
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -79,7 +79,7 @@ func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infere
 	serviceUrl := getServiceUrl(isvc, ir.ingressConfig)
 	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
 
-	// Check if the isvc is stopped
+	// If the "serving.kserve.io/stop" annotation is present in isvc, follow the force stop logic
 	forceStopRuntime := "false"
 	if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
 		forceStopRuntime = val
@@ -89,7 +89,7 @@ func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infere
 		// Delete the service
 		existingService := &corev1.Service{}
 		if err := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existingService); err == nil {
-			log.Info("Delete services")
+			log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated Service")
 			if err := ir.client.Delete(ctx, existingService); err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infere
 		// Delete the virtualservice
 		existingVService := &istioclientv1beta1.VirtualService{}
 		if err := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existingVService); err == nil {
-			log.Info("Delete vservices")
+			log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated VirtualService")
 			if err := ir.client.Delete(ctx, existingVService); err != nil {
 				return err
 			}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -78,7 +78,7 @@ func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infere
 	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
 
 	if err := ir.reconcileVirtualService(ctx, isvc); err != nil {
-		return errors.Wrapf(err, "fails to reconcile external name service")
+		return errors.Wrapf(err, "fails to reconcile virtual service")
 	}
 	// Create external service which points to local gateway
 	if err := ir.reconcileExternalService(ctx, isvc, ir.ingressConfig); err != nil {
@@ -97,7 +97,7 @@ func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infere
 	serviceHost := getServiceHost(isvc)
 	serviceUrl := getServiceUrl(isvc, ir.ingressConfig)
 	if serviceHost == "" || serviceUrl == "" {
-		log.Info("service host and serviceurl are empty..... returning")
+		log.Info("service host and serviceurl are empty, skipping updating the inference service")
 		return nil
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -78,9 +78,44 @@ func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infere
 	serviceHost := getServiceHost(isvc)
 	serviceUrl := getServiceUrl(isvc, ir.ingressConfig)
 	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
-	if serviceHost == "" || serviceUrl == "" {
+
+	// Check if the isvc is stopped
+	forceStopRuntime := "false"
+	if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
+		forceStopRuntime = val
+	}
+
+	if strings.EqualFold(forceStopRuntime, "true") {
+		// Delete the service
+		existingService := &corev1.Service{}
+		if err := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existingService); err == nil {
+			log.Info("Delete services")
+			if err := ir.client.Delete(ctx, existingService); err != nil {
+				return err
+			}
+		} else if !apierr.IsNotFound(err) {
+			return err
+		}
+
+		// Delete the virtualservice
+		existingVService := &istioclientv1beta1.VirtualService{}
+		if err := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existingVService); err == nil {
+			log.Info("Delete vservices")
+			if err := ir.client.Delete(ctx, existingVService); err != nil {
+				return err
+			}
+		} else if !apierr.IsNotFound(err) {
+			return err
+		}
+
 		return nil
 	}
+
+	if serviceHost == "" || serviceUrl == "" {
+		log.Info("Service host or url is empty")
+		return nil
+	}
+
 	// When Istio virtual host is disabled, we return the underlying component url.
 	// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
 	if !disableIstioVirtualHost {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -75,86 +75,30 @@ func NewIngressReconciler(client client.Client, clientset kubernetes.Interface, 
 }
 
 func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.InferenceService) error {
-	serviceHost := getServiceHost(isvc)
-	serviceUrl := getServiceUrl(isvc, ir.ingressConfig)
 	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
 
-	// If the "serving.kserve.io/stop" annotation is present in isvc, follow the force stop logic
+	if err := ir.reconcileVirtualService(ctx, isvc); err != nil {
+		return errors.Wrapf(err, "fails to reconcile external name service")
+	}
+	// Create external service which points to local gateway
+	if err := ir.reconcileExternalService(ctx, isvc, ir.ingressConfig); err != nil {
+		return errors.Wrapf(err, "fails to reconcile external name service")
+	}
+
 	if isvc.GetForceStopRuntime() {
-		// Delete the service
-		existingService := &corev1.Service{}
-		if err := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existingService); err == nil {
-			log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated Service")
-			if err := ir.client.Delete(ctx, existingService); err != nil {
-				return err
-			}
-		} else if !apierr.IsNotFound(err) {
-			return err
-		}
-
-		// Delete the virtualservice
-		existingVService := &istioclientv1beta1.VirtualService{}
-		if err := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existingVService); err == nil {
-			log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated VirtualService")
-			if err := ir.client.Delete(ctx, existingVService); err != nil {
-				return err
-			}
-		} else if !apierr.IsNotFound(err) {
-			return err
-		}
+		isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
+			Type:   v1beta1.IngressReady,
+			Status: corev1.ConditionFalse,
+		})
 
 		return nil
 	}
 
+	serviceHost := getServiceHost(isvc)
+	serviceUrl := getServiceUrl(isvc, ir.ingressConfig)
 	if serviceHost == "" || serviceUrl == "" {
+		log.Info("service host and serviceurl are empty..... returning")
 		return nil
-	}
-
-	// When Istio virtual host is disabled, we return the underlying component url.
-	// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
-	if !disableIstioVirtualHost {
-		// Check if existing knative service name has default suffix
-		defaultNameExisting := &knservingv1.Service{}
-		useDefault := false
-		err := ir.client.Get(ctx, types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, defaultNameExisting)
-		if err == nil {
-			useDefault = true
-		}
-		domainList := getDomainList(ctx, ir.clientset)
-		desiredIngress := createIngress(isvc, useDefault, ir.ingressConfig, domainList, ir.isvcConfig)
-		if desiredIngress == nil {
-			return nil
-		}
-
-		// Create external service which points to local gateway
-		if err := ir.reconcileExternalService(ctx, isvc, ir.ingressConfig); err != nil {
-			return errors.Wrapf(err, "fails to reconcile external name service")
-		}
-
-		if err := controllerutil.SetControllerReference(isvc, desiredIngress, ir.scheme); err != nil {
-			return errors.Wrapf(err, "fails to set owner reference for ingress")
-		}
-
-		existing := &istioclientv1beta1.VirtualService{}
-		err = ir.client.Get(ctx, types.NamespacedName{Name: desiredIngress.Name, Namespace: desiredIngress.Namespace}, existing)
-		if err != nil {
-			if apierr.IsNotFound(err) {
-				log.Info("Creating Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
-				err = ir.client.Create(ctx, desiredIngress)
-			}
-		} else {
-			if !routeSemanticEquals(desiredIngress, existing) {
-				deepCopy := existing.DeepCopy()
-				deepCopy.Spec = *desiredIngress.Spec.DeepCopy()
-				deepCopy.Annotations = desiredIngress.Annotations
-				deepCopy.Labels = desiredIngress.Labels
-				log.Info("Update Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
-				err = ir.client.Update(ctx, deepCopy)
-			}
-		}
-		if err != nil {
-			return errors.Wrapf(err, "fails to create or update ingress")
-		}
 	}
 
 	if url, err := apis.ParseURL(serviceUrl); err == nil {
@@ -297,7 +241,74 @@ func getHostBasedServiceUrl(isvc *v1beta1.InferenceService, config *v1beta1.Ingr
 	}
 }
 
-func (r *IngressReconciler) reconcileExternalService(ctx context.Context, isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig) error {
+func (ir *IngressReconciler) reconcileVirtualService(ctx context.Context, isvc *v1beta1.InferenceService) error {
+	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
+
+	// Check if existing knative service name has default suffix
+	defaultNameExisting := &knservingv1.Service{}
+	useDefault := false
+	err := ir.client.Get(ctx, types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, defaultNameExisting)
+	if err == nil {
+		useDefault = true
+	}
+
+	domainList := getDomainList(ctx, ir.clientset)
+	desiredIngress := createIngress(isvc, useDefault, ir.ingressConfig, domainList, ir.isvcConfig) // actually the virtual service
+
+	existing := &istioclientv1beta1.VirtualService{}
+	getExistingErr := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existing)
+
+	if !isvc.GetForceStopRuntime() {
+		// When Istio virtual host is disabled, we return the underlying component url.
+		// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
+		if !disableIstioVirtualHost {
+			if desiredIngress == nil {
+				return nil
+			}
+
+			err = controllerutil.SetControllerReference(isvc, desiredIngress, ir.scheme)
+			if err != nil {
+				return errors.Wrapf(err, "fails to set owner reference for ingress")
+			}
+
+			if getExistingErr != nil {
+				if apierr.IsNotFound(getExistingErr) {
+					log.Info("Creating Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
+					err = ir.client.Create(ctx, desiredIngress)
+				}
+			} else {
+				if !routeSemanticEquals(desiredIngress, existing) {
+					deepCopy := existing.DeepCopy()
+					deepCopy.Spec = *desiredIngress.Spec.DeepCopy()
+					deepCopy.Annotations = desiredIngress.Annotations
+					deepCopy.Labels = desiredIngress.Labels
+					log.Info("Update Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
+					err = ir.client.Update(ctx, deepCopy)
+				}
+			}
+
+			if err != nil {
+				return errors.Wrapf(err, "fails to create or update ingress")
+			}
+		}
+	} else {
+		// Delete the virtualservice
+		if getExistingErr == nil {
+			log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated VirtualService")
+			if err := ir.client.Delete(ctx, existing); err != nil {
+				return err
+			}
+		} else if !apierr.IsNotFound(getExistingErr) {
+			return getExistingErr
+		}
+	}
+
+	return nil
+}
+
+func (ir *IngressReconciler) reconcileExternalService(ctx context.Context, isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig) error {
+	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
+
 	desired := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      isvc.Name,
@@ -309,39 +320,57 @@ func (r *IngressReconciler) reconcileExternalService(ctx context.Context, isvc *
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 	}
-	if err := controllerutil.SetControllerReference(isvc, desired, r.scheme); err != nil {
-		return err
-	}
 
-	// Create service if does not exist
 	existing := &corev1.Service{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
-	if err != nil {
-		if apierr.IsNotFound(err) {
-			log.Info("Creating external name service", "namespace", desired.Namespace, "name", desired.Name)
-			err = r.client.Create(ctx, desired)
-		}
+	getExistingErr := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existing)
+
+	if err := controllerutil.SetControllerReference(isvc, desired, ir.scheme); err != nil {
 		return err
 	}
 
-	// Return if no differences to reconcile.
-	if equality.Semantic.DeepEqual(desired, existing) {
-		return nil
-	}
+	if !isvc.GetForceStopRuntime() {
+		// When Istio virtual host is disabled, we return the underlying component url.
+		// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
+		if !disableIstioVirtualHost {
+			// Create service if does not exist
+			if getExistingErr != nil {
+				if apierr.IsNotFound(getExistingErr) {
+					log.Info("Creating external name service", "namespace", desired.Namespace, "name", desired.Name)
+					return ir.client.Create(ctx, desired)
+				}
+				return getExistingErr
+			}
 
-	// Reconcile differences and update
-	diff, err := kmp.SafeDiff(desired.Spec, existing.Spec)
-	if err != nil {
-		return errors.Wrapf(err, "failed to diff external name service")
-	}
-	log.Info("Reconciling external service diff (-desired, +observed):", "diff", diff)
-	log.Info("Updating external service", "namespace", existing.Namespace, "name", existing.Name)
-	existing.Spec = desired.Spec
-	existing.ObjectMeta.Labels = desired.ObjectMeta.Labels
-	existing.ObjectMeta.Annotations = desired.ObjectMeta.Annotations
-	err = r.client.Update(ctx, existing)
-	if err != nil {
-		return errors.Wrapf(err, "fails to update external name service")
+			// Return if no differences to reconcile.
+			if equality.Semantic.DeepEqual(desired, existing) {
+				return nil
+			}
+
+			// Reconcile differences and update
+			diff, err := kmp.SafeDiff(desired.Spec, existing.Spec)
+			if err != nil {
+				return errors.Wrapf(err, "failed to diff external name service")
+			}
+			log.Info("Reconciling external service diff (-desired, +observed):", "diff", diff)
+			log.Info("Updating external service", "namespace", existing.Namespace, "name", existing.Name)
+			existing.Spec = desired.Spec
+			existing.ObjectMeta.Labels = desired.ObjectMeta.Labels
+			existing.ObjectMeta.Annotations = desired.ObjectMeta.Annotations
+			err = ir.client.Update(ctx, existing)
+			if err != nil {
+				return errors.Wrapf(err, "fails to update external name service")
+			}
+		}
+	} else {
+		// Delete the service
+		if getExistingErr == nil {
+			log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated Service")
+			if err := ir.client.Delete(ctx, existing); err != nil {
+				return err
+			}
+		} else if !apierr.IsNotFound(getExistingErr) {
+			return getExistingErr
+		}
 	}
 
 	return nil

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -80,12 +80,7 @@ func (ir *IngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infere
 	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
 
 	// If the "serving.kserve.io/stop" annotation is present in isvc, follow the force stop logic
-	forceStopRuntime := "false"
-	if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
-		forceStopRuntime = val
-	}
-
-	if strings.EqualFold(forceStopRuntime, "true") {
+	if isvc.GetForceStopRuntime() {
 		// Delete the service
 		existingService := &corev1.Service{}
 		if err := ir.client.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existingService); err == nil {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
@@ -233,10 +234,26 @@ func (r *KsvcReconciler) Reconcile(ctx context.Context) (*knservingv1.ServiceSta
 	desired := r.Service
 	existing := &knservingv1.Service{}
 
+	forceStopRuntime := "false"
+	if val, exist := desired.Spec.Template.Annotations[constants.StopResumeAnnotationKey]; exist {
+		forceStopRuntime = val
+	}
+
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		log.Info("Updating knative service", "namespace", desired.Namespace, "name", desired.Name)
 		if err := r.client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing); err != nil {
 			return err
+		}
+
+		if strings.EqualFold(forceStopRuntime, "true") {
+			log.Info("Stopping knative service", "namespace", existing.Namespace, "name", existing.Name)
+			if existing.GetDeletionTimestamp() == nil { // check if the ksvc was already deleted
+				err := r.client.Delete(ctx, existing)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
 		}
 
 		// Set ResourceVersion which is required for update operation.
@@ -263,8 +280,12 @@ func (r *KsvcReconciler) Reconcile(ctx context.Context) (*knservingv1.ServiceSta
 	if err != nil {
 		// Create service if it does not exist
 		if apierr.IsNotFound(err) {
-			log.Info("Creating knative service", "namespace", desired.Namespace, "name", desired.Name)
-			return &desired.Status, r.client.Create(ctx, desired)
+			if strings.EqualFold(forceStopRuntime, "false") {
+				log.Info("Creating knative service", "namespace", desired.Namespace, "name", desired.Name)
+				return &desired.Status, r.client.Create(ctx, desired)
+			}
+
+			return &desired.Status, nil
 		}
 		return &existing.Status, errors.Wrapf(err, "fails to reconcile knative service")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -235,7 +235,7 @@ func (r *KsvcReconciler) Reconcile(ctx context.Context) (*knservingv1.ServiceSta
 	existing := &knservingv1.Service{}
 
 	forceStopRuntime := "false"
-	if val, exist := desired.Spec.Template.Annotations[constants.StopResumeAnnotationKey]; exist {
+	if val, exist := desired.Spec.Template.Annotations[constants.StopAnnotationKey]; exist {
 		forceStopRuntime = val
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**: 
 This adds the ability to stop and resume services without permanently deleting configurations or incurring delays caused by gradual scaling processes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4207 

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

cluster:
Client Version: v1.30.2
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: v1.28.15+ff493be

Test setup:
```
$ kubectl create ns stop-resume-demo
$ kubectl config set-context --current --namespace stop-resume-demo 
$ kustomize build ./config/runtimes/| sed 's/ClusterServingRuntime/ServingRuntime/g' |kubectl create -n stop-resume-demo -f -

$ podman build -t kserve:stop-resume . 
$ podman push kserve:stop-resume  quay.io/hdefazio/kserve:stop-resume

Edited kserve-controller-manager to use quay.io/hdefazio/kserve:stop-resume
```

Test: 

1. Normal deployment --> add the annotation

create a isvc without the annotation
```
$ cat <<EOF|kubectl apply -f -
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  annotations:
    serving.knative.openshift.io/enablePassthrough: 'true'
    sidecar.istio.io/inject: 'true'
    sidecar.istio.io/rewriteAppHTTPProbers: 'true'
  name: "sklearndemo1"
  namespace: stop-resume-demo
spec:
  predictor:
    model:
      modelFormat:
        name: sklearn
      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
EOF
```

observe that the inference service is Ready
```
$ kubectl get isvc -n stop-resume-demo
NAME           URL                                                                                         READY   PREV   LATEST   PREVROLLEDOUTREVISION   LATESTREADYREVISION            AGE
sklearndemo1   https://sklearndemo1-stop-resume-demo.apps.rosa.han-stop-resume.wtsd.p3.openshiftapps.com   True           100                              sklearndemo1-predictor-00002   2m8s
```

```
$ kubectl get pods -n stop-resume-demo
NAME                                                       READY   STATUS    RESTARTS   AGE
sklearndemo1-predictor-00002-deployment-679bd4754f-mwvsv   3/3     Running   0          4m50s
```

Stop the model
```
$ kubectl edit isvc/sklearndemo1 -n stop-resume-demo 
Add annotation `serving.kserve.io/stop: 'true'`
```

It should remove all objects except the isvc

Observe that the ISVC now has a Stopped condition
```
kubectl describe isvc/sklearndemo1 -n stop-resume-demo 
```


2. Stopped model--> set the annotation to false
Resume the model
```
$ kubectl edit isvc/sklearndemo1 -n stop-resume-demo 
Set annotation `serving.kserve.io/stop: 'false'`
```

Observe that the KSVC, deployment, and pods are created and ready. 


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [X] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.