### PR TITLE
[WIP] feat: detect Gateway for auto-migration to v1 InferencePool

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -211,8 +211,8 @@ func (r *LLMISVCReconciler) expectedHTTPRoute(ctx context.Context, llmSvc *v1alp
 	if routeExists {
 		migrationValue, hasMigrationAnnotation := curr.Annotations[AnnotationInferencePoolMigrated]
 		isMigrated = hasMigrationAnnotation && migrationValue == v1MigrationValue
-		infPoolV1Alpha2Support = IsInferencePoolV1Alpha2Supported(curr)
-		infPoolV1Support = IsInferencePoolV1Supported(curr)
+		infPoolV1Alpha2Support = IsInferencePoolV1Alpha2Supported(ctx, r.Client, curr)
+		infPoolV1Support = IsInferencePoolV1Supported(ctx, r.Client, curr)
 	}
 
 	// Switch to v1 if:


### PR DESCRIPTION
This helps when Gateway(s) or HTTPRoute(s) have other policies attached to them resulting in multiple parent refs and controllers.

Resovles a TODO.

Related to #5007 