### PR TITLE
No error reported in the status when storageUri protocol validation fails

### DIFF
--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -55,11 +55,6 @@ const (
 	DisallowedWorkerSpecTensorParallelSizeEnvError   = "the InferenceService %q is invalid: setting TENSOR_PARALLEL_SIZE in environment variables is not allowed"
 )
 
-// SupportedStorageSpecURIPrefixList Constants
-var (
-	SupportedStorageSpecURIPrefixList = []string{"s3://", "hdfs://", "webhdfs://"}
-)
-
 // ComponentImplementation interface is implemented by predictor, transformer, and explainer implementations
 // +kubebuilder:object:generate=false
 type ComponentImplementation interface {
@@ -327,24 +322,23 @@ func validateStorageSpec(storageSpec *StorageSpec, storageURI *string) error {
 	if storageSpec == nil {
 		return nil
 	}
-	if storageURI != nil {
-		if utils.IsPrefixSupported(*storageURI, SupportedStorageSpecURIPrefixList) {
-			return nil
-		} else {
-			return fmt.Errorf(UnsupportedStorageURIFormatError, strings.Join(SupportedStorageSpecURIPrefixList, ", "), *storageURI)
-		}
-	}
+
 	if storageSpec.Parameters != nil {
 		for k, v := range *storageSpec.Parameters {
 			if k == "type" {
-				if utils.IsPrefixSupported(v+"://", SupportedStorageSpecURIPrefixList) {
-					return nil
-				} else {
-					return fmt.Errorf(UnsupportedStorageSpecFormatError, strings.Join(SupportedStorageSpecURIPrefixList, ", "), v)
+				if !utils.IsPrefixSupported(v+"://", constants.SupportedStorageURIPrefixList) {
+					return fmt.Errorf(UnsupportedStorageSpecFormatError, strings.Join(constants.SupportedStorageURIPrefixList, ", "), v)
 				}
 			}
 		}
 	}
+
+	if nil == storageURI {
+		return fmt.Errorf(UnsupportedStorageURIFormatError, strings.Join(constants.SupportedStorageURIPrefixList, ", "), "empty")
+	} else if !utils.IsPrefixSupported(*storageURI, constants.SupportedStorageURIPrefixList) {
+		return fmt.Errorf(UnsupportedStorageURIFormatError, strings.Join(constants.SupportedStorageURIPrefixList, ", "), *storageURI)
+	}
+
 	return nil
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -151,6 +151,13 @@ var (
 	DefaultStorageSpecSecretPath = "/mnt/storage-secret" // #nosec G101
 )
 
+var SupportedStorageURIPrefixList = []string{"gs://", "s3://", "pvc://", "file://", "https://", "http://", "hdfs://", "webhdfs://", "oci://", "hf://"}
+
+const (
+	AzureBlobURL      = "blob.core.windows.net"
+	AzureBlobURIRegEx = "https://(.+?).blob.core.windows.net/(.+)"
+)
+
 // Controller Constants
 var (
 	ControllerLabelName                   = KServeName + "-controller-manager"

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -115,6 +115,10 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	// Knative does not support INIT containers or mounting, so we add annotations that trigger the
 	// StorageInitializer injector to mutate the underlying deployment to provision model data
 	if err := p.addStorageInitializerAnnotations(ctx, predictor, annotations); err != nil {
+		isvc.Status.UpdateModelTransitionStatus(v1beta1.InvalidSpec, &v1beta1.FailureInfo{
+			Reason:  v1beta1.InvalidPredictorSpec,
+			Message: err.Error(),
+		})
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -106,6 +106,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}
 			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
 			defer k8sClient.Delete(context.TODO(), configMap)
+
 			// Create ServingRuntime
 			servingRuntime := &v1alpha1.ServingRuntime{
 				ObjectMeta: metav1.ObjectMeta{
@@ -398,6 +399,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			Expect(updatedVirtualService.Annotations).To(Equal(annotations))
 			Expect(updatedVirtualService.Labels).To(Equal(labels))
 		})
+
 		It("Should fail if Knative Serving is not installed", func() {
 			// Simulate Knative Serving is absent by setting to false the relevant item in utils.gvResourcesCache variable
 			servingResources, getServingResourcesErr := utils.GetAvailableResourcesForApi(cfg, knservingv1.SchemeGroupVersion.String())
@@ -2006,7 +2008,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				}
 				Expect(virtualService.Spec.DeepCopy()).To(Equal(expectedVirtualService.Spec.DeepCopy()))
 
-				// get inference service
+				// get inference servicecharts/kserve-resources/templates/clusterrole.yaml
 				time.Sleep(10 * time.Second)
 				actualIsvc := &v1beta1.InferenceService{}
 				Eventually(func() bool {
@@ -3165,6 +3167,120 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			Expect(inferenceService.Status.ModelStatus.ModelRevisionStates.TargetModelState).To(Equal(v1beta1.FailedToLoad))
 			Expect(inferenceService.Status.ModelStatus.LastFailureInfo.Reason).To(Equal(v1beta1.ModelLoadFailed))
 			Expect(inferenceService.Status.ModelStatus.LastFailureInfo.Message).To(Equal("Invalid Storage URI provided"))
+		})
+	})
+
+	Context("When creating an inference service with a unsupported storageURI", func() {
+		It("Should fail if unsupported storageURI is set", func() {
+			defaultNamespace := "storage-uri-test"
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultNamespace,
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), namespace)).NotTo(HaveOccurred())
+
+			// Create configmap
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tf-serving",
+					Namespace: defaultNamespace,
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "tensorflow",
+							Version:    proto.String("1"),
+							AutoSelect: proto.Bool(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    constants.InferenceServiceContainerName,
+								Image:   "tensorflow/serving:1.14.0",
+								Command: []string{"/usr/bin/tensorflow_model_server"},
+								Args: []string{
+									"--port=9000",
+									"--rest_api_port=8080",
+									"--model_base_path=/mnt/models",
+									"--rest_api_timeout_in_ms=60000",
+								},
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: proto.Bool(false),
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), servingRuntime)
+
+			// Deploy a new inference service with invalid storage URI
+			serviceName := "foo-1"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: defaultNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "sss3://test/mnist/export"
+			ctx := context.Background()
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     &storageUri,
+								RuntimeVersion: proto.String("1.14.0"),
+								Container: corev1.Container{
+									Name:      constants.InferenceServiceContainerName,
+									Resources: defaultResource,
+								},
+							},
+						},
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MaxReplicas: 1,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+
+			inferenceService := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, inferenceService)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// status should contain InvalidStorageSpec error
+			val := fmt.Sprintf(v1beta1.UnsupportedStorageURIFormatError, strings.Join(constants.SupportedStorageURIPrefixList, ", "), storageUri)
+			message := "StorageURI not supported: " + val
+			lastFailureInfo := v1beta1.FailureInfo{
+				Reason:  v1beta1.InvalidPredictorSpec,
+				Message: message,
+			}
+
+			Eventually(func() bool {
+				// try a little more until the status is populated
+				if inferenceService.Status.ModelStatus == (v1beta1.ModelStatus{}) {
+					errr := k8sClient.Get(ctx, serviceKey, inferenceService)
+					return errr == nil
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(*inferenceService.Status.ModelStatus.LastFailureInfo).To(Equal(lastFailureInfo))
 		})
 	})
 

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -2008,7 +2008,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				}
 				Expect(virtualService.Spec.DeepCopy()).To(Equal(expectedVirtualService.Spec.DeepCopy()))
 
