### PR TITLE
fix: update base image for PMML to use eclipse-temurin JDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include kserve-deps.env
 
 # Base Image URL
 BASE_IMG ?= python:3.11-slim-bookworm
-PMML_BASE_IMG ?= openjdk:21-slim-bookworm
+PMML_BASE_IMG ?= eclipse-temurin:21-jdk-noble
 
 # Image URL to use all building/pushing image targets
 IMG ?= kserve-controller:latest

--- a/python/pmml.Dockerfile
+++ b/python/pmml.Dockerfile
@@ -1,6 +1,6 @@
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 ARG JAVA_VERSION=21
-ARG BASE_IMAGE=openjdk:${JAVA_VERSION}-slim-bookworm
+ARG BASE_IMAGE=eclipse-temurin:${JAVA_VERSION}-jdk-noble
 ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
@@ -73,7 +73,7 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Create non-root user
-RUN useradd kserve -m -u 1000 -d /home/kserve
+RUN useradd kserve -m -u 1001 -d /home/kserve
 
 COPY --from=builder --chown=kserve:kserve third_party third_party
 COPY --from=builder --chown=kserve:kserve $VIRTUAL_ENV $VIRTUAL_ENV
@@ -81,6 +81,6 @@ COPY --from=builder kserve kserve
 COPY --from=builder storage storage
 COPY --from=builder pmmlserver pmmlserver
 
-USER 1000
+USER 1001
 ENV PYTHONPATH=/pmmlserver
 ENTRYPOINT ["python3", "-m", "pmmlserver"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
<img width="1466" height="374" alt="Screenshot from 2025-11-04 12-02-44" src="https://github.com/user-attachments/assets/154537be-ed19-4524-8c79-71deaba3d2c6" />

`openjdk` image is deprecated and `openjdk-21-slim` image is no longer available in dockerhub. This is the offical quote from the [openjdk dockerhub page](https://hub.docker.com/_/openjdk)

> This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP. Some examples of other Official Image alternatives (listed in alphabetical order with no intentional or implied preference):
 - [amazoncorretto](https://hub.docker.com/_/amazoncorretto)
 - [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)
 - [ibm-semeru-runtimes](https://hub.docker.com/_/ibm-semeru-runtimes)
 - [ibmjava](https://hub.docker.com/_/ibmjava)
 - [sapmachine](https://hub.docker.com/_/sapmachine)
> See [docker-library/openjdk#505⁠](https://github.com/docker-library/openjdk/issues/505) for more information.
The only tags which will continue to receive updates beyond July 2022 will be Early Access builds (which are sourced  from [jdk.java.net⁠](https://jdk.java.net/)), as those are not published/supported by any of the above projects.

This PR uses the `eclipse-temurin:21-jdk-noble` image from `eclipse-temurin`.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update base image for PMML to use eclipse-temurin JDK
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.