### PR TITLE
Add `categories` to InferenceService, InferenceGraph, and TrainedModel CRDs to simplify listing resources

### DIFF
--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_inferencegraphs.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_inferencegraphs.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+    - all
+    - kserve
     kind: InferenceGraph
     listKind: InferenceGraphList
     plural: inferencegraphs

--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_inferenceservices.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_inferenceservices.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+    - all
+    - kserve
     kind: InferenceService
     listKind: InferenceServiceList
     plural: inferenceservices

--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_trainedmodels.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_trainedmodels.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+    - all
+    - kserve
     kind: TrainedModel
     listKind: TrainedModelList
     plural: trainedmodels

--- a/charts/kserve-crd/templates/serving.kserve.io_inferencegraphs.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_inferencegraphs.yaml
@@ -13,6 +13,9 @@ spec:
     shortNames:
     - ig
     singular: inferencegraph
+    categories:
+      - all
+      - kserve
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/kserve-crd/templates/serving.kserve.io_inferenceservices.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_inferenceservices.yaml
@@ -14,6 +14,9 @@ spec:
     shortNames:
     - isvc
     singular: inferenceservice
+    categories:
+      - all
+      - kserve
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/charts/kserve-crd/templates/serving.kserve.io_trainedmodels.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_trainedmodels.yaml
@@ -13,6 +13,9 @@ spec:
     shortNames:
     - tm
     singular: trainedmodel
+    categories:
+      - all
+      - kserve
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/config/crd/full/serving.kserve.io_inferencegraphs.yaml
+++ b/config/crd/full/serving.kserve.io_inferencegraphs.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+    - all
+    - kserve
     kind: InferenceGraph
     listKind: InferenceGraphList
     plural: inferencegraphs

--- a/config/crd/full/serving.kserve.io_inferenceservices.yaml
+++ b/config/crd/full/serving.kserve.io_inferenceservices.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+      - all
+      - kserve
     kind: InferenceService
     listKind: InferenceServiceList
     plural: inferenceservices

--- a/config/crd/full/serving.kserve.io_trainedmodels.yaml
+++ b/config/crd/full/serving.kserve.io_trainedmodels.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+    - all
+    - kserve
     kind: TrainedModel
     listKind: TrainedModelList
     plural: trainedmodels

--- a/config/crd/minimal/serving.kserve.io_inferencegraphs.yaml
+++ b/config/crd/minimal/serving.kserve.io_inferencegraphs.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+    - all
+    - kserve
     kind: InferenceGraph
     listKind: InferenceGraphList
     plural: inferencegraphs

--- a/config/crd/minimal/serving.kserve.io_inferenceservices.yaml
+++ b/config/crd/minimal/serving.kserve.io_inferenceservices.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+    - all
+    - kserve
     kind: InferenceService
     listKind: InferenceServiceList
     plural: inferenceservices

--- a/config/crd/minimal/serving.kserve.io_trainedmodels.yaml
+++ b/config/crd/minimal/serving.kserve.io_trainedmodels.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   group: serving.kserve.io
   names:
+    categories:
+    - all
+    - kserve
     kind: TrainedModel
     listKind: TrainedModelList
     plural: trainedmodels

--- a/pkg/apis/serving/v1alpha1/inference_graph.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph.go
@@ -31,7 +31,7 @@ import (
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:path=inferencegraphs,shortName=ig,singular=inferencegraph
+// +kubebuilder:resource:path=inferencegraphs,shortName=ig,singular=inferencegraph,categories={all,kserve}
 type InferenceGraph struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/serving/v1alpha1/trained_model.go
+++ b/pkg/apis/serving/v1alpha1/trained_model.go
@@ -29,7 +29,7 @@ import (
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.url"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:path=trainedmodels,shortName=tm,singular=trainedmodel
+// +kubebuilder:resource:path=trainedmodels,shortName=tm,singular=trainedmodel,categories={all,kserve}
 type TrainedModel struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/serving/v1beta1/inference_service.go
+++ b/pkg/apis/serving/v1beta1/inference_service.go
@@ -108,7 +108,7 @@ type Batcher struct {
 // +kubebuilder:printcolumn:name="PrevRolledoutRevision",type="string",JSONPath=".status.components.predictor.traffic[?(@.tag=='prev')].revisionName"
 // +kubebuilder:printcolumn:name="LatestReadyRevision",type="string",JSONPath=".status.components.predictor.traffic[?(@.latestRevision==true)].revisionName"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:path=inferenceservices,shortName=isvc
+// +kubebuilder:resource:path=inferenceservices,shortName=isvc,categories={all,kserve}
 // +kubebuilder:storageversion
 type InferenceService struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Users often use `kubectl get all` to get "all" resources in a namespace and with this PR, kserve resources will show up, in addition, to list kserve-related resources they can run `kubectl get kserve`.

For more details, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#categories

**Type of changes**

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] `KSERVE_ENABLE_SELF_SIGNED_CA=true make deploy-dev`
- [x] `kubectl apply -f docs/samples/v1beta1/tensorflow/tensorflow.yaml` (making it RawDeployment for simplicity)
- [x] Run `k get all` and `k get kserve`
  ```shell
  [kserve]$ k get all
  NAME                                          READY   STATUS    RESTARTS   AGE
  pod/flower-sample-predictor-6f54f57d9-5cft7   1/1     Running   0          82m
  
  NAME                              TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
  service/flower-sample-predictor   ClusterIP   10.96.7.94   <none>        80/TCP    82m
  service/kubernetes                ClusterIP   10.96.0.1    <none>        443/TCP   17h
  
  NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
  deployment.apps/flower-sample-predictor   1/1     1            1           82m
  
  NAME                                                DESIRED   CURRENT   READY   AGE
  replicaset.apps/flower-sample-predictor-6f54f57d9   1         1         1       82m
  
  NAME                                                          REFERENCE                            TARGETS              MINPODS   MAXPODS   REPLICAS   AGE
  horizontalpodautoscaler.autoscaling/flower-sample-predictor   Deployment/flower-sample-predictor   cpu: <unknown>/80%   1         1         1          82m
  
  NAME                                               URL                                        READY   PREV   LATEST   PREVROLLEDOUTREVISION   LATESTREADYREVISION   AGE
  inferenceservice.serving.kserve.io/flower-sample   http://flower-sample-default.example.com   True                                                                  87m
  ```
  ```
  [kserve]$ k get kserve
  NAME                                               URL                                        READY   PREV   LATEST   PREVROLLEDOUTREVISION   LATESTREADYREVISION   AGE
  inferenceservice.serving.kserve.io/flower-sample   http://flower-sample-default.example.com   True                                                                  87m
  ```

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Include Kserve developer resources in `kubectl get all` and `kubectl get kserve`.
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.