### PR TITLE
Add support for openEuler

### DIFF
--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -1,0 +1,45 @@
+# Copyright (C) 2025 Huawei Technologies Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Build the manager binary
+ARG BASE=openeuler/go:1.24.1-oe2403lts
+ARG VERSION=v0.15.2
+
+FROM ${BASE} AS builder
+
+RUN dnf install -y shadow-utils && \
+    groupadd -g 1001 kserve && \
+    useradd -u 1001 -g 1001 -s /sbin/nologin --badname 65532
+
+# Copy in the go src
+WORKDIR /go/src/github.com/kserve/kserve
+COPY go.mod  go.mod
+COPY go.sum  go.sum
+
+RUN go mod download
+
+COPY cmd/    cmd/
+COPY pkg/    pkg/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager ./cmd/manager
+
+# Generate third-party licenses
+COPY LICENSE LICENSE
+RUN go install github.com/google/go-licenses@latest
+# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
+RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
+RUN go-licenses save --save_path third_party/library ./cmd/manager
+
+# Copy the controller-manager into a thin image
+FROM openeuler/distroless-base-nonroot
+
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+COPY --from=builder /go/src/github.com/kserve/kserve/third_party /third_party
+COPY --from=builder /go/src/github.com/kserve/kserve/manager /
+
+USER 65532
+
+ENTRYPOINT ["/manager"]

--- a/agent.Dockerfile.openEuler
+++ b/agent.Dockerfile.openEuler
@@ -1,0 +1,43 @@
+# Copyright (C) 2025 Huawei Technologies Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Build the inference-agent binary
+ARG BASE=openeuler/go:1.24.1-oe2403lts
+ARG VERSION=v0.15.2
+
+FROM ${BASE} AS builder
+
+RUN dnf install -y shadow-utils && \
+    groupadd -g 1001 kserve && \
+    useradd -u 1001 -g 1001 -s /sbin/nologin --badname 65532
+
+# Copy in the go src
+WORKDIR /go/src/github.com/kserve/kserve
+COPY go.mod  go.mod
+COPY go.sum  go.sum
+
+RUN go mod download
+
+COPY cmd/    cmd/
+COPY pkg/    pkg/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o agent ./cmd/agent
+
+# Generate third-party licenses
+COPY LICENSE LICENSE
+RUN go install github.com/google/go-licenses@latest
+# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
+RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
+RUN go-licenses save --save_path third_party/library ./cmd/agent
+
+# Copy the inference-agent into a thin image
+FROM openeuler/distroless-base-nonroot
+
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+COPY --from=builder /go/src/github.com/kserve/kserve/third_party /third_party
+WORKDIR /ko-app
+COPY --from=builder /go/src/github.com/kserve/kserve/agent /ko-app/
+ENTRYPOINT ["/ko-app/agent"]

--- a/python/sklearn.Dockerfile.openEuler
+++ b/python/sklearn.Dockerfile.openEuler
@@ -1,0 +1,70 @@
+# Copyright (C) 2025 Huawei Technologies Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG PYTHON_VERSION=3.11.13
+ARG BASE_IMAGE=openeuler/python:${PYTHON_VERSION}-oe2403lts
+ARG VENV_PATH=/prod_venv
+
+FROM ${BASE_IMAGE} AS builder
+
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.8.3
+
+# Required for building packages for arm64 arch
+RUN yum update -y && \
+    yum install -y \
+    python3-devel \
+    gcc g++ make cmake && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
+ENV PATH="$PATH:${POETRY_HOME}/bin"
+
+# Activate virtual env
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${VENV_PATH}
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY kserve/pyproject.toml kserve/poetry.lock kserve/
+RUN cd kserve && poetry install --no-root --no-interaction --no-cache
+COPY kserve kserve
+RUN cd kserve && poetry install --no-interaction --no-cache
+
+COPY sklearnserver/pyproject.toml sklearnserver/poetry.lock sklearnserver/
+RUN cd sklearnserver && poetry install --no-root --no-interaction --no-cache
+COPY sklearnserver sklearnserver
+RUN cd sklearnserver && poetry install --no-interaction --no-cache
+
+# Generate third-party licenses
+COPY pyproject.toml pyproject.toml
+COPY third_party/pip-licenses.py pip-licenses.py
+# TODO: Remove this when upgrading to python 3.11+
+RUN pip install --no-cache-dir tomli
+RUN mkdir -p third_party/library && python3 pip-licenses.py
+
+
+FROM ${BASE_IMAGE} AS prod
+
+RUN yum update -y && \    
+    yum install -y \ 
+    shadow && \ 
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+# Activate virtual env
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${VENV_PATH}
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve third_party third_party
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
+COPY --from=builder kserve kserve
+COPY --from=builder sklearnserver sklearnserver
+
+USER 1000
+ENTRYPOINT ["python", "-m", "sklearnserver"]

