### PR TITLE
Avoid Pervasive Logging of SA Not Found Errors by Credential Builder

### DIFF
--- a/pkg/controller/v1alpha1/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha1/llmisvc/workload_multi_node.go
@@ -178,7 +178,7 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 		}
 		expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.ServiceAccountName = serviceAccount.GetName()
 
-		if err := r.attachModelArtifacts(ctx, llmSvc, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, config); err != nil {
+		if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, config); err != nil {
 			return nil, fmt.Errorf("failed to attach model artifacts to leader template: %w", err)
 		}
 
@@ -203,7 +203,7 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 		}
 		expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.ServiceAccountName = serviceAccount.GetName()
 
-		if err := r.attachModelArtifacts(ctx, llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, config); err != nil {
+		if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, config); err != nil {
 			return nil, fmt.Errorf("failed to attach model artifacts to worker template: %w", err)
 		}
 
@@ -289,7 +289,7 @@ func (r *LLMISVCReconciler) expectedPrefillMultiNodeLWS(ctx context.Context, llm
 			}
 			expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.ServiceAccountName = serviceAccount.GetName()
 
-			if err := r.attachModelArtifacts(ctx, llmSvc, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, config); err != nil {
+			if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, config); err != nil {
 				return nil, fmt.Errorf("failed to attach model artifacts to prefill leader template: %w", err)
 			}
 		}
@@ -297,7 +297,7 @@ func (r *LLMISVCReconciler) expectedPrefillMultiNodeLWS(ctx context.Context, llm
 			expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec = *llmSvc.Spec.Prefill.Worker.DeepCopy()
 			expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.ServiceAccountName = serviceAccount.GetName()
 
-			if err := r.attachModelArtifacts(ctx, llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, config); err != nil {
+			if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, config); err != nil {
 				return nil, fmt.Errorf("failed to attach model artifacts to prefill worker template: %w", err)
 			}
 		}
@@ -412,7 +412,7 @@ func (r *LLMISVCReconciler) expectedMultiNodeMainServiceAccount(ctx context.Cont
 		existingServiceAccount := &corev1.ServiceAccount{}
 		err := r.Client.Get(ctx, types.NamespacedName{Name: existingServiceAccountName, Namespace: llmSvc.Namespace}, existingServiceAccount)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch existing multi node service account %s/%s: %w", existingServiceAccountName, llmSvc.Namespace, err)
+			return nil, fmt.Errorf("failed to fetch existing multi node main service account %s/%s: %w", llmSvc.Namespace, existingServiceAccountName, err)
 		}
 		expectedServiceAccount.Annotations = existingServiceAccount.Annotations
 		expectedServiceAccount.Labels = existingServiceAccount.Labels
@@ -455,7 +455,7 @@ func (r *LLMISVCReconciler) expectedMultiNodePrefillServiceAccount(ctx context.C
 		existingServiceAccount := &corev1.ServiceAccount{}
 		err := r.Client.Get(ctx, types.NamespacedName{Name: existingServiceAccountName, Namespace: llmSvc.Namespace}, existingServiceAccount)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch existing multi node service account %s/%s: %w", existingServiceAccountName, llmSvc.Namespace, err)
+			return nil, fmt.Errorf("failed to fetch existing multi node prefill service account %s/%s: %w", llmSvc.Namespace, existingServiceAccountName, err)
 		}
 		expectedServiceAccount.Annotations = existingServiceAccount.Annotations
 		expectedServiceAccount.Labels = existingServiceAccount.Labels

--- a/pkg/controller/v1alpha1/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha1/llmisvc/workload_single_node.go
@@ -102,10 +102,13 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 
 	if llmSvc.Spec.Template != nil {
 		d.Spec.Template.Spec = *llmSvc.Spec.Template.DeepCopy()
+
+		var serviceAccount *corev1.ServiceAccount = nil
 		if hasRoutingSidecar(d.Spec.Template.Spec) {
 			log.FromContext(ctx).Info("Main container has a routing sidecar")
 
-			serviceAccount, err := r.expectedSingleNodeMainServiceAccount(ctx, llmSvc)
+			var err error
+			serviceAccount, err = r.expectedSingleNodeMainServiceAccount(ctx, llmSvc)
 			if err != nil {
 				return nil, fmt.Errorf("failed to created expected single node service account: %w", err)
 			}
@@ -118,9 +121,15 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 					ValueFrom: nil,
 				})
 			}
