### PR TITLE
fix(llmisvc): readiness logic for multiple ctrl statuses

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/fixture/gwapi_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/gwapi_builders.go
@@ -491,35 +491,6 @@ func WithGatewayReadyStatus() GatewayOption {
 	}
 }
 
-// Advanced fixture patterns for custom conditions
-
-// WithCustomHTTPRouteConditions allows setting custom conditions on HTTPRoute parent status
-func WithCustomHTTPRouteConditions(parentRef gwapiv1.ParentReference, controllerName string, conditions ...metav1.Condition) HTTPRouteOption {
-	return WithHTTPRouteParentStatus(parentRef, controllerName, conditions...)
-}
-
-// WithGatewayNotReadyStatus sets the Gateway status to not ready (for negative testing)
-func WithGatewayNotReadyStatus(reason, message string) GatewayOption {
-	return func(gw *gwapiv1.Gateway) {
-		gw.Status.Conditions = []metav1.Condition{
-			{
-				Type:               string(gwapiv1.GatewayConditionAccepted),
-				Status:             metav1.ConditionTrue,
-				Reason:             "Accepted",
-				Message:            "Gateway accepted",
-				LastTransitionTime: metav1.Now(),
-			},
-			{
-				Type:               string(gwapiv1.GatewayConditionProgrammed),
-				Status:             metav1.ConditionFalse,
-				Reason:             reason,
-				Message:            message,
-				LastTransitionTime: metav1.Now(),
-			},
-		}
-	}
-}
-
 // WithHTTPRouteNotReadyStatus sets the HTTPRoute status to not ready (for negative testing)
 func WithHTTPRouteNotReadyStatus(controllerName, reason, message string) HTTPRouteOption {
 	return func(route *gwapiv1.HTTPRoute) {
@@ -573,6 +544,83 @@ func WithHTTPRouteV1Alpha2RejectedStatus(controllerName string) HTTPRouteOption 
 					},
 				}
 			}
