### PR TITLE
Install `golangci-lint` using the official installation steps

### DIFF
--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -31,7 +31,7 @@ UV_VERSION ?= 0.7.8
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call curl-install-tool,$(GOLANGCI_LINT),https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh,$(GOLANGCI_LINT_VERSION))
 
 ## Download controller-gen locally if necessary.
 .PHONY: controller-gen
@@ -80,6 +80,21 @@ rm -f $(1) || true ;\
 GOBIN=$(LOCALBIN) go install $${package} ;\
 go mod tidy ;\
 mv $(1) $(1)-$(3) ;\
+} ;\
+ln -sf $(1)-$(3) $(1)
+endef
+
+# curl-install-tool 'go install' any package with custom target and name of binary, if it doesn't exist
+# $1 - target path with name of binary
+# $2 - package url which can be installed
+# $3 - specific version of package
+define curl-install-tool
+@[ -f "$(1)-$(3)" ] || { \
+set -e; \
+echo "Downloading $(2) version $(3)" ;\
+rm -f $(1) || true ;\
+curl -sSfL $(2) | sh -s -- -b $(LOCALBIN) $(3) ;\
+mv $(LOCALBIN)/$(notdir $(1)) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)
 endef


### PR DESCRIPTION
chore:	On OSX, the current way to install the `golangci-lit` does not work very well.
	It downloads but throws this error:
```bash
	Error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24)
```

Basically, using `go get`, the version installed does not seem to be up to date, it downloads the `1.64.8` version built with go1.23, which is incompatible with the version used by KServe.

With the provided way, it correctly downloads and installs the right version for OSx, also tested with Linux.

Linux:
```bash
➜  kserve git:(6d5eaee21) ✗ make go-lint
Downloading https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh version v1.64.8
golangci/golangci-lint info checking GitHub for tag 'v1.64.8'
golangci/golangci-lint info found version: 1.64.8 for v1.64.8/linux/amd64
golangci/golangci-lint info installed /home/fspolti/data/dev/sources/kserve/bin/golangci-lint
➜  kserve git:(6d5eaee21) ✗ bin/golangci-lint version
golangci-lint has version 1.64.8 built with go1.24.1 from 8b37f141 on 2025-03-17T20:41:53Z

```

OSX
```bash
❯ make go-lint
Downloading https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh version v1.64.8
golangci/golangci-lint info checking GitHub for tag 'v1.64.8'
golangci/golangci-lint info found version: 1.64.8 for v1.64.8/darwin/arm64
golangci/golangci-lint info installed /Users/fspolti/data/dev/sources/kserve/bin/golangci-lint
❯ bin/golangci-lint version
golangci-lint has version 1.64.8 built with go1.24.1 from 8b37f141 on 2025-03-17T20:41:53Z
```


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.