### PR TITLE
Fixed the issue of the same metrics across different deployments under different namespaces

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -10327,6 +10327,21 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									},
 								},
 							},
+							"resourcedetection/env": map[string]interface{}{
+								"detectors": []interface{}{string("env")},
+								"override":  bool(false),
+								"timeout":   string("2s"),
+							},
+							"transform": map[string]interface{}{
+								"metric_statements": []interface{}{map[string]interface{}{
+									"context": string("datapoint"),
+									"statements": []interface{}{
+										string("set(attributes[\"namespace\"], resource.attributes[\"k8s.namespace.name\"])"),
+										string("set(attributes[\"deployment\"], resource.attributes[\"k8s.deployment.name\"])"),
+										string("set(attributes[\"pod\"], resource.attributes[\"k8s.pod.name\"])"),
+									},
+								}},
+							},
 						}},
 						Exporters: otelv1beta1.AnyConfig{Object: map[string]interface{}{
 							"otlp": map[string]interface{}{
@@ -10341,7 +10356,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Pipelines: map[string]*otelv1beta1.Pipeline{
 								"metrics": {
 									Receivers:  []string{"prometheus"},
-									Processors: []string{"filter/metrics"},
+									Processors: []string{"resourcedetection/env", "transform", "filter/metrics"},
 									Exporters:  []string{"otlp"},
 								},
 							},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/otel/otel_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/otel/otel_reconciler.go
@@ -35,7 +35,54 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const ModeSidecar = "sidecar"
+const (
+	ProcessorResourcedetectionEnv = "resourcedetection/env"
+	ProcessorTransform            = "transform"
+	ProcessorFilterMetrics        = "filter/metrics"
+	JobNameOtelCollector          = "otel-collector"
+	PrometheusReceiver            = "prometheus"
+	OtlpExporter                  = "otlp"
+	ModeSidecar                   = "sidecar"
+
+	AnnotationPrometheusPort = "prometheus.kserve.io/port"
+	DefaultPrometheusPort    = "8080"
+
+	ResourcedetectionDetectorEnv = "env"
+	ResourcedetectionTimeout     = "2s"
+	ResourcedetectionOverride    = false
+	TransformContextDatapoint    = "datapoint"
+	StatementSetNamespace        = "set(attributes[\"namespace\"], resource.attributes[\"k8s.namespace.name\"])"
+	StatementSetDeployment       = "set(attributes[\"deployment\"], resource.attributes[\"k8s.deployment.name\"])"
+	StatementSetPod              = "set(attributes[\"pod\"], resource.attributes[\"k8s.pod.name\"])"
+
+	MatchTypeStrict = "strict"
+	PipelineMetrics = "metrics"
+	CompressionNone = "none"
+	TlsKey          = "tls"
+	TlsInsecureKey  = "insecure"
+	EndpointKey     = "endpoint"
+
+	KeyDetectors        = "detectors"
+	KeyTimeout          = "timeout"
+	KeyOverride         = "override"
+	KeyMetricStatements = "metric_statements"
+	KeyContext          = "context"
+	KeyStatements       = "statements"
+	KeyMetrics          = "metrics"
+	KeyInclude          = "include"
+	KeyMatchType        = "match_type"
+	KeyMetricNames      = "metric_names"
+	KeyConfig           = "config"
+	KeyScrapeConfigs    = "scrape_configs"
+	KeyJobName          = "job_name"
+	KeyScrapeInterval   = "scrape_interval"
+	KeyStaticConfigs    = "static_configs"
+	KeyTargets          = "targets"
+	KeyCompression      = "compression"
+	KeyTls              = "tls"
+	KeyInsecure         = "insecure"
+	KeyEndpoint         = "endpoint"
+)
 
 var log = logf.Log.WithName("OTelReconciler")
 
@@ -62,45 +109,45 @@ func createOtelCollector(componentMeta metav1.ObjectMeta,
 	metricNames []string,
 	otelConfig v1beta1.OtelCollectorConfig,
 ) *otelv1beta1.OpenTelemetryCollector {
-	port, ok := componentMeta.Annotations["prometheus.kserve.io/port"]
+	port, ok := componentMeta.Annotations[AnnotationPrometheusPort]
 	if !ok {
-		log.Info("Annotation prometheus.kserve.io/port is missing, using default value 8080 to configure OTel Collector")
-		port = "8080"
+		log.Info(fmt.Sprintf("Annotation %s is missing, using default value %s to configure OTel Collector", AnnotationPrometheusPort, DefaultPrometheusPort))
+		port = DefaultPrometheusPort
 	}
 
 	processors := map[string]interface{}{
-		"resourcedetection/env": map[string]interface{}{
-			"detectors": []interface{}{"env"},
-			"timeout":   "2s",
-			"override":  false,
+		ProcessorResourcedetectionEnv: map[string]interface{}{
+			KeyDetectors: []interface{}{ResourcedetectionDetectorEnv},
+			KeyTimeout:   ResourcedetectionTimeout,
+			KeyOverride:  ResourcedetectionOverride,
 		},
-		"transform": map[string]interface{}{
-			"metric_statements": []interface{}{
+		ProcessorTransform: map[string]interface{}{
+			KeyMetricStatements: []interface{}{
 				map[string]interface{}{
-					"context": "datapoint",
-					"statements": []interface{}{
-						"set(attributes[\"namespace\"], resource.attributes[\"k8s.namespace.name\"])",
-						"set(attributes[\"deployment\"], resource.attributes[\"k8s.deployment.name\"])",
-						"set(attributes[\"pod\"], resource.attributes[\"k8s.pod.name\"])",
+					KeyContext: TransformContextDatapoint,
+					KeyStatements: []interface{}{
+						StatementSetNamespace,
+						StatementSetDeployment,
+						StatementSetPod,
 					},
 				},
 			},
 		},
 	}
 
-	pipelineProcessors := []string{"resourcedetection/env", "transform"}
+	pipelineProcessors := []string{ProcessorResourcedetectionEnv, ProcessorTransform}
 
 	// Add filter processor to include all specified metrics
 	if len(metricNames) > 0 {
-		processors["filter/metrics"] = map[string]interface{}{
-			"metrics": map[string]interface{}{
-				"include": map[string]interface{}{
-					"match_type":   "strict",
-					"metric_names": metricNames,
+		processors[ProcessorFilterMetrics] = map[string]interface{}{
+			KeyMetrics: map[string]interface{}{
+				KeyInclude: map[string]interface{}{
+					KeyMatchType:   MatchTypeStrict,
+					KeyMetricNames: metricNames,
 				},
 			},
 		}
-		pipelineProcessors = append(pipelineProcessors, "filter/metrics")
+		pipelineProcessors = append(pipelineProcessors, ProcessorFilterMetrics)
 	}
 
 	otelCollector := &otelv1beta1.OpenTelemetryCollector{
@@ -110,18 +157,18 @@ func createOtelCollector(componentMeta metav1.ObjectMeta,
 			Annotations: componentMeta.Annotations,
 		},
 		Spec: otelv1beta1.OpenTelemetryCollectorSpec{
-			Mode: otelv1beta1.ModeSidecar,
+			Mode: ModeSidecar,
 			Config: otelv1beta1.Config{
 				Receivers: otelv1beta1.AnyConfig{Object: map[string]interface{}{
-					"prometheus": map[string]interface{}{
-						"config": map[string]interface{}{
-							"scrape_configs": []interface{}{
+					PrometheusReceiver: map[string]interface{}{
+						KeyConfig: map[string]interface{}{
+							KeyScrapeConfigs: []interface{}{
 								map[string]interface{}{
-									"job_name":        "otel-collector",
-									"scrape_interval": otelConfig.ScrapeInterval,
-									"static_configs": []interface{}{
+									KeyJobName:        JobNameOtelCollector,
+									KeyScrapeInterval: otelConfig.ScrapeInterval,
+									KeyStaticConfigs: []interface{}{
 										map[string]interface{}{
-											"targets": []interface{}{"localhost:" + port},
+											KeyTargets: []interface{}{"localhost:" + port},
 										},
 									},
 								},
@@ -130,21 +177,21 @@ func createOtelCollector(componentMeta metav1.ObjectMeta,
 					},
 				}},
 				Exporters: otelv1beta1.AnyConfig{Object: map[string]interface{}{
-					"otlp": map[string]interface{}{
-						"endpoint":    otelConfig.MetricReceiverEndpoint,
-						"compression": "none",
-						"tls": map[string]interface{}{
-							"insecure": true,
+					OtlpExporter: map[string]interface{}{
+						KeyEndpoint:    otelConfig.MetricReceiverEndpoint,
+						KeyCompression: CompressionNone,
+						KeyTls: map[string]interface{}{
+							KeyInsecure: true,
 						},
 					},
 				}},
 				Processors: &otelv1beta1.AnyConfig{Object: processors},
 				Service: otelv1beta1.Service{
 					Pipelines: map[string]*otelv1beta1.Pipeline{
-						"metrics": {
-							Receivers:  []string{"prometheus"},
+						PipelineMetrics: {
+							Receivers:  []string{PrometheusReceiver},
 							Processors: pipelineProcessors,
-							Exporters:  []string{"otlp"},
+							Exporters:  []string{OtlpExporter},
 						},
 					},
 				},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/otel/otel_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/otel/otel_reconciler_test.go
@@ -47,7 +47,7 @@ func TestCreateOtelCollector(t *testing.T) {
 				Name:      "test-service",
 				Namespace: "default",
 				Annotations: map[string]string{
-					"prometheus.kserve.io/port": "9090",
+					AnnotationPrometheusPort: "9090",
 				},
 			},
 			metricNames: []string{"request-count"},
@@ -56,11 +56,11 @@ func TestCreateOtelCollector(t *testing.T) {
 				MetricReceiverEndpoint: "otel-collector:4317",
 			},
 			expectedConfig: map[string]interface{}{
-				"job_name":        "otel-collector",
-				"scrape_interval": "15s",
-				"static_configs": []interface{}{
+				KeyJobName:        JobNameOtelCollector,
+				KeyScrapeInterval: "15s",
+				KeyStaticConfigs: []interface{}{
 					map[string]interface{}{
-						"targets": []interface{}{"localhost:9090"},
+						KeyTargets: []interface{}{"localhost:9090"},
 					},
 				},
 			},
@@ -76,11 +76,11 @@ func TestCreateOtelCollector(t *testing.T) {
 				ScrapeInterval: "30s",
 			},
 			expectedConfig: map[string]interface{}{
-				"job_name":        "otel-collector",
-				"scrape_interval": "30s",
-				"static_configs": []interface{}{
+				KeyJobName:        JobNameOtelCollector,
+				KeyScrapeInterval: "30s",
+				KeyStaticConfigs: []interface{}{
 					map[string]interface{}{
-						"targets": []interface{}{"localhost:8080"},
+						KeyTargets: []interface{}{"localhost:8080"},
 					},
 				},
 			},
@@ -97,47 +97,47 @@ func TestCreateOtelCollector(t *testing.T) {
 
 			// Assert config details
 			receivers := collector.Spec.Config.Receivers.Object
-			prometheusConfig := receivers["prometheus"].(map[string]interface{})
-			config := prometheusConfig["config"].(map[string]interface{})
-			scrapeConfigs := config["scrape_configs"].([]interface{})
+			prometheusConfig := receivers[PrometheusReceiver].(map[string]interface{})
+			config := prometheusConfig[KeyConfig].(map[string]interface{})
+			scrapeConfigs := config[KeyScrapeConfigs].([]interface{})
 			scrapeConfig := scrapeConfigs[0].(map[string]interface{})
 
-			assert.Equal(t, tc.expectedConfig["job_name"], scrapeConfig["job_name"])
-			assert.Equal(t, tc.expectedConfig["scrape_interval"], scrapeConfig["scrape_interval"])
+			assert.Equal(t, tc.expectedConfig[KeyJobName], scrapeConfig[KeyJobName])
+			assert.Equal(t, tc.expectedConfig[KeyScrapeInterval], scrapeConfig[KeyScrapeInterval])
 
-			staticConfigs := scrapeConfig["static_configs"].([]interface{})
+			staticConfigs := scrapeConfig[KeyStaticConfigs].([]interface{})
 			staticConfig := staticConfigs[0].(map[string]interface{})
-			targets := staticConfig["targets"].([]interface{})
+			targets := staticConfig[KeyTargets].([]interface{})
 
-			assert.Equal(t, tc.expectedConfig["static_configs"].([]interface{})[0].(map[string]interface{})["targets"], targets)
+			assert.Equal(t, tc.expectedConfig[KeyStaticConfigs].([]interface{})[0].(map[string]interface{})[KeyTargets], targets)
 
 			// Verify filter processor if metric names exist
 			if len(tc.metricNames) > 0 {
 				processors := collector.Spec.Config.Processors.Object
-				filterMetrics := processors["filter/metrics"].(map[string]interface{})
-				metrics := filterMetrics["metrics"].(map[string]interface{})
-				include := metrics["include"].(map[string]interface{})
-				metricNames := include["metric_names"].([]string)
+				filterMetrics := processors[ProcessorFilterMetrics].(map[string]interface{})
+				metrics := filterMetrics[KeyMetrics].(map[string]interface{})
+				include := metrics[KeyInclude].(map[string]interface{})
+				metricNames := include[KeyMetricNames].([]string)
 				assert.ElementsMatch(t, tc.metricNames, metricNames)
 			}
 
 			// Verify processors always include resourcedetection/env and transform
 			processors := collector.Spec.Config.Processors.Object
-			assert.Contains(t, processors, "resourcedetection/env")
-			assert.Contains(t, processors, "transform")
+			assert.Contains(t, processors, ProcessorResourcedetectionEnv)
+			assert.Contains(t, processors, ProcessorTransform)
 
 			// Verify pipeline processors
-			pipeline := collector.Spec.Config.Service.Pipelines["metrics"].Processors
+			pipeline := collector.Spec.Config.Service.Pipelines[PipelineMetrics].Processors
 			if len(tc.metricNames) > 0 {
-				assert.Equal(t, []string{"resourcedetection/env", "transform", "filter/metrics"}, pipeline)
+				assert.Equal(t, []string{ProcessorResourcedetectionEnv, ProcessorTransform, ProcessorFilterMetrics}, pipeline)
 				// Verify filter processor config
-				filterMetrics := processors["filter/metrics"].(map[string]interface{})
-				metrics := filterMetrics["metrics"].(map[string]interface{})
-				include := metrics["include"].(map[string]interface{})
-				metricNames := include["metric_names"].([]string)
+				filterMetrics := processors[ProcessorFilterMetrics].(map[string]interface{})
+				metrics := filterMetrics[KeyMetrics].(map[string]interface{})
+				include := metrics[KeyInclude].(map[string]interface{})
+				metricNames := include[KeyMetricNames].([]string)
 				assert.ElementsMatch(t, tc.metricNames, metricNames)
 			} else {
-				assert.Equal(t, []string{"resourcedetection/env", "transform"}, pipeline)
+				assert.Equal(t, []string{ProcessorResourcedetectionEnv, ProcessorTransform}, pipeline)
 			}
 		})
 	}
@@ -208,15 +208,15 @@ func TestReconcileUpdate(t *testing.T) {
 			Mode: otelv1beta1.ModeSidecar,
 			Config: otelv1beta1.Config{
 				Receivers: otelv1beta1.AnyConfig{Object: map[string]interface{}{
-					"prometheus": map[string]interface{}{
-						"config": map[string]interface{}{
-							"scrape_configs": []interface{}{
+					PrometheusReceiver: map[string]interface{}{
+						KeyConfig: map[string]interface{}{
+							KeyScrapeConfigs: []interface{}{
 								map[string]interface{}{
-									"job_name":        "old-collector",
-									"scrape_interval": "30s",
-									"static_configs": []interface{}{
+									KeyJobName:        "old-collector",
+									KeyScrapeInterval: "30s",
+									KeyStaticConfigs: []interface{}{
 										map[string]interface{}{
-											"targets": []interface{}{"localhost:8080"},
+											KeyTargets: []interface{}{"localhost:8080"},
 										},
 									},
 								},
@@ -226,8 +226,8 @@ func TestReconcileUpdate(t *testing.T) {
 				}},
 				Service: otelv1beta1.Service{
 					Pipelines: map[string]*otelv1beta1.Pipeline{
-						"metrics": {
-							Receivers:  []string{"prometheus"},
+						PipelineMetrics: {
+							Receivers:  []string{PrometheusReceiver},
 							Processors: []string{},
 							Exporters:  []string{"otlp"},
 						},
@@ -255,13 +255,13 @@ func TestReconcileUpdate(t *testing.T) {
 
 	// Verify updated config
 	receivers := updatedCollector.Spec.Config.Receivers.Object
-	prometheusConfig := receivers["prometheus"].(map[string]interface{})
-	config := prometheusConfig["config"].(map[string]interface{})
-	scrapeConfigs := config["scrape_configs"].([]interface{})
+	prometheusConfig := receivers[PrometheusReceiver].(map[string]interface{})
+	config := prometheusConfig[KeyConfig].(map[string]interface{})
+	scrapeConfigs := config[KeyScrapeConfigs].([]interface{})
 	scrapeConfig := scrapeConfigs[0].(map[string]interface{})
 
-	assert.Equal(t, "otel-collector", scrapeConfig["job_name"])
-	assert.Equal(t, "15s", scrapeConfig["scrape_interval"])
+	assert.Equal(t, JobNameOtelCollector, scrapeConfig[KeyJobName])
+	assert.Equal(t, "15s", scrapeConfig[KeyScrapeInterval])
 }
 
 func TestSetControllerReferences(t *testing.T) {

--- a/test/e2e/predictor/test_autoscaling.py
+++ b/test/e2e/predictor/test_autoscaling.py
@@ -649,7 +649,7 @@ async def test_scaling_sklearn_with_keda_otel_add_on(rest_v1_client, network_lay
     trigger_metadata = scaledobject_resp["items"][0]["spec"]["triggers"][0]["metadata"]
     trigger_type = scaledobject_resp["items"][0]["spec"]["triggers"][0]["type"]
     assert trigger_type == "external"
-    assert trigger_metadata["metricQuery"] == "http_requests_per_second"
+    assert trigger_metadata["metricQuery"] == 'sum(http_requests_per_second{namespace="kserve-ci-e2e-test", deployment="isvc-sklearn-keda-otel-add-on-predictor"})'
     assert trigger_metadata["scalerAddress"] == "keda-otel-scaler.keda.svc:4318"
     assert trigger_metadata["targetValue"] == "50.000000"
     res = await predict_isvc(


### PR DESCRIPTION
## What this PR does

- Fixes an issue where the OpenTelemetryCollector and KEDA ScaledObject did not properly isolate metrics by deployment and namespace.
- Now, the OTelCollector always injects `namespace` and `deployment` labels into metrics using the `resourcedetection/env` and `transform` processors.
- The KEDA ScaledObject’s PromQL query for pod metrics now always filters by `namespace` and `deployment`, ensuring correct autoscaling per workload.
- Unit tests for both reconcilers have been updated and now pass.

## Why is this needed?

- Without these changes, metrics from different deployments/namespaces could be mixed, causing incorrect autoscaling behavior.
- This resolves [issue #4542](https://github.com/kserve/kserve/issues/4542).

## How was this tested?

- All relevant unit tests were updated and pass (`go test ./pkg/controller/v1beta1/inferenceservice/reconcilers/...`).

## User impact

- No user-facing API changes.
- Autoscaling now works as expected when multiple deployments use the same metric name.
