### PR TITLE
Resolve inference endpoint using runtime protocol when applicable

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -160,7 +160,7 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				err := r.Client.Get(ctx, types.NamespacedName{Namespace: graph.Namespace, Name: route.ServiceName}, &isvc)
 				if err == nil {
 					if graph.Spec.Nodes[node].Steps[i].ServiceURL == "" {
-						serviceUrl, err := isvcutils.GetPredictorEndpoint(&isvc)
+						serviceUrl, err := isvcutils.GetPredictorEndpoint(ctx, r.Client, &isvc)
 						if err == nil {
 							graph.Spec.Nodes[node].Steps[i].ServiceURL = serviceUrl
 						} else {

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -136,7 +136,7 @@ func GetModelName(isvc *v1beta1.InferenceService) string {
 }
 
 // GetPredictorEndpoint returns the predictor endpoint if status.address.url is not nil else returns empty string with error.
-func GetPredictorEndpoint(isvc *v1beta1.InferenceService) (string, error) {
+func GetPredictorEndpoint(ctx context.Context, client client.Client, isvc *v1beta1.InferenceService) (string, error) {
 	if isvc.Status.Address != nil && isvc.Status.Address.URL != nil {
 		hostName := isvc.Status.Address.URL.String()
 		path := ""
@@ -149,7 +149,47 @@ func GetPredictorEndpoint(isvc *v1beta1.InferenceService) (string, error) {
 				path = constants.PredictPath(modelName, constants.ProtocolV2)
 			}
 		} else if !IsMMSPredictor(&isvc.Spec.Predictor) {
-			protocol := isvc.Spec.Predictor.GetImplementation().GetProtocol()
+			predictorImplementation := isvc.Spec.Predictor.GetImplementation()
+			protocol := predictorImplementation.GetProtocol()
+
+			if modelSpec, ok := predictorImplementation.(*v1beta1.ModelSpec); ok {
+				if modelSpec.Runtime != nil {
+					// When a Runtime is specified, and there is no protocol specified
+					// in the ISVC, the protocol cannot imply to be V1. The protocol
+					// needs to be extracted from the Runtime.
+
+					runtime, err := GetServingRuntime(ctx, client, *modelSpec.Runtime, isvc.Namespace)
+					if err != nil {
+						return "", err
+					}
+
+					// If the runtime has protocol versions, use the first one supported by IG.
+					// Otherwise, assume Protocol V1.
+					if len(runtime.ProtocolVersions) != 0 {
+						found := false
+						for _, pversion := range runtime.ProtocolVersions {
+							if pversion == constants.ProtocolV1 || pversion == constants.ProtocolV2 {
+								protocol = pversion
+								found = true
+								break
+							}
+						}
+
+						if !found {
+							return "", errors.New("the runtime does not support a protocol compatible with Inference Graphs")
+						}
+					}
+				}
+
+				// else {
+				//   Notice that when using auto-selection (i.e. Runtime is nil), the
+				//   ISVC is assumed to be protocol v1. Thus, for auto-select, a runtime
+				//   will only match if it lists protocol v1 as supported. In this case,
+				//   the code above (protocol := predictorImplementation.GetProtocol()) would
+				//   already get the right protocol to configure in the InferenceGraph.
+				// }
+			}
+
 			if protocol == constants.ProtocolV1 {
 				path = constants.PredictPath(modelName, constants.ProtocolV1)
 			} else if protocol == constants.ProtocolV2 {

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega/types"
+	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	knativeV1 "knative.dev/pkg/apis/duck/v1"
 
@@ -1561,6 +1562,34 @@ func TestGetPredictorEndpoint(t *testing.T) {
 			"cpu": resource.MustParse("90m"),
 		},
 	}
+	namespace := "default"
+
+	s := runtime.NewScheme()
+	err := v1alpha1.AddToScheme(s)
+	if err != nil {
+		t.Errorf("Failed to add v1alpha1 to scheme %s", err)
+	}
+	protocolV1Runtime := &v1alpha1.ServingRuntime{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mocked-v1-runtime",
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.ServingRuntimeSpec{
+			ProtocolVersions: []constants.InferenceServiceProtocol{"v1"},
+		},
+	}
+	protocolV2Runtime := &v1alpha1.ServingRuntime{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mocked-v2-runtime",
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.ServingRuntimeSpec{
+			ProtocolVersions: []constants.InferenceServiceProtocol{"v2"},
+		},
+	}
+	mockClient := fake.NewClientBuilder().WithScheme(s).WithObjects(protocolV1Runtime, protocolV2Runtime).Build()
 
 	scenarios := map[string]struct {
 		isvc        InferenceService
@@ -1829,11 +1858,73 @@ func TestGetPredictorEndpoint(t *testing.T) {
 			expectedUrl: "",
 			expectedErr: gomega.MatchError("service sklearn is not ready"),
 		},
+		"NoProtocolWithRuntimeProtocolV1": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sklearn",
+					Namespace: namespace,
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							Runtime: ptr.To("mocked-v1-runtime"),
+							ModelFormat: ModelFormat{
+								Name: "sklearn",
+							},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String("s3://test"),
+							},
+						},
+					},
+				},
+				Status: InferenceServiceStatus{
+					Address: &knativeV1.Addressable{
+						URL: &apis.URL{
+							Scheme: "http",
+							Host:   "sklearn-predictor.default.svc.cluster.local",
+						},
+					},
+				},
+			},
+			expectedUrl: "http://sklearn-predictor.default.svc.cluster.local/v1/models/sklearn:predict",
+			expectedErr: gomega.BeNil(),
+		},
+		"NoProtocolWithRuntimeProtocolV2": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sklearn",
+					Namespace: namespace,
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							Runtime: ptr.To("mocked-v2-runtime"),
+							ModelFormat: ModelFormat{
+								Name: "sklearn",
+							},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String("s3://test"),
+							},
+						},
+					},
+				},
+				Status: InferenceServiceStatus{
+					Address: &knativeV1.Addressable{
+						URL: &apis.URL{
+							Scheme: "http",
+							Host:   "sklearn-predictor.default.svc.cluster.local",
+						},
+					},
+				},
+			},
+			expectedUrl: "http://sklearn-predictor.default.svc.cluster.local/v2/models/sklearn/infer",
+			expectedErr: gomega.BeNil(),
+		},
 	}
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			res, err := GetPredictorEndpoint(&scenario.isvc)
+			res, err := GetPredictorEndpoint(t.Context(), mockClient, &scenario.isvc)
 			g.Expect(err).To(scenario.expectedErr)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedUrl)) {
 				t.Errorf("got %s, want %s", res, scenario.expectedUrl)


### PR DESCRIPTION
**What this PR does / why we need it**:

Typically, protocol v1 is assumed. However, there is a corner case: if the runtime name is specified in the InferenceService, then kserve-controller won't validate that the protocol in the InferenceService and the ServingRuntime matches (likely, assuming the user knows what is doing). More importantly, if the protocol is not specified in the InferenceService, the GetPredictorEndpoint function returns the V1 endpoint even if the ServingRuntime only supports V2 (and correctly specifies it). This has an impact on the InferenceGraph feature because the kserve-router will be misconfigured.

These changes cover this corner case to properly resolve the protocol.

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

1. Deploy an InferenceService using a runtime that only supports protocol v2 (e.g. Triton). Avoid auto-selection by specifying the `runtime` name in the model spec. Omit specifying the `protocolVersion` in the ISVC.
2. Deploy an InferenceGraph using the InferenceService.
3. Notice the graph workload is correctly configured with the v2 endpoint, instead of v1 endpoint.

Also, do sanity checks for other cases.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- N/A Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.