### PR TITLE
ci: upgrade minikube to 1.37.0 to fix E2E test flakiness

### DIFF
--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Setup Minikube
       uses: medyagh/setup-minikube@latest
       with:
-        minikube-version: '1.35.0'
+        minikube-version: '1.37.0'
         kubernetes-version: 'v1.30.7'
         driver: ${{ inputs.driver }}
         wait: 'all'


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades minikube from 1.35.0 to 1.37.0 to address a CoreDNS deployment scaling race condition observed during minikube setup.

**Which issue(s) this PR fixes**:
N/A

**Feature/Issue validation/testing**:

- [x] Verified minikube 1.37.0 is the latest stable release

**Special notes for your reviewer**:

This PR only changes the minikube version in CI.

**Checklist**:

- [x] N/A - CI infrastructure change

```release-note
NONE
```