### PR TITLE
feat(llmisvc): move vLLM args to command field

### DIFF
--- a/charts/kserve-llmisvc-resources/templates/config-llm-decode-template.yaml
+++ b/charts/kserve-llmisvc-resources/templates/config-llm-decode-template.yaml
@@ -15,7 +15,6 @@ spec:
           - vllm
           - serve
           - /mnt/models
-        args:
           - --served-model-name
           - "{{`{{ .Spec.Model.Name }}`}}"
           - --port

--- a/charts/kserve-llmisvc-resources/templates/config-llm-decode-worker-data-parallel.yaml
+++ b/charts/kserve-llmisvc-resources/templates/config-llm-decode-worker-data-parallel.yaml
@@ -73,7 +73,6 @@ spec:
         command:
           - "/bin/bash"
           - "-c"
-        args:
           - |-
 
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
@@ -162,7 +161,7 @@ spec:
                       fi
                   done
 
-                  # Use deterministic fallback if counts are equal - prefer lower index number  
+                  # Use deterministic fallback if counts are equal - prefer lower index number
                   if [ ${#gid_index_count[@]} -gt 1 ]; then
                       echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                       # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -208,6 +207,7 @@ spec:
               --data-parallel-rpc-port {{`{{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }}`}} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
+              $@ \
               --trust-remote-code"
               # BackendTLSPolicy is not implemented yet so disable SSL for now
               # --enable-ssl-refresh \
@@ -215,6 +215,8 @@ spec:
               # /etc/ssl/certs/tls.crt \
               # --ssl-keyfile \
               # /etc/ssl/certs/tls.key"
+          # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+          - "--"
         env:
           - name: HOME
             value: /home
@@ -289,7 +291,6 @@ spec:
         command:
           - "/bin/bash"
           - "-c"
-        args:
           - |-
 
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
@@ -378,7 +379,7 @@ spec:
                       fi
                   done
 
-                  # Use deterministic fallback if counts are equal - prefer lower index number  
+                  # Use deterministic fallback if counts are equal - prefer lower index number
                   if [ ${#gid_index_count[@]} -gt 1 ]; then
                       echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                       # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -423,6 +424,7 @@ spec:
               --data-parallel-rpc-port {{`{{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }}`}} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
+              $@ \
               --trust-remote-code \
               --headless"
               # BackendTLSPolicy is not implemented yet so disable SSL for now
@@ -431,6 +433,8 @@ spec:
               # /etc/ssl/certs/tls.crt \
               # --ssl-keyfile \
               # /etc/ssl/certs/tls.key"
+          # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+          - "--"
         env:
           - name: HOME
             value: /home

--- a/charts/kserve-llmisvc-resources/templates/config-llm-prefill-template.yaml
+++ b/charts/kserve-llmisvc-resources/templates/config-llm-prefill-template.yaml
@@ -16,7 +16,6 @@ spec:
             - vllm
             - serve
             - /mnt/models
-          args:
             - --served-model-name
             - "{{`{{ .Spec.Model.Name }}`}}"
             - --port

--- a/charts/kserve-llmisvc-resources/templates/config-llm-prefill-worker-data-parallel.yaml
+++ b/charts/kserve-llmisvc-resources/templates/config-llm-prefill-worker-data-parallel.yaml
@@ -15,7 +15,6 @@ spec:
           command:
             - "/bin/bash"
             - "-c"
-          args:
             - |-
 
               if [ "$KSERVE_INFER_ROCE" = "true" ]; then
@@ -104,7 +103,7 @@ spec:
                         fi
                     done
 
-                    # Use deterministic fallback if counts are equal - prefer lower index number  
+                    # Use deterministic fallback if counts are equal - prefer lower index number
                     if [ ${#gid_index_count[@]} -gt 1 ]; then
                         echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                         # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -150,6 +149,7 @@ spec:
                 --data-parallel-rpc-port {{`{{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }}`}} \
                 --data-parallel-start-rank $START_RANK \
                 ${VLLM_ADDITIONAL_ARGS} \
+                $@ \
                 --trust-remote-code"
                 # BackendTLSPolicy is not implemented yet so disable SSL for now
                 # --enable-ssl-refresh \
@@ -157,6 +157,8 @@ spec:
                 # /etc/ssl/certs/tls.crt \
                 # --ssl-keyfile \
                 # /etc/ssl/certs/tls.key"
+            # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+            - "--"
           env:
             - name: HOME
               value: /home
@@ -231,7 +233,6 @@ spec:
           command:
             - "/bin/bash"
             - "-c"
-          args:
             - |-
 
               if [ "$KSERVE_INFER_ROCE" = "true" ]; then
@@ -320,7 +321,7 @@ spec:
                         fi
                     done
 
-                    # Use deterministic fallback if counts are equal - prefer lower index number  
+                    # Use deterministic fallback if counts are equal - prefer lower index number
                     if [ ${#gid_index_count[@]} -gt 1 ]; then
                         echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                         # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -365,14 +366,17 @@ spec:
                 --data-parallel-rpc-port {{`{{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }}`}} \
                 --data-parallel-start-rank $START_RANK \
                 ${VLLM_ADDITIONAL_ARGS} \
+                $@ \
                 --trust-remote-code \
-                --headless"                
+                --headless"
                 # BackendTLSPolicy is not implemented yet so disable SSL for now
                 # --enable-ssl-refresh \
                 # --ssl-certfile \
                 # /etc/ssl/certs/tls.crt \
                 # --ssl-keyfile \
                 # /etc/ssl/certs/tls.key"
+            # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+            - "--"
           env:
             - name: HOME
               value: /home

--- a/charts/kserve-llmisvc-resources/templates/config-llm-template.yaml
+++ b/charts/kserve-llmisvc-resources/templates/config-llm-template.yaml
@@ -15,7 +15,6 @@ spec:
           - vllm
           - serve
           - /mnt/models
-        args:
           - --served-model-name
           - "{{`{{ .Spec.Model.Name }}`}}"
           - --port

--- a/charts/kserve-llmisvc-resources/templates/config-llm-worker-data-parallel.yaml
+++ b/charts/kserve-llmisvc-resources/templates/config-llm-worker-data-parallel.yaml
@@ -14,7 +14,6 @@ spec:
         command:
           - "/bin/bash"
           - "-c"
-        args:
           - |-
 
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
@@ -103,7 +102,7 @@ spec:
                       fi
                   done
 
-                  # Use deterministic fallback if counts are equal - prefer lower index number  
+                  # Use deterministic fallback if counts are equal - prefer lower index number
                   if [ ${#gid_index_count[@]} -gt 1 ]; then
                       echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                       # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -149,6 +148,7 @@ spec:
               --data-parallel-rpc-port {{`{{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }}`}} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
+              $@ \
               --trust-remote-code"
               # BackendTLSPolicy is not implemented yet so disable SSL for now
               # --enable-ssl-refresh \
@@ -156,6 +156,8 @@ spec:
               # /etc/ssl/certs/tls.crt \
               # --ssl-keyfile \
               # /etc/ssl/certs/tls.key"
+          # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+          - "--"
         env:
           - name: HOME
             value: /home
@@ -230,7 +232,6 @@ spec:
         command:
           - "/bin/bash"
           - "-c"
-        args:
           - |-
 
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
@@ -286,10 +287,10 @@ spec:
                   # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
                   declare -A gid_index_count
                   declare -A hca_gid_index
-                  
+
                   for hca_name in "${active_hcas[@]}"; do
                       echo "[Infer RoCE] Processing HCA: ${hca_name}"
-                      
+
                       # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
                       for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
                           if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
@@ -319,7 +320,7 @@ spec:
                       fi
                   done
 
-                  # Use deterministic fallback if counts are equal - prefer lower index number  
+                  # Use deterministic fallback if counts are equal - prefer lower index number
                   if [ ${#gid_index_count[@]} -gt 1 ]; then
                       echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                       # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -337,11 +338,11 @@ spec:
                       echo "[Infer RoCE] Using hardcoded GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
                   elif [ -n "$best_gid_index" ]; then
                       echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
-                      
+
                       export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
                       export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
                       export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
-                      
+
                       echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
                   else
                       echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
@@ -364,6 +365,7 @@ spec:
               --data-parallel-rpc-port {{`{{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }}`}} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
+              $@ \
               --trust-remote-code \
               --headless"
               # BackendTLSPolicy is not implemented yet so disable SSL for now
@@ -372,6 +374,8 @@ spec:
               # /etc/ssl/certs/tls.crt \
               # --ssl-keyfile \
               # /etc/ssl/certs/tls.key
+          # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+          - "--"
         env:
           - name: HOME
             value: /home

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -15,7 +15,6 @@ spec:
           - vllm
           - serve
           - /mnt/models
-        args:
           - --served-model-name
           - "{{ .Spec.Model.Name }}"
           - --port
@@ -26,6 +25,7 @@ spec:
           #- /etc/ssl/certs/tls.crt
           #- --ssl-keyfile
           #- /etc/ssl/certs/tls.key
+
         env:
           - name: HOME
             value: /home

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -72,16 +72,15 @@ spec:
         command:
           - "/bin/bash"
           - "-c"
-        args:
           - |-
-            
+
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
               grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
               grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
-            
+
               KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
-            
+
               echo "[Infer RoCE] Discovering active HCAs ..."
               active_hcas=()
               # Loop through all mlx5 devices found in sysfs
@@ -101,7 +100,7 @@ spec:
                       fi
                   fi
               done
-            
+
               ucx_hcas=()
               for hca in "${active_hcas[@]}"; do
                 ucx_hcas+=("${hca}:1")
@@ -121,17 +120,17 @@ spec:
               else
                   echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
               fi
-            
+
               if [ ${#active_hcas[@]} -gt 0 ]; then
                   echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
-            
+
                   # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
                   declare -A gid_index_count
                   declare -A hca_gid_index
-            
+
                   for hca_name in "${active_hcas[@]}"; do
                       echo "[Infer RoCE] Processing HCA: ${hca_name}"
-            
+
                       # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
                       for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
                           if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
@@ -148,7 +147,7 @@ spec:
                           fi
                       done
                   done
-            
+
                   # Find the most common GID index (most likely to be consistent across nodes)
                   best_gid_index=""
                   max_count=0
@@ -160,8 +159,8 @@ spec:
                           best_gid_index="$idx"
                       fi
                   done
-            
-                  # Use deterministic fallback if counts are equal - prefer lower index number  
+
+                  # Use deterministic fallback if counts are equal - prefer lower index number
                   if [ ${#gid_index_count[@]} -gt 1 ]; then
                       echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                       # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -170,7 +169,7 @@ spec:
                           echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
                       fi
                   fi
-            
+
                   # Check if GID_INDEX is already set via environment variables
                   if [ -n "${NCCL_IB_GID_INDEX}" ]; then
                       echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
@@ -179,11 +178,11 @@ spec:
                       echo "[Infer RoCE] Using hardcoded GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
                   elif [ -n "$best_gid_index" ]; then
                       echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
-            
+
                       export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
                       export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
                       export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
-            
+
                       echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
                   else
                       echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
@@ -207,6 +206,7 @@ spec:
               --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
+              $@ \
               --trust-remote-code"
               # BackendTLSPolicy is not implemented yet so disable SSL for now
               # --enable-ssl-refresh \
@@ -214,6 +214,9 @@ spec:
               # /etc/ssl/certs/tls.crt \
               # --ssl-keyfile \
               # /etc/ssl/certs/tls.key"
+          # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+          - "--"
+
         env:
           - name: HOME
             value: /home
@@ -288,16 +291,15 @@ spec:
         command:
           - "/bin/bash"
           - "-c"
-        args:
           - |-
-            
+
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
               grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
               grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
-            
+
               KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
-            
+
               echo "[Infer RoCE] Discovering active HCAs ..."
               active_hcas=()
               # Loop through all mlx5 devices found in sysfs
@@ -317,7 +319,7 @@ spec:
                       fi
                   fi
               done
-            
+
               ucx_hcas=()
               for hca in "${active_hcas[@]}"; do
                 ucx_hcas+=("${hca}:1")
@@ -337,17 +339,17 @@ spec:
               else
                   echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
               fi
-            
+
               if [ ${#active_hcas[@]} -gt 0 ]; then
                   echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
-            
+
                   # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
                   declare -A gid_index_count
                   declare -A hca_gid_index
-            
+
                   for hca_name in "${active_hcas[@]}"; do
                       echo "[Infer RoCE] Processing HCA: ${hca_name}"
-            
+
                       # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
                       for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
                           if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
@@ -364,7 +366,7 @@ spec:
                           fi
                       done
                   done
-            
+
                   # Find the most common GID index (most likely to be consistent across nodes)
                   best_gid_index=""
                   max_count=0
@@ -376,8 +378,8 @@ spec:
                           best_gid_index="$idx"
                       fi
                   done
-            
-                  # Use deterministic fallback if counts are equal - prefer lower index number  
+
+                  # Use deterministic fallback if counts are equal - prefer lower index number
                   if [ ${#gid_index_count[@]} -gt 1 ]; then
                       echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                       # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -386,7 +388,7 @@ spec:
                           echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
                       fi
                   fi
-            
+
                   # Check if GID_INDEX is already set via environment variables
                   if [ -n "${NCCL_IB_GID_INDEX}" ]; then
                       echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
@@ -395,11 +397,11 @@ spec:
                       echo "[Infer RoCE] Using hardcoded GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
                   elif [ -n "$best_gid_index" ]; then
                       echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
-            
+
                       export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
                       export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
                       export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
-            
+
                       echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
                   else
                       echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
@@ -422,6 +424,7 @@ spec:
               --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
+              $@ \
               --trust-remote-code \
               --headless"
               # BackendTLSPolicy is not implemented yet so disable SSL for now
@@ -430,6 +433,9 @@ spec:
               # /etc/ssl/certs/tls.crt \
               # --ssl-keyfile \
               # /etc/ssl/certs/tls.key"
+          # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+          - "--"
+
         env:
           - name: HOME
             value: /home

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -16,7 +16,6 @@ spec:
             - vllm
             - serve
             - /mnt/models
-          args:
             - --served-model-name
             - "{{ .Spec.Model.Name }}"
             - --port
@@ -27,6 +26,7 @@ spec:
             # - /etc/ssl/certs/tls.crt
             # - --ssl-keyfile
             # - /etc/ssl/certs/tls.key
+
           env:
             - name: HOME
               value: /home

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -15,16 +15,15 @@ spec:
           command:
             - "/bin/bash"
             - "-c"
-          args:
             - |-
 
               if [ "$KSERVE_INFER_ROCE" = "true" ]; then
                 echo "Trying to infer RoCE configs ... "
                 grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
                 grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
-              
+
                 KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
-              
+
                 echo "[Infer RoCE] Discovering active HCAs ..."
                 active_hcas=()
                 # Loop through all mlx5 devices found in sysfs
@@ -44,7 +43,7 @@ spec:
                         fi
                     fi
                 done
-              
+
                 ucx_hcas=()
                 for hca in "${active_hcas[@]}"; do
                   ucx_hcas+=("${hca}:1")
@@ -64,17 +63,17 @@ spec:
                 else
                     echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
                 fi
-              
+
                 if [ ${#active_hcas[@]} -gt 0 ]; then
                     echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
-              
+
                     # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
                     declare -A gid_index_count
                     declare -A hca_gid_index
-              
+
                     for hca_name in "${active_hcas[@]}"; do
                         echo "[Infer RoCE] Processing HCA: ${hca_name}"
-              
+
                         # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
                         for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
                             if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
@@ -91,7 +90,7 @@ spec:
                             fi
                         done
                     done
-              
+
                     # Find the most common GID index (most likely to be consistent across nodes)
                     best_gid_index=""
                     max_count=0
@@ -103,8 +102,8 @@ spec:
                             best_gid_index="$idx"
                         fi
                     done
-              
-                    # Use deterministic fallback if counts are equal - prefer lower index number  
+
+                    # Use deterministic fallback if counts are equal - prefer lower index number
                     if [ ${#gid_index_count[@]} -gt 1 ]; then
                         echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                         # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -113,7 +112,7 @@ spec:
                             echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
                         fi
                     fi
-              
+
                     # Check if GID_INDEX is already set via environment variables
                     if [ -n "${NCCL_IB_GID_INDEX}" ]; then
                         echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
@@ -122,11 +121,11 @@ spec:
                         echo "[Infer RoCE] Using hardcoded GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
                     elif [ -n "$best_gid_index" ]; then
                         echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
-              
+
                         export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
                         export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
                         export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
-              
+
                         echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
                     else
                         echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
@@ -150,6 +149,7 @@ spec:
                 --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                 --data-parallel-start-rank $START_RANK \
                 ${VLLM_ADDITIONAL_ARGS} \
+                $@ \
                 --trust-remote-code"
                 # BackendTLSPolicy is not implemented yet so disable SSL for now
                 # --enable-ssl-refresh \
@@ -157,6 +157,9 @@ spec:
                 # /etc/ssl/certs/tls.crt \
                 # --ssl-keyfile \
                 # /etc/ssl/certs/tls.key"
+            # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+            - "--"
+
           env:
             - name: HOME
               value: /home
@@ -231,16 +234,15 @@ spec:
           command:
             - "/bin/bash"
             - "-c"
-          args:
             - |-
 
               if [ "$KSERVE_INFER_ROCE" = "true" ]; then
                 echo "Trying to infer RoCE configs ... "
                 grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
                 grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
-              
+
                 KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
-              
+
                 echo "[Infer RoCE] Discovering active HCAs ..."
                 active_hcas=()
                 # Loop through all mlx5 devices found in sysfs
@@ -260,7 +262,7 @@ spec:
                         fi
                     fi
                 done
-              
+
                 ucx_hcas=()
                 for hca in "${active_hcas[@]}"; do
                   ucx_hcas+=("${hca}:1")
@@ -280,17 +282,17 @@ spec:
                 else
                     echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
                 fi
-              
+
                 if [ ${#active_hcas[@]} -gt 0 ]; then
                     echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
-              
+
                     # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
                     declare -A gid_index_count
                     declare -A hca_gid_index
-              
+
                     for hca_name in "${active_hcas[@]}"; do
                         echo "[Infer RoCE] Processing HCA: ${hca_name}"
-              
+
                         # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
                         for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
                             if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
@@ -307,7 +309,7 @@ spec:
                             fi
                         done
                     done
-              
+
                     # Find the most common GID index (most likely to be consistent across nodes)
                     best_gid_index=""
                     max_count=0
@@ -319,8 +321,8 @@ spec:
                             best_gid_index="$idx"
                         fi
                     done
-              
-                    # Use deterministic fallback if counts are equal - prefer lower index number  
+
+                    # Use deterministic fallback if counts are equal - prefer lower index number
                     if [ ${#gid_index_count[@]} -gt 1 ]; then
                         echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                         # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -329,7 +331,7 @@ spec:
                             echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
                         fi
                     fi
-              
+
                     # Check if GID_INDEX is already set via environment variables
                     if [ -n "${NCCL_IB_GID_INDEX}" ]; then
                         echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
@@ -338,11 +340,11 @@ spec:
                         echo "[Infer RoCE] Using hardcoded GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
                     elif [ -n "$best_gid_index" ]; then
                         echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
-              
+
                         export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
                         export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
                         export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
-              
+
                         echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
                     else
                         echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
@@ -365,14 +367,18 @@ spec:
                 --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                 --data-parallel-start-rank $START_RANK \
                 ${VLLM_ADDITIONAL_ARGS} \
+                $@ \
                 --trust-remote-code \
-                --headless"                
+                --headless"
                 # BackendTLSPolicy is not implemented yet so disable SSL for now
                 # --enable-ssl-refresh \
                 # --ssl-certfile \
                 # /etc/ssl/certs/tls.crt \
                 # --ssl-keyfile \
                 # /etc/ssl/certs/tls.key"
+            # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+            - "--"
+
           env:
             - name: HOME
               value: /home

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -15,7 +15,6 @@ spec:
           - vllm
           - serve
           - /mnt/models
-        args:
           - --served-model-name
           - "{{ .Spec.Model.Name }}"
           - --port
@@ -26,6 +25,7 @@ spec:
           # - /etc/ssl/certs/tls.crt
           # - --ssl-keyfile
           # - /etc/ssl/certs/tls.key
+
         env:
           - name: HOME
             value: /home

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -14,16 +14,15 @@ spec:
         command:
           - "/bin/bash"
           - "-c"
-        args:
           - |-
-            
+
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
               grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
               grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
-            
+
               KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
-            
+
               echo "[Infer RoCE] Discovering active HCAs ..."
               active_hcas=()
               # Loop through all mlx5 devices found in sysfs
@@ -43,7 +42,7 @@ spec:
                       fi
                   fi
               done
-            
+
               ucx_hcas=()
               for hca in "${active_hcas[@]}"; do
                 ucx_hcas+=("${hca}:1")
@@ -63,17 +62,17 @@ spec:
               else
                   echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
               fi
-            
+
               if [ ${#active_hcas[@]} -gt 0 ]; then
                   echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
-            
+
                   # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
                   declare -A gid_index_count
                   declare -A hca_gid_index
-            
+
                   for hca_name in "${active_hcas[@]}"; do
                       echo "[Infer RoCE] Processing HCA: ${hca_name}"
-            
+
                       # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
                       for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
                           if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
@@ -90,7 +89,7 @@ spec:
                           fi
                       done
                   done
-            
+
                   # Find the most common GID index (most likely to be consistent across nodes)
                   best_gid_index=""
                   max_count=0
@@ -102,8 +101,8 @@ spec:
                           best_gid_index="$idx"
                       fi
                   done
-            
-                  # Use deterministic fallback if counts are equal - prefer lower index number  
+
+                  # Use deterministic fallback if counts are equal - prefer lower index number
                   if [ ${#gid_index_count[@]} -gt 1 ]; then
                       echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                       # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -112,7 +111,7 @@ spec:
                           echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
                       fi
                   fi
-            
+
                   # Check if GID_INDEX is already set via environment variables
                   if [ -n "${NCCL_IB_GID_INDEX}" ]; then
                       echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
@@ -121,11 +120,11 @@ spec:
                       echo "[Infer RoCE] Using hardcoded GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
                   elif [ -n "$best_gid_index" ]; then
                       echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
-            
+
                       export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
                       export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
                       export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
-            
+
                       echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
                   else
                       echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
@@ -149,6 +148,7 @@ spec:
               --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
+              $@ \
               --trust-remote-code"
               # BackendTLSPolicy is not implemented yet so disable SSL for now
               # --enable-ssl-refresh \
@@ -156,6 +156,9 @@ spec:
               # /etc/ssl/certs/tls.crt \
               # --ssl-keyfile \
               # /etc/ssl/certs/tls.key"
+          # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+          - "--"
+
         env:
           - name: HOME
             value: /home
@@ -230,16 +233,15 @@ spec:
         command:
           - "/bin/bash"
           - "-c"
-        args:
           - |-
-            
+
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
               grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
               grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
-            
+
               KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
-            
+
               echo "[Infer RoCE] Discovering active HCAs ..."
               active_hcas=()
               # Loop through all mlx5 devices found in sysfs
@@ -259,7 +261,7 @@ spec:
                       fi
                   fi
               done
-            
+
               ucx_hcas=()
               for hca in "${active_hcas[@]}"; do
                 ucx_hcas+=("${hca}:1")
@@ -279,17 +281,17 @@ spec:
               else
                   echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
               fi
-            
+
               if [ ${#active_hcas[@]} -gt 0 ]; then
                   echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
-            
+
                   # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
                   declare -A gid_index_count
                   declare -A hca_gid_index
-                  
+
                   for hca_name in "${active_hcas[@]}"; do
                       echo "[Infer RoCE] Processing HCA: ${hca_name}"
-                      
+
                       # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
                       for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
                           if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
@@ -306,7 +308,7 @@ spec:
                           fi
                       done
                   done
-            
+
                   # Find the most common GID index (most likely to be consistent across nodes)
                   best_gid_index=""
                   max_count=0
@@ -318,8 +320,8 @@ spec:
                           best_gid_index="$idx"
                       fi
                   done
-            
-                  # Use deterministic fallback if counts are equal - prefer lower index number  
+
+                  # Use deterministic fallback if counts are equal - prefer lower index number
                   if [ ${#gid_index_count[@]} -gt 1 ]; then
                       echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
                       # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
@@ -328,7 +330,7 @@ spec:
                           echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
                       fi
                   fi
-            
+
                   # Check if GID_INDEX is already set via environment variables
                   if [ -n "${NCCL_IB_GID_INDEX}" ]; then
                       echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
@@ -337,11 +339,11 @@ spec:
                       echo "[Infer RoCE] Using hardcoded GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
                   elif [ -n "$best_gid_index" ]; then
                       echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
-                      
+
                       export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
                       export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
                       export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
-                      
+
                       echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
                   else
                       echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
@@ -364,6 +366,7 @@ spec:
               --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
+              $@ \
               --trust-remote-code \
               --headless"
               # BackendTLSPolicy is not implemented yet so disable SSL for now
@@ -372,6 +375,9 @@ spec:
               # /etc/ssl/certs/tls.crt \
               # --ssl-keyfile \
               # /etc/ssl/certs/tls.key
+          # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
+          - "--"
+
         env:
           - name: HOME
             value: /home


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves default vLLM CLI arguments (e.g. `--served-model-name`, `--port`) from `args` to `command` in all 6 LLMInferenceServiceConfig kustomize templates and their corresponding 6 Helm chart templates.

Currently, both `command` and `args` are populated in the config templates, which means users cannot override `args` via the LLMInferenceService CR - Kubernetes strategic merge patch replaces `args` atomically, wiping the defaults. By moving the defaults into `command` and leaving `args` empty, users can now specify custom vLLM arguments (e.g. `--max-model-len`, `--dtype`, `--tensor-parallel-size`) directly in their LLMInferenceService `args` field without needing the `VLLM_ADDITIONAL_ARGS` environment variable.

For data-parallel templates, `$@` is appended to the bash script so that user-provided `args` are forwarded to the `vllm serve` invocation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kserve/kserve/issues/5048

**Feature/Issue validation/testing**:

- [x] Regression test: Created LLMInferenceService without custom args on kind cluster - pod spec shows `command: [vllm, serve, /mnt/models, --served-model-name, facebook/opt-125m, --port, 8000]` and empty `args`. Behavior unchanged.
- [x] Feature test: Created LLMInferenceService with `args: ["--max-model-len=2048", "--dtype=float32"]` - pod spec shows same `command` and `args: ["--max-model-len=2048", "--dtype=float32"]`. Custom args correctly passed through.
- [x] Unit tests: `TestPresetFiles` (8/8) and `TestMergeSpecs` (27/27) all pass.

Tested on kind cluster deployed via `make deploy-dev`.

**Special notes for your reviewer**:

- Both kustomize templates (`config/llmisvcconfig/`) and Helm chart templates (`charts/kserve-llmisvc-resources/templates/`) are updated in this PR.
- `config-llm-router-route.yaml` and `config-llm-scheduler.yaml` are intentionally unchanged - the former has no containers, and the latter's args are scheduler CLI flags (not user-overridable vLLM args).
- InitContainer args (routing sidecar in P/D decode templates) are intentionally left untouched.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Users can now pass custom vLLM arguments (e.g. --max-model-len, --dtype) directly via the LLMInferenceService args field, without needing the VLLM_ADDITIONAL_ARGS environment variable.