### PR TITLE
Fix for KEDA scaledobject target value is set to pointer instead of specified value

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
@@ -88,16 +88,14 @@ func getKedaMetrics(componentExt *v1beta1.ComponentExtensionSpec,
 							averageUtil = &constants.DefaultCPUUtilization
 						}
 					}
-					if metric.Resource.Target.AverageUtilization != nil {
-						targetValue = fmt.Sprintf("%d", averageUtil)
-					}
+					targetValue = strconv.Itoa(int(*averageUtil))
 				case v1beta1.AverageValueMetricType:
 					if metric.Resource.Target.AverageValue != nil {
 						targetValue = metric.Resource.Target.AverageValue.String()
 					}
 				case v1beta1.ValueMetricType:
 					if metric.Resource.Target.Value != nil {
-						targetValue = fmt.Sprintf("%f", metric.Resource.Target.Value.AsApproximateFloat64())
+						targetValue = metric.Resource.Target.Value.String()
 					}
 				}
 				triggers = append(triggers, kedav1alpha1.ScaleTriggers{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
@@ -88,7 +88,9 @@ func getKedaMetrics(componentExt *v1beta1.ComponentExtensionSpec,
 							averageUtil = &constants.DefaultCPUUtilization
 						}
 					}
-					targetValue = strconv.Itoa(int(*averageUtil))
+					if averageUtil != nil {
+						targetValue = strconv.Itoa(int(*averageUtil))
+					}
 				case v1beta1.AverageValueMetricType:
 					if metric.Resource.Target.AverageValue != nil {
 						targetValue = metric.Resource.Target.AverageValue.String()

--- a/test/e2e/predictor/test_autoscaling.py
+++ b/test/e2e/predictor/test_autoscaling.py
@@ -303,7 +303,7 @@ async def test_sklearn_rolling_update():
 
 @pytest.mark.raw
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_keda_scale_new_spec_resource(rest_v1_client, network_layer):
+async def test_sklearn_keda_scale_resource_memory(rest_v1_client, network_layer):
     """
     Test KEDA autoscaling with new InferenceService (auto_scaling) spec
     """
@@ -362,6 +362,7 @@ async def test_sklearn_keda_scale_new_spec_resource(rest_v1_client, network_laye
         plural="scaledobjects",
     )
 
+    trigger_metadata = scaledobject_resp["items"][0]["spec"]["triggers"][0]["metadata"]
     assert (
         scaledobject_resp["items"][0]["spec"]["triggers"][0]["metricType"]
         == "Utilization"
@@ -370,6 +371,7 @@ async def test_sklearn_keda_scale_new_spec_resource(rest_v1_client, network_laye
     res = await predict_isvc(
         rest_v1_client, service_name, INPUT, network_layer=network_layer
     )
+    assert trigger_metadata["value"] == "50"
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The ScaledObject created from the InferenceService spec should reflect the given CPU averageUtilization instead of using the pointer as the target value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4414 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:


1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.