+		} else if llmSvc.Spec.Template.ServiceAccountName != "" {
+			serviceAccount = &corev1.ServiceAccount{}
+			err := r.Client.Get(ctx, types.NamespacedName{Name: llmSvc.Spec.Template.ServiceAccountName, Namespace: llmSvc.Namespace}, serviceAccount)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch existing single node main service account %s/%s: %w", llmSvc.Namespace, llmSvc.Spec.Template.ServiceAccountName, err)
+			}
 		}
 
-		if err := r.attachModelArtifacts(ctx, llmSvc, &d.Spec.Template.Spec, config); err != nil {
+		if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, &d.Spec.Template.Spec, config); err != nil {
 			return nil, fmt.Errorf("failed to attach model artifacts to main deployment: %w", err)
 		}
 	}
@@ -186,7 +195,16 @@ func (r *LLMISVCReconciler) expectedPrefillMainDeployment(ctx context.Context, l
 	if llmSvc.Spec.Prefill != nil && llmSvc.Spec.Prefill.Template != nil {
 		d.Spec.Template.Spec = *llmSvc.Spec.Prefill.Template.DeepCopy()
 
-		if err := r.attachModelArtifacts(ctx, llmSvc, &d.Spec.Template.Spec, config); err != nil {
+		var existingServiceAccount *corev1.ServiceAccount = nil
+		if llmSvc.Spec.Prefill.Template.ServiceAccountName != "" {
+			existingServiceAccount = &corev1.ServiceAccount{}
+			err := r.Client.Get(ctx, types.NamespacedName{Name: llmSvc.Spec.Prefill.Template.ServiceAccountName, Namespace: llmSvc.Namespace}, existingServiceAccount)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch existing single node prefill service account %s/%s: %w", llmSvc.Namespace, llmSvc.Spec.Prefill.Template.ServiceAccountName, err)
+			}
+		}
+
+		if err := r.attachModelArtifacts(ctx, existingServiceAccount, llmSvc, &d.Spec.Template.Spec, config); err != nil {
 			return nil, fmt.Errorf("failed to attach model artifacts to prefill deployment: %w", err)
 		}
 	}
@@ -326,7 +344,7 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainServiceAccount(ctx context.Con
 		existingServiceAccount := &corev1.ServiceAccount{}
 		err := r.Client.Get(ctx, types.NamespacedName{Name: llmSvc.Spec.Template.ServiceAccountName, Namespace: llmSvc.Namespace}, existingServiceAccount)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch existing single node service account %s/%s: %w", llmSvc.Spec.Template.ServiceAccountName, llmSvc.Namespace, err)
+			return nil, fmt.Errorf("failed to fetch existing single node main service account %s/%s: %w", llmSvc.Namespace, llmSvc.Spec.Template.ServiceAccountName, err)
 		}
 		expectedServiceAccount.Annotations = existingServiceAccount.Annotations
 		expectedServiceAccount.Labels = existingServiceAccount.Labels

--- a/pkg/controller/v1alpha1/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha1/llmisvc/workload_storage.go
@@ -23,11 +23,14 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/credentials"
-	"github.com/kserve/kserve/pkg/types"
+	kserveTypes "github.com/kserve/kserve/pkg/types"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
@@ -35,7 +38,18 @@ import (
 // The storage backend (PVC, OCI, Hugging Face, or S3) is determined from the URI schema and the appropriate helper function
 // is called to configure the PodSpec. This function will adjust volumes, container arguments, container volume mounts,
 // add containers, and do other changes to the PodSpec to ensure the model is fetched properly from storage.
-func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService, podSpec *corev1.PodSpec, config *Config) error {
+//
+// Parameters:
+//   - ctx: The context for API calls and logging.
+//   - serviceAccount: service account associated with the LLMInferenceService.
+//   - llmSvc: The LLMInferenceService resource containing the model specification.
+//   - podSpec: The PodSpec to configure with the model artifact.
+//   - config: The configuration information for LLMInferenceServices.
+//
+// Returns:
+//
+//	An error if the configuration fails, otherwise nil.
+func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha1.LLMInferenceService, podSpec *corev1.PodSpec, config *Config) error {
 	modelUri := llmSvc.Spec.Model.URI.String()
 	schema, _, sepFound := strings.Cut(modelUri, "://")
 
@@ -56,10 +70,10 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, llmSvc *v1
 		return r.attachOciModelArtifact(modelUri, podSpec, config.StorageConfig)
 
 	case constants.HfURIPrefix:
-		return r.attachHfModelArtifact(ctx, llmSvc.Namespace, llmSvc.Annotations, modelUri, podSpec, config.StorageConfig, config.CredentialConfig)
+		return r.attachHfModelArtifact(ctx, serviceAccount, llmSvc, modelUri, podSpec, config.StorageConfig, config.CredentialConfig)
 
 	case constants.S3URIPrefix:
-		return r.attachS3ModelArtifact(ctx, llmSvc.Namespace, llmSvc.Annotations, modelUri, podSpec, config.StorageConfig, config.CredentialConfig)
+		return r.attachS3ModelArtifact(ctx, serviceAccount, llmSvc, modelUri, podSpec, config.StorageConfig, config.CredentialConfig)
 	}
 
 	return fmt.Errorf("unsupported schema in model URI: %s", modelUri)
@@ -77,7 +91,7 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, llmSvc *v1
 // Returns:
 //
 //	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachOciModelArtifact(modelUri string, podSpec *corev1.PodSpec, storageConfig *types.StorageInitializerConfig) error {
+func (r *LLMISVCReconciler) attachOciModelArtifact(modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig) error {
 	if err := utils.ConfigureModelcarToContainer(modelUri, podSpec, "main", storageConfig); err != nil {
 		return err
 	}
@@ -111,8 +125,8 @@ func (r *LLMISVCReconciler) attachPVCModelArtifact(modelUri string, podSpec *cor
 //
 // Parameters:
 //   - ctx: The context for API calls and logging.
-//   - podNamespace: The namespace in which the pod and llmisvc exist.
-//   - podAnnotations: The annotations present in the pod and llmisvc.
+//   - serviceAccount: service account associated with the LLMInferenceService.
+//   - llmSvc: The LLMInferenceService resource containing the model specification.
 //   - modelUri: The URI of the model in the S3-compatible object store.
 //   - podSpec: The PodSpec to which the S3 model should be attached.
 //   - storageConfig: The storage initializer configuration.
@@ -121,18 +135,26 @@ func (r *LLMISVCReconciler) attachPVCModelArtifact(modelUri string, podSpec *cor
 // Returns:
 //
 //	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, podNamespace string, podAnnotations map[string]string, modelUri string, podSpec *corev1.PodSpec, storageConfig *types.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig) error {
+func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha1.LLMInferenceService, modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig) error {
 	if err := r.attachStorageInitializer(modelUri, podSpec, storageConfig); err != nil {
 		return err
 	}
 	if initContainer := utils.GetInitContainerWithName(podSpec, constants.StorageInitializerContainerName); initContainer != nil {
+		// If service account is nil, fetch the default service account
+		if serviceAccount == nil {
+			serviceAccount = &corev1.ServiceAccount{}
+			err := r.Client.Get(ctx, types.NamespacedName{Name: "default", Namespace: llmSvc.Namespace}, serviceAccount)
+			if err != nil {
+				log.FromContext(ctx).Error(err, "Failed to find default service account", "namespace", llmSvc.Namespace)
+				return nil
+			}
+		}
 		// Check for AWS IAM Role for Service Account or AWS IAM User Credentials
 		credentialBuilder := credentials.NewCredentialBuilderFromConfig(r.Client, r.Clientset, *credentialConfig)
-		if err := credentialBuilder.CreateSecretVolumeAndEnv(
+		if err := credentialBuilder.CreateSecretVolumeAndEnvFromServiceAccount(
 			ctx,
-			podNamespace,
-			podAnnotations,
-			podSpec.ServiceAccountName,
+			serviceAccount,
+			llmSvc.Annotations,
 			initContainer,
 			&podSpec.Volumes,
 		); err != nil {
@@ -148,28 +170,36 @@ func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, podNamesp
 //
 // Parameters:
 //   - ctx: The context for API calls and logging.
-//   - podNamespace: The namespace in which the pod and llmisvc exist.
-//   - podAnnotations: The annotations present in the pod and llmisvc.
-//   - modelUri: The URI of the model in hugging face hub.
-//   - podSpec: The PodSpec to which the HF model should be attached.
+//   - serviceAccount: service account associated with the LLMInferenceService.
+//   - llmSvc: The LLMInferenceService resource containing the model specification.
+//   - modelUri: The URI of the model in the S3-compatible object store.
+//   - podSpec: The PodSpec to which the S3 model should be attached.
 //   - storageConfig: The storage initializer configuration.
 //   - credentialConfig: The credential configuration used for model downloads.
 //
 // Returns:
 //
 //	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, podNamespace string, podAnnotations map[string]string, modelUri string, podSpec *corev1.PodSpec, storageConfig *types.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig) error {
+func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha1.LLMInferenceService, modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig) error {
 	if err := r.attachStorageInitializer(modelUri, podSpec, storageConfig); err != nil {
 		return err
 	}
 	if initContainer := utils.GetInitContainerWithName(podSpec, constants.StorageInitializerContainerName); initContainer != nil {
+		// If service account is nil, fetch the default service account
+		if serviceAccount == nil {
+			serviceAccount = &corev1.ServiceAccount{}
+			err := r.Client.Get(ctx, types.NamespacedName{Name: "default", Namespace: llmSvc.Namespace}, serviceAccount)
+			if err != nil {
+				log.FromContext(ctx).Error(err, "Failed to find default service account", "namespace", llmSvc.Namespace)
+				return nil
+			}
+		}
 		// Check for service account with secret ref
 		credentialBuilder := credentials.NewCredentialBuilderFromConfig(r.Client, r.Clientset, *credentialConfig)
-		if err := credentialBuilder.CreateSecretVolumeAndEnv(
+		if err := credentialBuilder.CreateSecretVolumeAndEnvFromServiceAccount(
 			ctx,
-			podNamespace,
-			podAnnotations,
-			podSpec.ServiceAccountName,
+			serviceAccount,
+			llmSvc.Annotations,
 			initContainer,
 			&podSpec.Volumes,
 		); err != nil {
@@ -186,11 +216,12 @@ func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, podNamesp
 // Parameters:
 //   - modelUri: The URI of the model in compatible object store.
 //   - podSpec: The PodSpec to which the storage-initializer container should be attached.
+//   - storageConfig: The storage initializer configuration.
 //
 // Returns:
 //
 //	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, podSpec *corev1.PodSpec, storageConfig *types.StorageInitializerConfig) error {
+func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig) error {
 	utils.AddStorageInitializerContainer(podSpec, "main", modelUri, true, storageConfig)
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
After work was completed to [enable s3/hf credential usage](https://github.com/kserve/kserve/blob/master/pkg/controller/v1alpha1/llmisvc/workload_storage.go#L131) for llmisvc's using the service account attached to the llmisvc template spec, the `kserve-controller-manager` pod is now excessively logging "Failed to find service account" errors:
```
{"level":"error","ts":"2025-09-02T20:24:14Z","logger":"CredentialBuilder","msg":"Failed to find service account","ServiceAccountName":"facebook-opt-125m-single-kserve-mn","Namespace":"llm-test","error":"serviceaccounts \"facebook-opt-125m-single-kserve-mn\" not found","stacktrace":"github.com/kserve/kserve/pkg/credentials.(*CredentialBuilder).CreateSecretVolumeAndEnv\n\t/go/src/github.com/kserve/kserve/pkg/credentials/service_account_credentials.go:217\ngithub.com/kserve/kserve/pkg/controller/llmisvc.(*LLMInferenceServiceReconciler).attachHfModelArtifact\n\t/go/src/github.com/kserve/kserve/pkg/controller/llmisvc/workload_storage.go:179\ngithub.com/kserve/kserve/pkg/controller/llmisvc.(*LLMInferenceServiceReconciler).attachModelArtifacts\n\t/go/src/github.com/kserve/kserve/pkg/controller/llmisvc/workload_storage.go:70\ngithub.com/kserve/kserve/pkg/controller/llmisvc.(*LLMInferenceServiceReconciler).expectedMainMultiNodeLWS\n\t/go/src/github.com/kserve/kserve/pkg/controller/llmisvc/workload_multi_node.go:186\ngithub.com/kserve/kserve/pkg/controller/llmisvc.(*LLMInferenceServiceReconciler).reconcileMultiNodeMainWorkload\n\t/go/src/github.com/kserve/kserve/pkg/controller/llmisvc/workload_multi_node.go:63\ngithub.com/kserve/kserve/pkg/controller/llmisvc.(*LLMInferenceServiceReconciler).reconcileMultiNodeWorkload\n\t/go/src/github.com/kserve/kserve/pkg/controller/llmisvc/workload_multi_node.go:53\ngithub.com/kserve/kserve/pkg/controller/llmisvc.(*LLMInferenceServiceReconciler).reconcileWorkload\n\t/go/src/github.com/kserve/kserve/pkg/controller/llmisvc/workload.go:63\ngithub.com/kserve/kserve/pkg/controller/llmisvc.(*LLMInferenceServiceReconciler).reconcile\n\t/go/src/github.com/kserve/kserve/pkg/controller/llmisvc/controller.go:174\ngithub.com/kserve/kserve/pkg/controller/llmisvc.(*LLMInferenceServiceReconciler).Reconcile\n\t/go/src/github.com/kserve/kserve/pkg/controller/llmisvc/controller.go:137\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.7/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.7/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.7/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.7/pkg/internal/controller/controller.go:224"} 
```

These error logs are a product of the order in which reconciliation is performed for multi node llmisvcs. Service account reconciliation is performed as the [first](https://github.com/kserve/kserve/blob/master/pkg/controller/v1alpha1/llmisvc/workload_multi_node.go#L42) part of multi node llmisvc reconciliation. In the case of a desired [single node](https://github.com/opendatahub-io/kserve/blob/release-v0.15/pkg/controller/llmisvc/workload_multi_node.go#L330) llmisvc, the service account will be deleted if it exists, or not created. The same thing applies in reverse for single node reconciliation when multi-node is desired. After the service account is reconciled the workload reconciliation will continue and utilize the llmisvc spec which contains the nonexistent service account. When the expected pod spec is created for the llmisvc as a part of this continued reconciliation it will attach model artifacts to the pod spec. Given that the credential builder used for model artifact attachment relies completely on credentials configured via service accounts, if the service account set in the pod spec does not exist the credential builder will log the above error.

To suppress this error, a new method `CreateSecretVolumeAndEnvFromServiceAccount` has been added to the credential builder. This method takes a service account spec as input, thus avoiding the need to fetch the service account. This allows us to pass the expected service account spec directly from llmisvc reconciliation to the attach model artifacts functionality. In scenarios where no service account is set in the llmisvc template spec, we will pass the service account as `nil` and the `default` service account from the same namespace as the llmisvc will be utilized.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] All unit and fvt tests passing
- [x] Manual integration testing results in the error no longer being logged, while the expected functionality is maintained.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid pervasive logging of sa not found errors by credential builder
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.