### PR TITLE
feat(envtest): simplifies CRD lookup

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/suite_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/suite_test.go
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel := context.WithCancel(context.Background())
 	By("bootstrapping test environment")
 	crdDirectoryPaths := []string{
-		filepath.Join("..", "..", "..", "..", "test", "crds"),
+		filepath.Join(pkgtest.ProjectRoot(), "test", "crds"),
 	}
 	testEnv := pkgtest.SetupEnvTest(crdDirectoryPaths)
 	var err error

--- a/pkg/controller/v1alpha1/localmodel/suite_test.go
+++ b/pkg/controller/v1alpha1/localmodel/suite_test.go
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	By("bootstrapping test environment")
 	crdDirectoryPaths := []string{
-		filepath.Join("..", "..", "..", "..", "test", "crds"),
+		filepath.Join(pkgtest.ProjectRoot(), "test", "crds"),
 	}
 	testEnv := pkgtest.SetupEnvTest(crdDirectoryPaths)
 	var err error

--- a/pkg/controller/v1alpha1/localmodelnode/suite_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/suite_test.go
@@ -61,7 +61,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel := context.WithCancel(context.TODO())
 	By("bootstrapping test environment")
 	crdDirectoryPaths := []string{
-		filepath.Join("..", "..", "..", "..", "test", "crds"),
+		filepath.Join(pkgtest.ProjectRoot(), "test", "crds"),
 	}
 	testEnv := pkgtest.SetupEnvTest(crdDirectoryPaths)
 	var err error

--- a/pkg/controller/v1alpha1/trainedmodel/suite_test.go
+++ b/pkg/controller/v1alpha1/trainedmodel/suite_test.go
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel := context.WithCancel(context.TODO())
 	By("bootstrapping test environment")
 	crdDirectoryPaths := []string{
-		filepath.Join("..", "..", "..", "..", "test", "crds"),
+		filepath.Join(pkgtest.ProjectRoot(), "test", "crds"),
 	}
 	testEnv := pkgtest.SetupEnvTest(crdDirectoryPaths)
 	var err error

--- a/pkg/controller/v1beta1/inferenceservice/suite_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel := context.WithCancel(context.TODO())
 	By("bootstrapping test environment")
 	crdDirectoryPaths := []string{
-		filepath.Join("..", "..", "..", "..", "test", "crds"),
+		filepath.Join(pkgtest.ProjectRoot(), "test", "crds"),
 	}
 	testEnv := pkgtest.SetupEnvTest(crdDirectoryPaths)
 	var err error

--- a/pkg/credentials/credentials_suite_test.go
+++ b/pkg/credentials/credentials_suite_test.go
@@ -37,7 +37,7 @@ var (
 
 func TestMain(m *testing.M) {
 	crdDirectoryPaths := []string{
-		filepath.Join("..", "..", "test", "crds"),
+		filepath.Join(pkgtest.ProjectRoot(), "test", "crds"),
 	}
 	t := pkgtest.SetupEnvTest(crdDirectoryPaths)
 	var err error

--- a/pkg/testing/envtest_setup.go
+++ b/pkg/testing/envtest_setup.go
@@ -17,21 +17,16 @@ limitations under the License.
 package testing
 
 import (
-	"context"
-	"sync"
-
 	"google.golang.org/protobuf/proto"
 	istioclientv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	netv1 "k8s.io/api/networking/v1"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
-	"github.com/onsi/gomega"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -40,10 +35,8 @@ var log = logf.Log.WithName("TestingEnvSetup")
 func SetupEnvTest(crdDirectoryPaths []string) *envtest.Environment {
 	t := &envtest.Environment{
 		ErrorIfCRDPathMissing: true,
-		// The relative paths must be provided for each level of test nesting
-		// This code should be illegal
-		CRDDirectoryPaths:  crdDirectoryPaths,
-		UseExistingCluster: proto.Bool(false),
+		CRDDirectoryPaths:     crdDirectoryPaths,
+		UseExistingCluster:    proto.Bool(false),
 	}
 
 	if err := netv1.SchemeBuilder.AddToScheme(scheme.Scheme); err != nil {
@@ -68,15 +61,4 @@ func SetupEnvTest(crdDirectoryPaths []string) *envtest.Environment {
 		log.Error(err, "Failed to add OpenTelemetry scheme")
 	}
 	return t
-}
-
-// StartTestManager adds recFn
-func StartTestManager(ctx context.Context, mgr manager.Manager, g *gomega.GomegaWithT) *sync.WaitGroup {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		g.Expect(mgr.Start(ctx)).NotTo(gomega.HaveOccurred())
-	}()
-	return wg
 }

--- a/pkg/testing/utils.go
+++ b/pkg/testing/utils.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ProjectRoot returns the root directory of the project by searching for the go.mod file up from where it is called.
+func ProjectRoot() string {
+	rootDir := ""
+
+	currentDir, errCurrDir := os.Getwd()
+	if errCurrDir != nil {
+		panic(fmt.Sprintf("failed to get current working directory: %v", errCurrDir))
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(currentDir, "go.mod")); err == nil {
+			rootDir = filepath.FromSlash(currentDir)
+			break
+		}
+
+		parentDir := filepath.Dir(currentDir)
+		if parentDir == currentDir {
+			break
+		}
+
+		currentDir = parentDir
+	}
+
+	if rootDir == "" {
+		panic("failed to get project root directory. no go.mod file found")
+	}
+
+	return rootDir
+}

--- a/pkg/webhook/admission/pod/suite_test.go
+++ b/pkg/webhook/admission/pod/suite_test.go
@@ -39,7 +39,7 @@ var (
 
 func TestMain(m *testing.M) {
 	crdDirectoryPaths := []string{
-		filepath.Join("..", "..", "..", "..", "test", "crds"),
+		filepath.Join(pkgtest.ProjectRoot(), "test", "crds"),
 	}
 	t := pkgtest.SetupEnvTest(crdDirectoryPaths)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Relying on relative paths for resolving CRD to be loaded when starting EnvTest is error prone.

This PR introduces a simple `GetProjectRoot()` lookup function that traverses project tree up until it finds first `go.mod` file and assumes this is the root of the project. That is sufficient to make EnvTest tests resilient.

Also... makes the code legal ;)

**Type of changes**

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Changes are for EnvTest bootstrap logic so if those tests pass we should be good :)


**Release note**:
```release-note
NONE
```
