### PR TITLE
feat(modelserver): add asyncmodel for sync predict

### DIFF
--- a/python/kserve/kserve/__init__.py
+++ b/python/kserve/kserve/__init__.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 from .model import Model
+from .async_model import AsyncModel
 from .predictor_config import PredictorConfig
 from .model_server import ModelServer
 from .inference_client import InferenceGRPCClient, InferenceRESTClient, RESTConfig

--- a/python/kserve/kserve/async_model.py
+++ b/python/kserve/kserve/async_model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The KServe Authors.
+# Copyright 2026 The KServe Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/kserve/kserve/async_model.py
+++ b/python/kserve/kserve/async_model.py
@@ -1,0 +1,98 @@
+# Copyright 2024 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import functools
+import inspect
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+from .model import Model
+
+
+class AsyncModel(Model):
+    """Model base class that offloads sync predict() to a thread executor.
+
+    Example
+    -------
+    from kserve import AsyncModel
+
+    class MyModel(AsyncModel):
+        def predict(self, payload, headers=None):
+            return slow_inference(payload)
+
+    Why
+    Many custom predictors are written with sync predict() and include blocking
+    I/O or long-running inference. When KServe's async __call__() executes a sync
+    predict() directly, the event loop can be blocked, reducing concurrency and
+    causing timeouts. Rewriting the full stack to async is often impractical, so
+    AsyncModel provides a safe default that keeps the event loop responsive while
+    preserving existing sync code.
+
+    How it works
+    1) Subclass defines sync predict() as usual.
+    2) __init_subclass__ wraps it in async + run_in_executor.
+    3) KServe's __call__ sees async predict and awaits it.
+    4) Sync code runs in a thread pool (non-blocking).
+
+    Configuration
+    - ASYNC_MODEL_WORKERS env var for max workers, or ModelServer --max_asyncio_workers.
+    - Default (when using ModelServer): min(32, cpu_count + 4).
+    """
+
+    _shared_executor: Optional[ThreadPoolExecutor] = None
+    _max_workers: Optional[int] = None
+
+    @classmethod
+    def _get_executor(cls) -> Optional[ThreadPoolExecutor]:
+        if cls._shared_executor is not None:
+            return cls._shared_executor
+
+        if cls._max_workers is None:
+            env_workers = os.getenv("ASYNC_MODEL_WORKERS")
+            if env_workers:
+                try:
+                    cls._max_workers = int(env_workers)
+                except ValueError:
+                    cls._max_workers = None
+
+        if cls._max_workers and cls._max_workers > 0:
+            cls._shared_executor = ThreadPoolExecutor(max_workers=cls._max_workers)
+            return cls._shared_executor
+
+        return None
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        predict_attr = cls.__dict__.get("predict")
+        if predict_attr is None:
+            return
+
+        if isinstance(predict_attr, (staticmethod, classmethod)):
+            raise TypeError("AsyncModel.predict must be an instance method.")
+
+        original_predict = predict_attr
+
+        if inspect.iscoroutinefunction(original_predict):
+            return
+
+        @functools.wraps(original_predict)
+        async def async_predict(self, *args, **kwargs):
+            loop = asyncio.get_running_loop()
+            executor = cls._get_executor()
+            bound = functools.partial(original_predict, self, *args, **kwargs)
+            return await loop.run_in_executor(executor, bound)
+
+        setattr(cls, "predict", async_predict)

--- a/python/kserve/kserve/async_model.py
+++ b/python/kserve/kserve/async_model.py
@@ -106,4 +106,4 @@ class AsyncModel(Model):
             bound = functools.partial(original_predict, self, *args, **kwargs)
             return await loop.run_in_executor(executor, bound)
 
-        setattr(cls, "predict", async_predict)
+        cls.predict = async_predict

--- a/python/kserve/test/test_async_model.py
+++ b/python/kserve/test/test_async_model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The KServe Authors.
+# Copyright 2026 The KServe Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/kserve/test/test_async_model.py
+++ b/python/kserve/test/test_async_model.py
@@ -1,0 +1,45 @@
+# Copyright 2024 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from kserve import AsyncModel
+
+
+class SyncPredictModel(AsyncModel):
+    def __init__(self, name="sync-model"):
+        super().__init__(name)
+        self.ready = True
+
+    def predict(self, payload, headers=None):
+        return threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_async_model_offloads_sync_predict():
+    model = SyncPredictModel()
+    loop_thread_id = threading.get_ident()
+    result = await model.predict({"instances": [1]})
+    assert result != loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_async_model_env_workers(monkeypatch):
+    monkeypatch.setenv("ASYNC_MODEL_WORKERS", "1")
+    executor = SyncPredictModel._get_executor()
+    assert isinstance(executor, ThreadPoolExecutor)
+    assert executor._max_workers == 1

