### PR TITLE
Configure HF Downloads to Lower Memory Usage

### DIFF
--- a/pkg/credentials/hf/hf_secret.go
+++ b/pkg/credentials/hf/hf_secret.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	HFTokenKey = "HF_TOKEN"
-	HFTransfer = "HF_HUB_ENABLE_HF_TRANSFER"
 )
 
 func BuildSecretEnvs(secret *corev1.Secret) []corev1.EnvVar {
@@ -40,10 +39,6 @@ func BuildSecretEnvs(secret *corev1.Secret) []corev1.EnvVar {
 						Key: HFTokenKey,
 					},
 				},
-			},
-			{
-				Name:  HFTransfer,
-				Value: "1",
 			},
 		}...)
 	}

--- a/pkg/credentials/hf/hf_secret_test.go
+++ b/pkg/credentials/hf/hf_secret_test.go
@@ -36,12 +36,10 @@ func TestBuildSecretEnvs_WithToken(t *testing.T) {
 
 	envs := BuildSecretEnvs(secret)
 
-	assert.Len(t, envs, 2)
+	assert.Len(t, envs, 1)
 	assert.Equal(t, HFTokenKey, envs[0].Name)
 	assert.Equal(t, HFTokenKey, envs[0].ValueFrom.SecretKeyRef.Key)
 	assert.Equal(t, secret.Name, envs[0].ValueFrom.SecretKeyRef.LocalObjectReference.Name)
-	assert.Equal(t, HFTransfer, envs[1].Name)
-	assert.Equal(t, "1", envs[1].Value)
 }
 
 func TestBuildSecretEnvs_WithoutToken(t *testing.T) {

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -190,6 +190,20 @@ func AddStorageInitializerContainer(podSpec *corev1.PodSpec, mainContainerName, 
 				MountPath: constants.DefaultModelLocalMountPath,
 				ReadOnly:  false,
 			}},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "HF_HUB_ENABLE_HF_TRANSFER",
+					Value: "1",
+				},
+				{
+					Name:  "HF_XET_HIGH_PERFORMANCE",
+					Value: "1",
+				},
+				{
+					Name:  "HF_XET_NUM_CONCURRENT_RANGE_GETS",
+					Value: "8",
+				},
+			},
 			Resources: corev1.ResourceRequirements{
 				Limits: map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceCPU:    resource.MustParse(storageConfig.CpuLimit),

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -179,10 +179,15 @@ func TestStorageInitializerInjector(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -240,10 +245,15 @@ func TestStorageInitializerInjector(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -302,10 +312,15 @@ func TestStorageInitializerInjector(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -364,10 +379,15 @@ func TestStorageInitializerInjector(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -483,6 +503,9 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name:  credentials.StorageOverrideConfigEnvKey,
 									Value: `{"bucket":"my-bucket","type":"s3"}`,
@@ -765,6 +788,9 @@ func TestCredentialInjection(t *testing.T) {
 								},
 							},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -870,6 +896,9 @@ func TestCredentialInjection(t *testing.T) {
 								},
 							},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name:  gcs.GCSCredentialEnvKey,
 									Value: gcs.GCSCredentialVolumeMountPath + "gcloud-application-credentials.json",
@@ -958,6 +987,9 @@ func TestCredentialInjection(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: credentials.StorageConfigEnvKey,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1053,6 +1085,9 @@ func TestCredentialInjection(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: credentials.StorageConfigEnvKey,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1165,10 +1200,15 @@ func TestStorageInitializerConfigmap(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    "kserve/storage-initializer@sha256:xxx",
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     "kserve/storage-initializer@sha256:xxx",
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -1409,6 +1449,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1510,6 +1553,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1630,6 +1676,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1752,6 +1801,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1867,6 +1919,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1973,6 +2028,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -2711,6 +2769,9 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{Name: "name", Value: "value"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 						},
 					},
@@ -2761,10 +2822,15 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"https://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement, // from configMap instead of the CR
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"https://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement, // from configMap instead of the CR
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3196,10 +3262,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3272,6 +3343,11 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -3352,10 +3428,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Name: constants.IstioInitContainerName,
 						},
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3414,10 +3495,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3488,10 +3574,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3562,10 +3653,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3636,10 +3732,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3709,10 +3810,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3782,10 +3888,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -3856,10 +3967,15 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:                     "storage-initializer",
-							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
-							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
-							Resources:                resourceRequirement,
+							Name:      "storage-initializer",
+							Image:     constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:      []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources: resourceRequirement,
+							Env: []corev1.EnvVar{
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
+							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When downloading models form hugging face storage using the latest version of the Huggingface Hub python library `Out Of Memory (OOM)` errors are consistently encountered for large models. The cause of this issue is the way kubernetes handles memory overhead when using the `xet` package for hf downloads (discussed in this [issue](https://github.com/huggingface/huggingface_hub/issues/3300#issuecomment-3234260268)).

To lower the memory usage, the following configuration will be used:
1. To maximize download speeds for legacy git lfs storage we will enable the use of the `hf_transfer` package: https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfhubenablehftransfer
2. To maximize download speeds for hf repos that support `xet` we will enable xet high performance mode: https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfxethighperformance
3. To minimize the memory usage of the `xet` package we will limit the number of chunks downloaded per file:
https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfxetnumconcurrentrangegets

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:
To test a simple inference service was deployed with the following configuration:
```
spec:
  predictor:
    automountServiceAccountToken: false
    maxReplicas: 1
    minReplicas: 1
    model:
      modelFormat:
        name: vLLM
      name: ''
      resources:
        limits:
          cpu: '2'
          memory: 8Gi
        requests:
          cpu: '1'
          memory: 4Gi
      runtime: hf-test
      storageUri: 'hf://deepseek-ai/DeepSeek-V2-Lite-Chat'
```

After deploying the isvc, the metrics of the storage-initalizer pod were captured utilizing an openshift console. The results are captured below.

**Current Configuration**

-  hf transfer enabled

<img width="720" height="349" alt="image" src="https://github.com/user-attachments/assets/ae14709b-51cc-44bf-8f93-f22a8717c4b9" />


**New Configuration**

- hf transfer enabled
- xet high performance enabled
- xet num concurrent range gets 8

<img width="720" height="349" alt="image" src="https://github.com/user-attachments/assets/2a940445-fef7-48fd-b6fe-1c67602a8b60" />


As seen above, the new configuration lowers memory usage by 75% (>2GB to <0.5GB), while maintaining a consistent time taken to download the model.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve HF model downloads by decreasing memory usage while minimizing download time.
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.