+		}
+	}
+}
+
+// Advanced fixture patterns for custom conditions
+
+// KuadrantControllerStatus creates a RouteParentStatus for Kuadrant policy controller
+func KuadrantControllerStatus(parentRef gwapiv1.ParentReference, generation int64) gwapiv1.RouteParentStatus {
+	return gwapiv1.RouteParentStatus{
+		ParentRef:      parentRef,
+		ControllerName: "kuadrant.io/policy-controller",
+		Conditions: []metav1.Condition{
+			{
+				Type:               "kuadrant.io/AuthPolicyAffected",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Accepted",
+				Message:            "Object affected by AuthPolicy [openshift-ingress/gateway-auth-policy]",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: generation,
+			},
+			{
+				Type:               "kuadrant.io/RateLimitPolicyAffected",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Accepted",
+				Message:            "Object affected by RateLimitPolicy [openshift-ingress/gateway-rate-limits]",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: generation,
+			},
+			{
+				Type:               "kuadrant.io/TokenRateLimitPolicyAffected",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Accepted",
+				Message:            "Object affected by TokenRateLimitPolicy [openshift-ingress/gateway-token-rate-limits]",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: generation,
+			},
+		},
+	}
+}
+
+// GatewayAPIControllerStatus creates a RouteParentStatus for Gateway API controller
+func GatewayAPIControllerStatus(parentRef gwapiv1.ParentReference, generation int64) gwapiv1.RouteParentStatus {
+	return gwapiv1.RouteParentStatus{
+		ParentRef:      parentRef,
+		ControllerName: "openshift.io/gateway-controller/v1",
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(gwapiv1.RouteConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				Reason:             "Accepted",
+				Message:            "Route was valid",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: generation,
+			},
+			{
+				Type:               string(gwapiv1.RouteConditionResolvedRefs),
+				Status:             metav1.ConditionTrue,
+				Reason:             "ResolvedRefs",
+				Message:            "All references resolved",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: generation,
+			},
+		},
+	}
+}
+
+// StatusFunc is a function that creates a RouteParentStatus for a given parent ref and generation
+type StatusFunc func(parentRef gwapiv1.ParentReference, generation int64) gwapiv1.RouteParentStatus
+
+// WithHTTPRouteMultipleControllerStatus sets HTTPRoute status with multiple controllers
+// This simulates real-world scenarios where policy controllers and gateway controllers
+// both add status entries for the same parent ref
+func WithHTTPRouteMultipleControllerStatus(parentRef gwapiv1.ParentReference, statusFuncs ...StatusFunc) HTTPRouteOption {
+	return func(route *gwapiv1.HTTPRoute) {
+		for _, statusFunc := range statusFuncs {
+			status := statusFunc(parentRef, route.Generation)
+			route.Status.RouteStatus.Parents = append(route.Status.RouteStatus.Parents, status)
 		}
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -502,7 +502,7 @@ func (r *LLMISVCReconciler) EvaluateHTTPRouteConditions(ctx context.Context, llm
 	if len(notReadyRoutes) > 0 {
 		nonReadyRouteMessages := make([]string, len(notReadyRoutes))
 		for i, route := range notReadyRoutes {
-			topLevelCondition, _ := nonReadyHTTPRouteTopLevelCondition(route)
+			topLevelCondition := findNonReadyGatewayCondition(route)
 			if topLevelCondition != nil {
 				nonReadyRouteMessages[i] = fmt.Sprintf("%s/%s: %#v (reason %q, message %q)", route.Namespace, route.Name, topLevelCondition.Status, topLevelCondition.Reason, topLevelCondition.Message)
 			} else {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -310,51 +310,101 @@ func IsHTTPRouteReady(route *gwapiv1.HTTPRoute) bool {
 		return false
 	}
 
-	if cond, missing := nonReadyHTTPRouteTopLevelCondition(route); cond != nil || missing {
-		return false
+	// Check that every spec ParentRef has at least one corresponding status entry.
+	// Multiple controllers may write separate status entries for the same ParentRef,
+	// so we only require that at least one entry exists per spec ref.
+	for _, specRef := range route.Spec.ParentRefs {
+		if !hasMatchingParentStatus(specRef, route.Status.RouteStatus.Parents) {
+			return false
+		}
 	}
 
-	return true
+	return areGatewayConditionsReady(route)
 }
 
-// nonReadyHTTPRouteTopLevelCondition checks for any non-ready conditions in an HTTPRoute
-// Returns the first problematic condition found, or indicates if any conditions are missing
-// A condition is considered stale if its ObservedGeneration is less than the route's current Generation
-func nonReadyHTTPRouteTopLevelCondition(route *gwapiv1.HTTPRoute) (*metav1.Condition, bool) {
-	if route == nil {
-		return nil, true
+// hasMatchingParentStatus checks whether at least one RouteParentStatus entry
+// corresponds to the given spec ParentReference and was written by a gateway
+// controller (i.e., has the Accepted condition set). Policy or extension
+// controllers may also write status entries for the same ParentRef but without
+// setting the Accepted condition, so those entries alone are not sufficient.
+func hasMatchingParentStatus(specRef gwapiv1.ParentReference, parents []gwapiv1.RouteParentStatus) bool {
+	for i := range parents {
+		if parentRefMatches(specRef, parents[i].ParentRef) &&
+			meta.FindStatusCondition(parents[i].Conditions, string(gwapiv1.RouteConditionAccepted)) != nil {
+			return true
+		}
 	}
+	return false
+}
 
-	routeConditionAcceptedMissing := true
+// parentRefMatches returns true when two ParentReferences identify the same parent,
+// applying Gateway API defaulting rules for optional fields.
+// Note: Namespace comparison uses empty string default. In practice, both spec and status
+// refs should have consistent namespace handling (either both explicit or both implicit).
+func parentRefMatches(a, b gwapiv1.ParentReference) bool {
+	return a.Name == b.Name &&
+		ptr.Deref(a.Group, gwapiv1.GroupName) == ptr.Deref(b.Group, gwapiv1.GroupName) &&
+		ptr.Deref(a.Kind, "Gateway") == ptr.Deref(b.Kind, "Gateway") &&
+		ptr.Deref(a.Namespace, "") == ptr.Deref(b.Namespace, "") &&
+		ptr.Deref(a.SectionName, "") == ptr.Deref(b.SectionName, "") &&
+		ptr.Deref(a.Port, 0) == ptr.Deref(b.Port, 0)
+}
 
+// areGatewayConditionsReady reports whether all gateway controller entries in the
+// HTTPRoute's status have Accepted and ResolvedRefs set to True and up-to-date.
+// Status entries without the Accepted condition (e.g. from policy controllers) are skipped.
+// A condition is stale when its ObservedGeneration is less than the route's Generation.
+func areGatewayConditionsReady(route *gwapiv1.HTTPRoute) bool {
+	if route == nil {
+		return false
+	}
 	for _, parent := range route.Status.RouteStatus.Parents {
 		acceptedCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionAccepted))
 		if acceptedCond == nil {
-			// This can happen when multiple controllers write to the HTTPRoute status. For example, in addition
-			// to the Gateway controller, policy or extension controllers may append their own conditions to
-			// a ParentRef without setting the RouteConditionAccepted condition themselves, so we simply skip
-			// such parents here and continue checking other entries.
 			continue
 		}
-		routeConditionAcceptedMissing = false
-		staleCondition := acceptedCond.ObservedGeneration > 0 && acceptedCond.ObservedGeneration < route.Generation
-		if acceptedCond.Status != metav1.ConditionTrue || staleCondition {
-			return acceptedCond, false
+		stale := acceptedCond.ObservedGeneration > 0 && acceptedCond.ObservedGeneration < route.Generation
+		if acceptedCond.Status != metav1.ConditionTrue || stale {
+			return false
 		}
-
 		resolvedRefCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionResolvedRefs))
 		if resolvedRefCond == nil {
-			// Unlike Accepted, we only reach here for gateway controller parents (Accepted was found).
-			// A gateway controller should always set ResolvedRefs. If missing, the route is not ready.
-			return nil, true
+			return false
 		}
-		staleCondition = resolvedRefCond.ObservedGeneration > 0 && resolvedRefCond.ObservedGeneration < route.Generation
-		if resolvedRefCond.Status != metav1.ConditionTrue || staleCondition {
-			return resolvedRefCond, false
+		stale = resolvedRefCond.ObservedGeneration > 0 && resolvedRefCond.ObservedGeneration < route.Generation
+		if resolvedRefCond.Status != metav1.ConditionTrue || stale {
+			return false
 		}
 	}
+	return true
+}
 
-	return nil, routeConditionAcceptedMissing
+// findNonReadyGatewayCondition returns the first non-ready or stale condition from a
+// gateway controller entry in the HTTPRoute's status, or nil if none found.
+// Status entries without the Accepted condition (e.g. from policy controllers) are skipped.
+func findNonReadyGatewayCondition(route *gwapiv1.HTTPRoute) *metav1.Condition {
+	if route == nil {
+		return nil
+	}
+	for _, parent := range route.Status.RouteStatus.Parents {
+		acceptedCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionAccepted))
+		if acceptedCond == nil {
+			continue
+		}
+		stale := acceptedCond.ObservedGeneration > 0 && acceptedCond.ObservedGeneration < route.Generation
+		if acceptedCond.Status != metav1.ConditionTrue || stale {
+			return acceptedCond
+		}
+		resolvedRefCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionResolvedRefs))
+		if resolvedRefCond == nil {
+			continue
+		}
+		stale = resolvedRefCond.ObservedGeneration > 0 && resolvedRefCond.ObservedGeneration < route.Generation
+		if resolvedRefCond.Status != metav1.ConditionTrue || stale {
+			return resolvedRefCond
+		}
+	}
+	return nil
 }
 
 // IsInferencePoolReady checks if an InferencePool has been accepted by all parents

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -344,7 +344,9 @@ func nonReadyHTTPRouteTopLevelCondition(route *gwapiv1.HTTPRoute) (*metav1.Condi
 
 		resolvedRefCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionResolvedRefs))
 		if resolvedRefCond == nil {
-			continue
+			// Unlike Accepted, we only reach here for gateway controller parents (Accepted was found).
+			// A gateway controller should always set ResolvedRefs. If missing, the route is not ready.
+			return nil, true
 		}
 		staleCondition = resolvedRefCond.ObservedGeneration > 0 && resolvedRefCond.ObservedGeneration < route.Generation
 		if resolvedRefCond.Status != metav1.ConditionTrue || staleCondition {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -330,9 +330,10 @@ func nonReadyHTTPRouteTopLevelCondition(route *gwapiv1.HTTPRoute) (*metav1.Condi
 	for _, parent := range route.Status.RouteStatus.Parents {
 		acceptedCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionAccepted))
 		if acceptedCond == nil {
-			// This can happen when multiple controllers write to the status, e.g., besides the gateway controller, there
-			// are conditions reported from the policy controller.
-			// See example https://gist.github.com/bartoszmajsak/4329206afe107357afdcb9b92ed778bd
+			// This can happen when multiple controllers write to the HTTPRoute status. For example, in addition
+			// to the Gateway controller, policy or extension controllers may append their own conditions to
+			// a ParentRef without setting the RouteConditionAccepted condition themselves, so we simply skip
+			// such parents here and continue checking other entries.
 			continue
 		}
 		routeConditionAcceptedMissing = false

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -310,13 +310,6 @@ func IsHTTPRouteReady(route *gwapiv1.HTTPRoute) bool {
 		return false
 	}
 
-	// Check that all parent references have corresponding status entries
-	if len(route.Status.RouteStatus.Parents) != len(route.Spec.ParentRefs) {
-		// HTTPRoute is ready only when _all_ parents have accepted the route.
-		return false
-	}
-
-	// Check for any non-ready conditions across all parents
 	if cond, missing := nonReadyHTTPRouteTopLevelCondition(route); cond != nil || missing {
 		return false
 	}
@@ -332,14 +325,17 @@ func nonReadyHTTPRouteTopLevelCondition(route *gwapiv1.HTTPRoute) (*metav1.Condi
 		return nil, true
 	}
 
+	routeConditionAcceptedMissing := true
+
 	for _, parent := range route.Status.RouteStatus.Parents {
-		// Look for the "Accepted" condition which indicates Gateway acceptance
 		acceptedCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionAccepted))
 		if acceptedCond == nil {
-			// Missing condition indicates the route is not ready
-			return nil, true
+			// This can happen when multiple controllers write to the status, e.g., besides the gateway controller, there
+			// are conditions reported from the policy controller.
+			// See example https://gist.github.com/bartoszmajsak/4329206afe107357afdcb9b92ed778bd
+			continue
 		}
-		// Check if condition is stale (based on older generation)
+		routeConditionAcceptedMissing = false
 		staleCondition := acceptedCond.ObservedGeneration > 0 && acceptedCond.ObservedGeneration < route.Generation
 		if acceptedCond.Status != metav1.ConditionTrue || staleCondition {
 			return acceptedCond, false
@@ -347,18 +343,15 @@ func nonReadyHTTPRouteTopLevelCondition(route *gwapiv1.HTTPRoute) (*metav1.Condi
 
 		resolvedRefCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionResolvedRefs))
 		if resolvedRefCond == nil {
-			// Missing condition indicates the route is not ready
-			return nil, true
+			continue
 		}
-
-		// Check if condition is stale (based on older generation)
 		staleCondition = resolvedRefCond.ObservedGeneration > 0 && resolvedRefCond.ObservedGeneration < route.Generation
 		if resolvedRefCond.Status != metav1.ConditionTrue || staleCondition {
 			return resolvedRefCond, false
 		}
 	}
 
