### PR TITLE
chore(test-setup): replaces gatewayclass in-memory

### DIFF
--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -40,8 +40,9 @@ if [[ $DEPLOYMENT_MODE == "raw" ]];then
   elif [[ $NETWORK_LAYER == "istio-gatewayapi" ]]; then
     echo "Creating Istio Gateway ..."
     # Replace gatewayclass name
-    sed -i 's/envoy/istio/g' config/overlays/test/gateway/ingress_gateway.yaml
-    kubectl apply -f config/overlays/test/gateway/ingress_gateway.yaml
+    kubectl apply -f - <<EOF
+$(sed 's/envoy/istio/g' config/overlays/test/gateway/ingress_gateway.yaml)
+EOF
     sleep 10
     echo "Waiting for istio gateway to be ready ..."
     kubectl wait --timeout=5m -n kserve pod -l serving.kserve.io/gateway=kserve-ingress-gateway --for=condition=Ready


### PR DESCRIPTION
**What this PR does / why we need it**:

This way we do not overwrite versioned file and risk pushing it by mistake.

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Release note**:
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.