### PR TITLE
Fix InferencePool version choice logic

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -103,7 +103,7 @@ func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1a
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling HTTPRoute")
 
-	expectedHTTPRoute := r.expectedHTTPRoute(ctx, llmSvc)
+	expectedHTTPRoute := r.ExpectedHTTPRoute(ctx, llmSvc)
 
 	// Clean up if router or routes are not configured
 	if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil {
@@ -162,9 +162,9 @@ func (r *LLMISVCReconciler) collectReferencedRoutes(ctx context.Context, llmSvc 
 	return referencedRoutes, nil
 }
 
-// expectedHTTPRoute creates the HTTPRoute specification for this service
+// ExpectedHTTPRoute creates the HTTPRoute specification for this service
 // This route is created when the service specifies inline routing configuration
-func (r *LLMISVCReconciler) expectedHTTPRoute(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) *gwapiv1.HTTPRoute {
+func (r *LLMISVCReconciler) ExpectedHTTPRoute(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) *gwapiv1.HTTPRoute {
 	httpRoute := &gwapiv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kmeta.ChildName(llmSvc.GetName(), "-kserve-route"),
@@ -215,54 +215,77 @@ func (r *LLMISVCReconciler) expectedHTTPRoute(ctx context.Context, llmSvc *v1alp
 		infPoolV1Support = IsInferencePoolV1Supported(curr)
 	}
 
-	// Switch to v1 if:
-	// - Gateway accepted v1 (route using v1 and ResolvedRefs=True), OR
-	// - Gateway rejected v1alpha2 (route using v1alpha2 and ResolvedRefs=False/InvalidKind), OR
-	// - Already migrated (annotation exists - one-way lock)
-	if isMigrated || infPoolV1Support == metav1.ConditionTrue || infPoolV1Alpha2Support == metav1.ConditionFalse {
-		// Switch backendRef to v1 API group
-		for i := range httpRoute.Spec.Rules {
-			for j := range httpRoute.Spec.Rules[i].BackendRefs {
-				if isDefaultBackendRef(llmSvc, httpRoute.Spec.Rules[i].BackendRefs[j].BackendRef) {
-					httpRoute.Spec.Rules[i].BackendRefs[j].Group = ptr.To(gwapiv1.Group(constants.InferencePoolV1APIGroupName))
-				}
+	// For new routes (routeExists=false), use v1 API group if available, otherwise use v1alpha2
+	if !routeExists {
+		if r.InferencePoolV1Available {
+			// Use v1 API for new routes if available
+			r.updateInferencePoolBackendGroup(llmSvc, httpRoute, constants.InferencePoolV1APIGroupName)
+			// Set migration annotation to prevent rollback
+			if httpRoute.Annotations == nil {
+				httpRoute.Annotations = make(map[string]string, 1)
 			}
-		}
-		// Persist migration annotation
-		if httpRoute.Annotations == nil {
-			httpRoute.Annotations = make(map[string]string, 1)
-		}
-		httpRoute.Annotations[AnnotationInferencePoolMigrated] = v1MigrationValue
+			httpRoute.Annotations[AnnotationInferencePoolMigrated] = v1MigrationValue
 
-		logger.Info("Using InferencePool v1 API for HTTPRoute",
-			"isMigrated", isMigrated,
-			"infPoolV1Support", infPoolV1Support,
-			"infPoolV1Alpha2Support", infPoolV1Alpha2Support,
-			"httproute.curr.spec", curr.Spec,
-			"httproute.curr.status", curr.Status,
-			"httproute.expected.spec", httpRoute.Spec,
-		)
-	} else if r.InferencePoolV1Alpha2Available {
-		// Not migrated yet, use v1alpha2
-		for i := range httpRoute.Spec.Rules {
-			for j := range httpRoute.Spec.Rules[i].BackendRefs {
-				if isDefaultBackendRef(llmSvc, httpRoute.Spec.Rules[i].BackendRefs[j].BackendRef) {
-					httpRoute.Spec.Rules[i].BackendRefs[j].Group = ptr.To(gwapiv1.Group(constants.InferencePoolV1Alpha2APIGroupName))
-				}
+			logger.Info("Using InferencePool v1 API for new HTTPRoute",
+				"httproute.expected.spec", httpRoute.Spec,
+			)
+		} else if r.InferencePoolV1Alpha2Available {
+			// Fallback to v1alpha2 if v1 is not available
+			r.updateInferencePoolBackendGroup(llmSvc, httpRoute, constants.InferencePoolV1Alpha2APIGroupName)
+
+			logger.Info("Using InferencePool v1alpha2 API for new HTTPRoute (v1 not available)",
+				"httproute.expected.spec", httpRoute.Spec,
+			)
+		}
+	} else {
+		// For existing routes, use migration logic
+		// Switch to v1 if:
+		// - Gateway accepted v1 (route using v1 and ResolvedRefs=True), OR
+		// - Gateway rejected v1alpha2 (route using v1alpha2 and ResolvedRefs=False/InvalidKind), OR
+		// - Already migrated (annotation exists - one-way lock)
+		if isMigrated || infPoolV1Support == metav1.ConditionTrue || infPoolV1Alpha2Support == metav1.ConditionFalse {
+			// Switch backendRef to v1 API group
+			r.updateInferencePoolBackendGroup(llmSvc, httpRoute, constants.InferencePoolV1APIGroupName)
+			// Persist migration annotation
+			if httpRoute.Annotations == nil {
+				httpRoute.Annotations = make(map[string]string, 1)
 			}
-		}
+			httpRoute.Annotations[AnnotationInferencePoolMigrated] = v1MigrationValue
 
-		logger.Info("Using InferencePool v1alpha2 API for HTTPRoute",
-			"isMigrated", isMigrated,
-			"infPoolV1Support", infPoolV1Support,
-			"infPoolV1Alpha2Support", infPoolV1Alpha2Support,
-			"httproute.curr.spec", curr.Spec,
-			"httproute.curr.status", curr.Status,
-			"httproute.expected.spec", httpRoute.Spec,
-		)
+			logger.Info("Using InferencePool v1 API for HTTPRoute",
+				"isMigrated", isMigrated,
+				"infPoolV1Support", infPoolV1Support,
+				"infPoolV1Alpha2Support", infPoolV1Alpha2Support,
+				"httproute.curr.spec", curr.Spec,
+				"httproute.curr.status", curr.Status,
+				"httproute.expected.spec", httpRoute.Spec,
+			)
+		} else if r.InferencePoolV1Alpha2Available {
+			// Not migrated yet, use v1alpha2 if available
+			r.updateInferencePoolBackendGroup(llmSvc, httpRoute, constants.InferencePoolV1Alpha2APIGroupName)
+
+			logger.Info("Using InferencePool v1alpha2 API for HTTPRoute",
+				"isMigrated", isMigrated,
+				"infPoolV1Support", infPoolV1Support,
+				"infPoolV1Alpha2Support", infPoolV1Alpha2Support,
+				"httproute.curr.spec", curr.Spec,
+				"httproute.curr.status", curr.Status,
+				"httproute.expected.spec", httpRoute.Spec,
+			)
+		}
 	}
 
 	return httpRoute
+}
+
+func (r *LLMISVCReconciler) updateInferencePoolBackendGroup(llmSvc *v1alpha2.LLMInferenceService, httpRoute *gwapiv1.HTTPRoute, group string) {
+	for i := range httpRoute.Spec.Rules {
+		for j := range httpRoute.Spec.Rules[i].BackendRefs {
+			if isDefaultBackendRef(llmSvc, httpRoute.Spec.Rules[i].BackendRefs[j].BackendRef) {
+				httpRoute.Spec.Rules[i].BackendRefs[j].Group = ptr.To(gwapiv1.Group(group))
+			}
+		}
+	}
 }
 
 func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, routes ...*gwapiv1.HTTPRoute) error {
@@ -479,7 +502,7 @@ func (r *LLMISVCReconciler) EvaluateHTTPRouteConditions(ctx context.Context, llm
 
 	// Get managed route if it exists
 	if llmSvc.Spec.Router.Route.HTTP.HasSpec() {
-		expectedHTTPRoute := r.expectedHTTPRoute(ctx, llmSvc)
+		expectedHTTPRoute := r.ExpectedHTTPRoute(ctx, llmSvc)
 		// Try to get the actual managed route from the cluster
 		managedRoute := &gwapiv1.HTTPRoute{}
 		if err := r.Client.Get(ctx, types.NamespacedName{

--- a/pkg/controller/v1alpha2/llmisvc/router_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestExpectedHTTPRoute_VersionSelection(t *testing.T) {
+
+	llmsvcName := "test-llm"
+	backendRefInfPoolV1 := gwapiv1.BackendRef{
+		BackendObjectReference: gwapiv1.BackendObjectReference{
+			Group: ptr.To(gwapiv1.Group("inference.networking.k8s.io")),
+			Kind:  ptr.To(gwapiv1.Kind("InferencePool")),
+			Name:  gwapiv1.ObjectName(llmsvcName + "-inference-pool"),
+		},
+	}
+	var backendRefInfPoolV1Alpha2 = gwapiv1.BackendRef{
+		BackendObjectReference: gwapiv1.BackendObjectReference{
+			Group: ptr.To(gwapiv1.Group("inference.networking.x-k8s.io")),
+			Kind:  ptr.To(gwapiv1.Kind("InferencePool")),
+			Name:  gwapiv1.ObjectName(llmsvcName + "-inference-pool"),
+		},
+	}
+
+	tests := []struct {
+		name                           string
+		inferencePoolV1Available       bool
+		inferencePoolV1Alpha2Available bool
+		initialRouterBackendRef        gwapiv1.BackendRef
+		wantAnnotation                 bool
+		wantGroup                      string
+	}{
+		{
+			name:                           "New route, v1 available, v1 from template input",
+			inferencePoolV1Available:       true,
+			inferencePoolV1Alpha2Available: true,
+			initialRouterBackendRef:        backendRefInfPoolV1,
+			wantAnnotation:                 true,
+			wantGroup:                      "inference.networking.k8s.io",
+		},
+		{
+			name:                           "New route, v1 available, v1alpha2 from template input",
+			inferencePoolV1Available:       true,
+			inferencePoolV1Alpha2Available: true,
+			initialRouterBackendRef:        backendRefInfPoolV1Alpha2,
+			wantAnnotation:                 true,
+			wantGroup:                      "inference.networking.k8s.io",
+		},
+		{
+			name:                           "New route, v1 not available, v1alpha2 available, v1 from template input",
+			inferencePoolV1Available:       false,
+			inferencePoolV1Alpha2Available: true,
+			initialRouterBackendRef:        backendRefInfPoolV1,
+			wantAnnotation:                 false,
+			wantGroup:                      "inference.networking.x-k8s.io",
+		},
+		{
+			name:                           "New route, v1 not available, v1alpha2 available, v1alpha2 from template input",
+			inferencePoolV1Available:       false,
+			inferencePoolV1Alpha2Available: true,
+			initialRouterBackendRef:        backendRefInfPoolV1Alpha2,
+			wantAnnotation:                 false,
+			wantGroup:                      "inference.networking.x-k8s.io",
+		},
+		{
+			name:                           "New route, neither v1 nor v1alpha2 available",
+			inferencePoolV1Available:       false,
+			inferencePoolV1Alpha2Available: false,
+			wantAnnotation:                 false,
+			wantGroup:                      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Create a fake client
+			fakeClient := fake.NewClientBuilder().Build()
+
+			// Create a test LLMInferenceService
+			llmSvc := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      llmsvcName,
+					Namespace: "test-namespace",
+				},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Router: &v1alpha2.RouterSpec{
+						Route: &v1alpha2.GatewayRoutesSpec{
+							HTTP: &v1alpha2.HTTPRouteSpec{
+								Spec: &gwapiv1.HTTPRouteSpec{
+									Rules: []gwapiv1.HTTPRouteRule{
+										{
+											BackendRefs: []gwapiv1.HTTPBackendRef{
+												{
+													BackendRef: tt.initialRouterBackendRef,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Scheduler: &v1alpha2.SchedulerSpec{
+							Pool: &v1alpha2.InferencePoolSpec{},
+						},
+					},
+				},
+			}
+
+			// Create a reconciler
+			reconciler := &llmisvc.LLMISVCReconciler{
+				Client:                         fakeClient,
+				InferencePoolV1Available:       tt.inferencePoolV1Available,
+				InferencePoolV1Alpha2Available: tt.inferencePoolV1Alpha2Available,
+			}
+
+			// Create context
+			ctx := context.Background()
+
+			// Get expected HTTPRoute
+			expectedRoute := reconciler.ExpectedHTTPRoute(ctx, llmSvc)
+
+			// Check annotation
+			if tt.wantAnnotation {
+				g.Expect(expectedRoute.Annotations).To(HaveKey(llmisvc.AnnotationInferencePoolMigrated))
+				g.Expect(expectedRoute.Annotations[llmisvc.AnnotationInferencePoolMigrated]).To(Equal("v1"))
+			} else {
+				if expectedRoute.Annotations != nil {
+					g.Expect(expectedRoute.Annotations).ToNot(HaveKey(llmisvc.AnnotationInferencePoolMigrated))
+				}
+			}
+
+			// Check backend group
+			if tt.wantGroup != "" {
+				// Check if any BackendRef has the correct group set
+				anyGroupSet := false
+				for _, rule := range expectedRoute.Spec.Rules {
+					for _, httpBackendRef := range rule.BackendRefs {
+						if httpBackendRef.BackendRef.Group != nil {
+							anyGroupSet = true
+							g.Expect(string(*httpBackendRef.BackendRef.Group)).To(Equal(tt.wantGroup), "Unexpected backend group")
+							break
+						}
+					}
+					if anyGroupSet {
+						break
+					}
+				}
+				// If no group is set, it might be because there's no matching default backend reference
+				// We don't force group setting here, just check that the set group is correct
+			} else {
+				// Check that no BackendRef has a group set
+				for _, rule := range expectedRoute.Spec.Rules {
+					for _, httpBackendRef := range rule.BackendRefs {
+						g.Expect(httpBackendRef.BackendRef.Group).To(BeNil(), "Expected no group when neither v1 nor v1alpha2 is available")
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5050


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
