### PR TITLE
fix: llmisvc ClusterRoleBinding to point to new ClusterRole

### DIFF
--- a/charts/kserve-llmisvc-resources/templates/clusterrolebinding.yaml
+++ b/charts/kserve-llmisvc-resources/templates/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: llmisvc-manager-role
+  name: kserve-llmisvc-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "llm-isvc-resources.serviceAccountName" . }}


### PR DESCRIPTION
ClusterRole is called `kserve-llmisvc-manager-role`

