### PR TITLE
fix(helm): make gatewayClassName configurable

### DIFF
--- a/charts/kserve-resources/files/kserve/ingress_gateway-patch.yaml
+++ b/charts/kserve-resources/files/kserve/ingress_gateway-patch.yaml
@@ -4,7 +4,7 @@ kind: Gateway
 metadata:
   name: kserve-ingress-gateway
 spec:
-  gatewayClassName: envoy
+  gatewayClassName: {{ .Values.kserve.controller.gateway.ingressGateway.className | default "envoy" }}
   listeners:
    - name: http
      port: 80


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously hardcoded "envoy" value prevented from using other Gateway API implementations unless changed by hand after installation

- Template now uses `className` defined `values.yaml`
- Backwards compatibility with "envoy" default

Fixes #4720

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

Not sure we need release notes for this? It's been exposed through the helm values but never applied.

```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.