### PR TITLE
Add Code Coverage change report for PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,181 +1,186 @@
 name: Go Test
 
 on:
-  push:
-    branches: [master, release*]
-  pull_request:
-    branches: []
-  workflow_dispatch:
+    push:
+        branches: [master, release*]
+    pull_request:
+        branches: []
+    workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-        id: go
+            - name: Check out code into the Go module directory
+              uses: actions/checkout@v4
 
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
+            - name: Set up Go 1.x
+              uses: actions/setup-go@v5
+              with:
+               go-version-file: go.mod
+              id: go
 
-      - name: Test
-        id: test
-        run: |
-          export GOPATH=/home/runner/go
-          export PATH=$PATH:/usr/local/kubebuilder/bin:/home/runner/go/bin
-          wget -O $GOPATH/bin/yq https://github.com/mikefarah/yq/releases/download/v4.28.1/yq_linux_amd64
-          chmod +x $GOPATH/bin/yq
-          make test
-          ./coverage.sh
-          echo ::set-output name=coverage::$(./coverage.sh | tr -s '\t' | cut -d$'\t' -f 3)
+            - name: Get dependencies
+              run: |
+                go get -v -t -d ./...
 
-      - name: upload cover profile artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage.out
-          path: coverage.out
-          if-no-files-found: error
+            - name: Test
+              id: test
+              run: |
+                export GOPATH=/home/runner/go
+                export PATH=$PATH:/usr/local/kubebuilder/bin:/home/runner/go/bin
+                wget -O $GOPATH/bin/yq https://github.com/mikefarah/yq/releases/download/v4.28.1/yq_linux_amd64
+                chmod +x $GOPATH/bin/yq
+                make test
+                ./coverage.sh
+                echo ::set-output name=coverage::$(./coverage.sh | tr -s '\t' | cut -d$'\t' -f 3)
+            
+            - name: Print coverage
+              run: |
+                echo "Coverage output is ${{ steps.test.outputs.coverage }}"
 
-  check-coverage:
-    needs: test
-    runs-on: ubuntu-latest
-    name: Check Coverage
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
+            - name: upload cover profile artifact
+              uses: actions/upload-artifact@v4
+              with:
+                name: coverage.out
+                path: coverage.out
+                if-no-files-found: error
 
-      - name: Download cover profile artifact
-        id: download-coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage.out
+    check-coverage:
+        needs: test
+        runs-on: ubuntu-latest
+        name: Check Coverage
+        steps:
+            - name: checkout
+              uses: actions/checkout@v4
 
