### PR TITLE
fix: Fix various bugs in quickstart scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 *.dylib
 *.pyc
 *.egg-info/
-bin
+bin/*
+!bin/.gitkeep
 .venv/
 venv/
 # Test binary, build with `go test -c`

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,4 +1,4 @@
 # Developer Guide
 
-Please review the [KServe Developer Guide](https://github.com/kserve/website/blob/main/docs/developer/developer.md) docs.
+Please review the [KServe Developer Guide](https://github.com/kserve/website/blob/main/docs/developer-guide/index.md) docs.
 

--- a/hack/setup/common.sh
+++ b/hack/setup/common.sh
@@ -36,11 +36,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -60,7 +60,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -70,7 +70,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -107,7 +107,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -115,11 +115,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/common.sh
+++ b/hack/setup/common.sh
@@ -36,7 +36,7 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD"
+        log_warning "Could not find git repository root, using current directory: $PWD" >&2
         echo "$PWD"
         return 0
     else

--- a/hack/setup/common.sh
+++ b/hack/setup/common.sh
@@ -435,8 +435,15 @@ version_gte() {
 if [[ -z "${REPO_ROOT:-}" ]]; then
     REPO_ROOT="$(find_repo_root "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")"
     export REPO_ROOT
-    export BIN_DIR="${REPO_ROOT}/bin"
-    ensure_dir "${BIN_DIR}"
+
+    # Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+    if [[ -d "${REPO_ROOT}/bin" ]]; then
+        export BIN_DIR="${REPO_ROOT}/bin"
+    else
+        export BIN_DIR="$(mktemp -d)"
+        log_info "Using temp BIN_DIR: ${BIN_DIR}"
+    fi
+
     export PATH="${BIN_DIR}:${PATH}"
 fi
 

--- a/hack/setup/common.sh
+++ b/hack/setup/common.sh
@@ -75,6 +75,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'

--- a/hack/setup/infra/external-lb/manage.external-lb.sh
+++ b/hack/setup/infra/external-lb/manage.external-lb.sh
@@ -141,7 +141,7 @@ install() {
 
         openshift|kubernetes)
             log_info "Platform ${PLATFORM} does not require external LB setup. Skipping."
-            exit 0
+            return 0
             ;;
 
         *)

--- a/hack/setup/infra/gateway-api/manage.gateway-api-gw.sh
+++ b/hack/setup/infra/gateway-api/manage.gateway-api-gw.sh
@@ -52,7 +52,7 @@ install() {
     if kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "KServe Gateway '${GATEWAY_NAME}' already exists in namespace '${GATEWAY_NAMESPACE}'. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
             uninstall

--- a/hack/setup/infra/gateway-api/manage.gateway-api-gwclass.sh
+++ b/hack/setup/infra/gateway-api/manage.gateway-api-gwclass.sh
@@ -49,7 +49,7 @@ install() {
     if kubectl get gatewayclass "${GATEWAYCLASS_NAME}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "GatewayClass '${GATEWAYCLASS_NAME}' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
             uninstall

--- a/hack/setup/infra/knative/manage.knative-operator-helm.sh
+++ b/hack/setup/infra/knative/manage.knative-operator-helm.sh
@@ -87,7 +87,7 @@ install() {
 
             if kubectl get knativeserving knative-serving -n "${SERVING_NAMESPACE}" &>/dev/null; then
                 log_info "Knative Serving is already deployed. Use --reinstall to reinstall."
-                exit 0
+                return 0
             fi
         else
             log_info "Reinstalling Knative..."

--- a/hack/setup/infra/manage.istio-ingress-class.sh
+++ b/hack/setup/infra/manage.istio-ingress-class.sh
@@ -44,7 +44,7 @@ install() {
     if kubectl get ingressclass "istio" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "Istio IngressClass 'istio' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating Istio IngressClass 'istio'..."
             uninstall

--- a/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
@@ -851,7 +851,7 @@ install_istio_ingress_class() {
     if kubectl get ingressclass "istio" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "Istio IngressClass 'istio' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating Istio IngressClass 'istio'..."
             uninstall

--- a/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
@@ -753,7 +753,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -797,7 +797,7 @@ install_istio() {
             return 0
         else
             log_info "Reinstalling Istio..."
-            uninstall
+            uninstall_istio
         fi
     fi
 
@@ -854,7 +854,7 @@ install_istio_ingress_class() {
             return 0
         else
             log_info "Recreating Istio IngressClass 'istio'..."
-            uninstall
+            uninstall_istio_ingress_class
         fi
     fi
 
@@ -893,7 +893,7 @@ install_keda() {
             return 0
         else
             log_info "Reinstalling KEDA..."
-            uninstall
+            uninstall_keda
         fi
     fi
 
@@ -937,7 +937,7 @@ install_keda_otel_addon() {
             return 0
         else
             log_info "Reinstalling KEDA OTel add-on..."
-            uninstall
+            uninstall_keda_otel_addon
         fi
     fi
 
@@ -975,7 +975,7 @@ install_opentelemetry() {
             return 0
         else
             log_info "Reinstalling OpenTelemetry Operator..."
-            uninstall
+            uninstall_opentelemetry
         fi
     fi
 

--- a/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -861,7 +861,7 @@ install_istio_ingress_class() {
     if kubectl get ingressclass "istio" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "Istio IngressClass 'istio' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating Istio IngressClass 'istio'..."
             uninstall

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -763,7 +763,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -807,7 +807,7 @@ install_istio() {
             return 0
         else
             log_info "Reinstalling Istio..."
-            uninstall
+            uninstall_istio
         fi
     fi
 
@@ -864,7 +864,7 @@ install_istio_ingress_class() {
             return 0
         else
             log_info "Recreating Istio IngressClass 'istio'..."
-            uninstall
+            uninstall_istio_ingress_class
         fi
     fi
 
@@ -903,7 +903,7 @@ install_keda() {
             return 0
         else
             log_info "Reinstalling KEDA..."
-            uninstall
+            uninstall_keda
         fi
     fi
 
@@ -947,7 +947,7 @@ install_keda_otel_addon() {
             return 0
         else
             log_info "Reinstalling KEDA OTel add-on..."
-            uninstall
+            uninstall_keda_otel_addon
         fi
     fi
 
@@ -985,7 +985,7 @@ install_opentelemetry() {
             return 0
         else
             log_info "Reinstalling OpenTelemetry Operator..."
-            uninstall
+            uninstall_opentelemetry
         fi
     fi
 
@@ -1040,7 +1040,7 @@ install_kserve() {
             return 0
         else
             log_info "Reinstalling KServe..."
-            uninstall
+            uninstall_kserve
         fi
     fi
 

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -861,7 +861,7 @@ install_istio_ingress_class() {
     if kubectl get ingressclass "istio" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "Istio IngressClass 'istio' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating Istio IngressClass 'istio'..."
             uninstall

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -763,7 +763,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -807,7 +807,7 @@ install_istio() {
             return 0
         else
             log_info "Reinstalling Istio..."
-            uninstall
+            uninstall_istio
         fi
     fi
 
@@ -864,7 +864,7 @@ install_istio_ingress_class() {
             return 0
         else
             log_info "Recreating Istio IngressClass 'istio'..."
-            uninstall
+            uninstall_istio_ingress_class
         fi
     fi
 
@@ -903,7 +903,7 @@ install_keda() {
             return 0
         else
             log_info "Reinstalling KEDA..."
-            uninstall
+            uninstall_keda
         fi
     fi
 
@@ -947,7 +947,7 @@ install_keda_otel_addon() {
             return 0
         else
             log_info "Reinstalling KEDA OTel add-on..."
-            uninstall
+            uninstall_keda_otel_addon
         fi
     fi
 
@@ -985,7 +985,7 @@ install_opentelemetry() {
             return 0
         else
             log_info "Reinstalling OpenTelemetry Operator..."
-            uninstall
+            uninstall_opentelemetry
         fi
     fi
 
@@ -1040,7 +1040,7 @@ install_kserve() {
             return 0
         else
             log_info "Reinstalling KServe..."
-            uninstall
+            uninstall_kserve
         fi
     fi
 

--- a/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
@@ -757,7 +757,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -802,7 +802,7 @@ install_keda() {
             return 0
         else
             log_info "Reinstalling KEDA..."
-            uninstall
+            uninstall_keda
         fi
     fi
 
@@ -846,7 +846,7 @@ install_keda_otel_addon() {
             return 0
         else
             log_info "Reinstalling KEDA OTel add-on..."
-            uninstall
+            uninstall_keda_otel_addon
         fi
     fi
 
@@ -900,7 +900,7 @@ uninstall_external_lb() {
 install_external_lb() {
     if [ "$REINSTALL" = true ]; then
         log_info "Reinstalling External LoadBalancer..."
-        uninstall
+        uninstall_external_lb
     fi
 
     log_info "Setting up External LoadBalancer for platform: ${PLATFORM}"
@@ -993,7 +993,7 @@ install_gateway_api_crd() {
             return 0
         else
             log_info "Reinstalling Gateway API CRDs..."
-            uninstall
+            uninstall_gateway_api_crd
         fi
     fi
 
@@ -1041,7 +1041,7 @@ install_envoy_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy Gateway..."
-            uninstall
+            uninstall_envoy_gateway
         fi
     fi
 
@@ -1086,7 +1086,7 @@ install_envoy_ai_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy AI Gateway..."
-            uninstall
+            uninstall_envoy_ai_gateway
         fi
     fi
 
@@ -1135,7 +1135,7 @@ install_gateway_api_gwclass() {
             return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gwclass
         fi
     fi
 
@@ -1171,7 +1171,7 @@ install_gateway_api_gw() {
             return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gw
         fi
     fi
 
@@ -1216,7 +1216,7 @@ install_lws_operator() {
             return 0
         else
             log_info "Reinstalling LWS..."
-            uninstall
+            uninstall_lws_operator
         fi
     fi
 

--- a/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
@@ -963,7 +963,7 @@ install_external_lb() {
 
         openshift|kubernetes)
             log_info "Platform ${PLATFORM} does not require external LB setup. Skipping."
-            exit 0
+            return 0
             ;;
 
         *)
@@ -1132,7 +1132,7 @@ install_gateway_api_gwclass() {
     if kubectl get gatewayclass "${GATEWAYCLASS_NAME}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "GatewayClass '${GATEWAYCLASS_NAME}' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
             uninstall
@@ -1168,7 +1168,7 @@ install_gateway_api_gw() {
     if kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "KServe Gateway '${GATEWAY_NAME}' already exists in namespace '${GATEWAY_NAMESPACE}'. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
             uninstall

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -767,7 +767,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -812,7 +812,7 @@ install_keda() {
             return 0
         else
             log_info "Reinstalling KEDA..."
-            uninstall
+            uninstall_keda
         fi
     fi
 
@@ -856,7 +856,7 @@ install_keda_otel_addon() {
             return 0
         else
             log_info "Reinstalling KEDA OTel add-on..."
-            uninstall
+            uninstall_keda_otel_addon
         fi
     fi
 
@@ -910,7 +910,7 @@ uninstall_external_lb() {
 install_external_lb() {
     if [ "$REINSTALL" = true ]; then
         log_info "Reinstalling External LoadBalancer..."
-        uninstall
+        uninstall_external_lb
     fi
 
     log_info "Setting up External LoadBalancer for platform: ${PLATFORM}"
@@ -1003,7 +1003,7 @@ install_gateway_api_crd() {
             return 0
         else
             log_info "Reinstalling Gateway API CRDs..."
-            uninstall
+            uninstall_gateway_api_crd
         fi
     fi
 
@@ -1051,7 +1051,7 @@ install_envoy_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy Gateway..."
-            uninstall
+            uninstall_envoy_gateway
         fi
     fi
 
@@ -1096,7 +1096,7 @@ install_envoy_ai_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy AI Gateway..."
-            uninstall
+            uninstall_envoy_ai_gateway
         fi
     fi
 
@@ -1145,7 +1145,7 @@ install_gateway_api_gwclass() {
             return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gwclass
         fi
     fi
 
@@ -1181,7 +1181,7 @@ install_gateway_api_gw() {
             return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gw
         fi
     fi
 
@@ -1226,7 +1226,7 @@ install_lws_operator() {
             return 0
         else
             log_info "Reinstalling LWS..."
-            uninstall
+            uninstall_lws_operator
         fi
     fi
 
@@ -1274,7 +1274,7 @@ install_kserve() {
             return 0
         else
             log_info "Reinstalling KServe..."
-            uninstall
+            uninstall_kserve
         fi
     fi
 

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -973,7 +973,7 @@ install_external_lb() {
 
         openshift|kubernetes)
             log_info "Platform ${PLATFORM} does not require external LB setup. Skipping."
-            exit 0
+            return 0
             ;;
 
         *)
@@ -1142,7 +1142,7 @@ install_gateway_api_gwclass() {
     if kubectl get gatewayclass "${GATEWAYCLASS_NAME}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "GatewayClass '${GATEWAYCLASS_NAME}' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
             uninstall
@@ -1178,7 +1178,7 @@ install_gateway_api_gw() {
     if kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "KServe Gateway '${GATEWAY_NAME}' already exists in namespace '${GATEWAY_NAMESPACE}'. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
             uninstall

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -767,7 +767,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -812,7 +812,7 @@ install_keda() {
             return 0
         else
             log_info "Reinstalling KEDA..."
-            uninstall
+            uninstall_keda
         fi
     fi
 
@@ -856,7 +856,7 @@ install_keda_otel_addon() {
             return 0
         else
             log_info "Reinstalling KEDA OTel add-on..."
-            uninstall
+            uninstall_keda_otel_addon
         fi
     fi
 
@@ -910,7 +910,7 @@ uninstall_external_lb() {
 install_external_lb() {
     if [ "$REINSTALL" = true ]; then
         log_info "Reinstalling External LoadBalancer..."
-        uninstall
+        uninstall_external_lb
     fi
 
     log_info "Setting up External LoadBalancer for platform: ${PLATFORM}"
@@ -1003,7 +1003,7 @@ install_gateway_api_crd() {
             return 0
         else
             log_info "Reinstalling Gateway API CRDs..."
-            uninstall
+            uninstall_gateway_api_crd
         fi
     fi
 
@@ -1051,7 +1051,7 @@ install_envoy_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy Gateway..."
-            uninstall
+            uninstall_envoy_gateway
         fi
     fi
 
@@ -1096,7 +1096,7 @@ install_envoy_ai_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy AI Gateway..."
-            uninstall
+            uninstall_envoy_ai_gateway
         fi
     fi
 
@@ -1145,7 +1145,7 @@ install_gateway_api_gwclass() {
             return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gwclass
         fi
     fi
 
@@ -1181,7 +1181,7 @@ install_gateway_api_gw() {
             return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gw
         fi
     fi
 
@@ -1226,7 +1226,7 @@ install_lws_operator() {
             return 0
         else
             log_info "Reinstalling LWS..."
-            uninstall
+            uninstall_lws_operator
         fi
     fi
 
@@ -1274,7 +1274,7 @@ install_kserve() {
             return 0
         else
             log_info "Reinstalling KServe..."
-            uninstall
+            uninstall_kserve
         fi
     fi
 

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -973,7 +973,7 @@ install_external_lb() {
 
         openshift|kubernetes)
             log_info "Platform ${PLATFORM} does not require external LB setup. Skipping."
-            exit 0
+            return 0
             ;;
 
         *)
@@ -1142,7 +1142,7 @@ install_gateway_api_gwclass() {
     if kubectl get gatewayclass "${GATEWAYCLASS_NAME}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "GatewayClass '${GATEWAYCLASS_NAME}' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
             uninstall
@@ -1178,7 +1178,7 @@ install_gateway_api_gw() {
     if kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "KServe Gateway '${GATEWAY_NAME}' already exists in namespace '${GATEWAY_NAMESPACE}'. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
             uninstall

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/quick-install/llmisvc-dependency-install.sh
+++ b/hack/setup/quick-install/llmisvc-dependency-install.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/llmisvc-dependency-install.sh
+++ b/hack/setup/quick-install/llmisvc-dependency-install.sh
@@ -712,7 +712,7 @@ uninstall_external_lb() {
 install_external_lb() {
     if [ "$REINSTALL" = true ]; then
         log_info "Reinstalling External LoadBalancer..."
-        uninstall
+        uninstall_external_lb
     fi
 
     log_info "Setting up External LoadBalancer for platform: ${PLATFORM}"
@@ -806,7 +806,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -847,7 +847,7 @@ install_gateway_api_crd() {
             return 0
         else
             log_info "Reinstalling Gateway API CRDs..."
-            uninstall
+            uninstall_gateway_api_crd
         fi
     fi
 
@@ -895,7 +895,7 @@ install_envoy_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy Gateway..."
-            uninstall
+            uninstall_envoy_gateway
         fi
     fi
 
@@ -940,7 +940,7 @@ install_envoy_ai_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy AI Gateway..."
-            uninstall
+            uninstall_envoy_ai_gateway
         fi
     fi
 
@@ -989,7 +989,7 @@ install_gateway_api_gwclass() {
             return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gwclass
         fi
     fi
 
@@ -1025,7 +1025,7 @@ install_gateway_api_gw() {
             return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gw
         fi
     fi
 
@@ -1070,7 +1070,7 @@ install_lws_operator() {
             return 0
         else
             log_info "Reinstalling LWS..."
-            uninstall
+            uninstall_lws_operator
         fi
     fi
 

--- a/hack/setup/quick-install/llmisvc-dependency-install.sh
+++ b/hack/setup/quick-install/llmisvc-dependency-install.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/llmisvc-dependency-install.sh
+++ b/hack/setup/quick-install/llmisvc-dependency-install.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/quick-install/llmisvc-dependency-install.sh
+++ b/hack/setup/quick-install/llmisvc-dependency-install.sh
@@ -775,7 +775,7 @@ install_external_lb() {
 
         openshift|kubernetes)
             log_info "Platform ${PLATFORM} does not require external LB setup. Skipping."
-            exit 0
+            return 0
             ;;
 
         *)
@@ -986,7 +986,7 @@ install_gateway_api_gwclass() {
     if kubectl get gatewayclass "${GATEWAYCLASS_NAME}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "GatewayClass '${GATEWAYCLASS_NAME}' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
             uninstall
@@ -1022,7 +1022,7 @@ install_gateway_api_gw() {
     if kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "KServe Gateway '${GATEWAY_NAME}' already exists in namespace '${GATEWAY_NAMESPACE}'. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
             uninstall

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -785,7 +785,7 @@ install_external_lb() {
 
         openshift|kubernetes)
             log_info "Platform ${PLATFORM} does not require external LB setup. Skipping."
-            exit 0
+            return 0
             ;;
 
         *)
@@ -996,7 +996,7 @@ install_gateway_api_gwclass() {
     if kubectl get gatewayclass "${GATEWAYCLASS_NAME}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "GatewayClass '${GATEWAYCLASS_NAME}' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
             uninstall
@@ -1032,7 +1032,7 @@ install_gateway_api_gw() {
     if kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "KServe Gateway '${GATEWAY_NAME}' already exists in namespace '${GATEWAY_NAMESPACE}'. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
             uninstall

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -722,7 +722,7 @@ uninstall_external_lb() {
 install_external_lb() {
     if [ "$REINSTALL" = true ]; then
         log_info "Reinstalling External LoadBalancer..."
-        uninstall
+        uninstall_external_lb
     fi
 
     log_info "Setting up External LoadBalancer for platform: ${PLATFORM}"
@@ -816,7 +816,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -857,7 +857,7 @@ install_gateway_api_crd() {
             return 0
         else
             log_info "Reinstalling Gateway API CRDs..."
-            uninstall
+            uninstall_gateway_api_crd
         fi
     fi
 
@@ -905,7 +905,7 @@ install_envoy_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy Gateway..."
-            uninstall
+            uninstall_envoy_gateway
         fi
     fi
 
@@ -950,7 +950,7 @@ install_envoy_ai_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy AI Gateway..."
-            uninstall
+            uninstall_envoy_ai_gateway
         fi
     fi
 
@@ -999,7 +999,7 @@ install_gateway_api_gwclass() {
             return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gwclass
         fi
     fi
 
@@ -1035,7 +1035,7 @@ install_gateway_api_gw() {
             return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gw
         fi
     fi
 
@@ -1080,7 +1080,7 @@ install_lws_operator() {
             return 0
         else
             log_info "Reinstalling LWS..."
-            uninstall
+            uninstall_lws_operator
         fi
     fi
 
@@ -1128,7 +1128,7 @@ install_kserve_helm() {
             return 0
         else
             log_info "Reinstalling KServe..."
-            uninstall
+            uninstall_kserve_helm
         fi
     fi
 

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -478,16 +478,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -785,7 +785,7 @@ install_external_lb() {
 
         openshift|kubernetes)
             log_info "Platform ${PLATFORM} does not require external LB setup. Skipping."
-            exit 0
+            return 0
             ;;
 
         *)
@@ -996,7 +996,7 @@ install_gateway_api_gwclass() {
     if kubectl get gatewayclass "${GATEWAYCLASS_NAME}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "GatewayClass '${GATEWAYCLASS_NAME}' already exists. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
             uninstall
@@ -1032,7 +1032,7 @@ install_gateway_api_gw() {
     if kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
             log_info "KServe Gateway '${GATEWAY_NAME}' already exists in namespace '${GATEWAY_NAMESPACE}'. Use --reinstall to recreate."
-            exit 0
+            return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
             uninstall

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -722,7 +722,7 @@ uninstall_external_lb() {
 install_external_lb() {
     if [ "$REINSTALL" = true ]; then
         log_info "Reinstalling External LoadBalancer..."
-        uninstall
+        uninstall_external_lb
     fi
 
     log_info "Setting up External LoadBalancer for platform: ${PLATFORM}"
@@ -816,7 +816,7 @@ install_cert_manager() {
             return 0
         else
             log_info "Reinstalling cert-manager..."
-            uninstall
+            uninstall_cert_manager
         fi
     fi
 
@@ -857,7 +857,7 @@ install_gateway_api_crd() {
             return 0
         else
             log_info "Reinstalling Gateway API CRDs..."
-            uninstall
+            uninstall_gateway_api_crd
         fi
     fi
 
@@ -905,7 +905,7 @@ install_envoy_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy Gateway..."
-            uninstall
+            uninstall_envoy_gateway
         fi
     fi
 
@@ -950,7 +950,7 @@ install_envoy_ai_gateway() {
             return 0
         else
             log_info "Reinstalling Envoy AI Gateway..."
-            uninstall
+            uninstall_envoy_ai_gateway
         fi
     fi
 
@@ -999,7 +999,7 @@ install_gateway_api_gwclass() {
             return 0
         else
             log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gwclass
         fi
     fi
 
@@ -1035,7 +1035,7 @@ install_gateway_api_gw() {
             return 0
         else
             log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
-            uninstall
+            uninstall_gateway_api_gw
         fi
     fi
 
@@ -1080,7 +1080,7 @@ install_lws_operator() {
             return 0
         else
             log_info "Reinstalling LWS..."
-            uninstall
+            uninstall_lws_operator
         fi
     fi
 
@@ -1128,7 +1128,7 @@ install_kserve_helm() {
             return 0
         else
             log_info "Reinstalling KServe..."
-            uninstall
+            uninstall_kserve_helm
         fi
     fi
 

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -88,6 +88,22 @@ detect_arch() {
     echo "$arch"
 }
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Color codes (disable if NO_COLOR is set or not a terminal)
 if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
     BLUE='\033[94m'
@@ -425,22 +441,6 @@ version_gte() {
 }
 
 # ============================================================================
-
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
 
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -49,11 +49,11 @@ find_repo_root() {
 
     # Git repository not found
     if [[ "$skip" == "true" ]]; then
-        log_warning "Could not find git repository root, using current directory: $PWD" >&2
+        log_warning "Could not find git repository root, using current directory: $PWD"
         echo "$PWD"
         return 0
     else
-        echo "Error: Could not find git repository root" >&2
+        log_error "Could not find git repository root"
         exit 1
     fi
 }
@@ -73,7 +73,7 @@ detect_os() {
     case "$(uname -s)" in
         Linux*)  os="linux" ;;
         Darwin*) os="darwin" ;;
-        *)       echo "Unsupported OS" >&2; exit 1 ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
     esac
     echo "$os"
 }
@@ -83,7 +83,7 @@ detect_arch() {
     case "$(uname -m)" in
         x86_64)  arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *)       echo "Unsupported architecture" >&2; exit 1 ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
     esac
     echo "$arch"
 }
@@ -120,7 +120,7 @@ else
 fi
 
 log_info() {
-    echo -e "${BLUE}[INFO]${RESET} $*"
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
 }
 
 log_error() {
@@ -128,11 +128,11 @@ log_error() {
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${RESET} $*"
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}[WARNING]${RESET} $*"
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
 }
 
 

--- a/hack/setup/scripts/install-script-generator/pkg/component_processor.py
+++ b/hack/setup/scripts/install-script-generator/pkg/component_processor.py
@@ -136,8 +136,16 @@ def process_component(comp_config: dict[str, Any], infra_dir: Path, method: Opti
     suffix = name.replace("-", "_")
     install_func = f"install_{suffix}"
     uninstall_func = f"uninstall_{suffix}"
+
+    # Rename install function and its calls
     install_code = bash_parser.rename_bash_function(install_raw, "install", install_func)
+    # Also rename any calls to uninstall within install function
+    install_code = bash_parser.rename_bash_function(install_code, "uninstall", uninstall_func)
+
+    # Rename uninstall function and its calls
     uninstall_code = bash_parser.rename_bash_function(uninstall_raw, "uninstall", uninstall_func)
+    # Also rename any calls to install within uninstall function (less common but possible)
+    uninstall_code = bash_parser.rename_bash_function(uninstall_code, "install", install_func)
 
     return {
         "name": name,

--- a/hack/setup/scripts/install-script-generator/templates/generated-script.template
+++ b/hack/setup/scripts/install-script-generator/templates/generated-script.template
@@ -34,22 +34,6 @@ set -o pipefail
 
 {{COMMON_FUNCTIONS}}
 
-cleanup_bin_dir() {
-    # Remove BIN_DIR if it was created by this script
-    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
-        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
-        rm -rf "${BIN_DIR}"
-    fi
-}
-
-cleanup() {
-    # Call all cleanup functions
-    cleanup_bin_dir
-}
-
-# Set up trap to run cleanup on exit
-trap cleanup EXIT
-
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default
 # Usage: set_env_with_priority VAR_NAME COMPONENT_ENV_VALUE GLOBAL_ENV_VALUE DEFAULT_VALUE

--- a/hack/setup/scripts/install-script-generator/templates/generated-script.template
+++ b/hack/setup/scripts/install-script-generator/templates/generated-script.template
@@ -70,16 +70,15 @@ set_env_with_priority() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
-export BIN_DIR="${REPO_ROOT}/bin"
 
-# Track if we created BIN_DIR so we can clean it up later
-BIN_DIR_CREATED_BY_SCRIPT=false
-if [[ ! -d "${BIN_DIR}" ]]; then
-    log_info "Creating BIN_DIR: ${BIN_DIR}"
-    BIN_DIR_CREATED_BY_SCRIPT=true
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
 fi
 
-ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"

--- a/hack/setup/scripts/install-script-generator/templates/generated-script.template
+++ b/hack/setup/scripts/install-script-generator/templates/generated-script.template
@@ -34,6 +34,22 @@ set -o pipefail
 
 {{COMMON_FUNCTIONS}}
 
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
 # Set environment variable based on priority order:
 # Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default
 # Usage: set_env_with_priority VAR_NAME COMPONENT_ENV_VALUE GLOBAL_ENV_VALUE DEFAULT_VALUE
@@ -71,6 +87,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
 REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
 export REPO_ROOT
 export BIN_DIR="${REPO_ROOT}/bin"
+
+# Track if we created BIN_DIR so we can clean it up later
+BIN_DIR_CREATED_BY_SCRIPT=false
+if [[ ! -d "${BIN_DIR}" ]]; then
+    log_info "Creating BIN_DIR: ${BIN_DIR}"
+    BIN_DIR_CREATED_BY_SCRIPT=true
+fi
+
+ensure_dir "${BIN_DIR}"
 export PATH="${BIN_DIR}:${PATH}"
 
 UNINSTALL="${UNINSTALL:-false}"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes installation failures when following the [quickstart guide](https://kserve.github.io/website/docs/getting-started/quickstart-guide) by fixing some issues along the same lines as #4813:

1. **BIN_DIR creation**: The `bin` directory is now created if it doesn't exist, preventing failures when tools like `kustomize`, `helm`, and `yq` are downloaded
2. **stderr redirection**: Warnings from `find_repo_root()` are now properly redirected to stderr, preventing them from polluting the `REPO_ROOT` variable when captured via command substitution
3. **Cleanup logic**: Added trap-based cleanup to remove `BIN_DIR` if created by the script, keeping the environment clean
4. **Early installation exit**: Removed `exit 0`s inside installation functions causing the install scripts to not finish
5. **Documentation fix**: Fixed broken contributor guide link in template

**Problem:**
Running the quickstart command:
```bash
curl -s "https://raw.githubusercontent.com/kserve/kserve/master/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh" | bash
```

Results in error:
```
mv: cannot move '/tmp/tmp.Hbxk19H93N/kustomize' to '\033[93m[WARNING]\033[0m Could not find git repository root, using current directory:
/home/jonah/Projects/github.com/kserve\n/home/jonah/Projects/github.com/kserve/bin/kustomize': No such file or directory
```

Additionally, after fixing these issues, the installation functions exit early, failing to install all the required components. 

Root causes:
1. Warning messages were sent to stdout instead of stderr, causing them to be captured in BIN_DIR variable
2. The bin/ directory was assumed to exist but was never created
3. The infra installation scripts had extra `exit 0`s inside them
4. The calls for the `uninstall` and `install`s do not get renamed.

**Which issue(s) this PR fixes:**
Fixes #4831
Fixes #4843

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing:**

Validated the fix by:

- Ran hack/setup/scripts/validate-install-scripts.py - all checks pass
- Tested installation in local environment - bin directory created and cleaned up properly
- Verified warning messages appear on stderr without polluting variables
- Confirmed tools (helm, kustomize, yq) install successfully to BIN_DIR

Test configuration:
- Environment: Fedora Linux 42, Bash 5.2.37
- Installation method: Direct script execution and curl piping
- Verified both with and without pre-existing bin/ directory

**Special notes for your reviewer:**

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. (N/A - This PR only modifies installation script logic, no image versions changed)
2. Changes are in the template file (templates/generated-script.template) so all generated scripts will benefit from these fixes
5. The cleanup logic uses a flag (`BIN_DIR_CREATED_BY_SCRIPT`) to only remove directories created by the script, preserving any pre-existing bin/ directories
6. Also fixed the broken contributor guide link

**Checklist:**

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  - Validated using existing test suite (validate-install-scripts.py)
- [x] Has code been commented, particularly in hard-to-understand areas?
  - Added comments explaining BIN_DIR tracking and cleanup logic
- [x] Have you made corresponding changes to the documentation?
  - No documentation changes needed (fixed existing broken link)

**Release note:**

```release-note
Fixed quickstart installation script to properly create bin directory and redirect warnings to stderr
```