### PR TITLE
Add Support For Protocol in S3 Endpoint

### DIFF
--- a/pkg/credentials/s3/s3_secret_test.go
+++ b/pkg/credentials/s3/s3_secret_test.go
@@ -224,6 +224,114 @@ func TestS3Secret(t *testing.T) {
 			},
 		},
 
+		"S3SecretAnnotationEndpointWithProtocol": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-secret",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "https://s3.aws.com",
+						InferenceServiceS3SecretHttpsAnnotation:    "0",
+						InferenceServiceS3SecretSSLAnnotation:      "1",
+					},
+				},
+			},
+
+			expected: []corev1.EnvVar{
+				{
+					Name: AWSAccessKeyId,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSAccessKeyIdName,
+						},
+					},
+				},
+				{
+					Name: AWSSecretAccessKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSSecretAccessKeyName,
+						},
+					},
+				},
+				{
+					Name:  S3UseHttps,
+					Value: "1",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "1",
+				},
+			},
+		},
+
+		"S3SecretDataEndpointWithProtocol": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-secret",
+				},
+				Data: map[string][]byte{
+					S3Endpoint:  []byte("http://s3.aws.com"),
+					S3UseHttps:  []byte("1"),
+					S3VerifySSL: []byte("0"),
+				},
+			},
+
+			expected: []corev1.EnvVar{
+				{
+					Name: AWSAccessKeyId,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSAccessKeyIdName,
+						},
+					},
+				},
+				{
+					Name: AWSSecretAccessKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSSecretAccessKeyName,
+						},
+					},
+				},
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "0",
+				},
+			},
+		},
+
 		"S3SecretAnnotationEnvsWithAnonymousCredentials": {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -326,6 +434,56 @@ func TestS3Secret(t *testing.T) {
 				S3SecretAccessKeyName: "test-access-key",
 				S3UseHttps:            "0",
 				S3Endpoint:            "s3.aws.com",
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-secret",
+				},
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name: AWSAccessKeyId,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: "test-keyId",
+						},
+					},
+				},
+				{
+					Name: AWSSecretAccessKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: "test-access-key",
+						},
+					},
+				},
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://s3.aws.com",
+				},
+			},
+		},
+
+		"S3ConfigWithProtocol": {
+			config: S3Config{
+				S3AccessKeyIDName:     "test-keyId",
+				S3SecretAccessKeyName: "test-access-key",
+				S3UseHttps:            "1",
+				S3Endpoint:            "http://s3.aws.com",
 			},
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/credentials/s3/s3_service_account_test.go
+++ b/pkg/credentials/s3/s3_service_account_test.go
@@ -91,6 +91,68 @@ func TestS3ServiceAccount(t *testing.T) {
 			},
 		},
 
