### PR TITLE
feat: add label selector support to storage container binding

### DIFF
--- a/config/crd/full/serving.kserve.io_clusterstoragecontainers.yaml
+++ b/config/crd/full/serving.kserve.io_clusterstoragecontainers.yaml
@@ -706,6 +706,32 @@ spec:
                 required:
                 - name
                 type: object
+              objectSelector:
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               supportedUriFormats:
                 items:
                   properties:
@@ -722,6 +748,10 @@ spec:
             - container
             - supportedUriFormats
             type: object
+            x-kubernetes-validations:
+            - message: '`objectSelector` is only supported for the ''initContainer''
+                workload type'
+              rule: self.workloadType != "initContainer" || !has(self.objectSelector)
         type: object
     served: true
     storage: true

--- a/hack/python-sdk/swagger_config.json
+++ b/hack/python-sdk/swagger_config.json
@@ -24,6 +24,7 @@
         "V1Volume": "from kubernetes.client import V1Volume",
         "V1ObjectMeta": "from kubernetes.client import V1ObjectMeta",
         "V1ListMeta": "from kubernetes.client import V1ListMeta",
-        "V1ResourceRequirements": "from kubernetes.client import V1ResourceRequirements"
+        "V1ResourceRequirements": "from kubernetes.client import V1ResourceRequirements",
+        "V1LabelSelector": "from kubernetes.client import V1LabelSelector"
     }
 }

