### PR TITLE
fix: isvc deletion using old label

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -495,6 +495,12 @@ func validateDeploymentMode(newIsvc *InferenceService, oldIsvc *InferenceService
 	if len(statusDeploymentMode) != 0 {
 		annotations := newIsvc.Annotations
 		annotationDeploymentMode, ok := annotations[constants.DeploymentMode]
+		if annotationDeploymentMode == string(constants.LegacyRawDeployment) {
+			annotationDeploymentMode = string(constants.Standard)
+		}
+		if annotationDeploymentMode == string(constants.LegacyServerless) {
+			annotationDeploymentMode = string(constants.Knative)
+		}
 		if ok && annotationDeploymentMode != statusDeploymentMode {
 			return fmt.Errorf("update rejected: deploymentMode cannot be changed from '%s' to '%s'", statusDeploymentMode, annotationDeploymentMode)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When an InferenceService resource is created using the deprecated deploymentMode values RawDeployment or Serverless, deleting the resource can fail. This happens because the InferenceService webhook validator compares the deployment mode stored in annotations with the value in status. While status is updated to use the new names (Standard and Knative), the annotations may still contain the old values, causing the validation to fail during deletion.

This PR fixes the issue by normalizing deprecated deployment mode values to their corresponding new names before performing the comparison. As a result, resources created with legacy deployment modes can now be validated and deleted correctly.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Steps to Reproduce

Create an InferenceService using the following manifest, which specifies the deprecated deployment mode RawDeployment via annotations:

```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  annotations:
    serving.kserve.io/deploymentMode: RawDeployment
  name: qwen-llm4
  namespace: kserve
spec:
  predictor:
    runtimeClassName: nvidia
    model:
      modelFormat:
        name: huggingface
      storageUri: hf://Qwen/Qwen2.5-0.5B-Instruct
      args:
        - --served-model-name=qwen
      env:
        - name: VLLM_LOGGING_LEVEL
          value: DEBUG
      resources:
        limits:
          cpu: "2"
          memory: 6Gi
          nvidia.com/gpu: "1"
        requests:
          cpu: "1"
          memory: 4Gi
          nvidia.com/gpu: "1"
```
and try to delete using cmd `kubectl delete isvc qwen-llm4 -n kserve`

we can bserve that the deletion is denied by the validating webhook. The `kserve-controller-manager` logs show the following error:

`"error":"admission webhook \"inferenceservice.kserve-webhook-server.validator\" denied the request: update rejected: deploymentMode cannot be changed from 'Standard' to 'RawDeployment'"`

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.