### PR TITLE
fix(inferenceservice): skip VS if Istio CRD missing

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -322,14 +322,23 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Reconcile ingress using factory
 	factory := reconcilers.NewReconcilerFactory()
 
+	// Notify user when the Istio VirtualService CRD is not present but
+	// Istio virtual host is expected (disableIstioVirtualHost == false).
+	// This makes the skip visible instead of silent.
+	if !r.VirtualServiceAvailable && !ingressConfig.DisableIstioVirtualHost {
+		r.Recorder.Event(isvc, corev1.EventTypeWarning, "VirtualServiceCRDNotFound",
+			"Istio VirtualService CRD not present; VirtualService reconciliation skipped. If you do not use Istio, set ingress.disableIstioVirtualHost=true.")
+	}
+
 	ingressReconciler, err := factory.CreateIngressReconciler(
 		deploymentMode,
 		reconcilers.IngressReconcilerParams{
-			Client:        r.Client,
-			Clientset:     r.Clientset,
-			Scheme:        r.Scheme,
-			IngressConfig: ingressConfig,
-			IsvcConfig:    isvcConfig,
+			Client:                    r.Client,
+			Clientset:                 r.Clientset,
+			Scheme:                    r.Scheme,
+			IngressConfig:             ingressConfig,
+			IsvcConfig:                isvcConfig,
+			IsVirtualServiceAvailable: r.VirtualServiceAvailable,
 		},
 	)
 	if err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -328,6 +328,8 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Istio virtual host is expected (disableIstioVirtualHost == false).
 	// This makes the skip visible instead of silent.
 	if !r.VirtualServiceAvailable && !ingressConfig.DisableIstioVirtualHost {
+		r.Log.Error(nil, "Istio VirtualService CRD not present; VirtualService reconciliation skipped",
+			"InferenceService", isvc.Name, "namespace", isvc.Namespace)
 		r.Recorder.Event(isvc, corev1.EventTypeWarning, "VirtualServiceCRDNotFound",
 			"Istio VirtualService CRD not present; VirtualService reconciliation skipped. If you do not use Istio, set ingress.disableIstioVirtualHost=true.")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -113,6 +113,8 @@ type InferenceServiceReconciler struct {
 	Log          logr.Logger
 	Scheme       *runtime.Scheme
 	Recorder     record.EventRecorder
+	// VirtualServiceAvailable indicates whether the Istio VirtualService CRD exists in the cluster.
+	VirtualServiceAvailable bool
 }
 
 func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -599,6 +601,8 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 	if err != nil {
 		return err
 	}
+	// Store the availability so Reconcile can pass it to the IngressReconciler.
+	r.VirtualServiceAvailable = vsFound
 
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1beta1.InferenceService{}, "spec.predictor.model.runtime", func(rawObj client.Object) []string {
 		isvc, ok := rawObj.(*v1beta1.InferenceService)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/factory.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/factory.go
@@ -62,6 +62,9 @@ type IngressReconcilerParams struct {
 	Scheme        *runtime.Scheme
 	IngressConfig *v1beta1.IngressConfig
 	IsvcConfig    *v1beta1.InferenceServicesConfig
+	// IsVirtualServiceAvailable indicates whether the Istio VirtualService CRD
+	// exists in the cluster and should be used by the Ingress reconciler.
+	IsVirtualServiceAvailable bool
 }
 
 // ReconcilerFactory creates appropriate reconcilers based on deployment mode
@@ -140,6 +143,7 @@ func (f *ReconcilerFactory) CreateIngressReconciler(
 		// Knative Service
 		return ingress.NewIngressReconciler(
 			params.Client, params.Clientset, params.Scheme, params.IngressConfig, params.IsvcConfig,
+			params.IsVirtualServiceAvailable,
 		), nil
 
 	default:

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/factory_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/factory_test.go
@@ -94,11 +94,12 @@ func TestCreateIngressReconciler(t *testing.T) {
 
 	// Standard mode with Gateway API
 	params := IngressReconcilerParams{
-		Client:        fakeClient,
-		Clientset:     fakeClientset,
-		Scheme:        scheme,
-		IngressConfig: &v1beta1.IngressConfig{EnableGatewayAPI: true},
-		IsvcConfig:    &v1beta1.InferenceServicesConfig{},
+		Client:                    fakeClient,
+		Clientset:                 fakeClientset,
+		Scheme:                    scheme,
+		IngressConfig:             &v1beta1.IngressConfig{EnableGatewayAPI: true},
+		IsvcConfig:                &v1beta1.InferenceServicesConfig{},
+		IsVirtualServiceAvailable: false,
 	}
 	rec, err := factory.CreateIngressReconciler(constants.Standard, params)
 	require.NoError(t, err)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -2188,7 +2188,7 @@ func TestNewIngressReconciler(t *testing.T) {
 	isvcConfig := &v1beta1.InferenceServicesConfig{}
 
 	// Call constructor
-	reconciler := NewIngressReconciler(client, clientset, scheme, ingressConfig, isvcConfig)
+	reconciler := NewIngressReconciler(client, clientset, scheme, ingressConfig, isvcConfig, false)
 
 	// Assertions
 	g.Expect(reconciler).NotTo(gomega.BeNil())
@@ -2197,4 +2197,5 @@ func TestNewIngressReconciler(t *testing.T) {
 	g.Expect(reconciler.scheme).To(gomega.Equal(scheme))
 	g.Expect(reconciler.ingressConfig).To(gomega.Equal(ingressConfig))
 	g.Expect(reconciler.isvcConfig).To(gomega.Equal(isvcConfig))
+	g.Expect(reconciler.isVirtualServiceAvailable).To(gomega.BeFalse())
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -2199,3 +2199,46 @@ func TestNewIngressReconciler(t *testing.T) {
 	g.Expect(reconciler.isvcConfig).To(gomega.Equal(isvcConfig))
 	g.Expect(reconciler.isVirtualServiceAvailable).To(gomega.BeFalse())
 }
+
+func TestIngressReconciler_Reconcile_SkipVirtualService(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	// Prepare scheme with KServe and Istio types so we can assert absence
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	_ = istioclientv1beta1.AddToScheme(scheme)
+
+	// Fake clients
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	clientset := kubernetesfake.NewSimpleClientset()
+
+	// Configs
+	ingressConfig := &v1beta1.IngressConfig{
+		IngressGateway:             constants.KnativeIngressGateway,
+		KnativeLocalGatewayService: "knative-local-gateway.istio-system.svc.cluster.local",
+		LocalGateway:               constants.KnativeLocalGateway,
+		DisableIstioVirtualHost:    false,
+	}
+	isvcConfig := &v1beta1.InferenceServicesConfig{}
+
+	// InferenceService with predictor URL (would normally create VirtualService)
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "skip-vs", Namespace: "default"},
+		Status: v1beta1.InferenceServiceStatus{
+			Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
+				v1beta1.PredictorComponent: {
+					URL: &apis.URL{Scheme: "http", Host: constants.InferenceServiceHostName(constants.PredictorServiceName("skip-vs"), "default", "example.com")},
+				},
+			},
+		},
+	}
+
+	reconciler := NewIngressReconciler(client, clientset, scheme, ingressConfig, isvcConfig, false)
+	res, err := reconciler.Reconcile(context.TODO(), isvc)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(res).To(gomega.Equal(ctrl.Result{}))
+
+	// Ensure no VirtualService was created
+	existingVS := &istioclientv1beta1.VirtualService{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: "skip-vs", Namespace: "default"}, existingVS)
+	g.Expect(apierr.IsNotFound(err)).To(gomega.BeTrue())
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -28,13 +28,16 @@ import (
 	istiov1beta1 "istio.io/api/networking/v1beta1"
 	istioclientv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/network"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -2205,9 +2208,9 @@ func TestIngressReconciler_Reconcile_SkipVirtualService(t *testing.T) {
 	// Prepare scheme with KServe and Istio types so we can assert absence
 	scheme := runtime.NewScheme()
 	_ = v1beta1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 	_ = istioclientv1beta1.AddToScheme(scheme)
 
-	// Fake clients
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 	clientset := kubernetesfake.NewSimpleClientset()
 
@@ -2233,12 +2236,12 @@ func TestIngressReconciler_Reconcile_SkipVirtualService(t *testing.T) {
 	}
 
 	reconciler := NewIngressReconciler(client, clientset, scheme, ingressConfig, isvcConfig, false)
-	res, err := reconciler.Reconcile(context.TODO(), isvc)
-	g.Expect(err).To(gomega.BeNil())
+	res, err := reconciler.Reconcile(t.Context(), isvc)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
 	g.Expect(res).To(gomega.Equal(ctrl.Result{}))
 
 	// Ensure no VirtualService was created
 	existingVS := &istioclientv1beta1.VirtualService{}
-	err = client.Get(context.TODO(), types.NamespacedName{Name: "skip-vs", Namespace: "default"}, existingVS)
+	err = client.Get(t.Context(), types.NamespacedName{Name: "skip-vs", Namespace: "default"}, existingVS)
 	g.Expect(apierr.IsNotFound(err)).To(gomega.BeTrue())
 }


### PR DESCRIPTION
This fixes #4984 where KServe InferenceServiceReconciler would fail to reconcile when Istio VirtualService CRD is not installed in the cluster

Ex: when using Kourier as the network layer

Changes:
- Add isVirtualServiceAvailable field to IngressReconciler to track VirtualService CRD availability
- Pass vsFound flag from InferenceServiceReconciler to IngressReconciler
- Guard reconcileVirtualService() with CRD availability check

When VirtualService CRD is not available, reconciliation gracefully skips VirtualService operations and continues with other ingress tasks, allowing successful InferenceService deployment on non-Istio clusters.

Tests:
Test A [ ]
(Unit tests - fast): [go test ./pkg/controller/v1beta1/inferenceservice/reconcilers/ingress -v](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — PASS (includes skip test).
Test B [ ]
(Integration - KinD + Kourier / no-Istio): validated locally by running the manager against a KinD cluster without Istio VirtualService CRD; manager logs show it skips watching VirtualService resources and no reconciliation errors occur.

Docs

[COMMON_ISSUES_AND_SOLUTIONS.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): added troubleshooting entry.
[OPENSHIFT_GUIDE.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): added note in the Kourier section.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE

```