### PR TITLE
fix: bump bitsandbytes to >=0.46.1 for vLLM compat

### DIFF
--- a/python/huggingfaceserver/pyproject.toml
+++ b/python/huggingfaceserver/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "kserve-storage @ file:///${PROJECT_ROOT}/../storage",
     "transformers>=4.53.2",
     "accelerate<2.0.0,>=1.6.0",
-    "bitsandbytes>=0.45.3",
+    "bitsandbytes>=0.46.1",
     "modelscope<2.0.0,>=1.16.0",
     "setuptools>=70.0.0",
 ]

--- a/python/huggingfaceserver/uv.lock
+++ b/python/huggingfaceserver/uv.lock
@@ -312,15 +312,18 @@ wheels = [
 
 [[package]]
 name = "bitsandbytes"
-version = "0.45.5"
+version = "0.49.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
+    { name = "packaging" },
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/b7/cb5ce4d1a382cf53c19ef06c5fc29e85f5e129b4da6527dd207d90a5b8ad/bitsandbytes-0.45.5-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:a5453f30cc6aab6ccaac364e6bf51a7808d3da5f71763dffeb6d9694c59136e4", size = 76059261, upload-time = "2025-04-07T13:32:52.573Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/4c/77b535e025ce780d2ada8271c1e481fb7337c1df2588a52fe1c9bd87d2e8/bitsandbytes-0.45.5-py3-none-win_amd64.whl", hash = "sha256:ed1c61b91d989d6a33fd05737d6edbf5086d8ebc89235ee632c7a19144085da2", size = 75430204, upload-time = "2025-04-07T13:32:57.553Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6f/32d0526e4e4ad309d9e7502c018399bb23b63f39277a361c305092e2f885/bitsandbytes-0.49.1-py3-none-macosx_14_0_arm64.whl", hash = "sha256:9de01d4384b6c71ef9ab052b98457dc0e4fff8fe06ab14833b5b712700deb005", size = 129848, upload-time = "2026-01-08T14:31:26.134Z" },
+    { url = "https://files.pythonhosted.org/packages/11/dd/5820e09213a3f7c0ee5aff20fce8b362ce935f9dd9958827274de4eaeec6/bitsandbytes-0.49.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:acd4730a0db3762d286707f4a3bc1d013d21dd5f0e441900da57ec4198578d4e", size = 31065659, upload-time = "2026-01-08T14:31:28.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4f/02d3cb62a1b0b5a1ca7ff03dce3606be1bf3ead4744f47eb762dbf471069/bitsandbytes-0.49.1-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:e7940bf32457dc2e553685285b2a86e82f5ec10b2ae39776c408714f9ae6983c", size = 59054193, upload-time = "2026-01-08T14:31:31.743Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/7cfbe3a93354764be85c2dfcbfc5b6536413e598155aa7ef7e85d74c9e49/bitsandbytes-0.49.1-py3-none-win_amd64.whl", hash = "sha256:6ead0763f4beb936f9a09acb49ec094a259180906fc0605d9ca0617249c3c798", size = 54700630, upload-time = "2026-01-08T14:31:35.638Z" },
 ]
 
 [[package]]
@@ -1733,7 +1736,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", specifier = ">=1.6.0,<2.0.0" },
-    { name = "bitsandbytes", specifier = ">=0.45.3" },
+    { name = "bitsandbytes", specifier = ">=0.46.1" },
     { name = "kserve", extras = ["llm"], directory = "../kserve" },
     { name = "kserve-storage", directory = "../storage" },
     { name = "modelscope", specifier = ">=1.16.0,<2.0.0" },


### PR DESCRIPTION
The version check lives in `vllm/model_executor/layers/quantization/bitsandbytes.py`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4875

**Feature/Issue validation/testing**:
- [x] Verified `uv.lock` resolves to `bitsandbytes==0.49.1` (satisfies `>=0.46.1`)
- [x] Confirmed vLLM source enforces this minimum version in `vllm/model_executor/layers/quantization/bitsandbytes.py`
- Logs: `make uv-lock` output shows `Updated bitsandbytes v0.45.5 -> v0.49.1`

**Special notes for your reviewer**:
This is a minimal dependency version bump — only `pyproject.toml` and `uv.lock` are changed. No image version changes.

**Checklist**:
- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? (No new tests needed — dependency version bump only)
- [x] Has code been commented, particularly in hard-to-understand areas? (N/A)
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? (N/A — no doc changes needed)

**Release note**:
```release-note
Bumped bitsandbytes minimum version to >=0.46.1 in the HuggingFace runtime to fix compatibility with vLLM's BitsAndBytes quantization backend.
```