### PR TITLE
Fix Bug in LLMISVC E2E Test Setup

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -197,6 +197,7 @@ jobs:
       - name: Install KServe Python SDK
         run: |
           echo "🐍 Installing KServe Python SDK with test dependencies..."
+          source hack/setup/common.sh
           pushd python/kserve >/dev/null
               uv sync --active --group test
           popd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
llmisvc test setup is currently fails with error:
```
Run echo "🐍 Installing KServe Python SDK with test dependencies..."
🐍 Installing KServe Python SDK with test dependencies...
/home/runner/work/_temp/cd167edf-8f5c-4b4c-8096-66aac420e34b.sh: line 3: uv: command not found
```

To configure the proper `PATH` to allow the `uv` command to be located while executing the setup, we can set the source as `hack/setup/common.sh` prior to running any `uv` commands.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] llmisvc test setup [successful](https://github.com/kserve/kserve/actions/runs/19341266494/job/55330388588?pr=4803) after commit pushed to separate [PR](https://github.com/kserve/kserve/pull/4803)

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.