### PR TITLE
fix: the quick install scripts temporarily.

### DIFF
--- a/hack/llmisvc_quick_install.sh
+++ b/hack/llmisvc_quick_install.sh
@@ -15,15 +15,14 @@ Help() {
    echo
 }
 
-export GATEWAY_API_VERSION=v1.2.1
-export KSERVE_VERSION=v0.16.0
-export LLMISVC_VERSION=v0.16.0
-export LWS_VERSION=0.7.0
-export ENVOY_GATEWAY_VERSION=v1.5.0
-export ENVOY_AI_GATEWAY_VERSION=v0.3.0
 SCRIPT_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
-export CERT_MANAGER_VERSION=v1.16.1
 export SCRIPT_DIR
+
+source "${SCRIPT_DIR}/setup/common.sh"
+REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}")"
+
+source "${REPO_ROOT}/kserve-deps.env"
+installKserve=true
 
 uninstall() {
    # Uninstall Cert Manager
@@ -105,11 +104,8 @@ helm install \
    --set crds.enabled=true
 echo "😀 Successfully installed Cert Manager"
 
-echo "Installing Gateway API CRDs ..."
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml
-
 # Need to install before Envoy Gateway
-kubectl apply -f ${SCRIPT_DIR}/../config/llmisvc/gateway-inference-extension.yaml
+${SCRIPT_DIR}/setup/infra/gateway-api/manage.gateway-api-extension-crd.sh
 
 # Install Envoy Gateway
 echo "Installing Envoy Gateway ..."
@@ -193,29 +189,6 @@ EOF
   fi
 fi
 
-# Create Gateway resource
-echo "Creating kserve-ingress-gateway ..."
-kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: kserve-ingress-gateway
-  namespace: kserve
-spec:
-  gatewayClassName: envoy
-  listeners:
-    - name: http
-      protocol: HTTP
-      port: 80
-      allowedRoutes:
-        namespaces:
-          from: All
-  infrastructure:
-    labels:
-      serving.kserve.io/gateway: kserve-ingress-gateway
-EOF
-echo "😀 Successfully created kserve-ingress-gateway"
-
 # Install Leader Worker Set (LWS)
 echo "Installing Leader Worker Set ..."
 helm install lws oci://registry.k8s.io/lws/charts/lws \
@@ -237,27 +210,8 @@ spec:
 EOF
 echo "😀 Successfully created GatewayClass for Envoy"
 
-if [ "${installLLMISvc}" = false ]; then
-   exit
-fi
+LLMISVC=true ${SCRIPT_DIR}/setup/infra/manage.kserve-helm.sh
 
-if [ "${USE_LOCAL_CHARTS}" = true ]; then
-   # Install LLMISvc using local charts (to avoid template function errors in published charts)
-   echo "Installing LLMISvc using local charts..."
-   echo "📍 Using local charts from $(pwd)/charts/"
-   # Install LLMISvc CRDs from local chart
-   helm install kserve-llmisvc-crd ./charts/kserve-llmisvc-crd --namespace kserve --create-namespace --wait
-
-   # Install LLMISvc resources from local chart  
-   helm install kserve-llmisvc ./charts/kserve-llmisvc-resources --namespace kserve --create-namespace --wait --set kserve.llmisvc.controller.tag=local-test --set kserve.llmisvc.controller.imagePullPolicy=Never
-   echo "😀 Successfully installed LLMISvc using local charts"
-
-else
-   echo "Installing LLMISvc ..."
-   helm install kserve-llmisvc-crd oci://ghcr.io/kserve/charts/kserve-llmisvc-crd --version ${LLMISVC_VERSION} --namespace kserve --create-namespace --wait
-   helm install kserve-llmisvc oci://ghcr.io/kserve/charts/kserve-llmisvc-resources --version ${LLMISVC_VERSION} --namespace kserve --create-namespace --wait
-
-fi
 echo "😀 Successfully installed LLMISvc"
 
 # Create Gateway resource

--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -18,15 +18,14 @@ Help() {
    echo
 }
 
-export ISTIO_VERSION=1.27.1
-export KNATIVE_OPERATOR_VERSION=v1.15.7
-export KNATIVE_SERVING_VERSION=1.15.2
-export KSERVE_VERSION=v0.16.0
-export CERT_MANAGER_VERSION=v1.16.1
-export GATEWAY_API_VERSION=v1.2.1
-export KEDA_VERSION=2.14.0
 SCRIPT_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
 export SCRIPT_DIR
+
+source "${SCRIPT_DIR}/setup/common.sh"
+REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}")"
+
+source "${REPO_ROOT}/kserve-deps.env"
+installKserve=true
 
 uninstall() {
    helm uninstall --ignore-not-found istio-ingressgateway -n istio-system
@@ -161,7 +160,4 @@ if [ "${installKserve}" = false ]; then
    exit
 fi
 # Install KServe
-helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version ${KSERVE_VERSION} --namespace kserve --create-namespace --wait
-helm install kserve oci://ghcr.io/kserve/charts/kserve --version ${KSERVE_VERSION} --namespace kserve --create-namespace --wait \
-   --set-string kserve.controller.deploymentMode="${deploymentMode}"
-echo "😀 Successfully installed KServe"
+DEPLOYMENT_MODE=${deploymentMode} ${SCRIPT_DIR}/setup/infra/manage.kserve-helm.sh

--- a/hack/setup/infra/external-lb/manage.external-lb.sh
+++ b/hack/setup/infra/external-lb/manage.external-lb.sh
@@ -44,7 +44,7 @@ fi
 
 # VARIABLES
 PLATFORM="${PLATFORM:-$(detect_platform)}"
-TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+TEMPLATE_DIR="${REPO_ROOT}/hack/setup/infra/external-lb/templates"
 # VARIABLES END
 
 uninstall() {

--- a/hack/setup/infra/gateway-api/manage.gateway-api-crd.sh
+++ b/hack/setup/infra/gateway-api/manage.gateway-api-crd.sh
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 # Install Gateway API CRDs
-# Usage: install-crd.sh [--reinstall|--uninstall]
-#   or:  REINSTALL=true install-crd.sh
-#   or:  UNINSTALL=true install-crd.sh
+# Usage: manage.gateway-api-crd-only.sh [--reinstall|--uninstall]
+#   or:  REINSTALL=true manage.gateway-api-crd-only.sh
+#   or:  UNINSTALL=true manage.gateway-api-crd-only.sh
 
 # INIT
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
@@ -37,7 +37,6 @@ fi
 uninstall() {
     log_info "Uninstalling Gateway API CRDs..."
     kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml" --ignore-not-found=true 2>/dev/null || true
-    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
     log_success "Gateway API CRDs uninstalled"
 }
 
@@ -62,18 +61,6 @@ install() {
         "gatewayclasses.gateway.networking.k8s.io"
 
     log_success "Gateway API CRDs are ready!"
-
-    log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
-    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
-
-    log_success "Successfully installed Gateway Inference Extension CRDs ${GIE_VERSION}"
-
-    wait_for_crds "60s" \
-        "inferencepools.inference.networking.x-k8s.io" \
-        "inferencemodels.inference.networking.x-k8s.io"
-
-    log_success "Gateway Inference Extension CRDs are ready!"
-
 }
 
 if [ "$UNINSTALL" = true ]; then

--- a/hack/setup/infra/gateway-api/manage.gateway-api-extension-crd.sh
+++ b/hack/setup/infra/gateway-api/manage.gateway-api-extension-crd.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install Gateway Inference Extension CRDs
+# Usage: manage.gateway-inference-extension-crd.sh [--reinstall|--uninstall]
+#   or:  REINSTALL=true manage.gateway-inference-extension-crd.sh
+#   or:  UNINSTALL=true manage.gateway-inference-extension-crd.sh
+
+# INIT
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+
+source "${SCRIPT_DIR}/../../common.sh"
+
+REINSTALL="${REINSTALL:-false}"
+UNINSTALL="${UNINSTALL:-false}"
+
+if [[ "$*" == *"--uninstall"* ]]; then
+    UNINSTALL=true
+elif [[ "$*" == *"--reinstall"* ]]; then
+    REINSTALL=true
+fi
+# INIT END
+
+uninstall() {
+    log_info "Uninstalling Gateway Inference Extension CRDs..."
+    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
+    log_success "Gateway Inference Extension CRDs uninstalled"
+}
+
+install() {
+    if kubectl get crd inferencepools.inference.networking.x-k8s.io &>/dev/null; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "Gateway Inference Extension CRDs are already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling Gateway Inference Extension CRDs..."
+            uninstall
+        fi
+    fi
+
+    log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
+    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
+
+    log_success "Successfully installed Gateway Inference Extension CRDs ${GIE_VERSION}"
+
+    wait_for_crds "60s" \
+        "inferencepools.inference.networking.x-k8s.io" \
+        "inferencemodels.inference.networking.x-k8s.io"
+
+    log_success "Gateway Inference Extension CRDs are ready!"
+}
+
+if [ "$UNINSTALL" = true ]; then
+    uninstall
+    exit 0
+fi
+
+install

--- a/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-dependency-install.definition
+++ b/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-dependency-install.definition
@@ -12,7 +12,7 @@ COMPONENTS:
   - name: keda-otel-addon
   # LLMISVC
   - name: external-lb
-  - name: gateway-api-crd
+  - name: gateway-api-extension-crd
   - name: envoy-gateway
   - name: envoy-ai-gateway
   - name: gateway-api-gwclass

--- a/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-full-install-with-manifests.definition
+++ b/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-full-install-with-manifests.definition
@@ -14,11 +14,11 @@ COMPONENTS:
   - name: keda-otel-addon
   # LLMISVC
   - name: external-lb
-  - name: gateway-api-crd
+  - name: gateway-api-extension-crd
   - name: envoy-gateway
   - name: envoy-ai-gateway
   - name: gateway-api-gwclass
-  - name: gateway-api-gw  
+  - name: gateway-api-gw
   - name: lws-operator
   - name: kserve
     env:

--- a/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-full-install.definition
+++ b/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-full-install.definition
@@ -12,7 +12,6 @@ COMPONENTS:
   - name: keda-otel-addon
   # LLMISVC
   - name: external-lb
-  - name: gateway-api-crd
   - name: envoy-gateway
   - name: envoy-ai-gateway
   - name: gateway-api-gwclass

--- a/hack/setup/quick-install/definitions/llmisvc/llmisvc-dependency-install.definition
+++ b/hack/setup/quick-install/definitions/llmisvc/llmisvc-dependency-install.definition
@@ -8,7 +8,7 @@ TOOLS:
 COMPONENTS:
   - name: external-lb
   - name: cert-manager
-  - name: gateway-api-crd
+  - name: gateway-api-extension-crd
   - name: envoy-gateway
   - name: envoy-ai-gateway
   - name: gateway-api-gwclass

--- a/hack/setup/quick-install/definitions/llmisvc/llmisvc-full-install-with-manifests.definition
+++ b/hack/setup/quick-install/definitions/llmisvc/llmisvc-full-install-with-manifests.definition
@@ -9,7 +9,7 @@ TOOLS:
 COMPONENTS:
   - name: external-lb
   - name: cert-manager
-  - name: gateway-api-crd
+  - name: gateway-api-extension-crd
   - name: envoy-gateway
   - name: envoy-ai-gateway
   - name: gateway-api-gwclass

--- a/hack/setup/quick-install/definitions/llmisvc/llmisvc-full-install.definition
+++ b/hack/setup/quick-install/definitions/llmisvc/llmisvc-full-install.definition
@@ -9,7 +9,7 @@ TOOLS:
 COMPONENTS:
   - name: external-lb
   - name: cert-manager
-  - name: gateway-api-crd
+  - name: gateway-api-extension-crd
   - name: envoy-gateway
   - name: envoy-ai-gateway
   - name: gateway-api-gwclass

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -1097,13 +1097,31 @@ install_kserve() {
 
         # Install KServe resources
         log_info "Installing KServe resources..."
-        helm install "${KSERVE_RELEASE_NAME}" \
+        if ! helm install "${KSERVE_RELEASE_NAME}" \
             oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
             --version "${KSERVE_VERSION}" \
             --namespace "${KSERVE_NAMESPACE}" \
             --create-namespace \
             --wait \
-            ${KSERVE_EXTRA_ARGS:-}
+            ${KSERVE_EXTRA_ARGS:-}; then
+
+            # If installation fails, try using helm upgrade after kserve controller is Ready
+            log_info "Install failed, attempting upgrade instead..."
+
+            for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
+                    wait_for_deployment "${KSERVE_NAMESPACE}" "${deploy}" "120s"
+            done
+            if ! helm upgrade "${KSERVE_RELEASE_NAME}" \
+                oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
+                --version "${KSERVE_VERSION}" \
+                --namespace "${KSERVE_NAMESPACE}" \
+                --wait \
+                ${KSERVE_EXTRA_ARGS:-}; then
+
+                log_error "Failed to install/upgrade KServe ${KSERVE_VERSION}"
+                exit 1
+            fi
+        fi
 
         log_success "Successfully installed KServe ${KSERVE_VERSION}"
     fi
@@ -1133,7 +1151,11 @@ install_kserve() {
         update_isvc_config "${config_updates[@]}"
         kubectl rollout restart deployment kserve-controller-manager -n ${KSERVE_NAMESPACE}
     else
-        log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        if [ "${LLMISVC}" = "true" ]; then
+            log_info "No configuration updates needed for LLMISVC (GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        else
+            log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        fi
     fi
 
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
@@ -1191,8 +1213,8 @@ main() {
             CRD_DIR_NAME="kserve-llmisvc-crd"
             CORE_DIR_NAME="kserve-llmisvc-resources"
             KSERVE_CRD_RELEASE_NAME="kserve-llmisvc-crd"
-            KSERVE_RELEASE_NAME="kserve-llmisvc"
-            TARGET_DEPLOYMENT_NAMES=("llmisvc-controller-manager")
+            KSERVE_RELEASE_NAME="kserve-llmisvc-resources"
+            TARGET_DEPLOYMENT_NAMES=("kserve-llmisvc-controller-manager")
         fi
         
         if [ "${SET_KSERVE_VERSION}" != "" ]; then

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -1097,13 +1097,31 @@ install_kserve() {
 
         # Install KServe resources
         log_info "Installing KServe resources..."
-        helm install "${KSERVE_RELEASE_NAME}" \
+        if ! helm install "${KSERVE_RELEASE_NAME}" \
             oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
             --version "${KSERVE_VERSION}" \
             --namespace "${KSERVE_NAMESPACE}" \
             --create-namespace \
             --wait \
-            ${KSERVE_EXTRA_ARGS:-}
+            ${KSERVE_EXTRA_ARGS:-}; then
+
+            # If installation fails, try using helm upgrade after kserve controller is Ready
+            log_info "Install failed, attempting upgrade instead..."
+
+            for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
+                    wait_for_deployment "${KSERVE_NAMESPACE}" "${deploy}" "120s"
+            done
+            if ! helm upgrade "${KSERVE_RELEASE_NAME}" \
+                oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
+                --version "${KSERVE_VERSION}" \
+                --namespace "${KSERVE_NAMESPACE}" \
+                --wait \
+                ${KSERVE_EXTRA_ARGS:-}; then
+
+                log_error "Failed to install/upgrade KServe ${KSERVE_VERSION}"
+                exit 1
+            fi
+        fi
 
         log_success "Successfully installed KServe ${KSERVE_VERSION}"
     fi
@@ -1133,7 +1151,11 @@ install_kserve() {
         update_isvc_config "${config_updates[@]}"
         kubectl rollout restart deployment kserve-controller-manager -n ${KSERVE_NAMESPACE}
     else
-        log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        if [ "${LLMISVC}" = "true" ]; then
+            log_info "No configuration updates needed for LLMISVC (GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        else
+            log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        fi
     fi
 
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
@@ -1191,8 +1213,8 @@ main() {
             CRD_DIR_NAME="kserve-llmisvc-crd"
             CORE_DIR_NAME="kserve-llmisvc-resources"
             KSERVE_CRD_RELEASE_NAME="kserve-llmisvc-crd"
-            KSERVE_RELEASE_NAME="kserve-llmisvc"
-            TARGET_DEPLOYMENT_NAMES=("llmisvc-controller-manager")
+            KSERVE_RELEASE_NAME="kserve-llmisvc-resources"
+            TARGET_DEPLOYMENT_NAMES=("kserve-llmisvc-controller-manager")
         fi
         
         if [ "${SET_KSERVE_VERSION}" != "" ]; then

--- a/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
@@ -559,7 +559,7 @@ KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
 
 ADDON_RELEASE_NAME="keda-otel-scaler"
 PLATFORM="${PLATFORM:-$(detect_platform)}"
-TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+TEMPLATE_DIR="${REPO_ROOT}/hack/setup/infra/external-lb/templates"
 GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-envoy}"
 CONTROLLER_NAME="${CONTROLLER_NAME:-gateway.envoyproxy.io/gatewayclass-controller}"
 GATEWAY_NAME="kserve-ingress-gateway"
@@ -975,37 +975,25 @@ install_external_lb() {
 }
 
 # ----------------------------------------
-# CLI/Component: gateway-api-crd
+# CLI/Component: gateway-api-extension-crd
 # ----------------------------------------
 
-uninstall_gateway_api_crd() {
-    log_info "Uninstalling Gateway API CRDs..."
-    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml" --ignore-not-found=true 2>/dev/null || true
+uninstall_gateway_api_extension_crd() {
+    log_info "Uninstalling Gateway Inference Extension CRDs..."
     kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
-    log_success "Gateway API CRDs uninstalled"
+    log_success "Gateway Inference Extension CRDs uninstalled"
 }
 
-install_gateway_api_crd() {
-    if kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+install_gateway_api_extension_crd() {
+    if kubectl get crd inferencepools.inference.networking.x-k8s.io &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
-            log_info "Gateway API CRDs are already installed. Use --reinstall to reinstall."
+            log_info "Gateway Inference Extension CRDs are already installed. Use --reinstall to reinstall."
             return 0
         else
-            log_info "Reinstalling Gateway API CRDs..."
-            uninstall_gateway_api_crd
+            log_info "Reinstalling Gateway Inference Extension CRDs..."
+            uninstall_gateway_api_extension_crd
         fi
     fi
-
-    log_info "Installing Gateway API CRDs ${GATEWAY_API_VERSION}..."
-    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
-
-    log_success "Successfully installed Gateway API CRDs ${GATEWAY_API_VERSION}"
-
-    wait_for_crds "60s" \
-        "gateways.gateway.networking.k8s.io" \
-        "gatewayclasses.gateway.networking.k8s.io"
-
-    log_success "Gateway API CRDs are ready!"
 
     log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
     kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
@@ -1017,7 +1005,6 @@ install_gateway_api_crd() {
         "inferencemodels.inference.networking.x-k8s.io"
 
     log_success "Gateway Inference Extension CRDs are ready!"
-
 }
 
 # ----------------------------------------
@@ -1245,7 +1232,7 @@ main() {
         uninstall_gateway_api_gwclass
         uninstall_envoy_ai_gateway
         uninstall_envoy_gateway
-        uninstall_gateway_api_crd
+        uninstall_gateway_api_extension_crd
         uninstall_external_lb
         uninstall_keda_otel_addon
         uninstall_keda
@@ -1272,7 +1259,7 @@ main() {
     install_keda
     install_keda_otel_addon
     install_external_lb
-    install_gateway_api_crd
+    install_gateway_api_extension_crd
     install_envoy_gateway
     install_envoy_ai_gateway
     install_gateway_api_gwclass

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -559,7 +559,7 @@ KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
 
 ADDON_RELEASE_NAME="keda-otel-scaler"
 PLATFORM="${PLATFORM:-$(detect_platform)}"
-TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+TEMPLATE_DIR="${REPO_ROOT}/hack/setup/infra/external-lb/templates"
 GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-envoy}"
 CONTROLLER_NAME="${CONTROLLER_NAME:-gateway.envoyproxy.io/gatewayclass-controller}"
 GATEWAY_NAME="kserve-ingress-gateway"
@@ -985,52 +985,6 @@ install_external_lb() {
 }
 
 # ----------------------------------------
-# CLI/Component: gateway-api-crd
-# ----------------------------------------
-
-uninstall_gateway_api_crd() {
-    log_info "Uninstalling Gateway API CRDs..."
-    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml" --ignore-not-found=true 2>/dev/null || true
-    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
-    log_success "Gateway API CRDs uninstalled"
-}
-
-install_gateway_api_crd() {
-    if kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
-        if [ "$REINSTALL" = false ]; then
-            log_info "Gateway API CRDs are already installed. Use --reinstall to reinstall."
-            return 0
-        else
-            log_info "Reinstalling Gateway API CRDs..."
-            uninstall_gateway_api_crd
-        fi
-    fi
-
-    log_info "Installing Gateway API CRDs ${GATEWAY_API_VERSION}..."
-    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
-
-    log_success "Successfully installed Gateway API CRDs ${GATEWAY_API_VERSION}"
-
-    wait_for_crds "60s" \
-        "gateways.gateway.networking.k8s.io" \
-        "gatewayclasses.gateway.networking.k8s.io"
-
-    log_success "Gateway API CRDs are ready!"
-
-    log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
-    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
-
-    log_success "Successfully installed Gateway Inference Extension CRDs ${GIE_VERSION}"
-
-    wait_for_crds "60s" \
-        "inferencepools.inference.networking.x-k8s.io" \
-        "inferencemodels.inference.networking.x-k8s.io"
-
-    log_success "Gateway Inference Extension CRDs are ready!"
-
-}
-
-# ----------------------------------------
 # CLI/Component: envoy-gateway
 # ----------------------------------------
 
@@ -1331,13 +1285,31 @@ install_kserve() {
 
         # Install KServe resources
         log_info "Installing KServe resources..."
-        helm install "${KSERVE_RELEASE_NAME}" \
+        if ! helm install "${KSERVE_RELEASE_NAME}" \
             oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
             --version "${KSERVE_VERSION}" \
             --namespace "${KSERVE_NAMESPACE}" \
             --create-namespace \
             --wait \
-            ${KSERVE_EXTRA_ARGS:-}
+            ${KSERVE_EXTRA_ARGS:-}; then
+
+            # If installation fails, try using helm upgrade after kserve controller is Ready
+            log_info "Install failed, attempting upgrade instead..."
+
+            for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
+                    wait_for_deployment "${KSERVE_NAMESPACE}" "${deploy}" "120s"
+            done
+            if ! helm upgrade "${KSERVE_RELEASE_NAME}" \
+                oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
+                --version "${KSERVE_VERSION}" \
+                --namespace "${KSERVE_NAMESPACE}" \
+                --wait \
+                ${KSERVE_EXTRA_ARGS:-}; then
+
+                log_error "Failed to install/upgrade KServe ${KSERVE_VERSION}"
+                exit 1
+            fi
+        fi
 
         log_success "Successfully installed KServe ${KSERVE_VERSION}"
     fi
@@ -1367,7 +1339,11 @@ install_kserve() {
         update_isvc_config "${config_updates[@]}"
         kubectl rollout restart deployment kserve-controller-manager -n ${KSERVE_NAMESPACE}
     else
-        log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        if [ "${LLMISVC}" = "true" ]; then
+            log_info "No configuration updates needed for LLMISVC (GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        else
+            log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        fi
     fi
 
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
@@ -1393,7 +1369,6 @@ main() {
         uninstall_gateway_api_gwclass
         uninstall_envoy_ai_gateway
         uninstall_envoy_gateway
-        uninstall_gateway_api_crd
         uninstall_external_lb
         uninstall_keda_otel_addon
         uninstall_keda
@@ -1420,7 +1395,6 @@ main() {
     install_keda
     install_keda_otel_addon
     install_external_lb
-    install_gateway_api_crd
     install_envoy_gateway
     install_envoy_ai_gateway
     install_gateway_api_gwclass
@@ -1434,8 +1408,8 @@ main() {
             CRD_DIR_NAME="kserve-llmisvc-crd"
             CORE_DIR_NAME="kserve-llmisvc-resources"
             KSERVE_CRD_RELEASE_NAME="kserve-llmisvc-crd"
-            KSERVE_RELEASE_NAME="kserve-llmisvc"
-            TARGET_DEPLOYMENT_NAMES=("llmisvc-controller-manager")
+            KSERVE_RELEASE_NAME="kserve-llmisvc-resources"
+            TARGET_DEPLOYMENT_NAMES=("kserve-llmisvc-controller-manager")
         fi
         
         if [ "${SET_KSERVE_VERSION}" != "" ]; then

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -559,7 +559,7 @@ KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
 
 ADDON_RELEASE_NAME="keda-otel-scaler"
 PLATFORM="${PLATFORM:-$(detect_platform)}"
-TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+TEMPLATE_DIR="${REPO_ROOT}/hack/setup/infra/external-lb/templates"
 GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-envoy}"
 CONTROLLER_NAME="${CONTROLLER_NAME:-gateway.envoyproxy.io/gatewayclass-controller}"
 GATEWAY_NAME="kserve-ingress-gateway"
@@ -985,37 +985,25 @@ install_external_lb() {
 }
 
 # ----------------------------------------
-# CLI/Component: gateway-api-crd
+# CLI/Component: gateway-api-extension-crd
 # ----------------------------------------
 
-uninstall_gateway_api_crd() {
-    log_info "Uninstalling Gateway API CRDs..."
-    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml" --ignore-not-found=true 2>/dev/null || true
+uninstall_gateway_api_extension_crd() {
+    log_info "Uninstalling Gateway Inference Extension CRDs..."
     kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
-    log_success "Gateway API CRDs uninstalled"
+    log_success "Gateway Inference Extension CRDs uninstalled"
 }
 
-install_gateway_api_crd() {
-    if kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+install_gateway_api_extension_crd() {
+    if kubectl get crd inferencepools.inference.networking.x-k8s.io &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
-            log_info "Gateway API CRDs are already installed. Use --reinstall to reinstall."
+            log_info "Gateway Inference Extension CRDs are already installed. Use --reinstall to reinstall."
             return 0
         else
-            log_info "Reinstalling Gateway API CRDs..."
-            uninstall_gateway_api_crd
+            log_info "Reinstalling Gateway Inference Extension CRDs..."
+            uninstall_gateway_api_extension_crd
         fi
     fi
-
-    log_info "Installing Gateway API CRDs ${GATEWAY_API_VERSION}..."
-    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
-
-    log_success "Successfully installed Gateway API CRDs ${GATEWAY_API_VERSION}"
-
-    wait_for_crds "60s" \
-        "gateways.gateway.networking.k8s.io" \
-        "gatewayclasses.gateway.networking.k8s.io"
-
-    log_success "Gateway API CRDs are ready!"
 
     log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
     kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
@@ -1027,7 +1015,6 @@ install_gateway_api_crd() {
         "inferencemodels.inference.networking.x-k8s.io"
 
     log_success "Gateway Inference Extension CRDs are ready!"
-
 }
 
 # ----------------------------------------
@@ -1331,13 +1318,31 @@ install_kserve() {
 
         # Install KServe resources
         log_info "Installing KServe resources..."
-        helm install "${KSERVE_RELEASE_NAME}" \
+        if ! helm install "${KSERVE_RELEASE_NAME}" \
             oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
             --version "${KSERVE_VERSION}" \
             --namespace "${KSERVE_NAMESPACE}" \
             --create-namespace \
             --wait \
-            ${KSERVE_EXTRA_ARGS:-}
+            ${KSERVE_EXTRA_ARGS:-}; then
+
+            # If installation fails, try using helm upgrade after kserve controller is Ready
+            log_info "Install failed, attempting upgrade instead..."
+
+            for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
+                    wait_for_deployment "${KSERVE_NAMESPACE}" "${deploy}" "120s"
+            done
+            if ! helm upgrade "${KSERVE_RELEASE_NAME}" \
+                oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
+                --version "${KSERVE_VERSION}" \
+                --namespace "${KSERVE_NAMESPACE}" \
+                --wait \
+                ${KSERVE_EXTRA_ARGS:-}; then
+
+                log_error "Failed to install/upgrade KServe ${KSERVE_VERSION}"
+                exit 1
+            fi
+        fi
 
         log_success "Successfully installed KServe ${KSERVE_VERSION}"
     fi
@@ -1367,7 +1372,11 @@ install_kserve() {
         update_isvc_config "${config_updates[@]}"
         kubectl rollout restart deployment kserve-controller-manager -n ${KSERVE_NAMESPACE}
     else
-        log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        if [ "${LLMISVC}" = "true" ]; then
+            log_info "No configuration updates needed for LLMISVC (GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        else
+            log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        fi
     fi
 
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
@@ -1393,7 +1402,7 @@ main() {
         uninstall_gateway_api_gwclass
         uninstall_envoy_ai_gateway
         uninstall_envoy_gateway
-        uninstall_gateway_api_crd
+        uninstall_gateway_api_extension_crd
         uninstall_external_lb
         uninstall_keda_otel_addon
         uninstall_keda
@@ -1420,7 +1429,7 @@ main() {
     install_keda
     install_keda_otel_addon
     install_external_lb
-    install_gateway_api_crd
+    install_gateway_api_extension_crd
     install_envoy_gateway
     install_envoy_ai_gateway
     install_gateway_api_gwclass
@@ -1434,8 +1443,8 @@ main() {
             CRD_DIR_NAME="kserve-llmisvc-crd"
             CORE_DIR_NAME="kserve-llmisvc-resources"
             KSERVE_CRD_RELEASE_NAME="kserve-llmisvc-crd"
-            KSERVE_RELEASE_NAME="kserve-llmisvc"
-            TARGET_DEPLOYMENT_NAMES=("llmisvc-controller-manager")
+            KSERVE_RELEASE_NAME="kserve-llmisvc-resources"
+            TARGET_DEPLOYMENT_NAMES=("kserve-llmisvc-controller-manager")
         fi
         
         if [ "${SET_KSERVE_VERSION}" != "" ]; then

--- a/hack/setup/quick-install/llmisvc-dependency-install.sh
+++ b/hack/setup/quick-install/llmisvc-dependency-install.sh
@@ -558,7 +558,7 @@ KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
 #================================================
 
 PLATFORM="${PLATFORM:-$(detect_platform)}"
-TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+TEMPLATE_DIR="${REPO_ROOT}/hack/setup/infra/external-lb/templates"
 GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-envoy}"
 CONTROLLER_NAME="${CONTROLLER_NAME:-gateway.envoyproxy.io/gatewayclass-controller}"
 GATEWAY_NAME="kserve-ingress-gateway"
@@ -829,37 +829,25 @@ install_cert_manager() {
 }
 
 # ----------------------------------------
-# CLI/Component: gateway-api-crd
+# CLI/Component: gateway-api-extension-crd
 # ----------------------------------------
 
-uninstall_gateway_api_crd() {
-    log_info "Uninstalling Gateway API CRDs..."
-    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml" --ignore-not-found=true 2>/dev/null || true
+uninstall_gateway_api_extension_crd() {
+    log_info "Uninstalling Gateway Inference Extension CRDs..."
     kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
-    log_success "Gateway API CRDs uninstalled"
+    log_success "Gateway Inference Extension CRDs uninstalled"
 }
 
-install_gateway_api_crd() {
-    if kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+install_gateway_api_extension_crd() {
+    if kubectl get crd inferencepools.inference.networking.x-k8s.io &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
-            log_info "Gateway API CRDs are already installed. Use --reinstall to reinstall."
+            log_info "Gateway Inference Extension CRDs are already installed. Use --reinstall to reinstall."
             return 0
         else
-            log_info "Reinstalling Gateway API CRDs..."
-            uninstall_gateway_api_crd
+            log_info "Reinstalling Gateway Inference Extension CRDs..."
+            uninstall_gateway_api_extension_crd
         fi
     fi
-
-    log_info "Installing Gateway API CRDs ${GATEWAY_API_VERSION}..."
-    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
-
-    log_success "Successfully installed Gateway API CRDs ${GATEWAY_API_VERSION}"
-
-    wait_for_crds "60s" \
-        "gateways.gateway.networking.k8s.io" \
-        "gatewayclasses.gateway.networking.k8s.io"
-
-    log_success "Gateway API CRDs are ready!"
 
     log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
     kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
@@ -871,7 +859,6 @@ install_gateway_api_crd() {
         "inferencemodels.inference.networking.x-k8s.io"
 
     log_success "Gateway Inference Extension CRDs are ready!"
-
 }
 
 # ----------------------------------------
@@ -1099,7 +1086,7 @@ main() {
         uninstall_gateway_api_gwclass
         uninstall_envoy_ai_gateway
         uninstall_envoy_gateway
-        uninstall_gateway_api_crd
+        uninstall_gateway_api_extension_crd
         uninstall_cert_manager
         uninstall_external_lb
         
@@ -1120,7 +1107,7 @@ main() {
     install_yq
     install_external_lb
     install_cert_manager
-    install_gateway_api_crd
+    install_gateway_api_extension_crd
     install_envoy_gateway
     install_envoy_ai_gateway
     install_gateway_api_gwclass

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -558,7 +558,7 @@ KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
 #================================================
 
 PLATFORM="${PLATFORM:-$(detect_platform)}"
-TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+TEMPLATE_DIR="${REPO_ROOT}/hack/setup/infra/external-lb/templates"
 GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-envoy}"
 CONTROLLER_NAME="${CONTROLLER_NAME:-gateway.envoyproxy.io/gatewayclass-controller}"
 GATEWAY_NAME="kserve-ingress-gateway"
@@ -839,37 +839,25 @@ install_cert_manager() {
 }
 
 # ----------------------------------------
-# CLI/Component: gateway-api-crd
+# CLI/Component: gateway-api-extension-crd
 # ----------------------------------------
 
-uninstall_gateway_api_crd() {
-    log_info "Uninstalling Gateway API CRDs..."
-    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml" --ignore-not-found=true 2>/dev/null || true
+uninstall_gateway_api_extension_crd() {
+    log_info "Uninstalling Gateway Inference Extension CRDs..."
     kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
-    log_success "Gateway API CRDs uninstalled"
+    log_success "Gateway Inference Extension CRDs uninstalled"
 }
 
-install_gateway_api_crd() {
-    if kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+install_gateway_api_extension_crd() {
+    if kubectl get crd inferencepools.inference.networking.x-k8s.io &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
-            log_info "Gateway API CRDs are already installed. Use --reinstall to reinstall."
+            log_info "Gateway Inference Extension CRDs are already installed. Use --reinstall to reinstall."
             return 0
         else
-            log_info "Reinstalling Gateway API CRDs..."
-            uninstall_gateway_api_crd
+            log_info "Reinstalling Gateway Inference Extension CRDs..."
+            uninstall_gateway_api_extension_crd
         fi
     fi
-
-    log_info "Installing Gateway API CRDs ${GATEWAY_API_VERSION}..."
-    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
-
-    log_success "Successfully installed Gateway API CRDs ${GATEWAY_API_VERSION}"
-
-    wait_for_crds "60s" \
-        "gateways.gateway.networking.k8s.io" \
-        "gatewayclasses.gateway.networking.k8s.io"
-
-    log_success "Gateway API CRDs are ready!"
 
     log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
     kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
@@ -881,7 +869,6 @@ install_gateway_api_crd() {
         "inferencemodels.inference.networking.x-k8s.io"
 
     log_success "Gateway Inference Extension CRDs are ready!"
-
 }
 
 # ----------------------------------------
@@ -1185,13 +1172,31 @@ install_kserve_helm() {
 
         # Install KServe resources
         log_info "Installing KServe resources..."
-        helm install "${KSERVE_RELEASE_NAME}" \
+        if ! helm install "${KSERVE_RELEASE_NAME}" \
             oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
             --version "${KSERVE_VERSION}" \
             --namespace "${KSERVE_NAMESPACE}" \
             --create-namespace \
             --wait \
-            ${KSERVE_EXTRA_ARGS:-}
+            ${KSERVE_EXTRA_ARGS:-}; then
+
+            # If installation fails, try using helm upgrade after kserve controller is Ready
+            log_info "Install failed, attempting upgrade instead..."
+
+            for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
+                    wait_for_deployment "${KSERVE_NAMESPACE}" "${deploy}" "120s"
+            done
+            if ! helm upgrade "${KSERVE_RELEASE_NAME}" \
+                oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
+                --version "${KSERVE_VERSION}" \
+                --namespace "${KSERVE_NAMESPACE}" \
+                --wait \
+                ${KSERVE_EXTRA_ARGS:-}; then
+
+                log_error "Failed to install/upgrade KServe ${KSERVE_VERSION}"
+                exit 1
+            fi
+        fi
 
         log_success "Successfully installed KServe ${KSERVE_VERSION}"
     fi
@@ -1221,7 +1226,11 @@ install_kserve_helm() {
         update_isvc_config "${config_updates[@]}"
         kubectl rollout restart deployment kserve-controller-manager -n ${KSERVE_NAMESPACE}
     else
-        log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        if [ "${LLMISVC}" = "true" ]; then
+            log_info "No configuration updates needed for LLMISVC (GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        else
+            log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        fi
     fi
 
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
@@ -1247,7 +1256,7 @@ main() {
         uninstall_gateway_api_gwclass
         uninstall_envoy_ai_gateway
         uninstall_envoy_gateway
-        uninstall_gateway_api_crd
+        uninstall_gateway_api_extension_crd
         uninstall_cert_manager
         uninstall_external_lb
         
@@ -1268,7 +1277,7 @@ main() {
     install_yq
     install_external_lb
     install_cert_manager
-    install_gateway_api_crd
+    install_gateway_api_extension_crd
     install_envoy_gateway
     install_envoy_ai_gateway
     install_gateway_api_gwclass
@@ -1282,8 +1291,8 @@ main() {
             CRD_DIR_NAME="kserve-llmisvc-crd"
             CORE_DIR_NAME="kserve-llmisvc-resources"
             KSERVE_CRD_RELEASE_NAME="kserve-llmisvc-crd"
-            KSERVE_RELEASE_NAME="kserve-llmisvc"
-            TARGET_DEPLOYMENT_NAMES=("llmisvc-controller-manager")
+            KSERVE_RELEASE_NAME="kserve-llmisvc-resources"
+            TARGET_DEPLOYMENT_NAMES=("kserve-llmisvc-controller-manager")
         fi
         
         if [ "${SET_KSERVE_VERSION}" != "" ]; then

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -558,7 +558,7 @@ KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
 #================================================
 
 PLATFORM="${PLATFORM:-$(detect_platform)}"
-TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+TEMPLATE_DIR="${REPO_ROOT}/hack/setup/infra/external-lb/templates"
 GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-envoy}"
 CONTROLLER_NAME="${CONTROLLER_NAME:-gateway.envoyproxy.io/gatewayclass-controller}"
 GATEWAY_NAME="kserve-ingress-gateway"
@@ -839,37 +839,25 @@ install_cert_manager() {
 }
 
 # ----------------------------------------
-# CLI/Component: gateway-api-crd
+# CLI/Component: gateway-api-extension-crd
 # ----------------------------------------
 
-uninstall_gateway_api_crd() {
-    log_info "Uninstalling Gateway API CRDs..."
-    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml" --ignore-not-found=true 2>/dev/null || true
+uninstall_gateway_api_extension_crd() {
+    log_info "Uninstalling Gateway Inference Extension CRDs..."
     kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
-    log_success "Gateway API CRDs uninstalled"
+    log_success "Gateway Inference Extension CRDs uninstalled"
 }
 
-install_gateway_api_crd() {
-    if kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+install_gateway_api_extension_crd() {
+    if kubectl get crd inferencepools.inference.networking.x-k8s.io &>/dev/null; then
         if [ "$REINSTALL" = false ]; then
-            log_info "Gateway API CRDs are already installed. Use --reinstall to reinstall."
+            log_info "Gateway Inference Extension CRDs are already installed. Use --reinstall to reinstall."
             return 0
         else
-            log_info "Reinstalling Gateway API CRDs..."
-            uninstall_gateway_api_crd
+            log_info "Reinstalling Gateway Inference Extension CRDs..."
+            uninstall_gateway_api_extension_crd
         fi
     fi
-
-    log_info "Installing Gateway API CRDs ${GATEWAY_API_VERSION}..."
-    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
-
-    log_success "Successfully installed Gateway API CRDs ${GATEWAY_API_VERSION}"
-
-    wait_for_crds "60s" \
-        "gateways.gateway.networking.k8s.io" \
-        "gatewayclasses.gateway.networking.k8s.io"
-
-    log_success "Gateway API CRDs are ready!"
 
     log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
     kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
@@ -881,7 +869,6 @@ install_gateway_api_crd() {
         "inferencemodels.inference.networking.x-k8s.io"
 
     log_success "Gateway Inference Extension CRDs are ready!"
-
 }
 
 # ----------------------------------------
@@ -1185,13 +1172,31 @@ install_kserve_helm() {
 
         # Install KServe resources
         log_info "Installing KServe resources..."
-        helm install "${KSERVE_RELEASE_NAME}" \
+        if ! helm install "${KSERVE_RELEASE_NAME}" \
             oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
             --version "${KSERVE_VERSION}" \
             --namespace "${KSERVE_NAMESPACE}" \
             --create-namespace \
             --wait \
-            ${KSERVE_EXTRA_ARGS:-}
+            ${KSERVE_EXTRA_ARGS:-}; then
+
+            # If installation fails, try using helm upgrade after kserve controller is Ready
+            log_info "Install failed, attempting upgrade instead..."
+
+            for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
+                    wait_for_deployment "${KSERVE_NAMESPACE}" "${deploy}" "120s"
+            done
+            if ! helm upgrade "${KSERVE_RELEASE_NAME}" \
+                oci://ghcr.io/kserve/charts/${KSERVE_RELEASE_NAME} \
+                --version "${KSERVE_VERSION}" \
+                --namespace "${KSERVE_NAMESPACE}" \
+                --wait \
+                ${KSERVE_EXTRA_ARGS:-}; then
+
+                log_error "Failed to install/upgrade KServe ${KSERVE_VERSION}"
+                exit 1
+            fi
+        fi
 
         log_success "Successfully installed KServe ${KSERVE_VERSION}"
     fi
@@ -1221,7 +1226,11 @@ install_kserve_helm() {
         update_isvc_config "${config_updates[@]}"
         kubectl rollout restart deployment kserve-controller-manager -n ${KSERVE_NAMESPACE}
     else
-        log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        if [ "${LLMISVC}" = "true" ]; then
+            log_info "No configuration updates needed for LLMISVC (GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        else
+            log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+        fi
     fi
 
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
@@ -1247,7 +1256,7 @@ main() {
         uninstall_gateway_api_gwclass
         uninstall_envoy_ai_gateway
         uninstall_envoy_gateway
-        uninstall_gateway_api_crd
+        uninstall_gateway_api_extension_crd
         uninstall_cert_manager
         uninstall_external_lb
         
@@ -1268,7 +1277,7 @@ main() {
     install_yq
     install_external_lb
     install_cert_manager
-    install_gateway_api_crd
+    install_gateway_api_extension_crd
     install_envoy_gateway
     install_envoy_ai_gateway
     install_gateway_api_gwclass
@@ -1282,8 +1291,8 @@ main() {
             CRD_DIR_NAME="kserve-llmisvc-crd"
             CORE_DIR_NAME="kserve-llmisvc-resources"
             KSERVE_CRD_RELEASE_NAME="kserve-llmisvc-crd"
-            KSERVE_RELEASE_NAME="kserve-llmisvc"
-            TARGET_DEPLOYMENT_NAMES=("llmisvc-controller-manager")
+            KSERVE_RELEASE_NAME="kserve-llmisvc-resources"
+            TARGET_DEPLOYMENT_NAMES=("kserve-llmisvc-controller-manager")
         fi
         
         if [ "${SET_KSERVE_VERSION}" != "" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This is only a temporary workaround because the root issue is that the Helm chart creates `ClusterServingRuntime` and `LLMIsvcConfig` resources, which require the controller to be ready — but the controller itself is also managed by Helm, so we can’t guarantee the ordering.

To properly fix this, we should split those objects out of the `kserve-resources` / `kserve-llmisvc-resources` charts into separate charts. We should discuss this approach later.


With this PR, I addressed the following issues:

* **Helm CRD conflict (Helm v4):**
  Helm v3.16.3 had no issue applying the Gateway API/GIE CRDs before installing Envoy Gateway/Envoy AI Gateway. However, Helm v4.0.1 fails because the Envoy Gateway chart also includes the CRDs, causing a conflict.
  → I separated the Gateway API CRD and GIE CRD, and now only the GIE CRD is applied since the Envoy AI Gateway does not include it.

* **Unified install script:**
  Updated `quick_install.sh` and `llm_quick_install.sh` to use the new `hack/setup/infra/manage.kserve-helm.sh` script.
  → All installation scripts are now consolidated into a single script.

* **External LB script update:**
  Modified the external-lb setup script to use an absolute path (from the repository root: `kserve`) when calling the new quick-install script.

* **Retry mechanism for KServe installation:**
  Added a retry loop for installing KServe when `helm upgrade` fails.

 
**Verified platforms and scenarios**
- kind
  - `quick_install.sh -r` , `quick_install.sh -s`
  - `llm_quick_install.sh`
  - `llmisvc-full-install-with-manifests.sh`, `kserve-standard-mode-full-install-helm.sh`
- minikube
  - `quick_install.sh -r` , `quick_install.sh -s`
  - `llm_quick_install.sh`
  - `llmisvc-full-install-with-manifests.sh`, `kserve-standard-mode-full-install-helm.sh`



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kserve/kserve/issues/4844

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.