### PR TITLE
fix(codegen): pins code-generator binaries version

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -21,6 +21,7 @@ set -o pipefail
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SCRIPT_ROOT="${SCRIPT_DIR}/.."
 CODEGEN_VERSION=$(cd "${SCRIPT_ROOT}" && grep 'k8s.io/code-generator' go.mod | awk '{print $2}')
+KUBE_CODEGEN_TAG=${CODEGEN_VERSION}
 
 # For debugging purposes
 echo "Codegen version ${CODEGEN_VERSION}"


### PR DESCRIPTION
Without pinning the version of code-generator cmds, the underlying script falls back to downloading the latest vesion. This can result in regenerating client stubs with content diverging from the one under version control even if the current work does not touch this part of the project. That results in noise and can pollute PR with unrelated (or even breaking) changes.

To have consistent behavior the `KUBE_CODEGEN_TAG` is set to ensure that codegen binaries are matching defined version dependency in the project.

Fixes #4532

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

It's more a future-proof fix  (see linked issue for more background), but here's what one can try:
- clean your go mod cache (`go clean -cache -modcache`)
- upgrade codegen to e.g. `v0.33.1`
- run make generate or `./hack/update-codegen.sh`
- see WatchList funcs removed from autogenerated client code, even though this behavior is coming in v0.34.x release

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
