### PR TITLE
disallow `name` field in standard predictor

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -125,6 +125,10 @@ func validateInferenceService(isvc *InferenceService) (admission.Warnings, error
 		return allWarnings, err
 	}
 
+	if err := validatePredictor(isvc); err != nil {
+		return allWarnings, err
+	}
+
 	for _, component := range []Component{
 		&isvc.Spec.Predictor,
 		isvc.Spec.Transformer,
@@ -144,6 +148,40 @@ func validateInferenceService(isvc *InferenceService) (admission.Warnings, error
 		}
 	}
 	return allWarnings, nil
+}
+
+func validatePredictor(isvc *InferenceService) error {
+	predictor := isvc.Spec.Predictor
+
+	// log predictor
+	validatorLogger.Info("Incoming predictor struct", "predictor", predictor)
+
+	// in most of the case, standard predictors will all be packed into `predictor.model`, and decide the backend process through `modelFormat.name``
+	switch {
+	case predictor.SKLearn != nil && predictor.SKLearn.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.XGBoost != nil && predictor.XGBoost.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.Tensorflow != nil && predictor.Tensorflow.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.PyTorch != nil && predictor.PyTorch.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.Triton != nil && predictor.Triton.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.ONNX != nil && predictor.ONNX.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.HuggingFace != nil && predictor.HuggingFace.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.PMML != nil && predictor.PMML.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.LightGBM != nil && predictor.LightGBM.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.Paddle != nil && predictor.Paddle.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	case predictor.Model != nil && predictor.Model.Name != "":
+		return errors.New("the 'name' field is not allowed in standard predictor")
+	}
+	return nil
 }
 
 // validateMultiNodeVariables validates when there is workerSpec set in isvc

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/kserve/kserve/pkg/constants"
@@ -31,6 +32,31 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
+
+func TestInvalidNameInSKLearnPredictor(t *testing.T) {
+	isvc := InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-isvc",
+		},
+		Spec: InferenceServiceSpec{
+			Predictor: PredictorSpec{
+				SKLearn: &SKLearnSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						Container: corev1.Container{
+							Name:  "invalid-name",
+							Image: "dummy-image",
+						},
+						StorageURI: proto.String("gs://kfserving-examples/models/sklearn/1.0/model"),
+					},
+				},
+			},
+		},
+	}
+	err := validatePredictor(&isvc)
+	if err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Errorf("Expected error for name field in SKLearn predictor, got: %v", err)
+	}
+}
 
 func makeTestInferenceService() InferenceService {
 	inferenceservice := InferenceService{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds validation to catch misconfiguration in the `name` field of standard predictor in creation time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4472

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:
+ Add unit test: TestInvalidNameInSklearnPredictor
+ Verify webhook behavior by applying InferenceService with a non-empty `name` field in a simulated env
+ Ran make test, the newly added test passed (one test, v1alpha1/inferencegraph/suite_test.go, didn't pass, but it is not related to my modification)

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Unit test: Added `TestInvalidNameInSklearnPredictor` in `inference_service_validation_test.go` to test the newly added `validatePredictor` function in `inference_service_validation.go`. This test verifies that an error is returned when the `name` field is set in a standard predictor (e.g. Sklearn), which is not allowed.
- [x] Behavior test: Create a temporary docker image and loaded to `kind` to simulate the undated environment. Applied standard predictors with `name` field to verify that the webhook correctly trigger `validatePredictor` during InferenceService creation and block invalid configurations at creation time.

- Logs

**Special notes for your reviewer**:
- I ran both `make test` and `make precommit` at the root level:
  - `make test` failed due to **one unrelated unit test**, which is **not affected by my changes**.
  - `make precommit` failed with the following error:
    > the go language version (go1.23) used to build golangci-lint is lower than the target Go version (1.24)

    Even after upgrading to Go 1.24 and rebuilding `golangci-lint`, the issue persisted.

- My changes are **limited to**:
  - `inference_service_validation.go`
  - `inference_service_validation_test.go`

- To ensure correctness:
  - I ran `make test -v` inside the `pkg/controller/inferenceservice/resources/knative/serving/v1beta1` (or appropriate) directory, and **my unit tests passed**.
  - I also ran the **behavioral test** to confirm the new validation logic works as intended.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Validation added to prevent setting the `name` field in standard predictor.
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.