### PR TITLE
fix: update imports to fix vllm 0.12.0 compatibility

### DIFF
--- a/python/kserve/kserve/protocol/rest/openai/types/__init__.py
+++ b/python/kserve/kserve/protocol/rest/openai/types/__init__.py
@@ -12,27 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from vllm.entrypoints.openai.protocol import (
+from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponseChoice as ChatCompletionChoice,
     ChatCompletionLogProb,
     ChatCompletionLogProbs,
     ChatCompletionStreamResponse as ChatCompletionChunk,
     ChatCompletionResponseStreamChoice as ChunkChoice,
     ChatMessage,
-    DeltaMessage as ChoiceDelta,
+    ChatCompletionLogProbsContent,
+)
+from vllm.entrypoints.openai.completion.protocol import (
     CompletionResponseChoice as CompletionChoice,
     CompletionStreamResponse as CompletionChunk,
     CompletionResponseStreamChoice as CompletionChunkChoice,
     CompletionLogProbs,
     UsageInfo,
-    ChatCompletionLogProbsContent,
+)
+from vllm.entrypoints.openai.engine.protocol import (
     ModelCard as Model,
     ModelList,
+    DeltaMessage as ChoiceDelta,
 )
-from vllm.entrypoints.openai.protocol import ChatCompletionRequest, ChatCompletionResponse as ChatCompletion
-from vllm.entrypoints.openai.protocol import CompletionRequest, CompletionResponse as Completion
-from vllm.entrypoints.openai.protocol import EmbeddingRequest, EmbeddingResponse as Embedding, EmbeddingResponseData, EmbeddingCompletionRequest
-from vllm.entrypoints.openai.protocol import RerankRequest, RerankResponse as Rerank
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest, ChatCompletionResponse as ChatCompletion
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest, CompletionResponse as Completion
+from vllm.entrypoints.pooling.embed.protocol import EmbeddingRequest, EmbeddingResponse as Embedding, EmbeddingResponseData, EmbeddingCompletionRequest
+from vllm.entrypoints.pooling.score.protocol import RerankRequest, RerankResponse as Rerank
 from vllm.entrypoints.chat_utils import (
     ChatCompletionContentPartParam,
     CustomChatCompletionMessageParam,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Context:** Updating `vllm`  in nixpkgs (https://github.com/NixOS/nixpkgs/pull/467418).

EDIT: Updated to fix compatibility with vllm 0.15.0.

Latest `vllm` release [0.12.0](https://github.com/vllm-project/vllm/releases/tag/v0.12.0) changed the location of a few classes (`Embedding*` and `Rerank*`).
This PR updates the imports in `kserve/protocol/rest/openai/types/__init__.py`.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Before, this PR, running `kserve`'s test suite had a few failures:
```
=========================== short test summary info ============================
ERROR test/test_dataplane.py
ERROR test/test_model_repository.py
ERROR test/test_openai_completion.py
ERROR test/test_openai_encoder.py
================= 173 passed, 131 warnings, 4 errors in 32.00s =================
```

Example:
```
_________________ ERROR collecting test/test_openai_encoder.py _________________
ImportError while importing test module '/build/source/python/kserve/test/test_openai_encoder.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/test_openai_encoder.py:20: in <module>
    from kserve.protocol.rest.openai import (
kserve/protocol/rest/openai/__init__.py:16: in <module>
    from .openai_model import (
kserve/protocol/rest/openai/openai_model.py:22: in <module>
    from kserve.protocol.rest.openai.types import (
kserve/protocol/rest/openai/types/__init__.py:35: in <module>
    from vllm.entrypoints.pooling.embed.protocol import RerankRequest, RerankResponse as Rerank
E   ImportError: cannot import name 'RerankRequest' from 'vllm.entrypoints.pooling.embed.protocol'
```

After this change, all tests are successful.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.