--- a/pkg/apis/serving/v1alpha1/storage_container_types.go
+++ b/pkg/apis/serving/v1alpha1/storage_container_types.go
@@ -26,6 +26,7 @@ import (
 
 // StorageContainerSpec defines the container spec for the storage initializer init container, and the protocols it supports.
 // +k8s:openapi-gen=true
+// +kubebuilder:validation:XValidation:rule=`self.workloadType != "initContainer" || !has(self.objectSelector)`,message="`objectSelector` is only supported for the 'initContainer' workload type"
 type StorageContainerSpec struct {
 	// Container spec for the storage initializer init container
 	Container corev1.Container `json:"container" validate:"required"`
@@ -34,6 +35,12 @@ type StorageContainerSpec struct {
 	SupportedUriFormats []SupportedUriFormat `json:"supportedUriFormats" validate:"required"`
 	// +kubebuilder:default="initContainer"
 	WorkloadType WorkloadType `json:"workloadType,omitempty"`
+	// ObjectSelector decides whether to inject the storage container based on
+	// whether the inference service object has matching labels.
+	//
+	// Default to the empty LabelSelector, which matches everything.
+	// +optional
+	ObjectSelector *metav1.LabelSelector `json:"objectSelector,omitempty"`
 }
 
 // SupportedUriFormat can be either prefix or regex. Todo: Add validation that only one of them is set.

--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 import (
 	"github.com/kserve/kserve/pkg/constants"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -962,6 +963,11 @@ func (in *StorageContainerSpec) DeepCopyInto(out *StorageContainerSpec) {
 		in, out := &in.SupportedUriFormats, &out.SupportedUriFormats
 		*out = make([]SupportedUriFormat, len(*in))
 		copy(*out, *in)
+	}
+	if in.ObjectSelector != nil {
+		in, out := &in.ObjectSelector, &out.ObjectSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -77,7 +77,7 @@ func (e *Explainer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	// StorageInitializer injector to mutate the underlying deployment to provision model data
 	if sourceURI := explainer.GetStorageUri(); sourceURI != nil {
 		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = *sourceURI
-		err := isvcutils.ValidateStorageURI(ctx, sourceURI, e.client)
+		err := isvcutils.ValidateStorageURI(ctx, sourceURI, isvc.ObjectMeta, e.client)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("StorageURI not supported: %w", err)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -118,7 +118,7 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 
 	// Knative does not support INIT containers or mounting, so we add annotations that trigger the
 	// StorageInitializer injector to mutate the underlying deployment to provision model data
-	if err := p.addStorageInitializerAnnotations(ctx, predictor, annotations); err != nil {
+	if err := p.addStorageInitializerAnnotations(ctx, predictor, annotations, isvc); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -216,13 +216,13 @@ func (p *Predictor) reconcileModelConfig(ctx context.Context, isvc *v1beta1.Infe
 	return configMapReconciler.Reconcile(ctx, isvc)
 }
 
-func (p *Predictor) addStorageInitializerAnnotations(ctx context.Context, predictor v1beta1.ComponentImplementation, annotations map[string]string) error {
+func (p *Predictor) addStorageInitializerAnnotations(ctx context.Context, predictor v1beta1.ComponentImplementation, annotations map[string]string, isvc *v1beta1.InferenceService) error {
 	if sourceURI := predictor.GetStorageUri(); sourceURI != nil {
 		if _, ok := annotations[constants.StorageInitializerSourceUriInternalAnnotationKey]; ok {
 			return errors.New("must provide only one of storageUri and storage.path")
 		}
 		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = *sourceURI
-		err := isvcutils.ValidateStorageURI(ctx, sourceURI, p.client)
+		err := isvcutils.ValidateStorageURI(ctx, sourceURI, isvc.ObjectMeta, p.client)
 		if err != nil {
 			return fmt.Errorf("StorageURI not supported: %w", err)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -78,7 +78,7 @@ func (p *Transformer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServ
 	// StorageInitializer injector to mutate the underlying deployment to provision model data
 	if sourceURI := transformer.GetStorageUri(); sourceURI != nil {
 		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = *sourceURI
-		err := isvcutils.ValidateStorageURI(ctx, sourceURI, p.client)
+		err := isvcutils.ValidateStorageURI(ctx, sourceURI, isvc.ObjectMeta, p.client)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("StorageURI not supported: %w", err)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -335,13 +335,13 @@ func sortPodsByCreatedTimestampDesc(pods *corev1.PodList) {
 	})
 }
 
-func ValidateStorageURI(ctx context.Context, storageURI *string, client client.Client) error {
+func ValidateStorageURI(ctx context.Context, storageURI *string, objMeta metav1.ObjectMeta, client client.Client) error {
 	if storageURI == nil {
 		return nil
 	}
 
 	// Step 1: Passes the validation if we have a storage container CR that supports this storageURI.
-	storageContainerSpec, err := pod.GetContainerSpecForStorageUri(ctx, *storageURI, client)
+	storageContainerSpec, err := pod.GetContainerSpecForStorageUri(ctx, *storageURI, objMeta, client)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -1864,7 +1864,7 @@ func TestValidateStorageURIForDefaultStorageInitializer(t *testing.T) {
 	}
 	mockClient := fake.NewClientBuilder().WithScheme(s).Build()
 	for _, uri := range validUris {
-		if err := ValidateStorageURI(t.Context(), &uri, mockClient); err != nil {
+		if err := ValidateStorageURI(t.Context(), &uri, metav1.ObjectMeta{}, mockClient); err != nil {
 			t.Errorf("%q validation failed: %s", uri, err)
 		}
 	}
@@ -1881,7 +1881,7 @@ func TestValidateStorageURIForCustomPrefix(t *testing.T) {
 	}
 	mockClient := fake.NewClientBuilder().WithScheme(s).Build()
 	for _, uri := range invalidUris {
-		if err := ValidateStorageURI(t.Context(), &uri, mockClient); err == nil {
+		if err := ValidateStorageURI(t.Context(), &uri, metav1.ObjectMeta{}, mockClient); err == nil {
 			t.Errorf("%q validation failed: error expected", uri)
 		}
 	}
@@ -1919,7 +1919,7 @@ func TestValidateStorageURIForDefaultStorageInitializerCRD(t *testing.T) {
 	}
 	mockClient := fake.NewClientBuilder().WithLists(storageContainerSpecs).WithScheme(s).Build()
 	for _, uri := range validUris {
-		if err := ValidateStorageURI(t.Context(), &uri, mockClient); err != nil {
+		if err := ValidateStorageURI(t.Context(), &uri, metav1.ObjectMeta{}, mockClient); err != nil {
 			t.Errorf("%q validation failed: %s", uri, err)
 		}
 	}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1758,12 +1758,18 @@ func schema_pkg_apis_serving_v1alpha1_StorageContainerSpec(ref common.ReferenceC
 							Format: "",
 						},
 					},
+					"objectSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObjectSelector decides whether to inject the storage container based on whether the inference service object has matching labels.\n\nDefault to the empty LabelSelector, which matches everything.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
+						},
+					},
 				},
 				Required: []string{"container", "supportedUriFormats"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/kserve/kserve/pkg/apis/serving/v1alpha1.SupportedUriFormat", "k8s.io/api/core/v1.Container"},
+			"github.com/kserve/kserve/pkg/apis/serving/v1alpha1.SupportedUriFormat", "k8s.io/api/core/v1.Container", "k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},
 	}
 }
 

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -916,6 +916,10 @@
           "default": {},
           "$ref": "#/definitions/v1.Container"
         },
+        "objectSelector": {
+          "description": "ObjectSelector decides whether to inject the storage container based on whether the inference service object has matching labels.\n\nDefault to the empty LabelSelector, which matches everything.",
+          "$ref": "#/definitions/v1.LabelSelector"
+        },
         "supportedUriFormats": {
           "description": "List of URI formats that this container supports",
           "type": "array",

--- a/python/kserve/docs/V1alpha1StorageContainerSpec.md
+++ b/python/kserve/docs/V1alpha1StorageContainerSpec.md
@@ -5,6 +5,7 @@ StorageContainerSpec defines the container spec for the storage initializer init
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **container** | [**V1Container**](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Container.md) |  | 
+**object_selector** | [**V1LabelSelector**](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1LabelSelector.md) |  | [optional] 
 **supported_uri_formats** | [**list[V1alpha1SupportedUriFormat]**](V1alpha1SupportedUriFormat.md) | List of URI formats that this container supports | 
 **workload_type** | **str** |  | [optional] 
 

--- a/python/kserve/kserve/models/v1alpha1_storage_container_spec.py
+++ b/python/kserve/kserve/models/v1alpha1_storage_container_spec.py
@@ -48,28 +48,33 @@ class V1alpha1StorageContainerSpec(object):
     """
     openapi_types = {
         'container': 'V1Container',
+        'object_selector': 'V1LabelSelector',
         'supported_uri_formats': 'list[V1alpha1SupportedUriFormat]',
         'workload_type': 'str'
     }
 
     attribute_map = {
         'container': 'container',
+        'object_selector': 'objectSelector',
         'supported_uri_formats': 'supportedUriFormats',
         'workload_type': 'workloadType'
     }
 
-    def __init__(self, container=None, supported_uri_formats=None, workload_type=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, container=None, object_selector=None, supported_uri_formats=None, workload_type=None, local_vars_configuration=None):  # noqa: E501
         """V1alpha1StorageContainerSpec - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
         self.local_vars_configuration = local_vars_configuration
 
         self._container = None
+        self._object_selector = None
         self._supported_uri_formats = None
         self._workload_type = None
         self.discriminator = None
 
         self.container = container
+        if object_selector is not None:
+            self.object_selector = object_selector
         self.supported_uri_formats = supported_uri_formats
         if workload_type is not None:
             self.workload_type = workload_type
@@ -96,6 +101,27 @@ class V1alpha1StorageContainerSpec(object):
             raise ValueError("Invalid value for `container`, must not be `None`")  # noqa: E501
 
         self._container = container
+
+    @property
+    def object_selector(self):
+        """Gets the object_selector of this V1alpha1StorageContainerSpec.  # noqa: E501
+
+
+        :return: The object_selector of this V1alpha1StorageContainerSpec.  # noqa: E501
+        :rtype: V1LabelSelector
+        """
+        return self._object_selector
+
+    @object_selector.setter
+    def object_selector(self, object_selector):
+        """Sets the object_selector of this V1alpha1StorageContainerSpec.
+
+
+        :param object_selector: The object_selector of this V1alpha1StorageContainerSpec.  # noqa: E501
+        :type: V1LabelSelector
+        """
+
+        self._object_selector = object_selector
 
     @property
     def supported_uri_formats(self):

--- a/test/crds/serving.kserve.io_inferenceservices.yaml
+++ b/test/crds/serving.kserve.io_inferenceservices.yaml
@@ -4757,6 +4757,32 @@ spec:
                 required:
                 - name
                 type: object
+              objectSelector:
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               supportedUriFormats:
                 items:
                   properties:
@@ -4773,6 +4799,10 @@ spec:
             - container
             - supportedUriFormats
             type: object
+            x-kubernetes-validations:
+            - message: '`objectSelector` is only supported for the ''initContainer''
+                workload type'
+              rule: self.workloadType != "initContainer" || !has(self.objectSelector)
         type: object
     served: true
     storage: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR add a new field called `objectSelector` to `ClusterStorageContainer`, which allows users to specify different storage container based on workload labels.

**PS**: If `namespaceSelector` sounds reasonable, I'd like to implement it as well. 

**Which issue(s) this PR fixes**

Fixes #4258

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.