### PR TITLE
feat: llmisvc preserves externally managed replicas

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
@@ -489,5 +489,185 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 
 			Expect(expectedLWS.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations).To(HaveKeyWithValue(PreemptionReclaimAnnotationKey, preemptPriority))
 		})
+
+		It("should preserve externally set replicas when owner does not specify replicas", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-mn-preserve-replicas"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			// Create LLMInferenceService WITHOUT specifying replicas
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+				)),
+				WithWorker(&corev1.PodSpec{}),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				// Note: Not using WithReplicas() - replicas should be nil
+			)
+
+			// Verify replicas is nil in the spec
+			Expect(llmSvc.Spec.Replicas).To(BeNil())
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - LeaderWorkerSet should be created with default replicas (1)
+			expectedLWS := &lwsapi.LeaderWorkerSet{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, expectedLWS)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedLWS.Spec.Replicas).To(Equal(ptr.To[int32](1)))
+
+			// Simulate external scaling (e.g., HPA scaling to 3 replicas)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				lws := &lwsapi.LeaderWorkerSet{}
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, lws); err != nil {
+					return err
+				}
+				lws.Spec.Replicas = ptr.To[int32](3)
+				return envTest.Client.Update(ctx, lws)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Trigger a reconciliation by updating the LLMInferenceService
+			errRetry = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations["reconcile-trigger"] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Verify the externally set replicas are preserved after reconciliation
+			Consistently(func(g Gomega, ctx context.Context) {
+				lws := &lwsapi.LeaderWorkerSet{}
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, lws)).To(Succeed())
+
+				g.Expect(lws.Spec.Replicas).To(Equal(ptr.To[int32](3)),
+					"Externally set replicas should be preserved when owner doesn't specify replicas")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should override externally set replicas when owner specifies replicas", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-mn-override-replicas"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			// Create LLMInferenceService WITH explicit replicas
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+				)),
+				WithWorker(&corev1.PodSpec{}),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithReplicas(2), // Owner explicitly sets replicas
+			)
+
+			// Verify replicas is set in the spec
+			Expect(llmSvc.Spec.Replicas).To(Equal(ptr.To[int32](2)))
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - LeaderWorkerSet should be created with owner-specified replicas (2)
+			expectedLWS := &lwsapi.LeaderWorkerSet{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, expectedLWS)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedLWS.Spec.Replicas).To(Equal(ptr.To[int32](2)))
+
+			// Simulate external scaling attempt (e.g., someone tries to manually scale to 5)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				lws := &lwsapi.LeaderWorkerSet{}
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, lws); err != nil {
+					return err
+				}
+				lws.Spec.Replicas = ptr.To[int32](5)
+				return envTest.Client.Update(ctx, lws)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Trigger a reconciliation by updating the LLMInferenceService
+			errRetry = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations["reconcile-trigger"] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Verify the owner-specified replicas override the external change
+			Eventually(func(g Gomega, ctx context.Context) {
+				lws := &lwsapi.LeaderWorkerSet{}
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, lws)).To(Succeed())
+
+				g.Expect(lws.Spec.Replicas).To(Equal(ptr.To[int32](2)),
+					"Owner-specified replicas should override externally set replicas")
+			}).WithContext(ctx).Should(Succeed())
+		})
 	})
 })

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -237,6 +237,176 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Expect(expectedDeployment.Spec.Template.Labels).ToNot(HaveKeyWithValue(testValue, testValue))
 			Expect(expectedDeployment.Spec.Template.Annotations).ToNot(HaveKeyWithValue(testValue, testValue))
 		})
