### PR TITLE
fix: Static LoRA modules are not initialized by the Huggingface Server

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
@@ -124,6 +124,7 @@ class VLLMModel(
                 lora_modules=self.args.lora_modules,
                 prompt_adapters=self.args.prompt_adapters,
             )
+            await self.openai_serving_models.init_static_loras()
 
             self.openai_serving_chat = (
                 OpenAIServingChat(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
- Fixes #4338 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Test A
```bash
python3 -m huggingfaceserver --http_port=8083 --model_name=llama-3 --model_id=meta-llama/Llama-3.2-1B-Instruct \
    --dtype=float16 --max-model-len=4096 --enable-lora --max-lora-rank=256 \
    --lora-modules indonesian-lora=$HOME/.cache/huggingface/hub/models--digo-prayudha--Llama-3.2-1B-Indonesian-lora/snapshots/636127d560d858bf0b6bf95b798e65cd761aa273
```
```bash
curl -v -H "content-type: application/json" -d '{"model": "llama-3", "messages":[{"role": "user", "content": "Tentukan subjek dari kalimat berikut: Film tersebut dirilis kemarin."}]}' http://localhost:8083/openai/v1/chat/completions
```
Output:
```
*   Trying 127.0.0.1:8083...
* Connected to localhost (127.0.0.1) port 8083 (#0)
> POST /openai/v1/chat/completions HTTP/1.1
> Host: localhost:8083
> User-Agent: curl/7.81.0
> Accept: */*
> content-type: application/json
> Content-Length: 134
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< date: Thu, 27 Mar 2025 12:48:00 GMT
< server: uvicorn
< content-length: 446
< content-type: application/json
< 
* Connection #0 to host localhost left intact
{"id":"chatcmpl-7791e8e2b5f04d14b43d77137c0506dd","object":"chat.completion","created":1743079680,"model":"llama-3","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":"Subjek dari kalimat tersebut adalah Film.","tool_calls":[]},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":53,"total_tokens":64,"completion_tokens":11,"prompt_tokens_details":null},"prompt_logprobs":null}
```

- Logs
```
INFO 03-27 12:41:51 __init__.py:207] Automatically detected platform cuda.
2025-03-27 12:41:52.103 20026 kserve INFO [model_server.py:register_model():395] Registering model: llama-3
2025-03-27 12:41:52.104 20026 kserve INFO [model_server.py:setup_event_loop():278] Setting max asyncio worker threads as 6
WARNING 03-27 12:41:53 config.py:2448] Casting torch.bfloat16 to torch.float16.
INFO 03-27 12:42:02 config.py:549] This model supports multiple tasks: {'generate', 'score', 'classify', 'reward', 'embed'}. Defaulting to 'generate'.
INFO 03-27 12:42:02 llm_engine.py:234] Initializing a V0 LLM engine (v0.7.3) with config: model='meta-llama/Llama-3.2-1B-Instruct', speculative_config=None, tokenizer='meta-llama/Llama-3.2-1B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=meta-llama/Llama-3.2-1B-Instruct, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=False, chunked_prefill_enabled=False, use_async_output_proc=True, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":[],"compile_sizes":[],"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=False, 
INFO 03-27 12:42:04 cuda.py:178] Cannot use FlashAttention-2 backend for Volta and Turing GPUs.
INFO 03-27 12:42:04 cuda.py:226] Using XFormers backend.
INFO 03-27 12:42:05 model_runner.py:1110] Starting to load model meta-llama/Llama-3.2-1B-Instruct...
INFO 03-27 12:42:05 weight_utils.py:254] Using model weights format ['*.safetensors']
INFO 03-27 12:42:06 weight_utils.py:304] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:05<00:00,  5.05s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:05<00:00,  5.05s/it]

INFO 03-27 12:42:11 model_runner.py:1115] Loading model weights took 2.3185 GB
INFO 03-27 12:42:11 punica_selector.py:18] Using PunicaWrapperGPU.
INFO 03-27 12:42:15 worker.py:267] Memory profiling takes 3.14 seconds
INFO 03-27 12:42:15 worker.py:267] the current vLLM instance can use total_gpu_memory (14.74GiB) x gpu_memory_utilization (0.90) = 13.27GiB
INFO 03-27 12:42:15 worker.py:267] model weights take 2.32GiB; non_torch_memory takes 0.05GiB; PyTorch activation peak memory takes 1.19GiB; the rest of the memory reserved for KV Cache is 9.71GiB.
INFO 03-27 12:42:15 executor_base.py:111] # cuda blocks: 19888, # CPU blocks: 8192
INFO 03-27 12:42:15 executor_base.py:116] Maximum concurrency for 4096 tokens per request: 77.69x
INFO 03-27 12:42:17 model_runner.py:1434] Capturing cudagraphs for decoding. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI. If out-of-memory error occurs during cudagraph capture, consider decreasing `gpu_memory_utilization` or switching to eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
Capturing CUDA graph shapes: 100%|██████████| 35/35 [00:22<00:00,  1.55it/s]
INFO 03-27 12:42:40 model_runner.py:1562] Graph capturing finished in 23 secs, took 0.22 GiB
INFO 03-27 12:42:40 llm_engine.py:436] init engine (profile, create kv cache, warmup model) took 28.96 seconds
INFO 03-27 12:42:42 serving_models.py:174] Loaded new LoRA adapter: name 'indonesian-lora', path '/root/.cache/huggingface/hub/models--digo-prayudha--Llama-3.2-1B-Indonesian-lora/snapshots/636127d560d858bf0b6bf95b798e65cd761aa273'
2025-03-27 12:42:42.613 20026 kserve INFO [server.py:_register_endpoints():108] OpenAI endpoints registered
2025-03-27 12:42:42.613 20026 kserve INFO [server.py:start():161] Starting uvicorn with 1 workers
2025-03-27 12:42:42.631 20026 uvicorn.error INFO:     Started server process [20026]
2025-03-27 12:42:42.631 20026 uvicorn.error INFO:     Waiting for application startup.
2025-03-27 12:42:42.633 20026 kserve INFO [server.py:start():70] Starting gRPC server with 4 workers
2025-03-27 12:42:42.633 20026 kserve INFO [server.py:start():71] Starting gRPC server on [::]:8081
2025-03-27 12:42:42.634 20026 uvicorn.error INFO:     Application startup complete.
2025-03-27 12:42:42.634 20026 uvicorn.error INFO:     Uvicorn running on http://0.0.0.0:8083/ (Press CTRL+C to quit)
2025-03-27 12:47:50.201 uvicorn.access INFO:     127.0.0.1:59500 20026 - "POST /openai/v1/chat/completion HTTP/1.1" 404 Not Found
2025-03-27 12:47:50.201 20026 kserve.trace kserve.io.openai.v1.chat.completion: 0.0006198883056640625 ['http_status:404', 'http_method:POST', 'time:wall']
2025-03-27 12:47:50.201 20026 kserve.trace kserve.io.openai.v1.chat.completion: 0.0006099999999946704 ['http_status:404', 'http_method:POST', 'time:cpu']
INFO 03-27 12:48:00 chat_utils.py:332] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
2025-03-27 12:48:00.959 20026 kserve.trace Received request chatcmpl-7791e8e2b5f04d14b43d77137c0506dd: prompt: '<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nCutting Knowledge Date: December 2023\nToday Date: 27 Mar 2025\n\n<|eot_id|><|start_header_id|>user<|end_header_id|>\n\nTentukan subjek dari kalimat berikut: Film tersebut dirilis kemarin.<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4043, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None), prompt_token_ids: None, lora_request: None, prompt_adapter_request: None.
INFO 03-27 12:48:00 async_llm_engine.py:211] Added request chatcmpl-7791e8e2b5f04d14b43d77137c0506dd.
INFO 03-27 12:48:01 metrics.py:455] Avg prompt throughput: 0.2 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 1 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.
INFO 03-27 12:48:01 async_llm_engine.py:179] Finished request chatcmpl-7791e8e2b5f04d14b43d77137c0506dd.
2025-03-27 12:48:01.196 uvicorn.access INFO:     127.0.0.1:51284 20026 - "POST /openai/v1/chat/completions HTTP/1.1" 200 OK
2025-03-27 12:48:01.196 20026 kserve.trace kserve.io.kserve.protocol.rest.openai.endpoints.create_chat_completion: 0.31804895401000977 ['http_status:200', 'http_method:POST', 'time:wall']
2025-03-27 12:48:01.196 20026 kserve.trace kserve.io.kserve.protocol.rest.openai.endpoints.create_chat_completion: 0.28501600000000593 ['http_status:200', 'http_method:POST', 'time:cpu']
```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Static LoRA modules are not initialized by the Huggingface Server
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.