### PR TITLE
Fix: use correct image tag in LLMISvc E2E workflow

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -107,17 +107,17 @@ jobs:
 
           # Set environment variable to use local charts
           export USE_LOCAL_CHARTS=true
-          LLMISVC_CONTROLLER_IMG_TAG="${DOCKER_REPO}/${LLMISVC_CONTROLLER_IMG}:${{ github.sha }}"
 
           # Use the quick install script to install all dependencies and LLMISvc
           ./hack/llmisvc_quick_install.sh
 
           # Update the deployment to use our built image with Never pull policy
+          # Use 'local-test' tag since that's what was loaded into minikube
           kubectl patch deployment kserve-llmisvc-controller-manager -n kserve \
-            -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","image":"'${LLMISVC_CONTROLLER_IMG_TAG}'","imagePullPolicy":"Never"}]}}}}'
+            -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","image":"kserve/llmisvc-controller:local-test","imagePullPolicy":"Never"}]}}}}'
 
-          # Wait for deployment to be ready
-          kubectl wait --for=condition=available --timeout=300s deployment/kserve-llmisvc-controller-manager -n kserve
+          # Wait for deployment rollout to complete (ensures new pod is ready, not just the old one)
+          kubectl rollout status deployment/kserve-llmisvc-controller-manager -n kserve --timeout=300s
 
       - name: Verify LLMISvc setup
         run: |


### PR DESCRIPTION
The workflow was patching the deployment to use an image tag that wasn't loaded into minikube. The image is loaded as 'local-test' but the patch was using the github.sha tag.

Also change from `kubectl wait --for=condition=available` to `kubectl rollout status` to ensure the new pod is ready, not just the old one during rolling update.

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.