### PR TITLE
[Followup] Improve the stop/resume Inference Service tests and status

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -275,8 +275,8 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			Status: corev1.ConditionFalse,
 		}
 		isvc.Status.SetCondition(v1beta1.Stopped, defaultStoppedCondition)
+		existingStoppedCondition = defaultStoppedCondition
 	}
-	existingStoppedCondition = isvc.Status.GetCondition(v1beta1.Stopped)
 	if forceStopRuntime {
 		// If the inference service's stopped condition is not set or
 		// If the inference service is currently running, update its status to signal that it should be stopped

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -268,12 +268,19 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	// Handle InferenceService status updates based on the force stop annotation.
 	// If true, transition the service to a stopped and unready state; otherwise, ensure it's not marked as stopped.
+	existingStoppedCondition := isvc.Status.GetCondition(v1beta1.Stopped)
+	if existingStoppedCondition == nil {
+		defaultStoppedCondition := &apis.Condition{
+			Type:   v1beta1.Stopped,
+			Status: corev1.ConditionFalse,
+		}
+		isvc.Status.SetCondition(v1beta1.Stopped, defaultStoppedCondition)
+	}
+	existingStoppedCondition = isvc.Status.GetCondition(v1beta1.Stopped)
 	if forceStopRuntime {
-		// Exit early if we have already set the status to stopped
-		existingStoppedCondition := isvc.Status.GetCondition(v1beta1.Stopped)
-		if existingStoppedCondition != nil && existingStoppedCondition.Status == corev1.ConditionTrue {
-			// TODO: Set condition to stoppING
-		} else {
+		// If the inference service's stopped condition is not set or
+		// If the inference service is currently running, update its status to signal that it should be stopped
+		if existingStoppedCondition.Status == corev1.ConditionFalse {
 			// Add the stopped condition
 			stoppedCondition := &apis.Condition{
 				Type:   v1beta1.Stopped,
@@ -282,11 +289,15 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			isvc.Status.SetCondition(v1beta1.Stopped, stoppedCondition)
 		}
 	} else {
-		resumeCondition := &apis.Condition{
-			Type:   v1beta1.Stopped,
-			Status: corev1.ConditionFalse,
+		// If the inference service's stopped condition is not set or
+		// If the inference service is currently stopped, update its status to signal that it should resume
+		if existingStoppedCondition.Status == corev1.ConditionTrue {
+			resumeCondition := &apis.Condition{
+				Type:   v1beta1.Stopped,
+				Status: corev1.ConditionFalse,
+			}
+			isvc.Status.SetCondition(v1beta1.Stopped, resumeCondition)
 		}
-		isvc.Status.SetCondition(v1beta1.Stopped, resumeCondition)
 	}
 	// reconcile RoutesReady and LatestDeploymentReady conditions for serverless deployment
 	if deploymentMode == constants.Serverless {

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -1071,7 +1071,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 		// Wait for a specific condition on an InferenceService to reach the desired status
 		expectIsvcConditionStatus := func(ctx context.Context, serviceKey types.NamespacedName, conditionType apis.ConditionType, expectedStatus corev1.ConditionStatus) {
-			message := fmt.Sprintf("The '%s' condition for InferenceService'%s' should be '%s'",
+			message := fmt.Sprintf("The '%s' condition for InferenceService '%s' should be '%s'",
 				conditionType, serviceKey.Name, expectedStatus)
 
 			actualIsvc := &v1beta1.InferenceService{}

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -1060,51 +1060,31 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 		// Wait for the ISVC to exist.
 		expectIsvcToExist := func(ctx context.Context, serviceKey types.NamespacedName) v1beta1.InferenceService {
-			// Check that the ISVC was updated
-			updatedIsvc := &v1beta1.InferenceService{}
+			actualIsvc := &v1beta1.InferenceService{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			return *updatedIsvc
+			return *actualIsvc
 		}
 
-		// Wait for the InferenceService's Stopped condition to be false.
-		expectIsvcFalseStoppedStatus := func(ctx context.Context, serviceKey types.NamespacedName) {
-			// Check that the stopped condition is false
-			updatedIsvc := &v1beta1.InferenceService{}
+		// Wait for a specific condition on an InferenceService to reach the desired status
+		expectIsvcConditionStatus := func(ctx context.Context, serviceKey types.NamespacedName, conditionType apis.ConditionType, expectedStatus corev1.ConditionStatus) {
+			message := fmt.Sprintf("The '%s' condition for InferenceService'%s' should be '%s'",
+				conditionType, serviceKey.Name, expectedStatus)
+
+			actualIsvc := &v1beta1.InferenceService{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
 				if err == nil {
-					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
-					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionFalse {
+					cond := actualIsvc.Status.GetCondition(conditionType)
+					if cond != nil && cond.Status == expectedStatus {
 						return true
 					}
 				}
 				return false
-			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to false")
-		}
-
-		// Wait for the InferenceService's Stopped condition to be true.
-		expectIsvcTrueStoppedStatus := func(ctx context.Context, serviceKey types.NamespacedName) {
-			// Check that the ISVC status reflects that it is stopped
-			updatedIsvc := &v1beta1.InferenceService{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
-
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
-				if err == nil {
-					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
-					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionTrue {
-						return true
-					}
-				}
-				return false
-			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
+			}, timeout, interval).Should(BeTrue(), message)
 		}
 
 		// Wait for the InferenceService's PredictorReady and IngressReady condition.
@@ -1224,7 +1204,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 			})
 
@@ -1266,7 +1246,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceIsDeleted(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check that the ISVC status reflects that it is stopped
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 			})
 
 			It("Should delete the knative service/virtualService/service when the annotation is updated to true on an existing ISVC", func() {
@@ -1310,7 +1290,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 
 				// Stop the inference service
@@ -1327,7 +1307,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToBeDeleted(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check that the ISVC status reflects that it is stopped
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 			})
 
 			It("Should create the knative service/virtualService/service when the annotation is updated to false on an existing ISVC that is stopped", func() {
@@ -1369,7 +1349,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 				// Check that the ISVC status reflects that it is stopped
 				actualIsvc := expectIsvcToExist(ctx, serviceKey)
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 
 				// Resume the inference service
 				updatedIsvc := actualIsvc.DeepCopy()
@@ -1387,7 +1367,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 			})
 		})
@@ -1489,7 +1469,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 				expectIsvcTransformerReadyStatus(ctx, serviceKey)
 			})
@@ -1539,7 +1519,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceIsDeleted(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check that the ISVC status reflects that it is stopped
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 			})
 
 			It("Should delete the transformer knative service/virtualService/service when the annotation is updated to true on an existing ISVC", func() {
@@ -1590,7 +1570,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 				expectIsvcTransformerReadyStatus(ctx, serviceKey)
 
@@ -1609,7 +1589,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToBeDeleted(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check that the ISVC status reflects that it is stopped
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 			})
 
 			It("Should create the transformer knative service/virtualService/service when the annotation is updated to false on an existing ISVC that is stopped", func() {
@@ -1658,7 +1638,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 				// Check that the ISVC status reflects that it is stopped
 				actualIsvc := expectIsvcToExist(ctx, serviceKey)
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 
 				// Resume the inference service
 				updatedIsvc := actualIsvc.DeepCopy()
@@ -1677,7 +1657,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 				expectIsvcTransformerReadyStatus(ctx, serviceKey)
 			})
@@ -1786,7 +1766,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 				expectIsvcExplainerReadyStatus(ctx, serviceKey)
 			})
@@ -1836,7 +1816,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceIsDeleted(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check that the ISVC status reflects that it is stopped
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 			})
 
 			It("Should delete the explainer knative service/virtualService/service when the annotation is updated to true on an existing ISVC", func() {
@@ -1887,7 +1867,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 				expectIsvcExplainerReadyStatus(ctx, serviceKey)
 
@@ -1906,7 +1886,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToBeDeleted(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check that the ISVC status reflects that it is stopped
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 			})
 
 			It("Should create the explainer knative service/virtualService/service when the annotation is updated to false on an existing ISVC that is stopped", func() {
@@ -1955,7 +1935,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 				// Check that the ISVC status reflects that it is stopped
 				actualIsvc := expectIsvcToExist(ctx, serviceKey)
-				expectIsvcTrueStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionTrue)
 
 				// Resume the inference service
 				updatedIsvc := actualIsvc.DeepCopy()
@@ -1974,7 +1954,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				expectResourceToExist(context.Background(), &corev1.Service{}, serviceKey)
 
 				// Check the ISVC statuses
-				expectIsvcFalseStoppedStatus(ctx, serviceKey)
+				expectIsvcConditionStatus(ctx, serviceKey, v1beta1.Stopped, corev1.ConditionFalse)
 				expectIsvcReadyStatus(ctx, serviceKey)
 				expectIsvcExplainerReadyStatus(ctx, serviceKey)
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Several of the review comments noted in the Inference Graph PR (https://github.com/kserve/kserve/pull/4588) also apply to the already merged Inference Service implementation. 
This PR applies those fixes to the Inference Service files. 

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.