### PR TITLE
fix: Allow CA bundle path without config map

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -227,8 +227,8 @@ class Storage(object):
                 global_ca_bundle_volume_mount_path = os.getenv(
                     "CA_BUNDLE_VOLUME_MOUNT_POINT"
                 )
-                ca_bundle_full_path = (
-                    global_ca_bundle_volume_mount_path + "/cabundle.crt"
+                ca_bundle_full_path = os.path.join(
+                    global_ca_bundle_volume_mount_path, "cabundle.crt"
                 )
             if ca_bundle_set:
                 if os.path.exists(ca_bundle_full_path):

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -211,19 +211,26 @@ class Storage(object):
             verify_ssl = True
 
         # If verify_ssl is true, then check there is custom ca bundle cert
+        # The CA bundle can be any local file in the container under the path
+        # set in the AWS_CA_BUNDLE environment variable.
+        # It can also be coming from a ConfigMap, in which case the filename
+        # is cabundle.crt.
         if verify_ssl:
             global_ca_bundle_configmap = os.getenv("CA_BUNDLE_CONFIGMAP_NAME")
-            if global_ca_bundle_configmap:
-                isvc_aws_ca_bundle_path = os.getenv("AWS_CA_BUNDLE")
-                if isvc_aws_ca_bundle_path and isvc_aws_ca_bundle_path != "":
-                    ca_bundle_full_path = isvc_aws_ca_bundle_path
-                else:
-                    global_ca_bundle_volume_mount_path = os.getenv(
-                        "CA_BUNDLE_VOLUME_MOUNT_POINT"
-                    )
-                    ca_bundle_full_path = (
-                        global_ca_bundle_volume_mount_path + "/cabundle.crt"
-                    )
+            isvc_aws_ca_bundle_path = os.getenv("AWS_CA_BUNDLE")
+            ca_bundle_set = False
+            if isvc_aws_ca_bundle_path and isvc_aws_ca_bundle_path != "":
+                ca_bundle_set = True
+                ca_bundle_full_path = isvc_aws_ca_bundle_path
+            elif global_ca_bundle_configmap:
+                ca_bundle_set = True
+                global_ca_bundle_volume_mount_path = os.getenv(
+                    "CA_BUNDLE_VOLUME_MOUNT_POINT"
+                )
+                ca_bundle_full_path = (
+                    global_ca_bundle_volume_mount_path + "/cabundle.crt"
+                )
+            if ca_bundle_set:
                 if os.path.exists(ca_bundle_full_path):
                     logger.info("ca bundle file(%s) exists." % (ca_bundle_full_path))
                     kwargs.update({"verify": ca_bundle_full_path})

--- a/python/storage/kserve_storage/kserve_storage.py
+++ b/python/storage/kserve_storage/kserve_storage.py
@@ -221,8 +221,8 @@ class Storage(object):
                     global_ca_bundle_volume_mount_path = os.getenv(
                         "CA_BUNDLE_VOLUME_MOUNT_POINT"
                     )
-                    ca_bundle_full_path = (
-                        global_ca_bundle_volume_mount_path + "/cabundle.crt"
+                    ca_bundle_full_path = os.path.join(
+                        global_ca_bundle_volume_mount_path, "cabundle.crt"
                     )
                 if os.path.exists(ca_bundle_full_path):
                     logger.info("ca bundle file(%s) exists." % (ca_bundle_full_path))


### PR DESCRIPTION
**What this PR does / why we need it**:

In the previous code, the AWS_CA_BUNDLE environment variable is only considered if the CA_BUNDLE_CONFIGMAP_NAME environment variable is set, while the doc doesn't explicitely tie they together. This change allows using AWS_CA_BUNDLE independently to leverage a CA bundle certificate that would be preexisting in the image or injected by Kubernetes in a known path.

One use case is leveraging OpenShift service serving certificates, which injects the service CA in the containers via a projected ConfigMap. The service CA is always available in
/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt.

The documentation already says that this variable can be used to set the path to the CA bundle, while the ConfigMap uses a static file name (cabundle.crt) located in the ConfigMap volume mount point.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)