### PR TITLE
Implement authorization for Raw InferenceGraphs

### DIFF
--- a/charts/kserve-resources/templates/clusterrole.yaml
+++ b/charts/kserve-resources/templates/clusterrole.yaml
@@ -51,9 +51,17 @@ rules:
   - ""
   resources:
   - secrets
-  - serviceaccounts
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -175,6 +183,17 @@ rules:
   resources:
   - opentelemetrycollectors/status
   verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - kserve-inferencegraph-auth-verifiers
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
   - get
   - patch
   - update

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -38,6 +38,11 @@ import (
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 	"github.com/tidwall/gjson"
+	authnv1 "k8s.io/api/authentication/v1"
+	authzv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -420,11 +425,159 @@ func readyHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 var (
+	enableAuthFlag         = flag.Bool("enable-auth", false, "protect the inference graph with authorization")
+	graphName              = flag.String("inferencegraph-name", "", "the name of the associated inference graph Kubernetes resource")
 	jsonGraph              = flag.String("graph-json", "", "serialized json graph def")
 	compiledHeaderPatterns []*regexp.Regexp
 	isShuttingDown         = false
 	drainSleepDuration     = 30 * time.Second
 )
+
+// findBearerToken parses the standard HTTP Authorization header to find and return
+// a Bearer token that a client may have provided in the request. If the token
+// is found, it is returned. Else, an empty string is returned and the HTTP response
+// is sent to the client with proper status code and the reason for the request being
+// rejected.
+func findBearerToken(w http.ResponseWriter, r *http.Request) string {
+	// Find for HTTP Authentication header. Reject request if not available.
+	authHeader := r.Header.Get("Authorization")
+	if len(authHeader) == 0 {
+		w.Header().Set("X-Forbidden-Reason", "No credentials were provided")
+		w.WriteHeader(http.StatusUnauthorized)
+		return ""
+	}
+
+	// Parse Auth header
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	if token == authHeader {
+		w.Header().Set("X-Forbidden-Reason", "Only Bearer tokens are supported")
+		w.WriteHeader(http.StatusUnauthorized)
+		return ""
+	}
+	return token
+}
+
+// validateTokenIsAuthenticated queries the Kubernetes cluster to find if the provided token is
+// valid and flagged as authenticated. If the token is usable, the result of the TokenReview
+// is returned. Otherwise, the HTTP response is sent rejecting the request and setting
+// a meaningful status code along with a reason (if available).
+func validateTokenIsAuthenticated(w http.ResponseWriter, r *http.Request, token string, clientset *kubernetes.Clientset) *authnv1.TokenReview {
+	// Check the token is valid
+	tokenReview := authnv1.TokenReview{}
+	tokenReview.Spec.Token = token
+	tokenReviewResult, err := clientset.AuthenticationV1().TokenReviews().Create(r.Context(), &tokenReview, metav1.CreateOptions{})
+	if err != nil {
+		log.Error(err, "failed to create TokenReview when verifying credentials")
+		w.WriteHeader(http.StatusInternalServerError)
+		return nil
+	}
+	if len(tokenReviewResult.Status.Error) != 0 {
+		w.Header().Set("X-Forbidden-Reason", tokenReviewResult.Status.Error)
+		w.WriteHeader(http.StatusUnauthorized)
+		return nil
+	}
+	if !tokenReviewResult.Status.Authenticated {
+		w.Header().Set("X-Forbidden-Reason", "The provided token is unauthenticated")
+		w.WriteHeader(http.StatusUnauthorized)
+		return nil
+	}
+	return tokenReviewResult
+}
+
+// checkRequestIsAuthorized verifies that the user in the provided tokenReviewResult has privileges to query the
+// Kubernetes API and get the InferenceGraph resource that belongs to this pod. If so, the request is considered
+// as allowed and `true` is returned. Otherwise, the HTTP response is sent rejecting the request and setting
+// a meaningful status code along with a reason (if available).
+func checkRequestIsAuthorized(w http.ResponseWriter, r *http.Request, tokenReviewResult *authnv1.TokenReview, clientset *kubernetes.Clientset) bool {
+	// Read pod namespace
+	const namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	namespaceBytes, err := os.ReadFile(namespaceFile)
+	if err != nil {
+		log.Error(err, "failed to read namespace file while verifying credentials")
+		w.WriteHeader(http.StatusInternalServerError)
+		return false
+	}
+	namespace := string(namespaceBytes)
+
+	// Check the subject is authorized to query the InferenceGraph
+	if len(*graphName) == 0 {
+		log.Error(errors.New("no graph name provided"), "the --inferencegraph-name flag wasn't provided")
+		w.WriteHeader(http.StatusInternalServerError)
+		return false
+	}
+	accessReview := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      "get",
+				Group:     "serving.kserve.io",
+				Resource:  "inferencegraphs",
+				Name:      *graphName,
+			},
+			User:   tokenReviewResult.Status.User.Username,
+			Groups: nil,
+		},
+	}
+
+	accessReviewResult, err := clientset.AuthorizationV1().SubjectAccessReviews().Create(r.Context(), &accessReview, metav1.CreateOptions{})
+	if err != nil {
+		log.Error(err, "failed to create LocalSubjectAccessReview when verifying credentials")
+		w.WriteHeader(http.StatusInternalServerError)
+		return false
+	}
+	if accessReviewResult.Status.Allowed {
+		// Note: This is here so that the request is NOT allowed by default.
+		return true
+	}
+
+	w.Header().Add("X-Forbidden-Reason", "Access to the InferenceGraph is not allowed")
+	if len(accessReviewResult.Status.Reason) != 0 {
+		w.Header().Add("X-Forbidden-Reason", accessReviewResult.Status.Reason)
+	}
+	if len(accessReviewResult.Status.EvaluationError) != 0 {
+		w.Header().Add("X-Forbidden-Reason", accessReviewResult.Status.EvaluationError)
+	}
+
+	w.WriteHeader(http.StatusUnauthorized)
+	return false
+}
+
+// authMiddleware uses the Middleware pattern to protect the InferenceGraph behind authorization.
+// It expects that a Bearer token is provided in the request in the standard HTTP Authorization
+// header. The token is verified against Kubernetes using the TokenReview and SubjectAccessReview APIs.
+// If the token is valid and has enough privileges, the handler provided in the `next` argument is run.
+// Otherwise, `next` is not invoked and the reason for the rejection is sent in response headers.
+func authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		k8sConfig, k8sConfigErr := rest.InClusterConfig()
+		if k8sConfigErr != nil {
+			log.Error(k8sConfigErr, "failed to create rest configuration to connect to Kubernetes API")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		clientset, clientsetErr := kubernetes.NewForConfig(k8sConfig)
+		if clientsetErr != nil {
+			log.Error(k8sConfigErr, "failed to create Kubernetes client to connect to API")
+			return
+		}
+
+		token := findBearerToken(w, r)
+		if len(token) == 0 {
+			return
+		}
+
+		tokenReviewResult := validateTokenIsAuthenticated(w, r, token, clientset)
+		if tokenReviewResult == nil {
+			return
+		}
+
+		isAuthorized := checkRequestIsAuthorized(w, r, tokenReviewResult, clientset)
+		if isAuthorized {
+			next.ServeHTTP(w, r)
+		}
+	})
+}
 
 func main() {
 	flag.Parse()
@@ -445,7 +598,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	http.HandleFunc("/", graphHandler)
+	var entrypointHandler http.Handler
+	entrypointHandler = http.HandlerFunc(graphHandler)
+	if *enableAuthFlag {
+		entrypointHandler = authMiddleware(entrypointHandler)
+		log.Info("This Router has authorization enabled")
+	}
+
+	http.Handle("/", entrypointHandler)
 	http.HandleFunc(constants.RouterReadinessEndpoint, readyHandler)
 
 	server := &http.Server{

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,9 +38,17 @@ rules:
   - ""
   resources:
   - secrets
-  - serviceaccounts
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -162,6 +170,17 @@ rules:
   resources:
   - opentelemetrycollectors/status
   verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - kserve-inferencegraph-auth-verifiers
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
   - get
   - patch
   - update

--- a/pkg/apis/serving/v1alpha1/inference_graph.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -356,7 +354,7 @@ func (ig *InferenceGraph) ResolveServiceAccountName() string {
 	}
 
 	if ig.HasAuthEnabled() {
-		return fmt.Sprintf("%s-auth-verifier", ig.GetName())
+		return ig.GetName() + "-auth-verifier"
 	}
 
 	return "default"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -55,6 +55,8 @@ const (
 	InferenceGraphLabel          = "serving.kserve.io/inferencegraph"
 	RouterReadinessEndpoint      = "/readyz"
 	RouterPort                   = 8080
+	InferenceGraphAuthCRBName    = "kserve-inferencegraph-auth-verifiers"
+	InferenceGraphFinalizerName  = "inferencegraph.finalizers"
 )
 
 // TrainedModel Constants
@@ -107,6 +109,7 @@ var (
 	QueueProxyAggregatePrometheusMetricsPort    = "9088"
 	DefaultPodPrometheusPort                    = "9091"
 	NodeGroupAnnotationKey                      = KServeAPIGroupName + "/nodegroup"
+	EnableAuthAnnotationKey                     = KServeAPIGroupName + "/enable-auth"
 )
 
 // InferenceService Internal Annotations

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -25,12 +25,16 @@ import (
 	"google.golang.org/protobuf/proto"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/pkg/kmp"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -816,6 +820,131 @@ var _ = Describe("Inference Graph controller test", func() {
 			err := k8sClient.Update(context.TODO(), expectedKnService, client.DryRunAll)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(actualKnServiceCreated.Spec).To(BeComparableTo(expectedKnService.Spec))
+		})
+	})
+
+	Context("When creating an IG in Raw deployment mode with auth", func() {
+		var configMap *corev1.ConfigMap
+		var inferenceGraph *v1alpha1.InferenceGraph
+
+		BeforeEach(func() {
+			configMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+
+			graphName := "igrawauth1"
+			inferenceGraph = &v1alpha1.InferenceGraph{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      graphName,
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": string(constants.RawDeployment),
+						constants.EnableAuthAnnotationKey:  "true",
+					},
+				},
+				Spec: v1alpha1.InferenceGraphSpec{
+					Nodes: map[string]v1alpha1.InferenceRouter{
+						v1alpha1.GraphRootNodeName: {
+							RouterType: v1alpha1.Sequence,
+							Steps: []v1alpha1.InferenceStep{
+								{
+									InferenceTarget: v1alpha1.InferenceTarget{
+										ServiceURL: "http://someservice.exmaple.com",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, inferenceGraph)).Should(Succeed())
+		})
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, inferenceGraph)
+			igKey := types.NamespacedName{Namespace: inferenceGraph.GetNamespace(), Name: inferenceGraph.GetName()}
+			Eventually(func() error { return k8sClient.Get(ctx, igKey, inferenceGraph) }, timeout, interval).ShouldNot(Succeed())
+
+			_ = k8sClient.Delete(ctx, configMap)
+			cmKey := types.NamespacedName{Namespace: configMap.GetNamespace(), Name: configMap.GetName()}
+			Eventually(func() error { return k8sClient.Get(ctx, cmKey, configMap) }, timeout, interval).ShouldNot(Succeed())
+		})
+
+		It("Should create or update a ClusterRoleBinding giving privileges to validate auth", func() {
+			Eventually(func(g Gomega) {
+				crbKey := types.NamespacedName{Name: constants.InferenceGraphAuthCRBName}
+				clusterRoleBinding := rbacv1.ClusterRoleBinding{}
+				g.Expect(k8sClient.Get(ctx, crbKey, &clusterRoleBinding)).To(Succeed())
+
+				crGVK, err := apiutil.GVKForObject(&rbacv1.ClusterRole{}, scheme.Scheme)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(clusterRoleBinding.RoleRef).To(Equal(rbacv1.RoleRef{
+					APIGroup: crGVK.Group,
+					Kind:     crGVK.Kind,
+					Name:     "system:auth-delegator",
+				}))
+				g.Expect(clusterRoleBinding.Subjects).To(ContainElement(rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					APIGroup:  "",
+					Name:      inferenceGraph.ResolveServiceAccountName(),
+					Namespace: inferenceGraph.GetNamespace(),
+				}))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should create a ServiceAccount for querying the Kubernetes API to check tokens", func() {
+			Eventually(func(g Gomega) {
+				saKey := types.NamespacedName{Namespace: inferenceGraph.GetNamespace(), Name: inferenceGraph.ResolveServiceAccountName()}
+				serviceAccount := corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, saKey, &serviceAccount)).To(Succeed())
+				g.Expect(serviceAccount.OwnerReferences).ToNot(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should configure the InferenceGraph deployment with auth enabled", func() {
+			Eventually(func(g Gomega) {
+				igDeployment := appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: inferenceGraph.GetNamespace(), Name: inferenceGraph.GetName()}, &igDeployment)).To(Succeed())
+				g.Expect(igDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(Equal(proto.Bool(true)))
+				g.Expect(igDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(inferenceGraph.ResolveServiceAccountName()))
+				g.Expect(igDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+				g.Expect(igDeployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements("--enable-auth", "--inferencegraph-name", inferenceGraph.GetName()))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should delete the ServiceAccount when the InferenceGraph is deleted", func() {
+			serviceAccount := corev1.ServiceAccount{}
+			saKey := types.NamespacedName{Namespace: inferenceGraph.GetNamespace(), Name: inferenceGraph.ResolveServiceAccountName()}
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, saKey, &serviceAccount)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(k8sClient.Delete(ctx, inferenceGraph)).To(Succeed())
+			Eventually(func() error {
+				return k8sClient.Get(ctx, saKey, &serviceAccount)
+			}, timeout, interval).Should(WithTransform(errors.IsNotFound, BeTrue()))
+		})
+
+		It("Should remove the ServiceAccount as subject of the ClusterRoleBinding when the InferenceGraph is deleted", func() {
+			crbKey := types.NamespacedName{Name: constants.InferenceGraphAuthCRBName}
+
+			Eventually(func() []rbacv1.Subject {
+				clusterRoleBinding := rbacv1.ClusterRoleBinding{}
+				_ = k8sClient.Get(ctx, crbKey, &clusterRoleBinding)
+				return clusterRoleBinding.Subjects
+			}, timeout, interval).Should(ContainElement(HaveField("Name", inferenceGraph.ResolveServiceAccountName())))
+
+			Expect(k8sClient.Delete(ctx, inferenceGraph)).To(Succeed())
+			Eventually(func() []rbacv1.Subject {
+				clusterRoleBinding := rbacv1.ClusterRoleBinding{}
+				_ = k8sClient.Get(ctx, crbKey, &clusterRoleBinding)
+				return clusterRoleBinding.Subjects
+			}, timeout, interval).ShouldNot(ContainElement(HaveField("Name", inferenceGraph.ResolveServiceAccountName())))
 		})
 	})
 })

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -826,6 +826,7 @@ var _ = Describe("Inference Graph controller test", func() {
 	Context("When creating an IG in Raw deployment mode with auth", func() {
 		var configMap *corev1.ConfigMap
 		var inferenceGraph *v1alpha1.InferenceGraph
+		ctx := context.Background()
 
 		BeforeEach(func() {
 			configMap = &corev1.ConfigMap{

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -25,12 +25,18 @@ import (
 	"google.golang.org/protobuf/proto"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	corev1cfg "k8s.io/client-go/applyconfigurations/core/v1"
+	metav1cfg "k8s.io/client-go/applyconfigurations/meta/v1"
+	rbacv1cfg "k8s.io/client-go/applyconfigurations/rbac/v1"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
 	knapis "knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -84,7 +90,7 @@ func createInferenceGraphPodSpec(graph *v1alpha1.InferenceGraph, config *RouterC
 		ImagePullSecrets:             config.GetImagePullSecrets(),
 		NodeSelector:                 graph.Spec.NodeSelector,
 		NodeName:                     graph.Spec.NodeName,
-		ServiceAccountName:           graph.Spec.ServiceAccountName,
+		ServiceAccountName:           graph.ResolveServiceAccountName(),
 	}
 
 	// Only adding this env variable "PROPAGATE_HEADERS" if router's headers config has the key "propagate"
@@ -96,6 +102,20 @@ func createInferenceGraphPodSpec(graph *v1alpha1.InferenceGraph, config *RouterC
 				Value: strings.Join(value, ","),
 			},
 		}
+	}
+
+	// If auth is enabled for the InferenceGraph:
+	// * Add --enable-auth argument, to properly secure kserve-router
+	// * Add the --inferencegraph-name argument, so that the router is aware of its name
+	// * Enable auto-mount of the ServiceAccount, because it is required for validating tokens
+	// * Set a non-default ServiceAccount with enough privileges to verify auth
+	if graph.HasAuthEnabled() {
+		podSpec.Containers[0].Args = append(podSpec.Containers[0].Args, "--enable-auth")
+
+		podSpec.Containers[0].Args = append(podSpec.Containers[0].Args, "--inferencegraph-name")
+		podSpec.Containers[0].Args = append(podSpec.Containers[0].Args, graph.GetName())
+
+		podSpec.AutomountServiceAccountToken = proto.Bool(true)
 	}
 
 	return podSpec
@@ -186,6 +206,183 @@ func handleInferenceGraphRawDeployment(ctx context.Context, cl client.Client, cl
 	}
 
 	return deployment[0], reconciler.URL, nil
+}
+
+func handleInferenceGraphRawAuthResources(ctx context.Context, clientset kubernetes.Interface, scheme *runtime.Scheme, graph *v1alpha1.InferenceGraph) error {
+	saName := graph.ResolveServiceAccountName()
+
+	if graph.HasAuthEnabled() {
+		existingServiceAccount, isOwner, err := checkIfGraphServiceAccountIsOwned(ctx, clientset, graph)
+		if err != nil {
+			return err
+		}
+
+		if existingServiceAccount == nil || isOwner {
+			// If the target SA does not exist, it is created owned by the InferenceGraph.
+			// In case the SA already exists, the following code would reconcile it in case it
+			// is owned by the InferenceGraph. If it is _not_ owned by the IG, the SA is not touched.
+
+			graphGVK, errGvk := apiutil.GVKForObject(graph, scheme)
+			if errGvk != nil {
+				return errors.Wrap(errGvk, "fails get GVK for inference graph")
+			}
+
+			ownerReference := metav1cfg.OwnerReference().
+				WithKind(graphGVK.Kind).
+				WithAPIVersion(graphGVK.GroupVersion().String()).
+				WithName(graph.GetName()).
+				WithUID(graph.UID).
+				WithBlockOwnerDeletion(true).
+				WithController(true)
+
+			// Create a Service Account that can be used to check auth
+			saAuthVerifier := corev1cfg.ServiceAccount(saName, graph.GetNamespace()).
+				WithOwnerReferences(ownerReference)
+			_, err = clientset.CoreV1().ServiceAccounts(graph.GetNamespace()).Apply(ctx, saAuthVerifier, metav1.ApplyOptions{FieldManager: InferenceGraphControllerName})
+			if err != nil {
+				return errors.Wrap(err, "fails to apply auth-verifier service account for inference graph")
+			}
+		}
+
+		// Bind the required privileges to the Service Account
+		err = addAuthPrivilegesToGraphServiceAccount(ctx, clientset, graph)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := removeAuthPrivilegesFromGraphServiceAccount(ctx, clientset, graph)
+		if err != nil {
+			return err
+		}
+
+		err = deleteGraphServiceAccount(ctx, clientset, graph)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addAuthPrivilegesToGraphServiceAccount(ctx context.Context, clientset kubernetes.Interface, graph *v1alpha1.InferenceGraph) error {
+	clusterRoleBinding, err := clientset.RbacV1().ClusterRoleBindings().Get(ctx, constants.InferenceGraphAuthCRBName, metav1.GetOptions{})
+	if client.IgnoreNotFound(err) != nil {
+		return errors.Wrapf(err, "fails to get cluster role binding kserve-inferencegraph-auth-verifiers while configuring inference graph auth")
+	}
+
+	saName := graph.ResolveServiceAccountName()
+	if apierrors.IsNotFound(err) {
+		clusterRoleAuxiliary := rbacv1.ClusterRole{}
+		rbRoleRef := rbacv1cfg.RoleRef().
+			WithKind("ClusterRole").
+			WithName("system:auth-delegator").
+			WithAPIGroup(clusterRoleAuxiliary.GroupVersionKind().Group)
+		rbSubject := rbacv1cfg.Subject().
+			WithKind("ServiceAccount").
+			WithNamespace(graph.GetNamespace()).
+			WithName(saName)
+		crbApply := rbacv1cfg.ClusterRoleBinding(constants.InferenceGraphAuthCRBName).
+			WithRoleRef(rbRoleRef).
+			WithSubjects(rbSubject)
+
+		_, err = clientset.RbacV1().ClusterRoleBindings().Apply(ctx, crbApply, metav1.ApplyOptions{FieldManager: InferenceGraphControllerName})
+		if err != nil {
+			return errors.Wrapf(err, "fails to apply kserve-inferencegraph-auth-verifiers ClusterRoleBinding for inference graph")
+		}
+	} else {
+		isPresent := false
+		for _, subject := range clusterRoleBinding.Subjects {
+			if subject.Kind == "ServiceAccount" && subject.Name == saName && subject.Namespace == graph.GetNamespace() {
+				isPresent = true
+				break
+			}
+		}
+		if !isPresent {
+			clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      saName,
+				Namespace: graph.GetNamespace(),
+			})
+			_, err = clientset.RbacV1().ClusterRoleBindings().Update(ctx, clusterRoleBinding, metav1.UpdateOptions{FieldManager: InferenceGraphControllerName})
+			if err != nil {
+				return errors.Wrapf(err, "fails to bind privileges for auth verification to inference graph")
+			}
+		}
+	}
+
+	return nil
+}
+
+func removeAuthPrivilegesFromGraphServiceAccount(ctx context.Context, clientset kubernetes.Interface, graph *v1alpha1.InferenceGraph) error {
+	clusterRole, err := clientset.RbacV1().ClusterRoleBindings().Get(ctx, constants.InferenceGraphAuthCRBName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "fails to get cluster role binding kserve-inferencegraph-auth-verifiers while deconfiguring inference graph auth")
+	}
+
+	isPresent := false
+	saName := graph.ResolveServiceAccountName()
+	for idx, subject := range clusterRole.Subjects {
+		if subject.Kind == "ServiceAccount" && subject.Name == saName && subject.Namespace == graph.GetNamespace() {
+			isPresent = true
+
+			// Remove the no longer needed entry
+			clusterRole.Subjects[idx] = clusterRole.Subjects[len(clusterRole.Subjects)-1]
+			clusterRole.Subjects = clusterRole.Subjects[:len(clusterRole.Subjects)-1]
+			break
+		}
+	}
+
+	if isPresent {
+		_, err = clientset.RbacV1().ClusterRoleBindings().Update(ctx, clusterRole, metav1.UpdateOptions{FieldManager: InferenceGraphControllerName})
+		if err != nil {
+			return errors.Wrapf(err, "fails to remove privileges for auth verification from inference graph")
+		}
+	}
+
+	return nil
+}
+
+func checkIfGraphServiceAccountIsOwned(ctx context.Context, clientset kubernetes.Interface, graph *v1alpha1.InferenceGraph) (*corev1.ServiceAccount, bool, error) {
+	// Fetch the ServiceAccount, if it would exist
+	saName := graph.ResolveServiceAccountName()
+	existingServiceAccount, err := clientset.CoreV1().ServiceAccounts(graph.GetNamespace()).Get(ctx, saName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, errors.Wrap(err, "fails to get inference graph service account")
+	}
+
+	// Check if the SA is owned by the IG.
+	// TODO: For now, do a custom check. After updating to controller-runtime v0.20, change the check to use HasOwnerReference util func.
+	isOwner := false
+	saOwnerReference := existingServiceAccount.GetOwnerReferences()
+	if len(saOwnerReference) > 0 {
+		isOwner = saOwnerReference[0].APIVersion == graph.APIVersion &&
+			saOwnerReference[0].Kind == graph.Kind &&
+			saOwnerReference[0].Name == graph.GetName() &&
+			saOwnerReference[0].UID == graph.UID
+	}
+
+	return existingServiceAccount, isOwner, nil
+}
+
+func deleteGraphServiceAccount(ctx context.Context, clientset kubernetes.Interface, graph *v1alpha1.InferenceGraph) error {
+	existingServiceAccount, isOwned, err := checkIfGraphServiceAccountIsOwned(ctx, clientset, graph)
+	if err != nil {
+		return err
+	}
+
+	if existingServiceAccount != nil && isOwned {
+		err := clientset.CoreV1().ServiceAccounts(existingServiceAccount.GetNamespace()).Delete(ctx, existingServiceAccount.GetName(), metav1.DeleteOptions{})
+		if client.IgnoreNotFound(err) != nil {
+			return errors.Wrapf(err, "fails to delete service account for inference graph while deconfiguring auth")
+		}
+	}
+	return nil
 }
 
 /*

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
@@ -232,7 +232,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 					Name:  "basic-ig",
 					Args: []string{
 						"--graph-json",
-						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{},\"serviceAccountName\":\"default\"}",
+						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{}}",
 					},
 					Env: []corev1.EnvVar{
 						{

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
@@ -223,6 +223,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 			},
 			AutomountServiceAccountToken: proto.Bool(false),
 			ImagePullSecrets:             []corev1.LocalObjectReference{},
+			ServiceAccountName:           "default",
 		},
 		"basicgraphwithheaders": {
 			Containers: []corev1.Container{
@@ -231,7 +232,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 					Name:  "basic-ig",
 					Args: []string{
 						"--graph-json",
-						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{}}",
+						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{},\"serviceAccountName\":\"default\"}",
 					},
 					Env: []corev1.EnvVar{
 						{
@@ -263,6 +264,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 			},
 			AutomountServiceAccountToken: proto.Bool(false),
 			ImagePullSecrets:             []corev1.LocalObjectReference{},
+			ServiceAccountName:           "default",
 		},
 		"withresource": {
 			Containers: []corev1.Container{
@@ -297,6 +299,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 			},
 			AutomountServiceAccountToken: proto.Bool(false),
 			ImagePullSecrets:             []corev1.LocalObjectReference{},
+			ServiceAccountName:           "default",
 		},
 		"with tolerations": {
 			Containers: []corev1.Container{
@@ -339,6 +342,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 					Effect:   corev1.TaintEffectNoSchedule,
 				},
 			},
+			ServiceAccountName: "default",
 		},
 	}
 

--- a/pkg/controller/v1alpha1/inferencegraph/suite_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/suite_test.go
@@ -48,7 +48,6 @@ import (
 var (
 	cfg       *rest.Config
 	k8sClient client.Client
-	ctx       context.Context
 )
 
 func TestAPIs(t *testing.T) {
@@ -58,8 +57,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	localCtx, cancel := context.WithCancel(context.Background())
-	ctx = localCtx
+	ctx, cancel := context.WithCancel(context.Background())
 	By("bootstrapping test environment")
 	crdDirectoryPaths := []string{
 		filepath.Join("..", "..", "..", "..", "test", "crds"),

--- a/pkg/controller/v1alpha1/inferencegraph/suite_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/suite_test.go
@@ -48,6 +48,7 @@ import (
 var (
 	cfg       *rest.Config
 	k8sClient client.Client
+	ctx       context.Context
 )
 
 func TestAPIs(t *testing.T) {
@@ -57,7 +58,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	ctx, cancel := context.WithCancel(context.Background())
+	localCtx, cancel := context.WithCancel(context.Background())
+	ctx = localCtx
 	By("bootstrapping test environment")
 	crdDirectoryPaths := []string{
 		filepath.Join("..", "..", "..", "..", "test", "crds"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Authorization is implemented by using the TokenReview and the SubjectAccessReview Kubernetes APIs. A Middleware function is set up when some arguments are specified that trigger plugging-in the middleware func.

Some additional reconciliation is added toInferenceGraph controller to:
* Switch to a different ServiceAccount (in case the user hasn't customized it) so that privileges for using the cluster APIs are granted.
  * Creating the needed ServiceAccount for the auth-protected InferenceGraph to run.
* Managing a ClusterRoleBinding to give the required privileges for auth verification.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.