### PR TITLE
Add metadata propagation for Kueue configurations to both Deployment and LeaderWorkerSet workloads

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -42,6 +42,11 @@ var (
 	AutoscalerConfigmapNamespace = GetEnvOrDefault("KNATIVE_CONFIG_AUTOSCALER_NAMESPACE", DefaultKnServingNamespace)
 )
 
+// Kueue Constants
+const (
+	KueueAPIGroupName = "kueue.x-k8s.io"
+)
+
 // InferenceService Constants
 var (
 	InferenceServiceName                  = "inferenceservice"

--- a/pkg/controller/v1alpha1/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/v1alpha1/llmisvc/fixture/llmisvc_builders.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fixture
 
 import (
+	"maps"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -119,6 +121,24 @@ func WithManagedRoute() LLMInferenceServiceOption {
 		if llmSvc.Spec.Router.Route == nil {
 			llmSvc.Spec.Router.Route = &v1alpha1.GatewayRoutesSpec{}
 		}
+	}
+}
+
+func WithAnnotations(annotationsToAdd map[string]string) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha1.LLMInferenceService) {
+		if llmSvc.Annotations == nil {
+			llmSvc.Annotations = make(map[string]string)
+		}
+		maps.Copy(llmSvc.Annotations, annotationsToAdd)
+	}
+}
+
+func WithLabels(labelsToAdd map[string]string) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha1.LLMInferenceService) {
+		if llmSvc.Labels == nil {
+			llmSvc.Labels = make(map[string]string)
+		}
+		maps.Copy(llmSvc.Labels, labelsToAdd)
 	}
 }
 

--- a/pkg/controller/v1alpha1/llmisvc/suite_test.go
+++ b/pkg/controller/v1alpha1/llmisvc/suite_test.go
@@ -22,8 +22,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1alpha1/llmisvc/fixture"
 	pkgtest "github.com/kserve/kserve/pkg/testing"