+
+		It("should preserve externally set replicas when owner does not specify replicas", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-preserve-replicas"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			// Create LLMInferenceService WITHOUT specifying replicas
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				// Note: Not using WithReplicas() - replicas should be nil
+			)
+
+			// Verify replicas is nil in the spec
+			Expect(llmSvc.Spec.Replicas).To(BeNil())
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - Deployment should be created with default replicas (1)
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedDeployment.Spec.Replicas).To(Equal(ptr.To[int32](1)))
+
+			// Simulate external scaling (e.g., HPA scaling to 3 replicas)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				deployment := &appsv1.Deployment{}
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, deployment); err != nil {
+					return err
+				}
+				deployment.Spec.Replicas = ptr.To[int32](3)
+				return envTest.Client.Update(ctx, deployment)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Trigger a reconciliation by updating the LLMInferenceService
+			errRetry = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations["reconcile-trigger"] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Verify the externally set replicas are preserved after reconciliation
+			Consistently(func(g Gomega, ctx context.Context) {
+				deployment := &appsv1.Deployment{}
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, deployment)).To(Succeed())
+
+				g.Expect(deployment.Spec.Replicas).To(Equal(ptr.To[int32](3)),
+					"Externally set replicas should be preserved when owner doesn't specify replicas")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should override externally set replicas when owner specifies replicas", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-override-replicas"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			// Create LLMInferenceService WITH explicit replicas
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithReplicas(2), // Owner explicitly sets replicas
+			)
+
+			// Verify replicas is set in the spec
+			Expect(llmSvc.Spec.Replicas).To(Equal(ptr.To[int32](2)))
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - Deployment should be created with owner-specified replicas (2)
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedDeployment.Spec.Replicas).To(Equal(ptr.To[int32](2)))
+
+			// Simulate external scaling attempt (e.g., someone tries to manually scale to 5)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				deployment := &appsv1.Deployment{}
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, deployment); err != nil {
+					return err
+				}
+				deployment.Spec.Replicas = ptr.To[int32](5)
+				return envTest.Client.Update(ctx, deployment)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Trigger a reconciliation by updating the LLMInferenceService
+			errRetry = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations["reconcile-trigger"] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Verify the owner-specified replicas override the external change
+			Eventually(func(g Gomega, ctx context.Context) {
+				deployment := &appsv1.Deployment{}
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, deployment)).To(Succeed())
+
+				g.Expect(deployment.Spec.Replicas).To(Equal(ptr.To[int32](2)),
+					"Owner-specified replicas should override externally set replicas")
+			}).WithContext(ctx).Should(Succeed())
+		})
 	})
 
 	Context("Routing reconciliation ", func() {

--- a/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
@@ -255,6 +255,12 @@ func WithDataRPCPort(rpcPort int32) func(*v1alpha2.ParallelismSpec) {
 	}
 }
 
+func WithExpert(expert bool) func(*v1alpha2.ParallelismSpec) {
+	return func(p *v1alpha2.ParallelismSpec) {
+		p.Expert = expert
+	}
+}
+
 func WithManagedScheduler() LLMInferenceServiceOption {
 	return func(llmSvc *v1alpha2.LLMInferenceService) {
 		if llmSvc.Spec.Router == nil {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -152,7 +152,7 @@ func (r *LLMISVCReconciler) reconcileSchedulerDeployment(ctx context.Context, ll
 		}
 		return Delete(ctx, r, llmSvc, scheduler)
 	}
-	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, scheduler, semanticDeploymentIsEqual); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, scheduler, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
 		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", scheduler.GetNamespace(), scheduler.GetName(), err)
 	}
 	return r.propagateDeploymentStatus(ctx, scheduler, llmSvc.MarkSchedulerWorkloadReady, llmSvc.MarkSchedulerWorkloadNotReady)

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -72,7 +72,7 @@ func (r *LLMISVCReconciler) reconcileMultiNodeMainWorkload(ctx context.Context, 
 		}
 		return nil
 	}
-	if err := Reconcile(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{}, expected, semanticLWSIsEqual); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{}, expected, semanticLWSIsEqual, PreserveLWSReplicas()); err != nil {
 		return err
 	}
 	return r.propagateLeaderWorkerSetStatus(ctx, expected, llmSvc.MarkWorkerWorkloadReady, llmSvc.MarkWorkerWorkloadNotReady)
@@ -95,7 +95,7 @@ func (r *LLMISVCReconciler) reconcileMultiNodePrefillWorkload(ctx context.Contex
 		}
 		return nil
 	}
-	if err := Reconcile(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{}, expected, semanticLWSIsEqual); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{}, expected, semanticLWSIsEqual, PreserveLWSReplicas()); err != nil {
 		return err
 	}
 	return r.propagateLeaderWorkerSetStatus(ctx, expected, llmSvc.MarkPrefillWorkerWorkloadReady, llmSvc.MarkPrefillWorkerWorkloadNotReady)

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -69,7 +69,7 @@ func (r *LLMISVCReconciler) reconcileSingleNodeMainWorkload(ctx context.Context,
 		}
 		return Delete(ctx, r, llmSvc, expected)
 	}
-	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, expected, semanticDeploymentIsEqual); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, expected, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
 		return err
 	}
 	return r.propagateDeploymentStatus(ctx, expected, llmSvc.MarkMainWorkloadReady, llmSvc.MarkMainWorkloadNotReady)
@@ -165,7 +165,7 @@ func (r *LLMISVCReconciler) reconcileSingleNodePrefill(ctx context.Context, llmS
 		}
 		return nil
 	}
-	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, prefill, semanticDeploymentIsEqual); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, prefill, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
 		return fmt.Errorf("failed to reconcile prefill deployment %s/%s: %w", prefill.GetNamespace(), prefill.GetName(), err)
 	}
 	return r.propagateDeploymentStatus(ctx, prefill, llmSvc.MarkPrefillWorkloadReady, llmSvc.MarkPrefillWorkloadNotReady)


### PR DESCRIPTION
This enables external controllers like HPA to manage Deployment and LeaderWorkerSet replicas without being overwritten by the reconciler.

Add UpdateOption pattern with AfterDryRun hook to allow preserving fields from the current resource state when the owner doesn't explicitly set them.

Changes:
- Add UpdateOption[T] and AfterDryRun hook to lifecycle_crud.go
- Add PreserveDeploymentReplicas() helper for Deployments
- Add PreserveLWSReplicas() helper for LeaderWorkerSets
- Apply options to all Deployment and LWS Reconcile calls
- Add integration tests for both preserve and override scenarios

**Release note**:

```release-note
feat(llmisvc): preserve externally managed replicas when user does not specify them.
```
