### PR TITLE
deprecate: remove EnableDirectPvcVolumeMount flag

### DIFF
--- a/charts/kserve-resources/templates/configmap.yaml
+++ b/charts/kserve-resources/templates/configmap.yaml
@@ -114,7 +114,6 @@ data:
            "memoryLimit": "1Gi",
            "cpuRequest": "100m",
            "cpuLimit": "1",
-           "enableDirectPvcVolumeMount": true,
            "enableModelcar": false,
            "cpuModelcar": "10m",
            "memoryModelcar": "15Mi"
@@ -135,11 +134,6 @@ data:
 
            # cpuLimit is the limits.cpu to set for the storage initializer init container.
            "cpuLimit": "1",
-
-           # enableDirectPvcVolumeMount controls whether users can mount pvc volumes directly.
-           # if pvc volume is provided in storageuri then the pvc volume is directly mounted to /mnt/models in the user container.
-           # rather than symlink it to a shared volume. For more info see https://github.com/kserve/kserve/issues/2737
-           "enableDirectPvcVolumeMount": true,
 
            # enableModelcar enabled allows you to directly access an OCI container image by
            # using a source URL with an "oci://" schema.
@@ -241,7 +235,7 @@ data:
      # ====================================== INGRESS CONFIGURATION ======================================
      # Example
      ingress: |-