+		"S3EndpointWithHttpsProtocol": {
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-service-account",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "https://s3.aws.com",
+						InferenceServiceS3SecretHttpsAnnotation:    "0",
+						InferenceServiceS3SecretSSLAnnotation:      "1",
+					},
+				},
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "1",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "1",
+				},
+			},
+		},
+
+		"S3EndpointWithHttpProtocol": {
+			serviceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-service-account",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "http://s3.aws.com",
+						InferenceServiceS3SecretHttpsAnnotation:    "1",
+						InferenceServiceS3SecretSSLAnnotation:      "0",
+					},
+				},
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "0",
+				},
+			},
+		},
+
 		"S3EnvsWithAnonymousCredentials": {
 			serviceAccount: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/credentials/s3/utils_test.go
+++ b/pkg/credentials/s3/utils_test.go
@@ -214,30 +214,30 @@ func TestBuildS3EnvVars(t *testing.T) {
 			annotations: map[string]string{
 				InferenceServiceS3SecretEndpointAnnotation:    "s3.aws.com-annotation",
 				InferenceServiceS3SecretRegionAnnotation:      "us-east-2-annotation",
-				InferenceServiceS3SecretSSLAnnotation:         "0-annotation",
-				InferenceServiceS3UseVirtualBucketAnnotation:  "true-annotation",
-				InferenceServiceS3UseAccelerateAnnotation:     "true-annotation",
-				InferenceServiceS3UseAnonymousCredential:      "true-annotation",
+				InferenceServiceS3SecretSSLAnnotation:         "0",
+				InferenceServiceS3UseVirtualBucketAnnotation:  "true",
+				InferenceServiceS3UseAccelerateAnnotation:     "true",
+				InferenceServiceS3UseAnonymousCredential:      "true",
 				InferenceServiceS3CABundleAnnotation:          "value-annotation",
 				InferenceServiceS3CABundleConfigMapAnnotation: "value-annotation",
 			},
 			secret: &map[string][]byte{
 				S3Endpoint:             []byte("s3.aws.com-secret"),
-				S3VerifySSL:            []byte("0-secret"),
-				AWSAnonymousCredential: []byte("true-secret"),
+				S3VerifySSL:            []byte("1"),
+				AWSAnonymousCredential: []byte("fase"),
 				AWSRegion:              []byte("us-east-2-secret"),
-				S3UseVirtualBucket:     []byte("true-secret"),
-				S3UseAccelerate:        []byte("true-secret"),
+				S3UseVirtualBucket:     []byte("false"),
+				S3UseAccelerate:        []byte("false"),
 				AWSCABundle:            []byte("value-secret"),
 				AWSCABundleConfigMap:   []byte("value-secret"),
 			},
 			config: S3Config{
 				S3Endpoint:               "s3.aws.com-config",
 				S3Region:                 "us-east-2-config",
-				S3VerifySSL:              "0-config",
-				S3UseVirtualBucket:       "true-config",
-				S3UseAccelerate:          "true-config",
-				S3UseAnonymousCredential: "true-config",
+				S3VerifySSL:              "1",
+				S3UseVirtualBucket:       "false",
+				S3UseAccelerate:          "false",
+				S3UseAnonymousCredential: "false",
 				S3CABundleConfigMap:      "value-config",
 				S3CABundle:               "value-config",
 			},
@@ -252,11 +252,11 @@ func TestBuildS3EnvVars(t *testing.T) {
 				},
 				{
 					Name:  S3VerifySSL,
-					Value: "0-annotation",
+					Value: "0",
 				},
 				{
 					Name:  AWSAnonymousCredential,
-					Value: "true-annotation",
+					Value: "true",
 				},
 				{
 					Name:  AWSRegion,
@@ -264,11 +264,11 @@ func TestBuildS3EnvVars(t *testing.T) {
 				},
 				{
 					Name:  S3UseVirtualBucket,
-					Value: "true-annotation",
+					Value: "true",
 				},
 				{
 					Name:  S3UseAccelerate,
-					Value: "true-annotation",
+					Value: "true",
 				},
 				{
 					Name:  AWSCABundle,
@@ -283,21 +283,21 @@ func TestBuildS3EnvVars(t *testing.T) {
 		"SecretAndS3Config": {
 			secret: &map[string][]byte{
 				S3Endpoint:             []byte("s3.aws.com-secret"),
-				S3VerifySSL:            []byte("0-secret"),
-				AWSAnonymousCredential: []byte("true-secret"),
+				S3VerifySSL:            []byte("0"),
+				AWSAnonymousCredential: []byte("true"),
 				AWSRegion:              []byte("us-east-2-secret"),
-				S3UseVirtualBucket:     []byte("true-secret"),
-				S3UseAccelerate:        []byte("true-secret"),
+				S3UseVirtualBucket:     []byte("true"),
+				S3UseAccelerate:        []byte("true"),
 				AWSCABundle:            []byte("value-secret"),
 				AWSCABundleConfigMap:   []byte("value-secret"),
 			},
 			config: S3Config{
 				S3Endpoint:               "s3.aws.com-config",
 				S3Region:                 "us-east-2-config",
-				S3VerifySSL:              "0-config",
-				S3UseVirtualBucket:       "true-config",
-				S3UseAccelerate:          "true-config",
-				S3UseAnonymousCredential: "true-config",
+				S3VerifySSL:              "1",
+				S3UseVirtualBucket:       "false",
+				S3UseAccelerate:          "false",
+				S3UseAnonymousCredential: "false",
 				S3CABundleConfigMap:      "value-config",
 				S3CABundle:               "value-config",
 			},
@@ -312,11 +312,11 @@ func TestBuildS3EnvVars(t *testing.T) {
 				},
 				{
 					Name:  S3VerifySSL,
-					Value: "0-secret",
+					Value: "0",
 				},
 				{
 					Name:  AWSAnonymousCredential,
-					Value: "true-secret",
+					Value: "true",
 				},
 				{
 					Name:  AWSRegion,
@@ -324,11 +324,11 @@ func TestBuildS3EnvVars(t *testing.T) {
 				},
 				{
 					Name:  S3UseVirtualBucket,
-					Value: "true-secret",
+					Value: "true",
 				},
 				{
 					Name:  S3UseAccelerate,
-					Value: "true-secret",
+					Value: "true",
 				},
 				{
 					Name:  AWSCABundle,
@@ -337,6 +337,248 @@ func TestBuildS3EnvVars(t *testing.T) {
 				{
 					Name:  AWSCABundleConfigMap,
 					Value: "value-secret",
+				},
+			},
+		},
+		"EndpointWithHttpsProtocol": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "https://s3.aws.com",
+				InferenceServiceS3SecretSSLAnnotation:      "1",
+				InferenceServiceS3SecretHttpsAnnotation:    "0",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "1",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "1",
+				},
+			},
+		},
+		"EndpointWithHttpProtocol": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "http://s3.aws.com",
+				InferenceServiceS3SecretSSLAnnotation:      "0",
+				InferenceServiceS3SecretHttpsAnnotation:    "1",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "0",
+				},
+			},
+		},
+		"LocalWithHttpProtocol": {
+			secret: &map[string][]byte{
+				S3Endpoint: []byte("http://localhost:9000"),
+				S3UseHttps: []byte("1"),
+			},
+			config: S3Config{
+				S3Endpoint:               "s3.aws.com-config",
+				S3UseVirtualBucket:       "false",
+				S3UseAccelerate:          "false",
+				S3UseAnonymousCredential: "false",
+				S3CABundleConfigMap:      "value-config",
+				S3CABundle:               "value-config",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "localhost:9000",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://localhost:9000",
+				},
+				{
+					Name:  AWSAnonymousCredential,
+					Value: "false",
+				},
+				{
+					Name:  S3UseVirtualBucket,
+					Value: "false",
+				},
+				{
+					Name:  S3UseAccelerate,
+					Value: "false",
+				},
+				{
+					Name:  AWSCABundle,
+					Value: "value-config",
+				},
+				{
+					Name:  AWSCABundleConfigMap,
+					Value: "value-config",
+				},
+			},
+		},
+		"LocalWithoutHttpProtocol": {
+			secret: &map[string][]byte{
+				S3Endpoint: []byte("localhost:9000"),
+				S3UseHttps: []byte("0"),
+			},
+			config: S3Config{
+				S3Endpoint:               "s3.aws.com-config",
+				S3UseVirtualBucket:       "false",
+				S3UseAccelerate:          "false",
+				S3UseAnonymousCredential: "false",
+				S3CABundleConfigMap:      "value-config",
+				S3CABundle:               "value-config",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "localhost:9000",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://localhost:9000",
+				},
+				{
+					Name:  AWSAnonymousCredential,
+					Value: "false",
+				},
+				{
+					Name:  S3UseVirtualBucket,
+					Value: "false",
+				},
+				{
+					Name:  S3UseAccelerate,
+					Value: "false",
+				},
+				{
+					Name:  AWSCABundle,
+					Value: "value-config",
+				},
+				{
+					Name:  AWSCABundleConfigMap,
+					Value: "value-config",
+				},
+			},
+		},
+		"LocalWithHttpsProtocol": {
+			secret: &map[string][]byte{
+				S3Endpoint: []byte("https://localhost:9000/path"),
+				S3UseHttps: []byte("0"),
+			},
+			config: S3Config{
+				S3Endpoint:               "s3.aws.com-config",
+				S3UseVirtualBucket:       "false",
+				S3UseAccelerate:          "false",
+				S3UseAnonymousCredential: "false",
+				S3CABundleConfigMap:      "value-config",
+				S3CABundle:               "value-config",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "1",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "localhost:9000/path",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://localhost:9000/path",
+				},
+				{
+					Name:  AWSAnonymousCredential,
+					Value: "false",
+				},
+				{
+					Name:  S3UseVirtualBucket,
+					Value: "false",
+				},
+				{
+					Name:  S3UseAccelerate,
+					Value: "false",
+				},
+				{
+					Name:  AWSCABundle,
+					Value: "value-config",
+				},
+				{
+					Name:  AWSCABundleConfigMap,
+					Value: "value-config",
+				},
+			},
+		},
+		"LocalWithoutHttpsProtocol": {
+			secret: &map[string][]byte{
+				S3Endpoint: []byte("localhost:9000/path"),
+				S3UseHttps: []byte("1"),
+			},
+			config: S3Config{
+				S3Endpoint:               "s3.aws.com-config",
+				S3UseVirtualBucket:       "false",
+				S3UseAccelerate:          "false",
+				S3UseAnonymousCredential: "false",
+				S3CABundleConfigMap:      "value-config",
+				S3CABundle:               "value-config",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "1",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "localhost:9000/path",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://localhost:9000/path",
+				},
+				{
+					Name:  AWSAnonymousCredential,
+					Value: "false",
+				},
+				{
+					Name:  S3UseVirtualBucket,
+					Value: "false",
+				},
+				{
+					Name:  S3UseAccelerate,
+					Value: "false",
+				},
+				{
+					Name:  AWSCABundle,
+					Value: "value-config",
+				},
+				{
+					Name:  AWSCABundleConfigMap,
+					Value: "value-config",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Kserve currently does not support configured s3 endpoints that include a protocol unless using a storage spec. In the current state if an s3 endpoint is configured as `https://s3.aws.com` this endpoint will have `http://` or `https://` prepended to form the url based on the configured `s3UseHttps` value, resulting in an invalid url, e.g. `https://https://s3.aws.com`. This can present a confusing experience to the end user.

This PR updates the logic used to build the s3 env variables to parse the s3 endpoint and check if it includes a protocol prefix. If an `http://` or `https://` prefix is found in the endpoint, any configured s3UseHttps value is overridden based on the prefix. All other vars set in the init container env will remain the same.

**Example scenario**
Configuration:
- `s3UseHttps` = `0`
- `s3Endpoint` = `https://s3.aws.com`

Resulting storage init container env:
- `S3_USE_HTTPS` = `1`
- `S3_ENDPOINT` = `s3.aws.com`
- `AWS_ENDPOINT_URL` = `https://s3.aws.com`

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

1. Configure s3 endpoint using either `http://` or `https://` prefix in the s3 config, secret data, secret annotation, or service account annotation
2. Create an inference service or llm inference service that utilizes the configured s3 connection
3. In the created storage init pod env variables spec observe that the `AWS_ENDPOINT_URL` value is set to the configured endpoint, the `S3_ENDPOINT` value is set to the configured endpoint without the protocol prefix, and that the `S3_USE_HTTPS` value is set based on the endpoint prefix.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Supporting protocol prefix in configured s3 endpoints
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.