### PR TITLE
feat: add default node affinity injector for model pods

### DIFF
--- a/pkg/webhook/admission/pod/affinity_injector.go
+++ b/pkg/webhook/admission/pod/affinity_injector.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pod
+
+import (
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	DefaultNodepoolEnvVar   = "KSERVE_DEFAULT_NODEPOOL"
+	DefaultNodepoolLabelKey = "KSERVE_DEFAULT_NODEPOOL_LABEL_KEY"
+	defaultNodepoolLabelKey = "cloud.google.com/gke-nodepool"
+)
+
+// InjectAffinity injects a default affinity config (configurable through environment variables) to each kserve pod
+// if it is created without affinity. This allows cluster administrators to route inference workloads to specific
+// node pools by default.
+func InjectAffinity(pod *v1.Pod) error {
+	// If the default nodepool is not set in environment variable, skip injection.
+	pool := os.Getenv(DefaultNodepoolEnvVar)
+	if len(pool) == 0 {
+		return nil
+	}
+
+	// If the pod already has affinity configured, skip injection.
+	if pod.Spec.Affinity != nil {
+		return nil
+	}
+
+	// Get the label key from environment variable, or use default.
+	labelKey := os.Getenv(DefaultNodepoolLabelKey)
+	if len(labelKey) == 0 {
+		labelKey = defaultNodepoolLabelKey
+	}
+
+	// Add default affinity config to the pod.
+	pod.Spec.Affinity = defaultAffinity(labelKey, pool)
+	return nil
+}
+
+func defaultAffinity(labelKey, pool string) *v1.Affinity {
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      labelKey,
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{pool},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/webhook/admission/pod/affinity_injector.go
+++ b/pkg/webhook/admission/pod/affinity_injector.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KServe Authors.
+Copyright 2026 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import (
 const (
 	DefaultNodepoolEnvVar   = "KSERVE_DEFAULT_NODEPOOL"
 	DefaultNodepoolLabelKey = "KSERVE_DEFAULT_NODEPOOL_LABEL_KEY"
-	defaultNodepoolLabelKey = "cloud.google.com/gke-nodepool"
 )
 
 // InjectAffinity injects a default affinity config (configurable through environment variables) to each kserve pod
@@ -42,10 +41,10 @@ func InjectAffinity(pod *v1.Pod) error {
 		return nil
 	}
 
-	// Get the label key from environment variable, or use default.
+	// Get the label key from environment variable. If not set, skip injection.
 	labelKey := os.Getenv(DefaultNodepoolLabelKey)
 	if len(labelKey) == 0 {
-		labelKey = defaultNodepoolLabelKey
+		return nil
 	}
 
 	// Add default affinity config to the pod.
@@ -56,9 +55,10 @@ func InjectAffinity(pod *v1.Pod) error {
 func defaultAffinity(labelKey, pool string) *v1.Affinity {
 	return &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-				NodeSelectorTerms: []v1.NodeSelectorTerm{
-					{
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+				{
+					Weight: 100,
+					Preference: v1.NodeSelectorTerm{
 						MatchExpressions: []v1.NodeSelectorRequirement{
 							{
 								Key:      labelKey,

--- a/pkg/webhook/admission/pod/affinity_injector_test.go
+++ b/pkg/webhook/admission/pod/affinity_injector_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pod
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testDefaultNodepool = "default-pool"
+	testCustomNodepool  = "custom-pool"
+	testCustomLabelKey  = "custom.io/nodepool"
+)
+
+func TestAffinityInjector(t *testing.T) {
+	scenarios := map[string]struct {
+		envNodepool string
+		envLabelKey string
+		original    *v1.Pod
+		expected    *v1.Pod
+	}{
+		"AddAffinityWithDefaultLabelKey": {
+			envNodepool: testDefaultNodepool,
+			envLabelKey: "",
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: nil,
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: defaultAffinity(defaultNodepoolLabelKey, testDefaultNodepool),
+				},
+			},
+		},
+		"AddAffinityWithCustomLabelKey": {
+			envNodepool: testDefaultNodepool,
+			envLabelKey: testCustomLabelKey,
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: nil,
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: defaultAffinity(testCustomLabelKey, testDefaultNodepool),
+				},
+			},
+		},
+		"DoNotOverwriteExistingAffinity": {
+			envNodepool: testDefaultNodepool,
+			envLabelKey: "",
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: defaultAffinity(defaultNodepoolLabelKey, testCustomNodepool),
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: defaultAffinity(defaultNodepoolLabelKey, testCustomNodepool),
+				},
+			},
+		},
+		"SkipWhenEnvNotSet": {
+			envNodepool: "",
+			envLabelKey: "",
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: nil,
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: nil,
+				},
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			// Set environment variables
+			if scenario.envNodepool != "" {
+				assert.Nil(t, os.Setenv(DefaultNodepoolEnvVar, scenario.envNodepool))
+				defer os.Unsetenv(DefaultNodepoolEnvVar)
+			} else {
+				os.Unsetenv(DefaultNodepoolEnvVar)
+			}
+
+			if scenario.envLabelKey != "" {
+				assert.Nil(t, os.Setenv(DefaultNodepoolLabelKey, scenario.envLabelKey))
+				defer os.Unsetenv(DefaultNodepoolLabelKey)
+			} else {
+				os.Unsetenv(DefaultNodepoolLabelKey)
+			}
+
+			// Run the injector
+			assert.Nil(t, InjectAffinity(scenario.original))
+			assert.Equal(t, scenario.expected.Spec.Affinity, scenario.original.Spec.Affinity)
+		})
+	}
+}

--- a/pkg/webhook/admission/pod/affinity_injector_test.go
+++ b/pkg/webhook/admission/pod/affinity_injector_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KServe Authors.
+Copyright 2026 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 const (
 	testDefaultNodepool = "default-pool"
 	testCustomNodepool  = "custom-pool"
-	testCustomLabelKey  = "custom.io/nodepool"
+	testLabelKey        = "cloud.google.com/gke-nodepool"
 )
 
 func TestAffinityInjector(t *testing.T) {
@@ -37,9 +37,9 @@ func TestAffinityInjector(t *testing.T) {
 		original    *v1.Pod
 		expected    *v1.Pod
 	}{
-		"AddAffinityWithDefaultLabelKey": {
+		"AddAffinity": {
 			envNodepool: testDefaultNodepool,
-			envLabelKey: "",
+			envLabelKey: testLabelKey,
 			original: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "deployment",
@@ -53,39 +53,19 @@ func TestAffinityInjector(t *testing.T) {
 					Name: "deployment",
 				},
 				Spec: v1.PodSpec{
-					Affinity: defaultAffinity(defaultNodepoolLabelKey, testDefaultNodepool),
-				},
-			},
-		},
-		"AddAffinityWithCustomLabelKey": {
-			envNodepool: testDefaultNodepool,
-			envLabelKey: testCustomLabelKey,
-			original: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "deployment",
-				},
-				Spec: v1.PodSpec{
-					Affinity: nil,
-				},
-			},
-			expected: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "deployment",
-				},
-				Spec: v1.PodSpec{
-					Affinity: defaultAffinity(testCustomLabelKey, testDefaultNodepool),
+					Affinity: defaultAffinity(testLabelKey, testDefaultNodepool),
 				},
 			},
 		},
 		"DoNotOverwriteExistingAffinity": {
 			envNodepool: testDefaultNodepool,
-			envLabelKey: "",
+			envLabelKey: testLabelKey,
 			original: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "deployment",
 				},
 				Spec: v1.PodSpec{
-					Affinity: defaultAffinity(defaultNodepoolLabelKey, testCustomNodepool),
+					Affinity: defaultAffinity(testLabelKey, testCustomNodepool),
 				},
 			},
 			expected: &v1.Pod{
@@ -93,7 +73,27 @@ func TestAffinityInjector(t *testing.T) {
 					Name: "deployment",
 				},
 				Spec: v1.PodSpec{
-					Affinity: defaultAffinity(defaultNodepoolLabelKey, testCustomNodepool),
+					Affinity: defaultAffinity(testLabelKey, testCustomNodepool),
+				},
+			},
+		},
+		"SkipWhenLabelKeyNotSet": {
+			envNodepool: testDefaultNodepool,
+			envLabelKey: "",
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: nil,
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+				},
+				Spec: v1.PodSpec{
+					Affinity: nil,
 				},
 			},
 		},

