### PR TITLE
InferenceGraph: Fix response code when condition step is not fulfilled

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -322,7 +322,7 @@ func routeStep(nodeName string, graph v1alpha1.InferenceGraphSpec, input []byte,
 				}
 				// if the condition does not match for the step in the sequence we stop and return the response
 				if !gjson.GetBytes(responseBytes, step.Condition).Exists() {
-					return responseBytes, 500, nil
+					return responseBytes, 200, nil
 				}
 			}
 			if responseBytes, statusCode, err = executeStep(step, graph, request, headers); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a step in the InferenceGraph has a condition, if it is not fulfilled for a run, such step is skipped. Currently, when the step is skipped, the returned HTTP status code is 500. This is not compatible with KServe's python client which raises an exception when receiving the 500 status code.

This is changing the status code to 200 to let the python client to work correctly. It also makes more sense to return 200, since there were no errors processing the request.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- Setup the image classification example: https://kserve.github.io/website/latest/modelserving/inference_graph/image_pipeline/.
- Test inference using the cat sample. Observe a 200 (and no 500) status code is returned in HTTP headers.

**Checklist**:

- [N/A] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [N/A] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix response code of InferenceGraph when a condition in a Sequence is not fulfilled.
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.