### PR TITLE
feat: add version field to LocalModelCache

### DIFF
--- a/pkg/apis/serving/v1alpha1/local_model_cache_types.go
+++ b/pkg/apis/serving/v1alpha1/local_model_cache_types.go
@@ -35,6 +35,11 @@ type LocalModelCacheSpec struct {
 	// Todo: support more than 1 node groups
 	// +kubebuilder:validation:MinItems=1
 	NodeGroups []string `json:"nodeGroups" validate:"required"`
+	// Version of the model cache. Used for automatic migration when models are updated.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:default=1
+	// +optional
+	Version int32 `json:"version,omitempty"`
 }
 
 // LocalModelCache


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a `Version` field to `LocalModelCacheSpec` to support model versioning and enable easy model updates.

Currently, only one `LocalModelCache` can exist per `StorageURI`. This makes it impossible to update cached models without downtime (when we use the same StorageURI):
1. Delete existing `LocalModelCache` 
2. Create new `LocalModelCache` with modified model
3. Recreate `InferenceServices`

With versioning support:
1. Create new `LocalModelCache` with same `StorageURI` but higher version (e.g., v2)
2. While waiting for the modified and new model to be downloaded, v1 remains active. If needed, v2 `LocalModelCache` can be tested with a separate `InferenceService` without production traffic. This means v1 and v2 coexist simultaneously.
3. Rollout to the new version by updating `InferenceService`
4. Delete old version when no longer needed

Changes:
- Add `Version` field (int32) to `LocalModelCacheSpec` with default=1, minimum=1
- Replace `StorageURI` uniqueness check with version validation
- Prevent creating/updating to duplicate or older versions
- Add `validateUniqueVersion` check in both Create and Update webhooks
- Extract `buildLocalModelPVCName` helper to reduce duplication
- Preserve existing `LocalModel` label in `InferenceService` defaults

**Which issue(s) this PR fixes**:
Fixes https://github.com/kserve/kserve/issues/5030


**Feature/Issue validation/testing**:

- [x] TestValidateCreate_DuplicateVersion - Rejects creating duplicate version for same URI
- [x] TestValidateCreate_NewerVersion - Allows creating newer version for same URI
- [x] TestValidateCreate_OlderVersion - Rejects creating older version when newer exists
- [x] TestValidateCreate_DifferentURISameVersion - Allows same version for different URIs
- [x] TestValidateCreate_FirstLocalModelCache - Allows first cache creation
- [x] TestValidateUpdate_DuplicateVersion - Rejects updating to duplicate version
- [x] TestValidateUpdate_OlderVersion - Rejects updating to older version

```
=== RUN   TestValidateCreate_DuplicateVersion
--- PASS: TestValidateCreate_DuplicateVersion (0.00s)
=== RUN   TestValidateCreate_NewerVersion
--- PASS: TestValidateCreate_NewerVersion (0.00s)
=== RUN   TestValidateCreate_OlderVersion
--- PASS: TestValidateCreate_OlderVersion (0.00s)
=== RUN   TestValidateCreate_DifferentURISameVersion
--- PASS: TestValidateCreate_DifferentURISameVersion (0.00s)
=== RUN   TestValidateCreate_FirstLocalModelCache
--- PASS: TestValidateCreate_FirstLocalModelCache (0.00s)
=== RUN   TestValidateUpdate_DuplicateVersion
--- PASS: TestValidateUpdate_DuplicateVersion (0.00s)
=== RUN   TestValidateUpdate_OlderVersion
--- PASS: TestValidateUpdate_OlderVersion (0.00s)
PASS
```

**Special notes for your reviewer**:

In the future, when the version of a LocalModelCache with the same label is changed, a LocalModelCache job will be automatically created to download and maintain the new version. When an InferenceService rollout occurs, it will seamlessly connect to the new version of LocalModeCache. After a certain period of time(like TTL or bake time), the cached previous version will be automatically cleaned up.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Add Version field to LocalModelCache to support model versioning and modification
```
