### PR TITLE
fix: resolve flaky TestServerTimeout race condition

### DIFF
--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -1015,6 +1015,7 @@ func TestServerTimeout(t *testing.T) {
 			t.Cleanup(func() {
 				http.DefaultServeMux = http.NewServeMux() // reset http handlers
 				signalChan <- syscall.SIGTERM             // shutdown the server
+				time.Sleep(100 * time.Millisecond)        // wait for server to release port before next subtest
 			})
 
 			// Call the InferenceGraph


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a flaky test in `cmd/router/main_test.go` that causes intermittent CI failures.

`TestServerTimeout` uses table-driven subtests that each start a real HTTP server on port 8080 via `go func() { main() }()`. The `t.Cleanup()` function sends SIGTERM to shutdown the server, but doesn't wait for the shutdown to complete. This creates a race condition where the next subtest tries to bind port 8080 before the previous server fully releases it.

This has caused multiple CI failures across different branches, including master:
- Jan 26 - fix/format-tests-black 
- Jan 24 - master
- Jan 22 - gie-zero-downtime-migration (2 failures)

The fix adds a 100ms delay after SIGTERM to allow the server to complete graceful shutdown before the next subtest starts.

**Which issue(s) this PR fixes**:
N/A (test infrastructure fix)

**Feature/Issue validation/testing**:

- [x] TestServerTimeout passes consistently (verified 10+ consecutive runs locally)
- [x] All cmd/router tests pass

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```