### PR TITLE
fix: unset clampMax and clampMin, since they are not for replicas

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
@@ -144,8 +144,6 @@ func getKedaMetrics(componentExt *v1beta1.ComponentExtensionSpec,
 				if triggerType == string(constants.AutoScalerMetricsSourceOpenTelemetry) {
 					trigger.Type = "external"
 					trigger.Metadata = map[string]string{
-						"clampMin":      strconv.Itoa(int(minReplicas)),
-						"clampMax":      strconv.Itoa(int(maxReplicas)),
 						"metricQuery":   query,
 						"targetValue":   fmt.Sprintf("%f", targetValue),
 						"scalerAddress": MetricScalerEndpoint,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
@@ -67,8 +67,7 @@ func NewKedaReconciler(client client.Client,
 	}, nil
 }
 
-func getKedaMetrics(componentExt *v1beta1.ComponentExtensionSpec,
-	minReplicas int32, maxReplicas int32, configMap *corev1.ConfigMap,
+func getKedaMetrics(componentExt *v1beta1.ComponentExtensionSpec, configMap *corev1.ConfigMap,
 ) ([]kedav1alpha1.ScaleTriggers, error) {
 	var triggers []kedav1alpha1.ScaleTriggers
 
@@ -176,7 +175,7 @@ func createKedaScaledObject(componentMeta metav1.ObjectMeta,
 	if MaxReplicas < *MinReplicas {
 		MaxReplicas = *MinReplicas
 	}
-	triggers, err := getKedaMetrics(componentExtension, *MinReplicas, MaxReplicas, configMap)
+	triggers, err := getKedaMetrics(componentExtension, configMap)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go
@@ -89,8 +89,6 @@ func TestGetKedaMetrics_PodMetricSourceType(t *testing.T) {
 	assert.Equal(t, "http://otel-server", triggers[0].Metadata["scalerAddress"])
 	assert.Equal(t, "otel_query", triggers[0].Metadata["metricQuery"])
 	assert.Equal(t, "200.000000", triggers[0].Metadata["targetValue"])
-	assert.Equal(t, "1", triggers[0].Metadata["clampMin"])
-	assert.Equal(t, "3", triggers[0].Metadata["clampMax"])
 }
 
 func TestCreateKedaScaledObject(t *testing.T) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go
@@ -58,7 +58,7 @@ func TestGetKedaMetrics_ResourceMetricSourceType(t *testing.T) {
 	componentExt := createComponentExtensionWithResourceMetric()
 	configMap := &corev1.ConfigMap{}
 
-	triggers, err := getKedaMetrics(componentExt, 1, 3, configMap)
+	triggers, err := getKedaMetrics(componentExt, configMap)
 	require.NoError(t, err)
 	assert.Len(t, triggers, 1)
 	assert.Equal(t, "cpu", triggers[0].Type)
@@ -69,7 +69,7 @@ func TestGetKedaMetrics_ExternalMetricSourceType(t *testing.T) {
 	componentExt := createComponentExtensionWithExternalMetric()
 	configMap := &corev1.ConfigMap{}
 
-	triggers, err := getKedaMetrics(componentExt, 1, 3, configMap)
+	triggers, err := getKedaMetrics(componentExt, configMap)
 	require.NoError(t, err)
 	assert.Len(t, triggers, 1)
 	assert.Equal(t, "prometheus", triggers[0].Type)
@@ -82,7 +82,7 @@ func TestGetKedaMetrics_PodMetricSourceType(t *testing.T) {
 	componentExt := createComponentExtensionWithPodMetric()
 	configMap := &corev1.ConfigMap{}
 
-	triggers, err := getKedaMetrics(componentExt, 1, 3, configMap)
+	triggers, err := getKedaMetrics(componentExt, configMap)
 	require.NoError(t, err)
 	assert.Len(t, triggers, 1)
 	assert.Equal(t, "external", triggers[0].Type)
@@ -260,7 +260,7 @@ func TestGetKedaMetrics_AverageValueMetricSourceType(t *testing.T) {
 	}
 	configMap := &corev1.ConfigMap{}
 
-	triggers, err := getKedaMetrics(componentExt, 1, 3, configMap)
+	triggers, err := getKedaMetrics(componentExt, configMap)
 	require.NoError(t, err)
 	assert.Len(t, triggers, 1)
 	assert.Equal(t, "cpu", triggers[0].Type)
@@ -286,7 +286,7 @@ func TestGetKedaMetrics_ValueMetricSourceType(t *testing.T) {
 	}
 	configMap := &corev1.ConfigMap{}
 
-	triggers, err := getKedaMetrics(componentExt, 1, 3, configMap)
+	triggers, err := getKedaMetrics(componentExt, configMap)
 	require.NoError(t, err)
 	assert.Len(t, triggers, 1)
 	assert.Equal(t, "memory", triggers[0].Type)
@@ -311,7 +311,7 @@ func TestGetKedaMetrics_DefaultCPUUtilization(t *testing.T) {
 	}
 	configMap := &corev1.ConfigMap{}
 
-	triggers, err := getKedaMetrics(componentExt, 1, 3, configMap)
+	triggers, err := getKedaMetrics(componentExt, configMap)
 	require.NoError(t, err)
 	assert.Len(t, triggers, 1)
 	assert.Equal(t, "cpu", triggers[0].Type)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The fields like clampMax and clampMin should not be set, because these two fields set the lower and upper bound of the scale itself.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4551 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.