### PR TITLE
add azure protocol for kubeflow model registry

### DIFF
--- a/pkg/agent/storage/provider.go
+++ b/pkg/agent/storage/provider.go
@@ -33,7 +33,7 @@ const (
 	HTTP  Protocol = "http://"
 )
 
-var SupportedProtocols = []Protocol{S3, GCS, HTTPS, HTTP}
+var SupportedProtocols = []Protocol{S3, GCS, HTTPS, HTTP, AZURE}
 
 func GetAllProtocol() (protocols []string) {
 	for _, protocol := range SupportedProtocols {


### PR DESCRIPTION
**What this PR does / why we need it**:  I'm using Kserve and Kubeflow model registration standalone mode. Below is an example I use.
```
apiVersion: "serving.kserve.io/v1beta1"
kind: InferenceService
metadata:
  name: hello-world
  annotations:
    serving.kserve.io/deploymentMode: RawDeployment
spec:
  predictor:
    serviceAccountName: sa
    model:
      modelFormat:
        name: huggingface
      args:
        - "--max-model-len=8192"
        - "--tensor-parallel-size=1"
      storageUri: model-registry://ame-ame/v7
      resources:
        requests:
          cpu: "20"
          memory: "200Gi"
          nvidia.com/gpu: "1"
        limits:
          cpu: "20"
          memory: "200Gi"
          nvidia.com/gpu: "1"
```
Logs that occur in the storage-initializer container during deployment.

```
storage-initializer 2025/12/05 07:46:46 Initializing, args: src_uri [model-registry://ame-ame/v7] dest_path[ [/mnt/models]                                                                  
storage-initializer 2025/12/05 07:46:46 Falling back to base url model-registry-service.kubeflow.svc.cluster.local:8080 for model registry service                                          
storage-initializer 2025/12/05 07:46:46 Download model indexed in model registry: modelName=, storageUri=model-registry://ame-ame/v7, modelDir=/mnt/models                                  
storage-initializer 2025/12/05 07:46:46 Parsed storageUri=model-registry://ame-ame/v7 as: modelRegistryUrl=model-registry-service.kubeflow.svc.cluster.local:8080, registeredModelName=ame-ame, versionName=v7                                                                                                                                                                        
storage-initializer 2025/12/05 07:46:46 Fetching model: registeredModelName=ame-ame, versionName=v7                                                                                         
storage-initializer 2025/12/05 07:46:46 Fetching model version: model=&{map[_lastModified:{<nil> <nil> <nil> <nil> 0xc000473b60 <nil>}] 0xc000698cf0 <nil> ame-ame 0xc000698d00 0xc000698c 70 0xc000698d10 <nil> <nil> [] [] <nil> <nil> <nil> <nil> <nil> 0xc000698d20 0xc000698d30}                                                                                                  
storage-initializer 2025/12/05 07:46:46 Fetching model artifacts: version=&{map[] 0xc000698f50 <nil> v7 0xc000698f80 0xc000698f30 7 0xc000698f60 0xc000698f40 0xc000698f70}                 
storage-initializer 2025/12/05 07:46:46 Extracting protocol from model artifact URI: abfs://staz01devmagmamdst01.blob.core.windows.net/dev-external/models/Phi-4-mini-instruct-SFT-7.1.2    
storage-initializer 2025/12/05 07:46:46 Error downloading the model: protocol not supported for storageUri                                                                                  
```
So I checked and found out that in the kubeflow model-registry code, I get Providers and Protocols from "github.com/kserve/kserve/pkg/agent/storage " as below.

<modelregistry_provider.go>
```
....
	kserve "github.com/kserve/kserve/pkg/agent/storage"
	"github.com/kubeflow/model-registry/internal/apiutils"
...
	log.Printf("Getting KServe provider for protocol: %s", protocol)
	provider, err := kserve.GetProvider(p.Providers, protocol)
	if err != nil {
		return err
	}
```
<go.mod>
```
module github.com/kubeflow/model-registry

go 1.25.3

require (
....
	github.com/kserve/kserve v0.16.0
....
```
However, I can't use it because it's not registered as a protocol. So I want to change it to make it available.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.