### PR TITLE
[llmisvc] Support cluster-scoped objects in generic CRUD functions

### DIFF
--- a/pkg/controller/v1alpha1/llmisvc/lifecycle_crud.go
+++ b/pkg/controller/v1alpha1/llmisvc/lifecycle_crud.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,17 +42,25 @@ func Create[O client.Object, T client.Object](ctx context.Context, c clientWithR
 		return fmt.Errorf("failed to create %s %s/%s: %w", logLineForObject(expected), expected.GetNamespace(), expected.GetName(), err)
 	}
 
-	c.Eventf(owner, corev1.EventTypeNormal, "Created", "Created %s %s/%s", logLineForObject(expected), expected.GetNamespace(), expected.GetName())
+	if !reflect.ValueOf(owner).IsNil() {
+		c.Eventf(owner, corev1.EventTypeNormal, "Created", "Created %s %s/%s", logLineForObject(expected), expected.GetNamespace(), expected.GetName())
+	}
+
 	return nil
 }
 
 func Delete[O client.Object, T client.Object](ctx context.Context, c clientWithRecorder, owner O, expected T) error {
 	typeLogLine := logLineForObject(expected)
-	ownerLogLine := logLineForObject(owner)
+	isOwnerNil := reflect.ValueOf(owner).IsNil()
+
+	ownerLogLine := ""
+	if !isOwnerNil {
+		ownerLogLine = logLineForObject(owner)
+	}
 
 	if isNamespaced, err := apiutil.IsObjectNamespaced(expected, c.Scheme(), c.RESTMapper()); err != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("failed to resolve if resource is namespaced %s: %w", typeLogLine, err)
-	} else if isNamespaced {
+	} else if isNamespaced && !isOwnerNil {
 		if !metav1.IsControlledBy(expected, owner) {
 			return fmt.Errorf("failed to delete %s %s/%s: it is not controlled by %s %s/%s",
 				typeLogLine,
@@ -78,7 +87,10 @@ func Delete[O client.Object, T client.Object](ctx context.Context, c clientWithR
 		return nil
 	}
 
-	c.Eventf(owner, corev1.EventTypeNormal, "Deleted", "Deleted %s %s/%s", typeLogLine, expected.GetNamespace(), expected.GetName())
+	if !isOwnerNil {
+		c.Eventf(owner, corev1.EventTypeNormal, "Deleted", "Deleted %s %s/%s", typeLogLine, expected.GetNamespace(), expected.GetName())
+	}
+
 	return nil
 }
 
@@ -97,11 +109,16 @@ func Reconcile[O client.Object, T client.Object](ctx context.Context, c clientWi
 
 func Update[O client.Object, T client.Object](ctx context.Context, c clientWithRecorder, owner O, curr, expected T, isEqual SemanticEqual[T]) error {
 	typeLogLine := logLineForObject(expected)
-	ownerLogLine := logLineForObject(owner)
+	isOwnerNil := reflect.ValueOf(owner).IsNil()
+
+	ownerLogLine := ""
+	if !isOwnerNil {
+		ownerLogLine = logLineForObject(owner)
+	}
 
 	if isNamespaced, err := apiutil.IsObjectNamespaced(expected, c.Scheme(), c.RESTMapper()); err != nil {
 		return fmt.Errorf("failed to resolve if resource is namespaced %s: %w", typeLogLine, err)
-	} else if isNamespaced {
+	} else if isNamespaced && !isOwnerNil {
 		if !metav1.IsControlledBy(curr, owner) {
 			return fmt.Errorf("failed to update %s %s/%s: it is not controlled by %s %s/%s",
 				typeLogLine,
@@ -129,14 +146,17 @@ func Update[O client.Object, T client.Object](ctx context.Context, c clientWithR
 	if err := c.Update(ctx, expected); err != nil {
 		return fmt.Errorf("failed to update %s %s/%s: %w", typeLogLine, expected.GetNamespace(), expected.GetName(), err)
 	}
-	c.Eventf(owner, corev1.EventTypeNormal, "Updated", "Updated %s %s/%s", typeLogLine, expected.GetNamespace(), expected.GetName())
+
+	if !isOwnerNil {
+		c.Eventf(owner, corev1.EventTypeNormal, "Updated", "Updated %s %s/%s", typeLogLine, expected.GetNamespace(), expected.GetName())
+	}
 
 	return nil
 }
 
 func logLineForObject(obj client.Object) string {
 	// Note: don't use `obj.GetObjectKind()` as it's always empty.
-	return reflect.TypeOf(obj).String()
+	return strings.Replace(reflect.TypeOf(obj).String(), "*", "", 1)
 }
 
 type SemanticEqual[T client.Object] func(expected T, curr T) bool

--- a/pkg/controller/v1alpha1/llmisvc/lifecycle_crud.go
+++ b/pkg/controller/v1alpha1/llmisvc/lifecycle_crud.go
@@ -49,7 +49,7 @@ func Delete[O client.Object, T client.Object](ctx context.Context, c clientWithR
 	typeLogLine := logLineForObject(expected)
 	ownerLogLine := logLineForObject(owner)
 
-	if isNamespaced, err := apiutil.IsObjectNamespaced(expected, c.Scheme(), c.RESTMapper()); err != nil {
+	if isNamespaced, err := apiutil.IsObjectNamespaced(expected, c.Scheme(), c.RESTMapper()); err != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("failed to resolve if resource is namespaced %s: %w", typeLogLine, err)
 	} else if isNamespaced {
 		if !metav1.IsControlledBy(expected, owner) {


### PR DESCRIPTION
- Support cluster-scoped objects in generic CRUD functions
- Handle 'nil' for owner in generic CRUD (for cluster-scoped resources)

This will be used in https://github.com/kserve/kserve/pull/4666