### PR TITLE
fix: missing pytest-asyncio session scope marker in test_kserve_logger_cipn

### DIFF
--- a/test/e2e/logger/test_raw_logger.py
+++ b/test/e2e/logger/test_raw_logger.py
@@ -66,6 +66,7 @@ async def test_kserve_logger(rest_v1_client, network_layer):
     await base_test(msg_dumper, service_name, predictor, rest_v1_client, network_layer)
 
 
+@pytest.mark.asyncio(scope="session")
 @pytest.mark.rawcipn
 async def test_kserve_logger_cipn(rest_v1_client, network_layer):
     msg_dumper = "message-dumper-raw-cipn"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The test_kserve_logger_cipn function was missing the @pytest.mark.asyncio(scope="session") decorator which leads to the test being skipped.
<img width="1441" height="425" alt="Screenshot from 2025-07-23 12-56-25" src="https://github.com/user-attachments/assets/114d06f2-e6f8-453b-a0c2-fb5d071a3478" />

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

