### PR TITLE
fix: fixes misleading print for parallelism when $# > 2 (#784)

### DIFF
--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -22,15 +22,11 @@ set -o nounset
 set -o pipefail
 
 echo "Starting E2E functional tests ..."
-if [ $# -eq 2 ]; then
-  echo "Parallelism requested for pytest is $2"
-else
-  echo "No parallelism requested for pytest. Will use default value of 1"
-fi
-
 MARKER="${1}"
 PARALLELISM="${2:-1}"
 NETWORK_LAYER="${3:-'istio'}"
+
+echo "Parallelism requested for pytest is ${PARALLELISM}"
 
 source python/kserve/.venv/bin/activate
 pushd test/e2e >/dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes misleading info printed when running e2e tests.

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)


```release-note
NONE
```
