### PR TITLE
Fixed the panic nil pointer issue componentExt being nil

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
@@ -90,8 +90,10 @@ func createAutoscaler(client client.Client,
 ) (Autoscaler, error) {
 	ac := getAutoscalerClass(componentMeta)
 	switch ac {
-	case constants.AutoscalerClassHPA, constants.AutoscalerClassExternal, constants.AutoscalerClassNone:
+	case constants.AutoscalerClassHPA:
 		return hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt)
+	case constants.AutoscalerClassExternal, constants.AutoscalerClassNone:
+		return &NoOpAutoscaler{}, nil
 	case constants.AutoscalerClassKeda:
 		return keda.NewKedaReconciler(client, scheme, componentMeta, componentExt, configMap)
 	default:

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
@@ -90,10 +90,8 @@ func createAutoscaler(client client.Client,
 ) (Autoscaler, error) {
 	ac := getAutoscalerClass(componentMeta)
 	switch ac {
-	case constants.AutoscalerClassHPA:
+	case constants.AutoscalerClassHPA, constants.AutoscalerClassExternal, constants.AutoscalerClassNone:
 		return hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt)
-	case constants.AutoscalerClassExternal, constants.AutoscalerClassNone:
-		return &NoOpAutoscaler{}, nil
 	case constants.AutoscalerClassKeda:
 		return keda.NewKedaReconciler(client, scheme, componentMeta, componentExt, configMap)
 	default:

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler_test.go
@@ -123,15 +123,15 @@ func TestCreateAutoscaler(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:        "Return NoOpAutoscaler for external annotation",
+			name:        "Return HPAReconciler for external annotation",
 			annotations: map[string]string{"serving.kserve.io/autoscalerClass": "external"},
-			wantType:    "*autoscaler.NoOpAutoscaler",
+			wantType:    "*hpa.HPAReconciler",
 			wantErr:     false,
 		},
 		{
-			name:        "Return NoOpAutoscaler for none annotation",
+			name:        "Return HPAReconciler for none annotation",
 			annotations: map[string]string{"serving.kserve.io/autoscalerClass": "none"},
-			wantType:    "*autoscaler.NoOpAutoscaler",
+			wantType:    "*hpa.HPAReconciler",
 			wantErr:     false,
 		},
 		{
@@ -215,15 +215,15 @@ func TestNewAutoscalerReconciler(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:        "Return AutoscalerReconciler with NoOpAutoscaler for external annotation",
+			name:        "Return AutoscalerReconciler with HPAReconciler for external annotation",
 			annotations: map[string]string{"serving.kserve.io/autoscalerClass": "external"},
-			wantType:    "*autoscaler.NoOpAutoscaler",
+			wantType:    "*hpa.HPAReconciler",
 			wantErr:     false,
 		},
 		{
-			name:        "Return AutoscalerReconciler with NoOpAutoscaler for none annotation",
+			name:        "Return AutoscalerReconciler with HPAReconciler for none annotation",
 			annotations: map[string]string{"serving.kserve.io/autoscalerClass": "none"},
-			wantType:    "*autoscaler.NoOpAutoscaler",
+			wantType:    "*hpa.HPAReconciler",
 			wantErr:     false,
 		},
 		{
@@ -368,20 +368,14 @@ func TestExternalAutoscalerWithNilComponentExt(t *testing.T) {
 	}
 
 	if as == nil {
-		t.Errorf("Expected NoOpAutoscaler, got nil")
+		t.Errorf("Expected HPAReconciler, got nil")
 		return
 	}
 
 	gotType := fmt.Sprintf("%T", as)
-	expectedType := "*autoscaler.NoOpAutoscaler"
+	expectedType := "*hpa.HPAReconciler"
 	if gotType != expectedType {
 		t.Errorf("Expected autoscaler type %s, got %s", expectedType, gotType)
-	}
-
-	// Test that the NoOpAutoscaler can be used without causing panics
-	err = as.Reconcile(t.Context())
-	if err != nil {
-		t.Errorf("NoOpAutoscaler.Reconcile() should not return error, got: %v", err)
 	}
 }
 
@@ -401,19 +395,13 @@ func TestNoneAutoscalerWithNilComponentExt(t *testing.T) {
 	}
 
 	if as == nil {
-		t.Errorf("Expected NoOpAutoscaler, got nil")
+		t.Errorf("Expected HPAReconciler, got nil")
 		return
 	}
 
 	gotType := fmt.Sprintf("%T", as)
-	expectedType := "*autoscaler.NoOpAutoscaler"
+	expectedType := "*hpa.HPAReconciler"
 	if gotType != expectedType {
 		t.Errorf("Expected autoscaler type %s, got %s", expectedType, gotType)
-	}
-
-	// Test that the NoOpAutoscaler can be used without causing panics
-	err = as.Reconcile(t.Context())
-	if err != nil {
-		t.Errorf("NoOpAutoscaler.Reconcile() should not return error, got: %v", err)
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -158,7 +158,7 @@ func createRawDefaultDeployment(componentMeta metav1.ObjectMeta,
 			},
 		},
 	}
-	if componentExt.DeploymentStrategy != nil {
+	if componentExt != nil && componentExt.DeploymentStrategy != nil {
 		// User-specified deployment strategy takes precedence
 		deployment.Spec.Strategy = *componentExt.DeploymentStrategy
 	} else {
@@ -166,7 +166,7 @@ func createRawDefaultDeployment(componentMeta metav1.ObjectMeta,
 		setDefaultDeploymentSpec(&deployment.Spec)
 		applyRolloutStrategyFromConfigmap(&deployment.Spec, deployConfig)
 	}
-	if componentExt.MinReplicas != nil && deployment.Annotations[constants.AutoscalerClass] == string(constants.AutoscalerClassNone) {
+	if componentExt != nil && componentExt.MinReplicas != nil && deployment.Annotations[constants.AutoscalerClass] == string(constants.AutoscalerClassNone) {
 		deployment.Spec.Replicas = ptr.To(*componentExt.MinReplicas)
 	}
 
@@ -196,7 +196,7 @@ func createRawWorkerDeployment(componentMeta metav1.ObjectMeta,
 			},
 		},
 	}
-	if componentExt.DeploymentStrategy != nil {
+	if componentExt != nil && componentExt.DeploymentStrategy != nil {
 		// User-specified deployment strategy takes precedence
 		deployment.Spec.Strategy = *componentExt.DeploymentStrategy
 	} else {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -61,6 +61,9 @@ func getHPAMetrics(componentExt *v1beta1.ComponentExtensionSpec) []autoscalingv2
 	var metrics []autoscalingv2.MetricSpec
 	if componentExt != nil && componentExt.AutoScaling != nil {
 		for _, metric := range componentExt.AutoScaling.Metrics {
+			if metric.Resource == nil {
+				continue
+			}
 			switch metric.Resource.Name {
 			case v1beta1.ResourceMetricCPU:
 				averageUtilization := &constants.DefaultCPUUtilization

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler_test.go
@@ -371,6 +371,45 @@ func TestCreateHPA(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name: "nil componentExt for createHPA",
+			args: args{
+				objectMeta: metav1.ObjectMeta{
+					Name:      "nil-component-ext",
+					Namespace: "default",
+				},
+				componentExt: nil,
+			},
+			expected: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nil-component-ext",
+					Namespace: "default",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "nil-component-ext",
+					},
+					MinReplicas: &defaultMinReplicas,
+					MaxReplicas: 1,
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
+								Name: corev1.ResourceCPU,
+								Target: autoscalingv2.MetricTarget{
+									Type:               autoscalingv2.UtilizationMetricType,
+									AverageUtilization: &defaultUtilization,
+								},
+							},
+						},
+					},
+					Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{},
+				},
+			},
+			err: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -871,6 +910,22 @@ func TestGetHPAMetrics(t *testing.T) {
 						Target: autoscalingv2.MetricTarget{
 							Type:         autoscalingv2.AverageValueMetricType,
 							AverageValue: ptr.To(resource.MustParse("1Gi")),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "nil componentExt should return default CPU metric",
+			componentExt: nil,
+			expectedSpecs: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To(int32(80)),
 						},
 					},
 				},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
@@ -72,7 +72,7 @@ func getKedaMetrics(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compo
 	var triggers []kedav1alpha1.ScaleTriggers
 
 	// metric configuration from componentExtension.AutoScaling if it is set
-	if componentExt.AutoScaling != nil {
+	if componentExt != nil && componentExt.AutoScaling != nil {
 		metrics := componentExt.AutoScaling.Metrics
 		for _, metric := range metrics {
 			switch metric.Type {
@@ -183,12 +183,16 @@ func createKedaScaledObject(componentMeta metav1.ObjectMeta,
 ) (*kedav1alpha1.ScaledObject, error) {
 	annotations := componentMeta.GetAnnotations()
 
-	MinReplicas := componentExtension.MinReplicas
-	MaxReplicas := componentExtension.MaxReplicas
+	var MinReplicas *int32
+	var MaxReplicas int32
+	if componentExtension != nil {
+		MinReplicas = componentExtension.MinReplicas
+		MaxReplicas = componentExtension.MaxReplicas
+	}
 
 	var scaleDownStabilizationWindowSeconds, scaleUpStabilizationWindowSeconds *int32
 
-	if componentExtension.AutoScaling != nil && componentExtension.AutoScaling.Behavior != nil {
+	if componentExtension != nil && componentExtension.AutoScaling != nil && componentExtension.AutoScaling.Behavior != nil {
 		if sd := componentExtension.AutoScaling.Behavior.ScaleDown; sd != nil {
 			scaleDownStabilizationWindowSeconds = sd.StabilizationWindowSeconds
 		}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -68,7 +68,7 @@ func NewRawKubeReconciler(ctx context.Context,
 		return nil, err
 	}
 	// create OTel Collector if pod metrics is enabled for auto-scaling
-	if componentExt.AutoScaling != nil {
+	if componentExt != nil && componentExt.AutoScaling != nil {
 		var metricNames []string
 		metrics := componentExt.AutoScaling.Metrics
 		for _, metric := range metrics {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4703

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.