### PR TITLE
fix: Adds support for NVIDIA MIG GPU resource detection

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -259,10 +259,11 @@ var (
 
 // GPU Constants
 const (
-	NvidiaGPUResourceType = "nvidia.com/gpu"
-	AmdGPUResourceType    = "amd.com/gpu"
-	IntelGPUResourceType  = "intel.com/gpu"
-	GaudiGPUResourceType  = "habana.ai/gaudi"
+	NvidiaGPUResourceType          = "nvidia.com/gpu"
+	NvidiaMigGPUResourceTypePrefix = "nvidia.com/mig"
+	AmdGPUResourceType             = "amd.com/gpu"
+	IntelGPUResourceType           = "intel.com/gpu"
+	GaudiGPUResourceType           = "habana.ai/gaudi"
 )
 
 var CustomGPUResourceTypesAnnotationKey = KServeAPIGroupName + "/gpu-resource-types"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -55,7 +55,16 @@ func AppendVolumeIfNotExists(slice []corev1.Volume, volume corev1.Volume) []core
 
 func IsGPUEnabled(requirements corev1.ResourceRequirements) bool {
 	_, ok := requirements.Limits[constants.NvidiaGPUResourceType]
-	return ok
+	if ok {
+		return true
+	}
+	for resourceName := range requirements.Limits {
+		// Check if the resource name has the MIG prefix
+		if strings.HasPrefix(string(resourceName), constants.NvidiaMigGPUResourceTypePrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // FirstNonNilError returns the first non nil interface in the slice

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -459,6 +459,23 @@ func TestIsGpuEnabled(t *testing.T) {
 			},
 			expected: true,
 		},
+		"MigGpuEnabled": {
+			resource: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"cpu": resource.Quantity{
+						Format: "100",
+					},
+					corev1.ResourceName(constants.NvidiaMigGPUResourceTypePrefix + ".1g.5gb"): resource.MustParse("1"),
+				},
+				Requests: corev1.ResourceList{
+					"cpu": resource.Quantity{
+						Format: "90",
+					},
+					corev1.ResourceName(constants.NvidiaMigGPUResourceTypePrefix + ".1g.5gb"): resource.MustParse("1"),
+				},
+			},
+			expected: true,
+		},
 		"GPUDisabled": {
 			resource: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
@@ -478,7 +495,7 @@ func TestIsGpuEnabled(t *testing.T) {
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
 			res := IsGPUEnabled(scenario.resource)
-			g.Expect(res).To(gomega.Equal(scenario.expected))
+			g.Expect(res).To(gomega.BeComparableTo(scenario.expected))
 		})
 	}
 }


### PR DESCRIPTION
Extends GPU detection logic to recognize NVIDIA MIG resource names, enabling accurate identification of GPU-enabled workloads using MIG instances. Updates tests to cover MIG GPU scenarios for improved reliability.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4640

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**
