### PR TITLE
CI: Increase timeout for REST client connections to improve reliability

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -40,7 +40,7 @@ def event_loop():
 async def rest_v1_client():
     v1_client = InferenceRESTClient(
         config=RESTConfig(
-            timeout=60,
+            timeout=180,
             verbose=True,
             protocol=PredictorProtocol.REST_V1,
         )
@@ -53,7 +53,7 @@ async def rest_v1_client():
 async def rest_v2_client():
     v2_client = InferenceRESTClient(
         config=RESTConfig(
-            timeout=60,
+            timeout=180,
             verbose=True,
             protocol=PredictorProtocol.REST_V2,
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Increase timeout for REST client in CI to fix timeout error occurring in explainer test
![Screenshot from 2025-03-28 19-38-50](https://github.com/user-attachments/assets/e5db71f8-a844-4a07-91db-94da3322f299)


```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.