--- a/pkg/webhook/admission/pod/mutator.go
+++ b/pkg/webhook/admission/pod/mutator.go
@@ -129,6 +129,7 @@ func (mutator *Mutator) mutate(ctx context.Context, pod *corev1.Pod, configMap *
 
 	mutators := []func(pod *corev1.Pod) error{
 		InjectGKEAcceleratorSelector,
+		InjectAffinity,
 		func(pod *corev1.Pod) error {
 			return storageInitializer.InjectStorageInitializer(ctx, pod)
 		},

--- a/pkg/webhook/admission/pod/mutator_test.go
+++ b/pkg/webhook/admission/pod/mutator_test.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"encoding/json"
+	"os"
 	"sort"
 	"testing"
 
@@ -316,6 +317,140 @@ func TestMutator_Handle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMutator_HandleWithAffinityInjection(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Set affinity injector env vars
+	os.Setenv(DefaultNodepoolEnvVar, "gpu-pool")
+	os.Setenv(DefaultNodepoolLabelKey, "cloud.google.com/gke-nodepool")
+	defer os.Unsetenv(DefaultNodepoolEnvVar)
+	defer os.Unsetenv(DefaultNodepoolLabelKey)
+
+	mutator := Mutator{Client: c, Clientset: clientset, Decoder: admission.NewDecoder(c.Scheme())}
+
+	configMap := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.InferenceServiceConfigMapName,
+			Namespace: constants.KServeNamespace,
+		},
+		Data: map[string]string{
+			v1beta1.StorageInitializerConfigMapKeyName: `{
+				"image" : "kserve/storage-initializer:latest",
+				"memoryRequest": "100Mi",
+				"memoryLimit": "1Gi",
+				"cpuRequest": "100m",
+				"cpuLimit": "1",
+				"cpuModelcar": "100m",
+				"memoryModelcar": "50Mi",
+				"storageSpecSecretName": "storage-config"
+			}`,
+			LoggerConfigMapKeyName: `{
+				"image" : "kserve/agent:latest",
+				"memoryRequest": "100Mi",
+				"memoryLimit": "1Gi",
+				"cpuRequest": "100m",
+				"cpuLimit": "1",
+				"defaultUrl": "http://default-broker"
+			}`,
+			BatcherConfigMapKeyName: `{
+				"image" : "kserve/agent:latest",
+				"memoryRequest": "1Gi",
+				"memoryLimit": "1Gi",
+				"cpuRequest": "1",
+				"cpuLimit": "1"
+			}`,
+			constants.AgentConfigMapKeyName: `{
+				"image" : "kserve/agent:latest",
+				"memoryRequest": "100Mi",
+				"memoryLimit": "1Gi",
+				"cpuRequest": "100m",
+				"cpuLimit": "1"
+			}`,
+		},
+	}
+
+	if err := c.Create(t.Context(), &configMap); err != nil {
+		t.Fatalf("failed to create config map: %v", err)
+	}
+	defer c.Delete(t.Context(), &configMap)
+
+	pod := corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.InferenceServicePodLabelKey: "",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: constants.InferenceServiceContainerName,
+				},
+			},
+		},
+	}
+
+	byteData, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("failed to marshal pod data: %v", err)
+	}
+
+	request := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID: types.UID(uuid.NewString()),
+			Kind: metav1.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			},
+			RequestKind: &metav1.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+			RequestResource: &metav1.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			},
+			Name:      "",
+			Namespace: "default",
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: byteData},
+		},
+	}
+
+	res := mutator.Handle(t.Context(), request)
+	g.Expect(res.Allowed).To(gomega.BeTrue(), "expected pod to be allowed")
+
+	// Verify that the affinity patch is present
+	var hasAffinityPatch bool
+	for _, patch := range res.Patches {
+		if patch.Path == "/spec/affinity" && patch.Operation == "add" {
+			hasAffinityPatch = true
+			// Verify the patch value contains the expected affinity structure
+			affinityJSON, err := json.Marshal(patch.Value)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(string(affinityJSON)).To(gomega.ContainSubstring("cloud.google.com/gke-nodepool"))
+			g.Expect(string(affinityJSON)).To(gomega.ContainSubstring("gpu-pool"))
+			g.Expect(string(affinityJSON)).To(gomega.ContainSubstring("preferredDuringSchedulingIgnoredDuringExecution"))
+		}
+	}
+	g.Expect(hasAffinityPatch).To(gomega.BeTrue(), "expected affinity patch to be present")
 }
 
 // sortPatches sorts the slice of patches by Path so that the comparison works


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a webhook mutator that injects default node affinity to KServe pods without explicit affinity configured. This allows cluster admins to route inference workloads to specific node pools by default.

Configuration via environment variables:
- `KSERVE_DEFAULT_NODEPOOL`: target node pool value (required to enable)
- `KSERVE_DEFAULT_NODEPOOL_LABEL_KEY`: label key to match (default: `cloud.google.com/gke-nodepool`)

Skips injection if env var is not set or pod already has affinity configured.

**Which issue(s) this PR fixes**:
Fixes #4982

**Feature/Issue validation/testing**:

- [x] Unit tests for affinity injection when pod has no affinity
- [x] Unit tests for skipping injection when pod already has affinity
- [x] Unit tests for skipping when env var not set
- [x] Unit tests for custom label key configuration

**Special notes for your reviewer**:
This complements #730 (per-InferenceService affinity) by providing a cluster-wide default. User-specified affinity always takes precedence.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Add support for default node affinity injection via KSERVE_DEFAULT_NODEPOOL environment variable