--- a/python/storage-initializer.Dockerfile.openEuler
+++ b/python/storage-initializer.Dockerfile.openEuler
@@ -1,0 +1,79 @@
+# Copyright (C) 2025 Huawei Technologies Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG PYTHON_VERSION=3.11.13
+ARG BASE_IMAGE=openeuler/python:${PYTHON_VERSION}-oe2403lts
+ARG VENV_PATH=/prod_venv
+
+FROM ${BASE_IMAGE} AS builder
+
+# Install Poetry
+ARG POETRY_HOME=/opt/poetry
+ARG POETRY_VERSION=1.8.3
+
+# Required for building packages for arm64 arch
+RUN yum update -y && \
+    yum install -y \
+    python3-devel \
+    gcc g++ make cmake && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
+ENV PATH="$PATH:${POETRY_HOME}/bin"
+
+# Activate virtual env
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${VENV_PATH}
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY kserve/pyproject.toml kserve/poetry.lock kserve/
+RUN cd kserve && poetry install --no-root --no-interaction --no-cache --extras "storage"
+COPY kserve kserve
+RUN cd kserve && poetry install --no-interaction --no-cache --extras "storage"
+
+RUN yum update -y && \
+    yum install -y \
+    gcc \
+    krb5-devel && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN pip install --no-cache-dir krbcontext==0.10 hdfs~=2.6.0 requests-kerberos==0.14.0
+
+# Generate third-party licenses
+COPY pyproject.toml pyproject.toml
+COPY third_party/pip-licenses.py pip-licenses.py
+# TODO: Remove this when upgrading to python 3.11+
+RUN pip install --no-cache-dir tomli
+RUN mkdir -p third_party/library && python3 pip-licenses.py
+
+FROM ${BASE_IMAGE} AS prod
+
+RUN yum update -y && \ 
+    yum install -y \ 
+    shadow && \
+    yum clean all && \
+    rm -fr /var/cache/yum
+
+# Activate virtual env
+ARG VENV_PATH
+ENV VIRTUAL_ENV=${VENV_PATH}
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN useradd kserve -m -u 1000 -d /home/kserve
+
+COPY --from=builder --chown=kserve:kserve third_party third_party
+COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
+COPY --from=builder kserve kserve
+COPY ./storage-initializer /storage-initializer
+
+RUN chmod +x /storage-initializer/scripts/initializer-entrypoint
+RUN mkdir /work
+WORKDIR /work
+
+# Set a writable /mnt folder to avoid permission issue on Huggingface download. See https://huggingface.co/docs/hub/spaces-sdks-docker#permissions
+RUN chown -R kserve:kserve /mnt
+USER 1000
+ENTRYPOINT ["/storage-initializer/scripts/initializer-entrypoint"]

