### PR TITLE
Fix HF Token Vulnerability in Storage Initializer Container

### DIFF
--- a/pkg/credentials/hf/hf_secret.go
+++ b/pkg/credentials/hf/hf_secret.go
@@ -28,11 +28,18 @@ const (
 func BuildSecretEnvs(secret *corev1.Secret) []corev1.EnvVar {
 	envs := make([]corev1.EnvVar, 0)
 
-	if token, ok := secret.Data[HFTokenKey]; ok {
+	if _, ok := secret.Data[HFTokenKey]; ok {
 		envs = append(envs, []corev1.EnvVar{
 			{
-				Name:  HFTokenKey,
-				Value: string(token),
+				Name: HFTokenKey,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secret.Name,
+						},
+						Key: HFTokenKey,
+					},
+				},
 			},
 			{
 				Name:  HFTransfer,

--- a/pkg/credentials/hf/hf_secret_test.go
+++ b/pkg/credentials/hf/hf_secret_test.go
@@ -21,10 +21,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBuildSecretEnvs_WithToken(t *testing.T) {
 	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hf-secret",
+		},
 		Data: map[string][]byte{
 			HFTokenKey: []byte("my-secret-token"),
 		},
@@ -34,13 +38,17 @@ func TestBuildSecretEnvs_WithToken(t *testing.T) {
 
 	assert.Len(t, envs, 2)
 	assert.Equal(t, HFTokenKey, envs[0].Name)
-	assert.Equal(t, "my-secret-token", envs[0].Value)
+	assert.Equal(t, HFTokenKey, envs[0].ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, secret.Name, envs[0].ValueFrom.SecretKeyRef.LocalObjectReference.Name)
 	assert.Equal(t, HFTransfer, envs[1].Name)
 	assert.Equal(t, "1", envs[1].Value)
 }
 
 func TestBuildSecretEnvs_WithoutToken(t *testing.T) {
 	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hf-secret",
+		},
 		Data: map[string][]byte{},
 	}
 
@@ -51,6 +59,9 @@ func TestBuildSecretEnvs_WithoutToken(t *testing.T) {
 
 func TestBuildSecretEnvs_NilSecret(t *testing.T) {
 	var secret *corev1.Secret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hf-secret",
+		},
 		Data: nil,
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The HF_TOKEN token is injected into the storage-initializer container as plaintext: https://github.com/kserve/kserve/blob/master/pkg/credentials/hf/hf_secret.go#L35

This exposes the token to potential leaks.

For an additional layer of protection, this PR injects the HF token using `valueFrom`.

Prior to change - `kubectl get pod -o yaml`:
```
    initContainers:
    - args:
      - hf://meta-llama/meta-llama-3-8b-instruct
      - /mnt/models
      env:
      - name: HF_TOKEN
        value: test-token
      - name: HF_HUB_ENABLE_HF_TRANSFER
        value: "1"
      image: kserve/storage-initializer:v0.15.2
      imagePullPolicy: IfNotPresent
      name: storage-initializer
```

After change - `kubectl get pod -o yaml`:
```
  initContainers:
  - args:
    - hf://meta-llama/meta-llama-3-8b-instruct
    - /mnt/models
    env:
    - name: HF_TOKEN
      valueFrom:
        secretKeyRef:
          key: HF_TOKEN
          name: storage-config
    - name: HF_HUB_ENABLE_HF_TRANSFER
      value: "1"
    image: kserve/storage-initializer:v0.15.2
    imagePullPolicy: IfNotPresent
    name: storage-initializer

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4674 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] All unit and e2e tests pass

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent potential leaks of HF token in pod manifests.
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.