+)
+
+// Kueue Constants
+var (
+	LocalQueueNameLabelKey         = constants.KueueAPIGroupName + "/queue-name"
+	PreemptionReclaimAnnotationKey = constants.KueueAPIGroupName + "/preemption-reclaim-if-below-priority"
 )
 
 func TestLLMInferenceServiceController(t *testing.T) {

--- a/pkg/controller/v1alpha1/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha1/llmisvc/workload_multi_node.go
@@ -19,7 +19,6 @@ package llmisvc
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -34,6 +33,8 @@ import (
 	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 func (r *LLMISVCReconciler) reconcileMultiNodeWorkload(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService, config *Config) error {
@@ -519,35 +520,47 @@ func (r *LLMISVCReconciler) expectedMultiNodeRoleBinding(llmSvc *v1alpha1.LLMInf
 }
 
 func (r *LLMISVCReconciler) propagateLeaderWorkerSetMetadata(llmSvc *v1alpha1.LLMInferenceService, expected *lwsapi.LeaderWorkerSet) {
-	ann := make(map[string]string, len(expected.Annotations))
-	for k, v := range llmSvc.GetAnnotations() {
-		if strings.HasPrefix(k, "leaderworkerset.sigs.k8s.io") ||
-			strings.HasPrefix(k, "k8s.v1.cni.cncf.io") {
-			ann[k] = v
-			if expected.Annotations == nil {
-				expected.Annotations = make(map[string]string, 1)
-			}
-			expected.Annotations[k] = v
-		}
+	// Define the prefixes to approve for annotations and labels
+	approvedAnnotationPrefixes := []string{
+		"leaderworkerset.sigs.k8s.io",
+		"k8s.v1.cni.cncf.io",
+		constants.KueueAPIGroupName,
 	}
+	approvedLabelPrefixes := []string{
+		constants.KueueAPIGroupName,
+	}
+
+	// Propagate approved annotations to the LeaderWorkerSet's top-level metadata
+	utils.PropagatePrefixedMap(llmSvc.GetAnnotations(), &expected.Annotations, approvedAnnotationPrefixes...)
 
 	if expected.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
-		if expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations == nil {
-			expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations = ann
-		} else {
-			for k, v := range ann {
-				expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[k] = v
-			}
-		}
+		utils.PropagatePrefixedMap(
+			llmSvc.GetAnnotations(),
+			&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations,
+			approvedAnnotationPrefixes...,
+		)
 	}
 
-	if expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations == nil {
-		expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations = ann
-	} else {
-		for k, v := range ann {
-			expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[k] = v
-		}
+	utils.PropagatePrefixedMap(
+		llmSvc.GetAnnotations(),
+		&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations,
+		approvedAnnotationPrefixes...,
+	)
+
+	// Propagate approved labels
+	utils.PropagatePrefixedMap(llmSvc.GetLabels(), &expected.Labels, approvedLabelPrefixes...)
+	if expected.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
+		utils.PropagatePrefixedMap(
+			llmSvc.GetLabels(),
+			&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Labels,
+			approvedLabelPrefixes...,
+		)
 	}
+	utils.PropagatePrefixedMap(
+		llmSvc.GetLabels(),
+		&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Labels,
+		approvedLabelPrefixes...,
+	)
 }
 
 func semanticLWSIsEqual(expected *lwsapi.LeaderWorkerSet, curr *lwsapi.LeaderWorkerSet) bool {

--- a/pkg/controller/v1alpha1/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha1/llmisvc/workload_single_node.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"strings"
+
+	"github.com/kserve/kserve/pkg/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 func (r *LLMISVCReconciler) reconcileSingleNodeWorkload(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService, config *Config) error {
@@ -217,24 +219,17 @@ func (r *LLMISVCReconciler) expectedPrefillMainDeployment(ctx context.Context, l
 }
 
 func (r *LLMISVCReconciler) propagateDeploymentMetadata(llmSvc *v1alpha1.LLMInferenceService, expected *appsv1.Deployment) {
-	ann := make(map[string]string, len(expected.Annotations))
-	for k, v := range llmSvc.GetAnnotations() {
-		if strings.HasPrefix(k, "k8s.v1.cni.cncf.io") {
-			ann[k] = v
-			if expected.Annotations == nil {
-				expected.Annotations = make(map[string]string, 1)
-			}
-			expected.Annotations[k] = v
-		}
-	}
+	// Define the prefixes to approve for annotations and labels
+	approvedAnnotationPrefixes := []string{"k8s.v1.cni.cncf.io", constants.KueueAPIGroupName}
+	approvedLabelPrefixes := []string{constants.KueueAPIGroupName}
 
-	if expected.Spec.Template.Annotations == nil {
-		expected.Spec.Template.Annotations = ann
-	} else {
-		for k, v := range ann {
-			expected.Spec.Template.Annotations[k] = v
-		}
-	}
+	// Propagate approved annotations to the Deployment and its Pod template
+	utils.PropagatePrefixedMap(llmSvc.GetAnnotations(), &expected.Annotations, approvedAnnotationPrefixes...)
+	utils.PropagatePrefixedMap(llmSvc.GetAnnotations(), &expected.Spec.Template.Annotations, approvedAnnotationPrefixes...)
+
+	// Propagate approved labels to the Deployment and its Pod template
+	utils.PropagatePrefixedMap(llmSvc.GetLabels(), &expected.Labels, approvedLabelPrefixes...)
+	utils.PropagatePrefixedMap(llmSvc.GetLabels(), &expected.Spec.Template.Labels, approvedLabelPrefixes...)
 }
 
 func (r *LLMISVCReconciler) propagateDeploymentStatus(ctx context.Context, expected *appsv1.Deployment, ready func(), notReady func(reason, messageFormat string, messageA ...interface{})) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -99,6 +99,21 @@ func IsPrefixSupported(input string, prefixes []string) bool {
 	return false
 }
 
+// PropagatePrefixedMap filters keys in source by the provided prefixes and propagates matching key-value pairs to dest.
+// Initializes dest if nil.
+func PropagatePrefixedMap(source map[string]string, dest *map[string]string, prefixes ...string) {
+	for k, v := range source {
+		// The nested loop and if statement are replaced with a single, clear function call.
+		if IsPrefixSupported(k, prefixes) {
+			// Initialize the destination map if it's nil
+			if *dest == nil {
+				*dest = make(map[string]string)
+			}
+			(*dest)[k] = v
+		}
+	}
+}
+
 // MergeEnvs Merge a slice of EnvVars (`O`) into another slice of EnvVars (`B`), which does the following:
 // 1. If an EnvVar is present in B but not in O, value remains unchanged in the result
 // 2. If an EnvVar is present in `O` but not in `B`, appends to the result


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the integration of LLMInferenceService with Kueue, a Kubernetes-native job queueing system designed to manage resource-intensive batch workloads like AI/ML model serving.

Context: For Kueue to manage an LLMInferenceService, the underlying pods it creates must have specific metadata (labels and annotations) that link them to a queue. This PR implements the crucial logic to propagate that metadata from the high-level LLMInferenceService resource down to the Deployments or LeaderWorkerSets it generates. This allows Kueue to correctly identify, queue, and manage our model workloads for resource accounting and preemption.

Changes:
- Adds metadata propagation for Kueue configurations to both Deployment and LeaderWorkerSet workloads.
- Refactored propagateDeploymentMetadata and propagateLeaderWorkerSetMetadata for better code reusability
- Added label propagation rules to propagateDeploymentMetadata and propagateLeaderWorkerSetMetadata

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.