--- a/router.Dockerfile.openEuler
+++ b/router.Dockerfile.openEuler
@@ -1,0 +1,43 @@
+# Copyright (C) 2025 Huawei Technologies Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# Build the inference-router binary
+ARG BASE=openeuler/go:1.24.1-oe2403lts
+ARG VESION=v0.15.2
+
+FROM ${BASE} AS builder
+
+RUN dnf install -y shadow-utils && \
+    groupadd -g 1001 kserve && \
+    useradd -u 1001 -g 1001 -s /sbin/nologin --badname 65532
+    
+# Copy in the go src
+WORKDIR /go/src/github.com/kserve/kserve
+COPY go.mod  go.mod
+COPY go.sum  go.sum
+
+RUN go mod download
+
+COPY cmd/    cmd/
+COPY pkg/    pkg/
+
+# Build
+RUN CGO_ENABLED=0  go build -a -o router ./cmd/router
+
+# Generate third-party licenses
+COPY LICENSE LICENSE
+RUN go install github.com/google/go-licenses@latest
+# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
+RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
+RUN go-licenses save --save_path third_party/library ./cmd/router
+
+# Copy the inference-router into a thin image
+FROM openeuler/distroless-base-nonroot
+
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+COPY --from=builder /go/src/github.com/kserve/kserve/third_party /third_party
+WORKDIR /ko-app
+COPY --from=builder /go/src/github.com/kserve/kserve/router /ko-app/
+ENTRYPOINT ["/ko-app/router"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

openEuler is an open source OS run by the OpenAtom Foundation that builds a global community to enhance digital infrastructure and support diverse architectures.
This PR adds support for openEuler-based container images to KServe by introducing Dockerfiles that use openEuler as the base image instead of the current Ubuntu/Alpine base images.

**Benefits of this change**:
- Provides alternative base image option for users preferring openEuler ecosystem
- Enhances compatibility with openEuler-based Kubernetes clusters
- Supports diverse enterprise environments that standardize on openEuler
- Maintains feature parity with existing images while offering different base OS option

The changes include:
- New Dockerfiles using openEuler base images for core KServe components
- Updated package installation commands compatible with openEuler's package manager
- Preserved all existing functionality and dependencies
- Added openEuler-specific optimizations where applicable

**Which issue(s) this PR fixes** 
fixes #4611 

**Type of changes**

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

- [x] Built openEuler-based images successfully using `docker build`
- [x] Verified all dependencies install correctly on openEuler base
- [x] Tested basic KServe functionality with openEuler images
- [x] Confirmed image size and performance are comparable to existing images
- [x] Validated container startup and runtime behavior

**Test Environment**:
- openEuler version: 24.03 LTS
- Docker version: 25.0.3
- Kubernetes version: 1.33.1

**Test Commands**:
```bash
# Build openEuler-based images
docker build -f Dockerfile.openEuler -t kserve/kserve-controller:latest-openeuler .
...

# Create a namespace
kubectl create namespace kserve-test

# Load all openEuler-based images to the node
kind load docker-image kserve/kserve-controller:latest-openeuler
...

# Install KServe CRDs
helm install kserve-crd /path/to/chart/kserve-crd

# Install KServe Resources
helm install kserve /path/to/chart/kserve 
  --namespace kserve \
  --create-namespace \
  --set kserve.controller.deploymentMode=RawDeployment \
  --set kserve.controller.gateway.ingressGateway.className=istio

# Create an InferenceService
kubectl apply -n kserve-test -f - <<EOF
  apiVersion: "serving.kserve.io/v1beta1"
  kind: "InferenceService"
  metadata:
    name: "sklearn-iris"
    namespace: kserve-test
  spec:
    predictor:
      model:
        modelFormat:
          name: sklearn
        storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
EOF

# Get into the node and perform inference
curl -v -H "Content-Type: application/json" http://sklearn-iris.kserve-test/v1/models/sklearn-iris:predict -d @./iris-input.json
```

**Test Result**:
![image](https://github.com/user-attachments/assets/79c9cf9b-3a9f-40e4-a7ae-7130f4176e5e)
![image](https://github.com/user-attachments/assets/283453be-cb7e-435e-8871-57486590eb4c)
![image](https://github.com/user-attachments/assets/1c9c8ecf-a81d-4fff-8b9f-f7ab80652480)
![image](https://github.com/user-attachments/assets/0e3c08bc-731d-4508-9a8a-6e8ce2e4143d)
![image](https://github.com/user-attachments/assets/85ffc6e6-aa28-4cb0-bb87-b682d2e9102c)