--- a/python/kserve/test/test_async_model.py
+++ b/python/kserve/test/test_async_model.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -29,17 +31,59 @@ class SyncPredictModel(AsyncModel):
         return threading.get_ident()
 
 
+class GatedModel(AsyncModel):
+    """Blocks inside predict() until released.
+
+    Used to prove that a long-running prediction does not block the event loop
+    or new prediction requests.
+    """
+
+    def __init__(self, name="gated-model"):
+        super().__init__(name)
+        self.ready = True
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def predict(self, payload, headers=None):
+        if payload.get("block"):
+            self.started.set()
+            # Block the worker thread (not the event loop) until released.
+            if not self.release.wait(timeout=5):
+                raise TimeoutError("blocking predict was never released")
+            return "slow"
+        return "fast"
+
+
+class SlowModel(AsyncModel):
+    """Sleeps inside predict() to measure parallel throughput."""
+
+    def __init__(self, name="slow-model", delay=0.4):
+        super().__init__(name)
+        self.ready = True
+        self.delay = delay
+
+    def predict(self, payload, headers=None):
+        time.sleep(self.delay)
+        return threading.get_ident()
+
+
+_MODEL_CLASSES = (SyncPredictModel, GatedModel, SlowModel)
+
+
+def _reset_state(cls):
+    cls._cleanup_executor()
+    cls._shared_executor = None
+    cls._max_workers = None
+    cls._cleanup_registered = False
+
+
 @pytest.fixture(autouse=True)
 def reset_async_model_state():
-    SyncPredictModel._cleanup_executor()
-    SyncPredictModel._shared_executor = None
-    SyncPredictModel._max_workers = None
-    SyncPredictModel._cleanup_registered = False
+    for cls in _MODEL_CLASSES:
+        _reset_state(cls)
     yield
-    SyncPredictModel._cleanup_executor()
-    SyncPredictModel._shared_executor = None
-    SyncPredictModel._max_workers = None
-    SyncPredictModel._cleanup_registered = False
+    for cls in _MODEL_CLASSES:
+        _reset_state(cls)
 
 
 @pytest.mark.asyncio
@@ -71,3 +115,48 @@ def test_async_model_cleanup_shared_executor(monkeypatch):
     assert isinstance(executor, ThreadPoolExecutor)
     SyncPredictModel._cleanup_executor()
     assert SyncPredictModel._shared_executor is None
+
+
+@pytest.mark.asyncio
+async def test_long_predict_does_not_block_new_requests(monkeypatch):
+    # Two workers: one is held by the long prediction, the other must stay
+    # available to serve a new request concurrently.
+    monkeypatch.setenv("ASYNC_MODEL_WORKERS", "2")
+    model = GatedModel()
+
+    # Start a long-running prediction that blocks inside its worker thread.
+    slow_task = asyncio.create_task(model.predict({"block": True}))
+
+    # Spin until the slow predict is actually running. The event loop staying
+    # responsive enough to run this loop already proves it is not blocked.
+    while not model.started.is_set():
+        await asyncio.sleep(0.01)
+
+    # A new request must complete while the long prediction is still in flight.
+    fast_result = await asyncio.wait_for(model.predict({"block": False}), timeout=2)
+    assert fast_result == "fast"
+    assert not slow_task.done()
+
+    # Release the long prediction and confirm it finishes cleanly.
+    model.release.set()
+    assert await asyncio.wait_for(slow_task, timeout=2) == "slow"
+
+
+@pytest.mark.asyncio
+async def test_async_model_runs_predicts_concurrently(monkeypatch):
+    num_requests = 5
+    delay = 0.4
+    monkeypatch.setenv("ASYNC_MODEL_WORKERS", str(num_requests))
+    model = SlowModel(delay=delay)
+
+    start = time.perf_counter()
+    results = await asyncio.gather(
+        *(model.predict({"instances": [i]}) for i in range(num_requests))
+    )
+    elapsed = time.perf_counter() - start
+
+    # Each predict ran on its own worker thread, none on the event-loop thread.
+    assert len(set(results)) == num_requests
+    assert threading.get_ident() not in results
+    # Concurrent execution finishes in ~delay; serialized would be num*delay.
+    assert elapsed < num_requests * delay * 0.5


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an `AsyncModel` base class that wraps sync `predict()` in `run_in_executor`, preventing event-loop blocking for sync predictors while keeping existing code largely unchanged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5019


**Feature/Issue validation/testing**:

- [x] `uv run -m pytest test/test_async_model.py`

- Logs
  - 2 passed

**Special notes for your reviewer**:
- `AsyncModel.predict` must be an instance method; static/class methods are rejected.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Add AsyncModel to offload sync predict() to a threadpool executor to avoid blocking the event loop.
```