-				// get inference servicecharts/kserve-resources/templates/clusterrole.yaml
+				// get inference service
 				time.Sleep(10 * time.Second)
 				actualIsvc := &v1beta1.InferenceService{}
 				Eventually(func() bool {
@@ -3257,6 +3257,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
 
+			time.Sleep(5 * time.Second)
 			inferenceService := &v1beta1.InferenceService{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, serviceKey, inferenceService)
@@ -3277,10 +3278,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					errr := k8sClient.Get(ctx, serviceKey, inferenceService)
 					return errr == nil
 				}
-				return true
+				return *inferenceService.Status.ModelStatus.LastFailureInfo == lastFailureInfo
 			}, timeout, interval).Should(BeTrue())
-
-			Expect(*inferenceService.Status.ModelStatus.LastFailureInfo).To(Equal(lastFailureInfo))
 		})
 	})
 

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -42,16 +42,6 @@ import (
 	"github.com/kserve/kserve/pkg/webhook/admission/pod"
 )
 
-// Constants
-var (
-	SupportedStorageURIPrefixList = []string{"gs://", "s3://", "pvc://", "file://", "https://", "http://", "hdfs://", "webhdfs://", "oci://", "hf://"}
-)
-
-const (
-	AzureBlobURL      = "blob.core.windows.net"
-	AzureBlobURIRegEx = "https://(.+?).blob.core.windows.net/(.+)"
-)
-
 // IsMMSPredictor Only enable MMS predictor when predictor config sets MMS to true and neither
 // storage uri nor storage spec is set
 func IsMMSPredictor(predictor *v1beta1.PredictorSpec) bool {
@@ -356,16 +346,16 @@ func ValidateStorageURI(ctx context.Context, storageURI *string, client client.C
 	}
 
 	// need to verify Azure Blob first, because it uses http(s):// prefix
-	if strings.Contains(*storageURI, AzureBlobURL) {
-		azureURIMatcher := regexp.MustCompile(AzureBlobURIRegEx)
+	if strings.Contains(*storageURI, constants.AzureBlobURL) {
+		azureURIMatcher := regexp.MustCompile(constants.AzureBlobURIRegEx)
 		if parts := azureURIMatcher.FindStringSubmatch(*storageURI); parts != nil {
 			return nil
 		}
-	} else if utils.IsPrefixSupported(*storageURI, SupportedStorageURIPrefixList) {
+	} else if utils.IsPrefixSupported(*storageURI, constants.SupportedStorageURIPrefixList) {
 		return nil
 	}
 
-	return fmt.Errorf(v1beta1.UnsupportedStorageURIFormatError, strings.Join(SupportedStorageURIPrefixList, ", "), *storageURI)
+	return fmt.Errorf(v1beta1.UnsupportedStorageURIFormatError, strings.Join(constants.SupportedStorageURIPrefixList, ", "), *storageURI)
 }
 
 // Function to add a new environment variable to a specific container in the PodSpec

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -48,10 +48,24 @@ _AZURE_FILE_RE = [
 _LOCAL_PREFIX = "file://"
 _URI_RE = "https?://(.+)/(.+)"
 _HTTP_PREFIX = "http(s)://"
-_HEADERS_SUFFIX = "-headers"
 _PVC_PREFIX = "/mnt/pvc"
 _HF_PREFIX = "hf://"
 
+_SUPPORTED_PROTOCOLS = [
+    _GCS_PREFIX,
+    _S3_PREFIX,
+    _HDFS_PREFIX,
+    _WEBHDFS_PREFIX,
+    _AZURE_BLOB_RE,
+    _AZURE_FILE_RE,
+    _LOCAL_PREFIX,
+    _URI_RE,
+    _HTTP_PREFIX,
+    _HF_PREFIX,
+    _PVC_PREFIX,
+]
+
+_HEADERS_SUFFIX = "-headers"
 _HDFS_SECRET_DIRECTORY = "/var/secrets/kserve-hdfscreds"
 _HDFS_FILE_SECRETS = ["KERBEROS_KEYTAB", "TLS_CERT", "TLS_KEY", "TLS_CA"]
 
@@ -101,10 +115,8 @@ class Storage(object):
                 model_dir = Storage._download_hf(uri, out_dir)
             else:
                 raise Exception(
-                    "Cannot recognize storage type for "
-                    + uri
-                    + "\n'%s', '%s', '%s', and '%s' are the current available storage type."
-                    % (_GCS_PREFIX, _S3_PREFIX, _LOCAL_PREFIX, _HTTP_PREFIX)
+                    "Cannot recognize storage type for '%s'. \n'%s' are the current available storage type."
+                    % (uri, _SUPPORTED_PROTOCOLS)
                 )
 
         logger.info("Successfully copied %s to %s", uri, out_dir)

--- a/python/kserve/kserve/storage/test/test_storage.py
+++ b/python/kserve/kserve/storage/test/test_storage.py
@@ -14,6 +14,7 @@
 
 import io
 import os
+import re
 import tempfile
 import binascii
 import unittest.mock as mock
@@ -62,6 +63,16 @@ def test_no_prefix_local_path():
     relative_path = "."
     assert Storage.download(abs_path) == abs_path
     assert Storage.download(relative_path) == relative_path
+
+
+def test_storage_unsupported_protocol():
+    uri = "unsupported://models/model.joblib"
+    text = (
+        "Cannot recognize storage type for 'unsupported://models/model.joblib'. \n"
+        "'['gs://', 's3://', 'hdfs://', 'webhdfs://', ['https://(.+?).blob.core.windows.net/(.+)', 'https://(.+?).z[0-9]{1,2}.blob.storage.azure.net/(.+)'], ['https://(.+?).file.core.windows.net/(.+)', 'https://(.+?).z[0-9]{1,2}.file.storage.azure.net/(.+)'], 'file://', 'https?://(.+)/(.+)', 'http(s)://', 'hf://', '/mnt/pvc']' are the current available storage type."
+    )
+    with pytest.raises(Exception, match=re.escape(text)):
+        Storage.download(uri)
 
 
 def test_local_path_with_out_dir_exist():


### PR DESCRIPTION
chore:	Fixes:
	- #4309 - No error reported in the status when storageUri protocol validation fails
	- Also fixes the error message in the storage initializer when the protocol is unsupported.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.