### PR TITLE
Update installation scripts for Helm charts

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -72,11 +72,6 @@ jobs:
           echo "Images in minikube:"
           minikube image ls | grep llmisvc-controller || echo "No llmisvc-controller images found"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: "3.12.0"
-
       - name: Configure MetalLB for LoadBalancer services
         run: |
           echo "🔧 Configuring MetalLB for LoadBalancer services..."
@@ -110,14 +105,35 @@ jobs:
           LLMISVC_CONTROLLER_IMG_TAG="${DOCKER_REPO}/${LLMISVC_CONTROLLER_IMG}:${{ github.sha }}"
 
           # Use the quick install script to install all dependencies and LLMISvc
-          ./hack/llmisvc_quick_install.sh
+          # Note: The script uses --wait which may timeout, so we'll handle deployment waiting separately
+          ./hack/llmisvc_quick_install.sh || {
+            echo "⚠️ Helm install completed but may have timed out waiting for deployment"
+            echo "📋 Checking deployment status..."
+            kubectl get deployments -n kserve
+          }
 
-          # Update the deployment to use our built image with Never pull policy
-          kubectl patch deployment kserve-llmisvc-controller-manager -n kserve \
+          # Get deployment name from Helm chart template (deployment name is hardcoded in the chart)
+          DEPLOYMENT_NAME=$(helm template llmisvc ./charts/kserve-llmisvc-resources --namespace kserve | grep -A 3 "kind: Deployment" | grep "name:" | head -1 | awk '{print $2}')
+          if [ -z "$DEPLOYMENT_NAME" ]; then
+            echo "❌ Error: Could not determine deployment name from Helm chart"
+            echo "📋 Available deployments:"
+            kubectl get deployments -n kserve
+            exit 1
+          fi
+          echo "📦 Found deployment name from chart: $DEPLOYMENT_NAME"
+
+          if ! kubectl get deployment $DEPLOYMENT_NAME -n kserve >/dev/null 2>&1; then
+            echo "❌ Error: Deployment $DEPLOYMENT_NAME not found in cluster"
+            kubectl get deployments -n kserve
+            exit 1
+          fi
+
+          kubectl patch deployment $DEPLOYMENT_NAME -n kserve \
             -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","image":"'${LLMISVC_CONTROLLER_IMG_TAG}'","imagePullPolicy":"Never"}]}}}}'
 
           # Wait for deployment to be ready
-          kubectl wait --for=condition=available --timeout=300s deployment/kserve-llmisvc-controller-manager -n kserve
+          echo "⏳ Waiting for deployment $DEPLOYMENT_NAME to be ready..."
+          kubectl wait --for=condition=available --timeout=300s deployment/$DEPLOYMENT_NAME -n kserve
 
       - name: Verify LLMISvc setup
         run: |
@@ -192,11 +208,15 @@ jobs:
           echo "✅ Gateway configuration verified!"
 
       - name: Install UV
-        run: ./test/scripts/gh-actions/setup-uv.sh
+        run: |
+          ./test/scripts/gh-actions/setup-uv.sh
+          # Add bin directory to PATH for subsequent steps
+          echo "$(pwd)/bin" >> $GITHUB_PATH
 
       - name: Install KServe Python SDK
         run: |
           echo "🐍 Installing KServe Python SDK with test dependencies..."
+          # Source common.sh to set up PATH (same as setup-kserve.sh does)
           source hack/setup/common.sh
           pushd python/kserve >/dev/null
               uv sync --active --group test

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -691,6 +691,12 @@ jobs:
       - name: Install UV
         run: ./test/scripts/gh-actions/setup-uv.sh
 
+      - name: Install Python dependencies for chart generation
+        run: |
+          echo "📦 Installing Python dependencies for chart generation..."
+          pip install PyYAML>=6.0
+          echo "✅ Python build dependencies installed!"
+
       - name: Install Kserve from helm
         run: |
           ./test/scripts/gh-actions/setup-kserve-helm.sh

--- a/hack/llmisvc_quick_install.sh
+++ b/hack/llmisvc_quick_install.sh
@@ -246,16 +246,17 @@ if [ "${USE_LOCAL_CHARTS}" = true ]; then
    echo "Installing LLMISvc using local charts..."
    echo "📍 Using local charts from $(pwd)/charts/"
    # Install LLMISvc CRDs from local chart
-   helm install kserve-llmisvc-crd ./charts/kserve-llmisvc-crd --namespace kserve --create-namespace --wait
+   helm install llmisvc-crd ./charts/kserve-llmisvc-crd --namespace kserve --create-namespace --wait
+   echo "😀 Successfully installed LLMISvc CRDs using local charts"
 
    # Install LLMISvc resources from local chart  
-   helm install kserve-llmisvc ./charts/kserve-llmisvc-resources --namespace kserve --create-namespace --wait --set kserve.llmisvc.controller.tag=local-test --set kserve.llmisvc.controller.imagePullPolicy=Never
-   echo "😀 Successfully installed LLMISvc using local charts"
+   helm install llmisvc ./charts/kserve-llmisvc-resources --namespace kserve --create-namespace --wait --set llmisvcControllerManager.manager.image.tag=local-test --set llmisvcControllerManager.manager.imagePullPolicy=Never
+   echo "😀 Successfully installed LLMISvc resources using local charts"
 
 else
    echo "Installing LLMISvc ..."
-   helm install kserve-llmisvc-crd oci://ghcr.io/kserve/charts/kserve-llmisvc-crd --version ${LLMISVC_VERSION} --namespace kserve --create-namespace --wait
-   helm install kserve-llmisvc oci://ghcr.io/kserve/charts/kserve-llmisvc-resources --version ${LLMISVC_VERSION} --namespace kserve --create-namespace --wait
+   helm install llmisvc-crd oci://ghcr.io/kserve/charts/kserve-llmisvc-crd --version ${LLMISVC_VERSION} --namespace kserve --create-namespace --wait
+   helm install llmisvc oci://ghcr.io/kserve/charts/kserve-llmisvc-resources --version ${LLMISVC_VERSION} --namespace kserve --create-namespace --wait
 
 fi
 echo "😀 Successfully installed LLMISvc"


### PR DESCRIPTION
## Summary
Update E2E test workflows and installation scripts to use generated Helm charts.

This PR contains only the **manually maintained** workflow and script files. The auto-generated quick-install scripts are excluded as they will be regenerated via `make generate-quick-install-scripts` when the other PRs merge.

## Changes
- **E2E Tests**: Update GitHub Actions workflows for Helm-based installation
  - `.github/workflows/e2e-test-llmisvc.yaml`
  - `.github/workflows/e2e-test.yml`
- **Installation Scripts**: Update manual Helm installation scripts
  - `hack/llmisvc_quick_install.sh`
  - `hack/setup/infra/manage.kserve-helm.sh`
- **Knative Config**: Fix version to 1.15.2 in `test/overlays/knative/knative-serving-istio.yaml`

## Testing
- [ ] E2E test workflows pass with Helm installation
- [ ] LLMISvc deployment detection works correctly

## Dependencies
- Requires PR #4867, #4868, #4869 to be merged first

## Note
The auto-generated `hack/setup/quick-install/*.sh` files are **not** included in this PR. They will be regenerated automatically when running `make generate-quick-install-scripts` after the chart generation PRs merge.