### PR TITLE
fix(test): uses local httptest server urls for downloader tests

### DIFF
--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -703,6 +703,12 @@ var _ = Describe("Watcher", func() {
 					},
 				}
 				for protocol, scenario := range scenarios {
+					ts := scenario.server
+					defer ts.Close()
+					cl := storage.HTTPSProvider{
+						Client: ts.Client(),
+					}
+
 					logger.Printf("Setting up %s Server", protocol)
 					logger.Printf("Sync model config using temp dir %v\n", modelDir)
 					watcher := NewWatcher("/tmp/configs", modelDir, sugar)
@@ -710,24 +716,17 @@ var _ = Describe("Watcher", func() {
 						{
 							Name: "model1",
 							Spec: v1alpha1.ModelSpec{
-								StorageURI: "http://example.com/test.tar",
+								StorageURI: ts.URL + "/test.tar",
 								Framework:  "sklearn",
 							},
 						},
 						{
 							Name: "model2",
 							Spec: v1alpha1.ModelSpec{
-								StorageURI: "https://example.com/test.zip",
+								StorageURI: ts.URL + "/test.zip",
 								Framework:  "sklearn",
 							},
 						},
-					}
-
-					// Create HTTPS client
-					ts := scenario.server
-					defer ts.Close()
-					cl := storage.HTTPSProvider{
-						Client: ts.Client(),
 					}
 
 					watcher.parseConfig(modelConfigs, false)


### PR DESCRIPTION
**What this PR does / why we need it**:

The HTTP/HTTPS downloader tests were flaky, passing offline and failing online by hitting real example.com endpoints - see this [log for example](https://github.com/opendatahub-io/kserve/actions/runs/16350605009/job/46243788101?pr=750#step:5:619).

To eliminate nondeterminism, tests now target the local httptest server which is defined as test fixture. This prevents test environment leak.

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Release note**:
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.