### PR TITLE
docs: fixes invalid openshift subscription

### DIFF
--- a/docs/openshift/cert-manager/operator.yaml
+++ b/docs/openshift/cert-manager/operator.yaml
@@ -11,7 +11,6 @@ metadata:
   namespace: cert-manager-operator
 spec:
   targetNamespaces: []
-  spec: {}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription


### PR DESCRIPTION
**What this PR does / why we need it**:

When following Openshift guide I stumbled upon invalid manifest.

```shell
❯ kubectl apply -f ./docs/openshift/cert-manager/operator.yaml
namespace/cert-manager-operator created
subscription.operators.coreos.com/openshift-cert-manager-operator created
Error from server (BadRequest): error when creating "./docs/openshift/cert-manager/operator.yaml": OperatorGroup in version "v1" cannot be handled as a OperatorGroup: strict decoding error: unknown field "spec.spec"
```

This PR removes invalid field.

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Subsequent apply with fixed Subscription:

```
❯ kubectl apply -f ./docs/openshift/cert-manager/operator.yaml
namespace/cert-manager-operator unchanged
operatorgroup.operators.coreos.com/openshift-cert-manager-operator created
subscription.operators.coreos.com/openshift-cert-manager-operator unchanged
```


**Release note**:
```release-note
NONE
```