-      - name: Extract coverage percentage
-        id: current-coverage
-        run: |
-          if [ -f coverage.out ]; then
-            COVERAGE=$(go tool cover -func=coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
-            echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
-          else
-            echo "coverage=0" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: download artifact (master.breakdown)
-        id: download-master-breakdown
-        uses: dawidd6/action-download-artifact@v9
-        with:
-          branch: master
-          workflow_conclusion: success
-          name: master.breakdown
-          if_no_artifact_found: warn
+            - name: Download cover profile artifact
+              id: download-coverage
+              uses: actions/download-artifact@v4
+              with:
+                name: coverage.out
 
-      - name: download artifact (master-coverage.out)
-        id: download-master-coverage
-        uses: dawidd6/action-download-artifact@v9
-        with:
-          branch: master
-          workflow_conclusion: success
-          name: master-coverage.out
-          if_no_artifact_found: warn
+            - name: Extract coverage percentage
+              id: current-coverage
+              run: |
+                if [ -f coverage.out ]; then
+                  COVERAGE=$(go tool cover -func=coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
+                  echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
+                else
+                  echo "coverage=0" >> $GITHUB_OUTPUT
+                fi
+            
+            - name: download artifact (master.breakdown)
+              id: download-master-breakdown
+              uses: dawidd6/action-download-artifact@v9
+              with:
+                branch: master
+                workflow_conclusion: success
+                name: master.breakdown
+                if_no_artifact_found: warn
 
-      - name: Extract master coverage percentage
-        id: master-coverage
-        run: |
-          if [ -f master-coverage.out ]; then
-            MASTER_COVERAGE=$(go tool cover -func=master-coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
-            echo "coverage=$MASTER_COVERAGE" >> $GITHUB_OUTPUT
-          else
-            echo "coverage=0" >> $GITHUB_OUTPUT
-          fi
+            - name: download artifact (master-coverage.out)
+              id: download-master-coverage
+              uses: dawidd6/action-download-artifact@v9
+              with:
+                branch: master
+                workflow_conclusion: success
+                name: master-coverage.out
+                if_no_artifact_found: warn
 
-      - name: check test coverage
-        id: coverage
-        uses: vladopajic/go-test-coverage@v2
-        continue-on-error: true
-        with:
-          config: ./.github/.testcoverage.yml
-          breakdown-file-name: ${{ github.ref_name == 'master' && 'master.breakdown' || '' }}
-          diff-base-breakdown-file-name: ${{ steps.download-master-breakdown.outputs.found_artifact == 'true' && 'master.breakdown' || '' }}
-      
-      - name: upload artifact (master.breakdown)
-        uses: actions/upload-artifact@v4
-        if: github.ref_name == 'master'
-        with:
-          name: master.breakdown
-          path: master.breakdown
-          if-no-files-found: error
-          
-      - name: Previous coverage
-        run: |
-          echo "Previous Coverage ${{ steps.master-coverage.outputs.coverage }}"
+            - name: Extract master coverage percentage
+              id: master-coverage
+              run: |
+                if [ -f master-coverage.out ]; then
+                  MASTER_COVERAGE=$(go tool cover -func=master-coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
+                  echo "coverage=$MASTER_COVERAGE" >> $GITHUB_OUTPUT
+                else
+                  echo "coverage=0" >> $GITHUB_OUTPUT
+                fi
 
-      - name: Current coverage
-        run: |
-          echo "Current Coverage ${{ steps.current-coverage.outputs.coverage }}"
+            - name: Generate full coverage breakdown
+              id: full_coverage_report
+              run: |
+                if [ -f coverage.out ]; then
+                  REPORT_CONTENT=$(go tool cover -func=coverage.out) # This command outputs function-level coverage [5]
+                  echo "report<<EOF" >> $GITHUB_OUTPUT # Start HERE-doc for multi-line output [3]
+                  echo "$REPORT_CONTENT" >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT # End HERE-doc
+                else
+                  echo "report=No coverage report found." >> $GITHUB_OUTPUT
+                fi
 
-      - name: post coverage report
-        if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-tag: coverage-report
-          pr-number: ${{ github.event.pull_request.number }}
-          message: |
-            ## 📊 Go Test Coverage Report
+            - name: check test coverage
+              id: coverage
+              uses: vladopajic/go-test-coverage@v2
+              continue-on-error: true
+              with:
+                config: ./.github/.testcoverage.yml
+                breakdown-file-name: ${{ github.ref_name == 'master' && 'master.breakdown' || '' }}
+                diff-base-breakdown-file-name: ${{ steps.download-master-breakdown.outputs.found_artifact == 'true' && 'master.breakdown' || '' }}
+            
+            - name: upload artifact (master.breakdown)
+              uses: actions/upload-artifact@v4
+              if: github.ref_name == 'master'
+              with:
+                name: master.breakdown
+                path: master.breakdown
+                if-no-files-found: error
+                
+            - name: Previous coverage
+              run: |
+                echo "Previous Coverage ${{ steps.master-coverage.outputs.coverage }}"
 
-            ${{ 
-              steps.current-coverage.outputs.coverage > steps.master-coverage.outputs.coverage 
-              && '✅ **Overall code coverage increased.**' 
-              || steps.current-coverage.outputs.coverage < steps.master-coverage.outputs.coverage 
-              && '❌ **Overall code coverage decreased.**' 
-              || 'ℹ️ **Overall code coverage unchanged.**' 
-            }}
+            - name: Current coverage
+              run: |
+                echo "Current Coverage ${{ steps.current-coverage.outputs.coverage }}"
 
-            **🔍 Coverage Summary**
-            - **Pull Request Coverage:** `${{ steps.current-coverage.outputs.coverage }}%`
-            - **Main Branch Coverage:** `${{ steps.master-coverage.outputs.coverage }}%`
+            - name: post coverage report
+              if: github.event_name == 'pull_request'
+              uses: thollander/actions-comment-pull-request@v3
+              with:
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                comment-tag: coverage-report
+                pr-number: ${{ github.event.pull_request.number }}
+                message: |
+                  ## 📊 Go Test Coverage Report
 
-            <details>
-            <summary>📄 Click to expand full coverage breakdown</summary>
+                  ${{ 
+                    steps.current-coverage.outputs.coverage > steps.master-coverage.outputs.coverage 
+                    && '✅ **Overall code coverage increased.**' 
+                    || steps.current-coverage.outputs.coverage < steps.master-coverage.outputs.coverage 
+                    && '❌ **Overall code coverage decreased.**' 
+                    || 'ℹ️ **Overall code coverage unchanged.**' 
+                  }}
 
-            ```
-            ${{ fromJSON(steps.coverage.outputs.report) }}
-            ```
+                  **🔍 Coverage Summary**
+                  - **Pull Request Coverage:** `${{ steps.current-coverage.outputs.coverage }}%`
+                  - **Main Branch Coverage:** `${{ steps.master-coverage.outputs.coverage }}%`
 
-            </details>
-      - name: Rename and upload master coverage  # to avoid collision with the current run
-        if: github.ref_name == 'master'
-        run: mv coverage.out master-coverage.out
+                  <details>
+                  <summary>📄 Click to expand full coverage breakdown</summary>
 
-      - name: Upload master coverage artifact
-        # This is used to compare the coverage of the current branch with the master branch
-        if: github.ref_name == 'master'
-        uses: actions/upload-artifact@v4
-        with:
-          name: master-coverage.out
-          path: master-coverage.out
-          if-no-files-found: error
+                  ```
+                  ${{ steps.full_coverage_report.outputs.report }}
+                  ```
 
-      - name: Update coverage badge
-        if: github.ref == 'refs/heads/master'
-        uses: schneegans/dynamic-badges-action@v1.7.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: 5174bd748ac63a6e4803afea902e9810
-          filename: coverage.json
-          label: coverage
-          message: ${{ steps.test.outputs.coverage }}
-          color: green
+                  </details>
+            - name: Rename and upload master coverage
+              if: github.ref_name == 'master'
+              run: mv coverage.out master-coverage.out
+
+            - name: Upload master coverage artifact
+              if: github.ref_name == 'master'
+              uses: actions/upload-artifact@v4
+              with:
+                name: master-coverage.out
+                path: master-coverage.out
+                if-no-files-found: error

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Go Test
 
 on:
   push:
@@ -10,10 +10,12 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -40,9 +42,132 @@ jobs:
           ./coverage.sh
           echo ::set-output name=coverage::$(./coverage.sh | tr -s '\t' | cut -d$'\t' -f 3)
 
-      - name: Print coverage
+      - name: upload cover profile artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage.out
+          path: coverage.out
+          if-no-files-found: error
+
+  check-coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Check Coverage
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Download cover profile artifact
+        id: download-coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage.out
+
+      - name: Extract coverage percentage
+        id: current-coverage
         run: |
-          echo "Coverage output is ${{ steps.test.outputs.coverage }}"
+          if [ -f coverage.out ]; then
+            COVERAGE=$(go tool cover -func=coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
+            echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
+          else
+            echo "coverage=0" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: download artifact (master.breakdown)
+        id: download-master-breakdown
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          branch: master
+          workflow_conclusion: success
+          name: master.breakdown
+          if_no_artifact_found: warn
+
+      - name: download artifact (master-coverage.out)
+        id: download-master-coverage
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          branch: master
+          workflow_conclusion: success
+          name: master-coverage.out
+          if_no_artifact_found: warn
+
+      - name: Extract master coverage percentage
+        id: master-coverage
+        run: |
+          if [ -f master-coverage.out ]; then
+            MASTER_COVERAGE=$(go tool cover -func=master-coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
+            echo "coverage=$MASTER_COVERAGE" >> $GITHUB_OUTPUT
+          else
+            echo "coverage=0" >> $GITHUB_OUTPUT
+          fi
+
+      - name: check test coverage
+        id: coverage
+        uses: vladopajic/go-test-coverage@v2
+        continue-on-error: true
+        with:
+          config: ./.github/.testcoverage.yml
+          breakdown-file-name: ${{ github.ref_name == 'master' && 'master.breakdown' || '' }}
+          diff-base-breakdown-file-name: ${{ steps.download-master-breakdown.outputs.found_artifact == 'true' && 'master.breakdown' || '' }}
+      
+      - name: upload artifact (master.breakdown)
+        uses: actions/upload-artifact@v4
+        if: github.ref_name == 'master'
+        with:
+          name: master.breakdown
+          path: master.breakdown
+          if-no-files-found: error
+          
+      - name: Previous coverage
+        run: |
+          echo "Previous Coverage ${{ steps.master-coverage.outputs.coverage }}"
+
+      - name: Current coverage
+        run: |
+          echo "Current Coverage ${{ steps.current-coverage.outputs.coverage }}"
+
+      - name: post coverage report
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-tag: coverage-report
+          pr-number: ${{ github.event.pull_request.number }}
+          message: |
+            ## 📊 Go Test Coverage Report
+
+            ${{ 
+              steps.current-coverage.outputs.coverage > steps.master-coverage.outputs.coverage 
+              && '✅ **Overall code coverage increased.**' 
+              || steps.current-coverage.outputs.coverage < steps.master-coverage.outputs.coverage 
+              && '❌ **Overall code coverage decreased.**' 
+              || 'ℹ️ **Overall code coverage unchanged.**' 
+            }}
+
+            **🔍 Coverage Summary**
+            - **Pull Request Coverage:** `${{ steps.current-coverage.outputs.coverage }}%`
+            - **Main Branch Coverage:** `${{ steps.master-coverage.outputs.coverage }}%`
+
+            <details>
+            <summary>📄 Click to expand full coverage breakdown</summary>
+
+            ```
+            ${{ fromJSON(steps.coverage.outputs.report) }}
+            ```
+
+            </details>
+      - name: Rename and upload master coverage  # to avoid collision with the current run
+        if: github.ref_name == 'master'
+        run: mv coverage.out master-coverage.out
+
+      - name: Upload master coverage artifact
+        # This is used to compare the coverage of the current branch with the master branch
+        if: github.ref_name == 'master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-coverage.out
+          path: master-coverage.out
+          if-no-files-found: error
 
       - name: Update coverage badge
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add coverage check and compare the coverage between master and PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4502 

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.