### PR TITLE
Fix: Update ModelCopies.TotalCopies for all model states

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -537,7 +537,7 @@ func (ss *InferenceServiceStatus) ClearCondition(conditionType apis.ConditionTyp
 	}
 }
 
-func (ss *InferenceServiceStatus) UpdateModelRevisionStates(modelState ModelState, totalCopies int, info *FailureInfo) {
+func (ss *InferenceServiceStatus) UpdateModelRevisionStates(modelState ModelState, info *FailureInfo) {
 	if ss.ModelStatus.ModelRevisionStates == nil {
 		ss.ModelStatus.ModelRevisionStates = &ModelRevisionStates{TargetModelState: modelState}
 	} else {
@@ -549,7 +549,6 @@ func (ss *InferenceServiceStatus) UpdateModelRevisionStates(modelState ModelStat
 		ss.ModelStatus.TransitionStatus = InProgress
 	case Loaded:
 		ss.ModelStatus.TransitionStatus = UpToDate
-		ss.ModelStatus.ModelCopies = &ModelCopies{TotalCopies: totalCopies}
 		ss.ModelStatus.ModelRevisionStates.ActiveModelState = Loaded
 	case FailedToLoad:
 		ss.ModelStatus.TransitionStatus = BlockedByFailedLoad
@@ -582,9 +581,33 @@ func (ss *InferenceServiceStatus) SetModelFailureInfo(info *FailureInfo) bool {
 	return true
 }
 
+// countReadyPods counts the number of pods that are in Ready state and can serve inference requests
+func countReadyPods(podList *corev1.PodList) int {
+	if podList == nil {
+		return 0
+	}
+	readyCount := 0
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					readyCount++
+					break
+				}
+			}
+		}
+	}
+	return readyCount
+}
+
 func (ss *InferenceServiceStatus) PropagateModelStatus(statusSpec ComponentStatusSpec, podList *corev1.PodList, rawDeployment bool, serviceStatus *knservingv1.ServiceStatus) bool {
 	// Check at least one pod is running for the latest revision of inferenceservice
+	readyCopies := countReadyPods(podList)
 	totalCopies := len(podList.Items)
+	if ss.ModelStatus.ModelCopies == nil {
+		ss.ModelStatus.ModelCopies = &ModelCopies{}
+	}
+	ss.ModelStatus.ModelCopies.TotalCopies = readyCopies
 	if totalCopies == 0 {
 		if !rawDeployment {
 			// Make sure we haven't scaled down to 0 because of an error
@@ -592,14 +615,15 @@ func (ss *InferenceServiceStatus) PropagateModelStatus(statusSpec ComponentStatu
 				if knativeCond.Status == "False" {
 					// If any of the knative statuses are False, the model failed
 					// Hopefully the lastFailureInfo already has the info we need, so we don't update it here
-					ss.UpdateModelRevisionStates(FailedToLoad, totalCopies, nil)
+					ss.UpdateModelRevisionStates(FailedToLoad, nil)
 					return true
 				}
 			}
 		}
 
 		// If we made it here then hopefully there are 0 pods because we're just getting started and therefore Pending seems appropriate
-		ss.UpdateModelRevisionStates(Pending, totalCopies, nil)
+		ss.UpdateModelRevisionStates(Pending, nil)
+
 		return true
 	}
 
@@ -617,19 +641,19 @@ func (ss *InferenceServiceStatus) PropagateModelStatus(statusSpec ComponentStatu
 					return false
 				} else {
 					// If there is no previous error, we should be okay to move into the Loading state
-					ss.UpdateModelRevisionStates(Loading, totalCopies, nil)
+					ss.UpdateModelRevisionStates(Loading, nil)
 					return true
 				}
 
 			case cs.State.Terminated != nil && cs.State.Terminated.Reason == constants.StateReasonError:
-				ss.UpdateModelRevisionStates(FailedToLoad, totalCopies, &FailureInfo{
+				ss.UpdateModelRevisionStates(FailedToLoad, &FailureInfo{
 					Reason:   ModelLoadFailed,
 					Message:  cs.State.Terminated.Message,
 					ExitCode: cs.State.Terminated.ExitCode,
 				})
 				return true
 			case cs.State.Waiting != nil && cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff:
-				ss.UpdateModelRevisionStates(FailedToLoad, totalCopies, &FailureInfo{
+				ss.UpdateModelRevisionStates(FailedToLoad, &FailureInfo{
 					Reason:   ModelLoadFailed,
 					Message:  cs.LastTerminationState.Terminated.Message,
 					ExitCode: cs.LastTerminationState.Terminated.ExitCode,
@@ -643,10 +667,10 @@ func (ss *InferenceServiceStatus) PropagateModelStatus(statusSpec ComponentStatu
 	// For serverless deployment, the latest created revision and the latest ready revision should be equal
 	if ss.IsReady() {
 		if rawDeployment {
-			ss.UpdateModelRevisionStates(Loaded, totalCopies, nil)
+			ss.UpdateModelRevisionStates(Loaded, nil)
 			return true
 		} else if statusSpec.LatestCreatedRevision == statusSpec.LatestReadyRevision {
-			ss.UpdateModelRevisionStates(Loaded, totalCopies, nil)
+			ss.UpdateModelRevisionStates(Loaded, nil)
 			return true
 		}
 	}
@@ -657,19 +681,19 @@ func (ss *InferenceServiceStatus) PropagateModelStatus(statusSpec ComponentStatu
 		if cs.Name == constants.InferenceServiceContainerName {
 			switch {
 			case cs.State.Terminated != nil && cs.State.Terminated.Reason == constants.StateReasonError:
-				ss.UpdateModelRevisionStates(FailedToLoad, totalCopies, &FailureInfo{
+				ss.UpdateModelRevisionStates(FailedToLoad, &FailureInfo{
 					Reason:   ModelLoadFailed,
 					Message:  cs.State.Terminated.Message,
 					ExitCode: cs.State.Terminated.ExitCode,
 				})
 			case cs.State.Waiting != nil && cs.State.Waiting.Reason == constants.StateReasonCrashLoopBackOff:
-				ss.UpdateModelRevisionStates(FailedToLoad, totalCopies, &FailureInfo{
+				ss.UpdateModelRevisionStates(FailedToLoad, &FailureInfo{
 					Reason:   ModelLoadFailed,
 					Message:  cs.LastTerminationState.Terminated.Message,
 					ExitCode: cs.LastTerminationState.Terminated.ExitCode,
 				})
 			default:
-				ss.UpdateModelRevisionStates(Pending, totalCopies, nil)
+				ss.UpdateModelRevisionStates(Pending, nil)
 			}
 		}
 	}

--- a/pkg/apis/serving/v1beta1/inference_service_status_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status_test.go
@@ -1388,6 +1388,97 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 	}
 }
 
+func TestPropagateModelStatus_ReadyPodsCountingOnly(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Test case that specifically verifies PropagateModelStatus only counts ready pods
+	// regardless of model state transitions or other conditions
+	scenarios := map[string]struct {
+		name                    string
+		initialModelState       ModelState
+		initialTransitionStatus TransitionStatus
+		podList                 *corev1.PodList
+		rawDeployment           bool
+		serviceStatus           *knservingv1.ServiceStatus
+		statusSpec              ComponentStatusSpec
+		expectedReadyCount      int
+	}{
+		"ready pods count independent of Loading state": {
+			initialModelState:       Loading,
+			initialTransitionStatus: InProgress,
+			podList: &corev1.PodList{Items: []corev1.Pod{
+				{Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}},  // Ready
+				{Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}},  // Ready
+				{Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}}}}, // Unready
+			}},
+			rawDeployment:      true,
+			serviceStatus:      &knservingv1.ServiceStatus{},
+			statusSpec:         ComponentStatusSpec{LatestReadyRevision: "test", LatestCreatedRevision: "test"},
+			expectedReadyCount: 2,
+		},
+		"ready pods count independent of FailedToLoad state": {
+			initialModelState:       FailedToLoad,
+			initialTransitionStatus: BlockedByFailedLoad,
+			podList: &corev1.PodList{Items: []corev1.Pod{
+				{Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}},  // Ready
+				{Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}}}}, // Unready
+			}},
+			rawDeployment:      true,
+			serviceStatus:      &knservingv1.ServiceStatus{},
+			statusSpec:         ComponentStatusSpec{LatestReadyRevision: "test", LatestCreatedRevision: "test"},
+			expectedReadyCount: 1,
+		},
+		"ready pods count independent of Pending state": {
+			initialModelState:       Pending,
+			initialTransitionStatus: InProgress,
+			podList: &corev1.PodList{Items: []corev1.Pod{
+				{Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}}, // Ready
+				{Status: corev1.PodStatus{Phase: corev1.PodPending, Conditions: []corev1.PodCondition{}}},                                                      // Unready (pending)
+			}},
+			rawDeployment:      true,
+			serviceStatus:      &knservingv1.ServiceStatus{},
+			statusSpec:         ComponentStatusSpec{LatestReadyRevision: "test", LatestCreatedRevision: "test"},
+			expectedReadyCount: 1,
+		},
+		"no ready pods in any state": {
+			initialModelState:       Loaded,
+			initialTransitionStatus: UpToDate,
+			podList: &corev1.PodList{Items: []corev1.Pod{
+				{Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}}}}, // Unready
+				{Status: corev1.PodStatus{Phase: corev1.PodPending, Conditions: []corev1.PodCondition{}}},                                                       // Unready (pending)
+			}},
+			rawDeployment:      true,
+			serviceStatus:      &knservingv1.ServiceStatus{},
+			statusSpec:         ComponentStatusSpec{LatestReadyRevision: "test", LatestCreatedRevision: "test"},
+			expectedReadyCount: 0,
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			isvcStatus := &InferenceServiceStatus{
+				ModelStatus: ModelStatus{
+					TransitionStatus: scenario.initialTransitionStatus,
+					ModelRevisionStates: &ModelRevisionStates{
+						ActiveModelState: scenario.initialModelState,
+						TargetModelState: scenario.initialModelState,
+					},
+				},
+			}
+
+			returnValue := isvcStatus.PropagateModelStatus(scenario.statusSpec, scenario.podList, scenario.rawDeployment, scenario.serviceStatus)
+
+			g.Expect(returnValue).To(gomega.BeTrue())
+			g.Expect(isvcStatus.ModelStatus.ModelCopies).ToNot(gomega.BeNil())
+			g.Expect(isvcStatus.ModelStatus.ModelCopies.TotalCopies).To(gomega.Equal(scenario.expectedReadyCount))
+
+			// Verify consistency with countReadyPods
+			directCount := countReadyPods(scenario.podList)
+			g.Expect(isvcStatus.ModelStatus.ModelCopies.TotalCopies).To(gomega.Equal(directCount))
+		})
+	}
+}
+
 func TestInferenceServiceStatus_UpdateModelRevisionStates(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/python/kserve/docs/V1beta1ModelCopies.md
+++ b/python/kserve/docs/V1beta1ModelCopies.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **failed_copies** | **int** | How many copies of this predictor&#39;s models failed to load recently | [default to 0]
-**total_copies** | **int** | Total number copies of this predictor&#39;s models that are currently loaded | [optional] 
+**total_copies** | **int** | Total number of copies of this predictor's models across all states (Pending, Loading, Loaded, FailedToLoad). | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The ModelStatus.ModelCopies field in the InferenceService status was only updated when the model reached the "Loaded" state, creating a visibility gap during model deployment and scaling operations. For all other states (Pending, Loading, FailedToLoad), the totalCopies value was calculated but not stored in the status
https://github.com/kserve/kserve/issues/4665

**Which issue(s) this PR fixes**:
Fixes #4665 

**Type of changes**
- Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.
- [ ] New test validates ModelCopies.TotalCopies is correctly set for all model states

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
No change in image versions.

**Checklist**:
- [✓] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ✓] Has code been commented, particularly in hard-to-understand areas?
- [ ✓] Have you made corresponding changes to the documentation?

**Release note**:
```NONE```