-	return nil, false
+	return nil, routeConditionAcceptedMissing
 }
 
 // IsInferencePoolReady checks if an InferencePool has been accepted by all parents

--- a/pkg/controller/v1alpha2/llmisvc/router_gateway_conditions_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_gateway_conditions_test.go
@@ -1,0 +1,589 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+func TestGatewayConditionsEvaluation(t *testing.T) {
+	tests := []struct {
+		name             string
+		llmSvc           *v1alpha2.LLMInferenceService
+		gateways         []*gwapiv1.Gateway
+		expectedErrorMsg string
+		assertCondition  func(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc
+	}{
+		{
+			name: "single ready gateway - router should be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithGatewayRefs(v1alpha2.UntypedObjectReference{
+					Name:      "ready-gateway",
+					Namespace: "test-ns",
+				}),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("ready-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.1"),
+					WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway is ready"),
+				),
+			},
+			assertCondition: assertRouterReady,
+		},
+		{
+			name: "single not ready gateway - router should not be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithGatewayRefs(v1alpha2.UntypedObjectReference{
+					Name:      "not-ready-gateway",
+					Namespace: "test-ns",
+				}),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("not-ready-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.1"),
+					WithProgrammedCondition(metav1.ConditionFalse, "NotReady", "Gateway is not ready"),
+				),
+			},
+			assertCondition: func(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, gatewayCondition, "GatewaysNotReady")
+			},
+		},
+		{
+			name: "multiple gateways - all ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithGatewayRefs(
+					v1alpha2.UntypedObjectReference{Name: "gateway-1", Namespace: "test-ns"},
+					v1alpha2.UntypedObjectReference{Name: "gateway-2", Namespace: "test-ns"},
+				),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("gateway-1",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway 1 is ready"),
+				),
+				Gateway("gateway-2",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway 2 is ready"),
+				),
+			},
+			assertCondition: assertRouterReady,
+		},
+		{
+			name: "multiple gateways - some not ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithGatewayRefs(
+					v1alpha2.UntypedObjectReference{Name: "ready-gateway", Namespace: "test-ns"},
+					v1alpha2.UntypedObjectReference{Name: "not-ready-gateway", Namespace: "test-ns"},
+				),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("ready-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway is ready"),
+				),
+				Gateway("not-ready-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithProgrammedCondition(metav1.ConditionFalse, "NotReady", "Gateway is not ready"),
+				),
+			},
+			assertCondition: func(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, gatewayCondition, "GatewaysNotReady")
+			},
+		},
+		{
+			name: "gateway with no programmed condition - should be not ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithGatewayRefs(v1alpha2.UntypedObjectReference{
+					Name:      "no-condition-gateway",
+					Namespace: "test-ns",
+				}),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("no-condition-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					// No programmed condition set
+				),
+			},
+			assertCondition: func(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, gatewayCondition, "GatewaysNotReady")
+			},
+		},
+		{
+			name: "gateway not found - should return error",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithGatewayRefs(v1alpha2.UntypedObjectReference{
+					Name:      "missing-gateway",
+					Namespace: "test-ns",
+				}),
+			),
+			gateways:         []*gwapiv1.Gateway{},
+			expectedErrorMsg: "failed to get Gateway",
+		},
+		{
+			name: "no gateway refs - should skip evaluation",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				// No gateway refs
+			),
+			gateways:        []*gwapiv1.Gateway{},
+			assertCondition: assertConditionUnset,
+		},
+		{
+			name: "gateway without namespace uses LLMInferenceService namespace",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithGatewayRefs(v1alpha2.UntypedObjectReference{
+					Name: "same-ns-gateway",
+					// Namespace omitted - should use test-ns
+				}),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("same-ns-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway is ready"),
+				),
+			},
+			assertCondition: assertRouterReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctx := t.Context()
+
+			scheme := runtime.NewScheme()
+			err := v1alpha2.AddToScheme(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+			err = gwapiv1.Install(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var objects []client.Object
+			objects = append(objects, tt.llmSvc)
+			for _, gw := range tt.gateways {
+				objects = append(objects, gw)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			reconciler := &llmisvc.LLMISVCReconciler{
+				Client: fakeClient,
+			}
+
+			err = reconciler.EvaluateGatewayConditions(ctx, tt.llmSvc)
+
+			if tt.expectedErrorMsg != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErrorMsg))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			tt.llmSvc.DetermineRouterReadiness()
+
+			routerCondition := tt.llmSvc.GetStatus().GetCondition(v1alpha2.RouterReady)
+			gatewayCondition := tt.llmSvc.GetStatus().GetCondition(v1alpha2.GatewaysReady)
+
+			if tt.assertCondition != nil {
+				tt.assertCondition(routerCondition, gatewayCondition)(g)
+			}
+		})
+	}
+}
+
+func TestIsGatewayReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		gateway  *gwapiv1.Gateway
+		expected bool
+	}{
+		{
+			name: "gateway with programmed condition true - should be ready",
+			gateway: Gateway("test-gateway",
+				WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway is ready"),
+			),
+			expected: true,
+		},
+		{
+			name: "gateway with programmed condition false - should not be ready",
+			gateway: Gateway("test-gateway",
+				WithProgrammedCondition(metav1.ConditionFalse, "NotReady", "Gateway is not ready"),
+			),
+			expected: false,
+		},
+		{
+			name: "gateway with programmed condition unknown - should not be ready",
+			gateway: Gateway("test-gateway",
+				WithProgrammedCondition(metav1.ConditionUnknown, "Unknown", "Gateway status unknown"),
+			),
+			expected: false,
+		},
+		{
+			name: "gateway with no conditions - should not be ready",
+			gateway: Gateway("test-gateway",
+				WithListener(gwapiv1.HTTPProtocolType),
+			),
+			expected: false,
+		},
+		{
+			name: "gateway with other conditions but no programmed - should not be ready",
+			gateway: Gateway("test-gateway",
+				WithGatewayCondition("Accepted", metav1.ConditionTrue, "Accepted", "Gateway accepted"),
+			),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			result := llmisvc.IsGatewayReady(tt.gateway)
+
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestHTTPRouteConditionsEvaluation(t *testing.T) {
+	tests := []struct {
+		name             string
+		llmSvc           *v1alpha2.LLMInferenceService
+		httpRoutes       []*gwapiv1.HTTPRoute
+		expectedErrorMsg string
+		createAssertion  func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc
+	}{
+		{
+			name: "HTTPRoute with multiple controllers - should be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("llm"),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithHTTPRouteRefs(HTTPRouteRef("facebook-opt-125m-single-simulated-kserve-route")),
+			),
+			httpRoutes: []*gwapiv1.HTTPRoute{
+				HTTPRoute("facebook-opt-125m-single-simulated-kserve-route",
+					InNamespace[*gwapiv1.HTTPRoute]("llm"),
+					WithParentRefs(GatewayParentRef("openshift-ai-inference", "openshift-ingress")),
+					WithHTTPRule(
+						Matches(PathPrefixMatch("/llm/facebook-opt-125m-single-simulated")),
+						BackendRefs(ServiceRef("facebook-opt-125m-single-simulated-kserve-workload-svc", 8000, 1)),
+						Timeouts("0s", "0s"),
+						Filters(gwapiv1.HTTPRouteFilter{
+							Type: gwapiv1.HTTPRouteFilterURLRewrite,
+							URLRewrite: &gwapiv1.HTTPURLRewriteFilter{
+								Path: &gwapiv1.HTTPPathModifier{
+									Type:               gwapiv1.PrefixMatchHTTPPathModifier,
+									ReplacePrefixMatch: ptr.To("/"),
+								},
+							},
+						}),
+					),
+					WithHTTPRouteMultipleControllerStatus(
+						GatewayParentRef("openshift-ai-inference", "openshift-ingress"),
+						KuadrantControllerStatus,
+						GatewayAPIControllerStatus,
+					),
+				),
+			},
+			createAssertion: assertRouterReady,
+		},
+		{
+			name: "HTTPRoute with standard controller only - should be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteRefs(HTTPRouteRef("test-route")),
+			),
+			httpRoutes: []*gwapiv1.HTTPRoute{
+				HTTPRoute("test-route",
+					InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+					WithHTTPRouteReadyStatus("openshift.io/gateway-controller/v1"),
+				),
+			},
+			createAssertion: assertRouterReady,
+		},
+		{
+			name: "HTTPRoute not ready - should not be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteRefs(HTTPRouteRef("not-ready-route")),
+			),
+			httpRoutes: []*gwapiv1.HTTPRoute{
+				HTTPRoute("not-ready-route",
+					InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+					WithHTTPRouteNotReadyStatus("openshift.io/gateway-controller/v1", "NotAccepted", "Route was not accepted"),
+				),
+			},
+			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "HTTPRoutesNotReady")
+			},
+		},
+		{
+			name: "no HTTPRoute refs - should skip evaluation",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				// No HTTPRoute refs
+			),
+			httpRoutes:      []*gwapiv1.HTTPRoute{},
+			createAssertion: assertHTTPRouteConditionUnset,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctx := t.Context()
+
+			scheme := runtime.NewScheme()
+			err := v1alpha2.AddToScheme(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+			err = gwapiv1.Install(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var objects []client.Object
+			objects = append(objects, tt.llmSvc)
+			for _, route := range tt.httpRoutes {
+				objects = append(objects, route)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			reconciler := &llmisvc.LLMISVCReconciler{
+				Client: fakeClient,
+			}
+
+			err = reconciler.EvaluateHTTPRouteConditions(ctx, tt.llmSvc)
+
+			if tt.expectedErrorMsg != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErrorMsg))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			tt.llmSvc.DetermineRouterReadiness()
+
+			routerCondition := tt.llmSvc.GetStatus().GetCondition(v1alpha2.RouterReady)
+			httpRouteCondition := tt.llmSvc.GetStatus().GetCondition(v1alpha2.HTTPRoutesReady)
+
+			if tt.createAssertion != nil {
+				tt.createAssertion(routerCondition, httpRouteCondition)(g)
+			}
+		})
+	}
+}
+
+func TestFetchReferencedGateways(t *testing.T) {
+	tests := []struct {
+		name          string
+		llmSvc        *v1alpha2.LLMInferenceService
+		gateways      []*gwapiv1.Gateway
+		expectedCount int
+		expectedError string
+	}{
+		{
+			name: "fetch single gateway successfully",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithGatewayRefs(v1alpha2.UntypedObjectReference{
+					Name:      "test-gateway",
+					Namespace: "test-ns",
+				}),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway", InNamespace[*gwapiv1.Gateway]("test-ns")),
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "fetch multiple gateways successfully",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithGatewayRefs(
+					v1alpha2.UntypedObjectReference{Name: "gateway-1", Namespace: "test-ns"},
+					v1alpha2.UntypedObjectReference{Name: "gateway-2", Namespace: "other-ns"},
+				),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("gateway-1", InNamespace[*gwapiv1.Gateway]("test-ns")),
+				Gateway("gateway-2", InNamespace[*gwapiv1.Gateway]("other-ns")),
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "gateway not found - should return error",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithGatewayRefs(v1alpha2.UntypedObjectReference{
+					Name:      "missing-gateway",
+					Namespace: "test-ns",
+				}),
+			),
+			gateways:      []*gwapiv1.Gateway{},
+			expectedCount: 0,
+			expectedError: "failed to get Gateway",
+		},
+		{
+			name: "no gateway refs - should return empty slice",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				// No gateway refs
+			),
+			gateways:      []*gwapiv1.Gateway{},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctx := t.Context()
+
+			scheme := runtime.NewScheme()
+			err := v1alpha2.AddToScheme(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+			err = gwapiv1.Install(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var objects []client.Object
+			objects = append(objects, tt.llmSvc)
+			for _, gw := range tt.gateways {
+				objects = append(objects, gw)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			reconciler := &llmisvc.LLMISVCReconciler{
+				Client: fakeClient,
+			}
+
+			gateways, err := reconciler.CollectReferencedGateways(ctx, tt.llmSvc)
+
+			if tt.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedError))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(gateways).To(HaveLen(tt.expectedCount))
+		})
+	}
+}
+
+// assertConditionsFunc defines the signature for condition assertion functions
+type assertConditionsFunc func(g *WithT)
+
+// assertConditionUnset returns a function that verifies the router is ready but gateway condition is not set
+func assertConditionUnset(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
+		g.Expect(gatewayCondition).To(BeNil(), "Gateway condition should not be set when no gateway refs")
+	}
+}
+
+// assertRouterReady returns a function that verifies both router and gateway conditions are set and ready
+func assertRouterReady(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition).ToNot(BeNil(), "Router condition should be set")
+		g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
+		g.Expect(gatewayCondition).ToNot(BeNil(), "Gateway condition should be set")
+		g.Expect(gatewayCondition.IsTrue()).To(BeTrue(), "Gateways should be ready")
+	}
+}
+
+// assertRouterNotReady returns a function that verifies both router and gateway conditions are set but not ready
+func assertRouterNotReady(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition).ToNot(BeNil(), "Router condition should be set")
+		g.Expect(routerCondition.IsFalse()).To(BeTrue(), "Router should not be ready")
+		g.Expect(gatewayCondition).ToNot(BeNil(), "Gateway condition should be set")
+		g.Expect(gatewayCondition.IsFalse()).To(BeTrue(), "Gateways should not be ready")
+	}
+}
+
+// assertRouterNotReadyWithReason returns a function that verifies conditions are not ready and checks the reason
+func assertRouterNotReadyWithReason(routerCondition, gatewayCondition *apis.Condition, expectedReason string) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition).ToNot(BeNil(), "Router condition should be set")
+		g.Expect(routerCondition.IsFalse()).To(BeTrue(), "Router should not be ready")
+		g.Expect(gatewayCondition).ToNot(BeNil(), "Gateway condition should be set")
+		g.Expect(gatewayCondition.IsFalse()).To(BeTrue(), "Gateways should not be ready")
+		g.Expect(routerCondition.Reason).To(Equal(gatewayCondition.Reason))
+		g.Expect(routerCondition.Reason).To(Equal(expectedReason))
+	}
+}
+
+// assertHTTPRouteConditionUnset returns a function that verifies the router is ready and HTTPRoute condition is cleared
+func assertHTTPRouteConditionUnset(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
+		g.Expect(httpRouteCondition).To(BeNil(), "HTTPRoute condition should not be set when no HTTPRoute refs")
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_gateway_conditions_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_gateway_conditions_test.go
@@ -386,6 +386,56 @@ func TestHTTPRouteConditionsEvaluation(t *testing.T) {
 			httpRoutes:      []*gwapiv1.HTTPRoute{},
 			createAssertion: assertHTTPRouteConditionUnset,
 		},
+		{
+			name: "HTTPRoute with only policy-controller status (no Accepted) - should not be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteRefs(HTTPRouteRef("policy-only-route")),
+			),
+			httpRoutes: []*gwapiv1.HTTPRoute{
+				HTTPRoute("policy-only-route",
+					InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+					WithHTTPRouteMultipleControllerStatus(
+						GatewayParentRef("test-gateway", "test-ns"),
+						KuadrantControllerStatus, // Only policy controller, no gateway controller
+					),
+				),
+			},
+			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "HTTPRoutesNotReady")
+			},
+		},
+		{
+			name: "HTTPRoute with Accepted=True but ResolvedRefs missing - should not be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteRefs(HTTPRouteRef("accepted-no-resolved-route")),
+			),
+			httpRoutes: []*gwapiv1.HTTPRoute{
+				HTTPRoute("accepted-no-resolved-route",
+					InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+					WithHTTPRouteParentStatus(
+						GatewayParentRef("test-gateway", "test-ns"),
+						"openshift.io/gateway-controller/v1",
+						metav1.Condition{
+							Type:               string(gwapiv1.RouteConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             "Accepted",
+							Message:            "Route was valid",
+							LastTransitionTime: metav1.Now(),
+						},
+						// ResolvedRefs intentionally omitted
+					),
+				),
+			},
+			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "HTTPRoutesNotReady")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controller/v1alpha2/llmisvc/router_gateway_conditions_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_gateway_conditions_test.go
@@ -486,6 +486,128 @@ func TestHTTPRouteConditionsEvaluation(t *testing.T) {
 	}
 }
 
