### PR TITLE
ci: Add charts/kserve-llmisvc-resources to workflow paths

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -7,11 +7,11 @@ on:
       - "pkg/apis/serving/v1alpha2/llm*"
       - "pkg/controller/v1alpha1/llmisvc/**"
       - "pkg/controller/v1alpha2/llmisvc/**"
+      - "charts/kserve-llmisvc-resources/**"
       - "config/llmisvc/**"
       - "config/rbac/llmisvc/**"
       - "cmd/llmisvc/**"
       - "test/e2e/llmisvc/**"
-      - "charts/kserve-llmisvc-resources/**"
       - ".github/workflows/e2e-test-llmisvc.yaml"
       - "hack/setup/quick-install/llmisvc-dependency-install.sh"
 

--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -11,6 +11,7 @@ on:
       - "config/rbac/llmisvc/**"
       - "cmd/llmisvc/**"
       - "test/e2e/llmisvc/**"
+      - "charts/kserve-llmisvc-resources/**"
       - ".github/workflows/e2e-test-llmisvc.yaml"
       - "hack/setup/quick-install/llmisvc-dependency-install.sh"
 


### PR DESCRIPTION
This can potentially fix the stuck CI: `test-llmisvc Expected — Waiting for status to be reported`

https://github.com/kserve/kserve/pull/5022