### PR TITLE
chore: Add .gitattributes to mark vendored and generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh linguist-vendored
+python/kserve/kserve/models/** linguist-generated=true


### PR DESCRIPTION
Configure Linguist to ignore shell scripts and generated Python code in language stats since currently this repo is identified as a shell script project.

<img width="319" height="141" alt="image" src="https://github.com/user-attachments/assets/33bb68d9-69a8-4acc-9dc1-fa5bf564a1d2" />

