### PR TITLE
fix: path traversal vulnerability in extractTarFiles

### DIFF
--- a/pkg/agent/storage/https.go
+++ b/pkg/agent/storage/https.go
@@ -189,10 +189,10 @@ func extractZipFiles(reader io.Reader, dest string) error {
 	if err != nil {
 		return fmt.Errorf("unable to create new reader: %w", err)
 	}
+	dest = filepath.Clean(dest)
 
 	// Read all the files from zip archive
 	for _, zipFile := range zipReader.File {
-		dest = filepath.Clean(dest)
 		fileFullPath := filepath.Clean(filepath.Join(dest, filepath.Clean(zipFile.Name)))
 		if !strings.HasPrefix(fileFullPath, dest+string(os.PathSeparator)) {
 			return fmt.Errorf("%s: illegal file path", fileFullPath)
@@ -246,6 +246,7 @@ func extractTarFiles(reader io.Reader, dest string) error {
 	}(gzr)
 
 	tr := tar.NewReader(gzr)
+	dest = filepath.Clean(dest)
 
 	// Read all the files from tar archive
 	for {
@@ -256,8 +257,10 @@ func extractTarFiles(reader io.Reader, dest string) error {
 			return fmt.Errorf("unable to access next tar file: %w", err)
 		}
 
-		dest = filepath.Clean(dest)
 		fileFullPath := filepath.Clean(filepath.Join(dest, filepath.Clean(header.Name)))
+		if !strings.HasPrefix(fileFullPath, dest+string(os.PathSeparator)) {
+			return fmt.Errorf("%s: illegal file path", fileFullPath)
+		}
 		if header.Typeflag == tar.TypeDir {
 			err = os.MkdirAll(fileFullPath, 0o755)
 			if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
Refactor path handling in extractTarFiles function to ensure destination paths are cleaned and validated