-       {   
+       {
            "enableGatewayApi": false,
            "kserveIngressGateway" : "kserve/kserve-ingress-gateway",
            "ingressGateway" : "knative-serving/knative-ingress-gateway",
@@ -256,17 +250,17 @@ data:
            "disableIngressCreation": false
        }
      ingress: |-
-       {   
+       {
            # enableGatewayApi specifies whether to use Gateway API instead of Ingress for serving external traffic.
            "enableGatewayApi": false,
-           
-           # KServe implements [Gateway API](https://gateway-api.sigs.k8s.io/) to serve external traffic. 
+
+           # KServe implements [Gateway API](https://gateway-api.sigs.k8s.io/) to serve external traffic.
            # By default, KServe configures a default gateway to serve external traffic.
            # But, KServe can be configured to use a custom gateway by modifying this configuration.
            # The gateway should be specified in format <gateway namespace>/<gateway name>
            # NOTE: This configuration only applicable for raw deployment.
            "kserveIngressGateway": "kserve/kserve-ingress-gateway",
-           
+
            # ingressGateway specifies the ingress gateway to serve external traffic.
            # The gateway should be specified in format <gateway namespace>/<gateway name>
            # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
@@ -480,7 +474,7 @@ data:
 
            # imagePullPolicy specifies when the router image should be pulled from registry.
            "imagePullPolicy": "IfNotPresent",
-          
+
           # imagePullSecrets specifies the list of secrets to be used for pulling the router image from registry.
           # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
           "imagePullSecrets": ["docker-secret"]
@@ -620,7 +614,7 @@ data:
         }
     }
   ingress: |-
-    {   
+    {
         "enableGatewayApi": {{ .Values.kserve.controller.gateway.ingressGateway.enableGatewayApi }},
         "kserveIngressGateway" : "{{ .Values.kserve.controller.gateway.ingressGateway.kserveGateway }}",
         "ingressGateway" : "{{ .Values.kserve.controller.gateway.ingressGateway.gateway }}",
@@ -655,7 +649,6 @@ data:
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1",
-        "enableDirectPvcVolumeMount": true,
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -155,7 +155,6 @@ data:
            "cpuLimit": "1",
            "caBundleConfigMapName": "",
            "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-           "enableDirectPvcVolumeMount": false,
            "enableModelcar": false,
            "cpuModelcar": "10m",
            "memoryModelcar": "15Mi"
@@ -182,11 +181,6 @@ data:
 
            # caBundleVolumeMountPath is the mount point for the configmap set by caBundleConfigMapName for the storage initializer init container.
            "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-
-           # enableDirectPvcVolumeMount controls whether users can mount pvc volumes directly.
-           # if pvc volume is provided in storageuri then the pvc volume is directly mounted to /mnt/models in the user container.
-           # rather than symlink it to a shared volume. For more info see https://github.com/kserve/kserve/issues/2737
-           "enableDirectPvcVolumeMount": true,
 
            # enableModelcar enabled allows you to directly access an OCI container image by
            # using a source URL with an "oci://" schema.
@@ -641,7 +635,6 @@ data:
         "cpuLimit": "1",
         "caBundleConfigMapName": "",
         "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-        "enableDirectPvcVolumeMount": true,
         "enableModelcar": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -18,7 +18,6 @@ data:
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1",
-        "enableDirectPvcVolumeMount": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
         "enableModelcar": true,

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -78,8 +78,7 @@ var _ = Describe("Inference Graph controller test", func() {
 			"cpuRequest": "100m",
 			"cpuLimit": "1",
 			"CaBundleConfigMapName": "",
-			"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-			"enableDirectPvcVolumeMount": false
+			"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 		}`,
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -89,8 +89,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 		}
 	)
@@ -4830,8 +4829,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							"cpuRequest": "100m",
 							"cpuLimit": "1",
 							"CaBundleConfigMapName": "not-exist-configmap",
-							"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-							"enableDirectPvcVolumeMount": false						
+							"caBundleVolumeMountPath": "/etc/ssl/custom-certs"						
 					}`
 				} else {
 					copiedConfigs[key] = value
@@ -4905,8 +4903,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							"cpuRequest": "100m",
 							"cpuLimit": "1",
 							"CaBundleConfigMapName": "test-cabundle-with-wrong-file-name",
-							"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-							"enableDirectPvcVolumeMount": false						
+							"caBundleVolumeMountPath": "/etc/ssl/custom-certs"						
 					}`
 				} else {
 					copiedConfigs[key] = value
@@ -4994,8 +4991,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					"cpuRequest": "100m",
 					"cpuLimit": "1",
 					"CaBundleConfigMapName": "test-cabundle-with-right-file-name",
-					"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-					"enableDirectPvcVolumeMount": false						
+					"caBundleVolumeMountPath": "/etc/ssl/custom-certs"						
 			}`
 				} else {
 					copiedConfigs[key] = value

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -95,8 +95,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 	}
 	Context("When creating inference service with raw kube predictor", func() {
@@ -1941,8 +1940,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 		}
 
@@ -3803,8 +3801,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 		}
 		ctx := context.Background()
@@ -5507,8 +5504,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 		}
 
@@ -6410,8 +6406,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 		}
 
@@ -7364,8 +7359,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 		}
 
@@ -7996,8 +7990,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 		}
 
@@ -8949,8 +8942,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 		}
 
@@ -9989,8 +9981,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"cpuRequest": "100m",
 				"cpuLimit": "1",
 				"CaBundleConfigMapName": "",
-				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-				"enableDirectPvcVolumeMount": false
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
 			}`,
 			"opentelemetryCollector": `{
 				"scrapeInterval": "5s",
@@ -10844,8 +10835,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
             		"cpuRequest": "100m",
             		"cpuLimit": "1",
             		"CaBundleConfigMapName": "",
-            		"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-            		"enableDirectPvcVolumeMount": false
+            		"caBundleVolumeMountPath": "/etc/ssl/custom-certs"
         		}`,
 			}
 			configMap := &corev1.ConfigMap{

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -17,16 +17,15 @@ limitations under the License.
 package types
 
 type StorageInitializerConfig struct {
-	Image                      string `json:"image"`
-	CpuRequest                 string `json:"cpuRequest"`
-	CpuLimit                   string `json:"cpuLimit"`
-	CpuModelcar                string `json:"cpuModelcar"`
-	MemoryRequest              string `json:"memoryRequest"`
-	MemoryLimit                string `json:"memoryLimit"`
-	CaBundleConfigMapName      string `json:"caBundleConfigMapName"`
-	CaBundleVolumeMountPath    string `json:"caBundleVolumeMountPath"`
-	MemoryModelcar             string `json:"memoryModelcar"`
-	EnableDirectPvcVolumeMount bool   `json:"enableDirectPvcVolumeMount"`
-	EnableOciImageSource       bool   `json:"enableModelcar"`
-	UidModelcar                *int64 `json:"uidModelcar"`
+	Image                   string `json:"image"`
+	CpuRequest              string `json:"cpuRequest"`
+	CpuLimit                string `json:"cpuLimit"`
+	CpuModelcar             string `json:"cpuModelcar"`
+	MemoryRequest           string `json:"memoryRequest"`
+	MemoryLimit             string `json:"memoryLimit"`
+	CaBundleConfigMapName   string `json:"caBundleConfigMapName"`
+	CaBundleVolumeMountPath string `json:"caBundleVolumeMountPath"`
+	MemoryModelcar          string `json:"memoryModelcar"`
+	EnableOciImageSource    bool   `json:"enableModelcar"`
+	UidModelcar             *int64 `json:"uidModelcar"`
 }

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -42,24 +42,22 @@ import (
 )
 
 const (
-	StorageInitializerDefaultCPURequest                 = "100m"
-	StorageInitializerDefaultCPULimit                   = "1"
-	StorageInitializerDefaultMemoryRequest              = "200Mi"
-	StorageInitializerDefaultMemoryLimit                = "1Gi"
-	StorageInitializerDefaultCaBundleConfigMapName      = ""
-	StorageInitializerDefaultCaBundleVolumeMountPath    = "/etc/ssl/custom-certs"
-	StorageInitializerDefaultEnableDirectPvcVolumeMount = false
+	StorageInitializerDefaultCPURequest              = "100m"
+	StorageInitializerDefaultCPULimit                = "1"
+	StorageInitializerDefaultMemoryRequest           = "200Mi"
+	StorageInitializerDefaultMemoryLimit             = "1Gi"
+	StorageInitializerDefaultCaBundleConfigMapName   = ""
+	StorageInitializerDefaultCaBundleVolumeMountPath = "/etc/ssl/custom-certs"
 )
 
 var (
 	storageInitializerConfig = &kserveTypes.StorageInitializerConfig{
-		CpuRequest:                 StorageInitializerDefaultCPURequest,
-		CpuLimit:                   StorageInitializerDefaultCPULimit,
-		MemoryRequest:              StorageInitializerDefaultMemoryRequest,
-		MemoryLimit:                StorageInitializerDefaultMemoryLimit,
-		CaBundleConfigMapName:      StorageInitializerDefaultCaBundleConfigMapName,
-		CaBundleVolumeMountPath:    StorageInitializerDefaultCaBundleVolumeMountPath,
-		EnableDirectPvcVolumeMount: StorageInitializerDefaultEnableDirectPvcVolumeMount,
+		CpuRequest:              StorageInitializerDefaultCPURequest,
+		CpuLimit:                StorageInitializerDefaultCPULimit,
+		MemoryRequest:           StorageInitializerDefaultMemoryRequest,
+		MemoryLimit:             StorageInitializerDefaultMemoryLimit,
+		CaBundleConfigMapName:   StorageInitializerDefaultCaBundleConfigMapName,
+		CaBundleVolumeMountPath: StorageInitializerDefaultCaBundleVolumeMountPath,
 	}
 
 	resourceRequirement = corev1.ResourceRequirements{
@@ -419,44 +417,14 @@ func TestStorageInitializerInjector(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-pvc-source",
-									MountPath: "/mnt/pvc",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
-									ReadOnly:  true,
-								},
-							},
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"/mnt/pvc/some/path/on/pvc", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
-							TerminationMessagePolicy: "FallbackToLogsOnError",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
-								},
-								{
-									Name:      "kserve-pvc-source",
-									MountPath: "/mnt/pvc",
+									MountPath: "/mnt/models",
+									SubPath:   "some/path/on/pvc",
 									ReadOnly:  true,
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
-						{
-							Name: "kserve-provision-location",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
 						{
 							Name: "kserve-pvc-source",
 							VolumeSource: corev1.VolumeSource{
@@ -2301,9 +2269,7 @@ func TestDirectVolumeMountForPvc(t *testing.T) {
 			credentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{
 				Data: map[string]string{},
 			}),
-			config: &kserveTypes.StorageInitializerConfig{
-				EnableDirectPvcVolumeMount: true, // enable direct volume mount for PVC
-			},
+			config: &kserveTypes.StorageInitializerConfig{},
 			client: c,
 		}
 		if err := injector.InjectStorageInitializer(scenario.original); err != nil {
@@ -2364,12 +2330,8 @@ func TestTransformerCollocation(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-pvc-source",
-									MountPath: "/mnt/pvc",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
+									MountPath: "/mnt/models",
+									SubPath:   "some/path/on/pvc",
 									ReadOnly:  true,
 								},
 							},
@@ -2380,44 +2342,14 @@ func TestTransformerCollocation(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-pvc-source",
-									MountPath: "/mnt/pvc",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
-									ReadOnly:  true,
-								},
-							},
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"/mnt/pvc/some/path/on/pvc", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
-							TerminationMessagePolicy: "FallbackToLogsOnError",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
-								},
-								{
-									Name:      "kserve-pvc-source",
-									MountPath: "/mnt/pvc",
+									MountPath: "/mnt/models",
+									SubPath:   "some/path/on/pvc",
 									ReadOnly:  true,
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
-						{
-							Name: "kserve-provision-location",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
 						{
 							Name: "kserve-pvc-source",
 							VolumeSource: corev1.VolumeSource{
@@ -2432,9 +2364,7 @@ func TestTransformerCollocation(t *testing.T) {
 			},
 		},
 		"Transformer collocation with pvc direct mount": {
-			storageConfig: &kserveTypes.StorageInitializerConfig{
-				EnableDirectPvcVolumeMount: true, // enable direct volume mount for PVC
-			},
+			storageConfig: &kserveTypes.StorageInitializerConfig{},
 			original: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -2548,44 +2478,14 @@ func TestTransformerCollocation(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-pvc-source",
-									MountPath: "/mnt/pvc",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
-									ReadOnly:  true,
-								},
-							},
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"/mnt/pvc/some/path/on/pvc", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
-							TerminationMessagePolicy: "FallbackToLogsOnError",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
-								},
-								{
-									Name:      "kserve-pvc-source",
-									MountPath: "/mnt/pvc",
+									MountPath: "/mnt/models",
+									SubPath:   "some/path/on/pvc",
 									ReadOnly:  true,
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
-						{
-							Name: "kserve-provision-location",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
 						{
 							Name: "kserve-pvc-source",
 							VolumeSource: corev1.VolumeSource{
@@ -4003,9 +3903,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 }
 
 func TestLocalModelPVC(t *testing.T) {
-	storageConfig := &kserveTypes.StorageInitializerConfig{
-		EnableDirectPvcVolumeMount: true, // enable direct volume mount for PVC
-	}
+	storageConfig := &kserveTypes.StorageInitializerConfig{}
 	scenarios := map[string]struct {
 		storageUri               string
 		localModelLabel          string


### PR DESCRIPTION
EnableDirectPvcVolumeMount has been defaulted to true for several releases, making the legacy false path effectively dead. The code and tests supporting EnableDirectPvcVolumeMount=false remain in the repo, complicating the Storage Initializer logic and increasing maintenance burden and test surface without user value.

Fixes: https://github.com/kserve/kserve/issues/4691