+func TestIsHTTPRouteReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    *gwapiv1.HTTPRoute
+		expected bool
+	}{
+		{
+			name:     "nil route",
+			route:    nil,
+			expected: false,
+		},
+		{
+			name: "no parent refs",
+			route: HTTPRoute("empty-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+			),
+			expected: false,
+		},
+		{
+			name: "single parent ref - ready",
+			route: HTTPRoute("ready-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRefs(GatewayParentRef("gw", "test-ns")),
+				WithHTTPRouteReadyStatus("controller"),
+			),
+			expected: true,
+		},
+		{
+			name: "single parent ref with multiple controllers - ready",
+			route: HTTPRoute("multi-ctrl-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRefs(GatewayParentRef("gw", "test-ns")),
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayParentRef("gw", "test-ns"),
+					KuadrantControllerStatus,
+					GatewayAPIControllerStatus,
+				),
+			),
+			expected: true,
+		},
+		{
+			name: "multiple parent refs - all have status - ready",
+			route: HTTPRoute("multi-parent-ready",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRefs(
+					GatewayParentRef("gw-a", "test-ns"),
+					GatewayParentRef("gw-b", "test-ns"),
+				),
+				WithHTTPRouteParentStatus(
+					GatewayParentRef("gw-a", "test-ns"), "controller",
+					metav1.Condition{Type: string(gwapiv1.RouteConditionAccepted), Status: metav1.ConditionTrue, Reason: "Accepted", LastTransitionTime: metav1.Now()},
+					metav1.Condition{Type: string(gwapiv1.RouteConditionResolvedRefs), Status: metav1.ConditionTrue, Reason: "ResolvedRefs", LastTransitionTime: metav1.Now()},
+				),
+				WithHTTPRouteParentStatus(
+					GatewayParentRef("gw-b", "test-ns"), "controller",
+					metav1.Condition{Type: string(gwapiv1.RouteConditionAccepted), Status: metav1.ConditionTrue, Reason: "Accepted", LastTransitionTime: metav1.Now()},
+					metav1.Condition{Type: string(gwapiv1.RouteConditionResolvedRefs), Status: metav1.ConditionTrue, Reason: "ResolvedRefs", LastTransitionTime: metav1.Now()},
+				),
+			),
+			expected: true,
+		},
+		{
+			name: "single parent ref with Accepted=False - not ready",
+			route: HTTPRoute("rejected-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRefs(GatewayParentRef("gw", "test-ns")),
+				WithHTTPRouteParentStatus(
+					GatewayParentRef("gw", "test-ns"), "controller",
+					metav1.Condition{Type: string(gwapiv1.RouteConditionAccepted), Status: metav1.ConditionFalse, Reason: "NotAllowed", LastTransitionTime: metav1.Now()},
+				),
+			),
+			expected: false,
+		},
+		{
+			name: "multiple parent refs - one has no status entry - not ready",
+			route: HTTPRoute("multi-parent-partial",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRefs(
+					GatewayParentRef("gw-a", "test-ns"),
+					GatewayParentRef("gw-b", "test-ns"),
+				),
+				// Only gw-a has a status entry; gw-b has none
+				WithHTTPRouteParentStatus(
+					GatewayParentRef("gw-a", "test-ns"), "controller",
+					metav1.Condition{Type: string(gwapiv1.RouteConditionAccepted), Status: metav1.ConditionTrue, Reason: "Accepted", LastTransitionTime: metav1.Now()},
+					metav1.Condition{Type: string(gwapiv1.RouteConditionResolvedRefs), Status: metav1.ConditionTrue, Reason: "ResolvedRefs", LastTransitionTime: metav1.Now()},
+				),
+			),
+			expected: false,
+		},
+		{
+			name: "multiple parent refs - one has only policy controller status - not ready",
+			route: HTTPRoute("multi-parent-policy-only",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRefs(
+					GatewayParentRef("gw-a", "test-ns"),
+					GatewayParentRef("gw-b", "test-ns"),
+				),
+				// gw-a: gateway controller ready
+				WithHTTPRouteParentStatus(
+					GatewayParentRef("gw-a", "test-ns"), "controller",
+					metav1.Condition{Type: string(gwapiv1.RouteConditionAccepted), Status: metav1.ConditionTrue, Reason: "Accepted", LastTransitionTime: metav1.Now()},
+					metav1.Condition{Type: string(gwapiv1.RouteConditionResolvedRefs), Status: metav1.ConditionTrue, Reason: "ResolvedRefs", LastTransitionTime: metav1.Now()},
+				),
+				// gw-b: only a policy controller entry, no gateway controller status
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayParentRef("gw-b", "test-ns"),
+					KuadrantControllerStatus,
+				),
+			),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(llmisvc.IsHTTPRouteReady(tt.route)).To(Equal(tt.expected))
+		})
+	}
+}
+
 func TestFetchReferencedGateways(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
When multiple controllers (e.g. Kuadrant policy controller alongside the gateway controller) write to the HTTPRoute status, the current logic fails to recognize it, expecting status only from the gateway controller, with top-level standard condition `Accepted` being `true`.

This change handles the scenario of the status with multiple controllers updates, adjusting the logic to check for the standard condition.

Port of opendatahub-io/kserve#908.