### PR TITLE
fix(llmisvc): move gateway ref update to config merge phase

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -1760,3 +1760,149 @@ spec:
 		})
 	}
 }
+
+func TestToParentRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		refs []v1alpha2.UntypedObjectReference
+		want []gwapiv1.ParentReference
+	}{
+		{
+			name: "single gateway ref",
+			refs: []v1alpha2.UntypedObjectReference{
+				{Name: "my-gateway", Namespace: "my-ns"},
+			},
+			want: []gwapiv1.ParentReference{
+				{
+					Name:      "my-gateway",
+					Namespace: ptr.To(gwapiv1.Namespace("my-ns")),
+					Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+					Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+				},
+			},
+		},
+		{
+			name: "multiple gateway refs",
+			refs: []v1alpha2.UntypedObjectReference{
+				{Name: "gw-1", Namespace: "ns-1"},
+				{Name: "gw-2", Namespace: "ns-2"},
+			},
+			want: []gwapiv1.ParentReference{
+				{
+					Name:      "gw-1",
+					Namespace: ptr.To(gwapiv1.Namespace("ns-1")),
+					Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+					Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+				},
+				{
+					Name:      "gw-2",
+					Namespace: ptr.To(gwapiv1.Namespace("ns-2")),
+					Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+					Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+				},
+			},
+		},
+		{
+			name: "gateway ref with empty namespace",
+			refs: []v1alpha2.UntypedObjectReference{
+				{Name: "my-gateway", Namespace: ""},
+			},
+			want: []gwapiv1.ParentReference{
+				{
+					Name:      "my-gateway",
+					Namespace: ptr.To(gwapiv1.Namespace("")),
+					Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+					Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+				},
+			},
+		},
+		{
+			name: "empty refs returns empty slice",
+			refs: []v1alpha2.UntypedObjectReference{},
+			want: []gwapiv1.ParentReference{},
+		},
+		{
+			name: "nil refs returns empty slice",
+			refs: nil,
+			want: []gwapiv1.ParentReference{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llmisvc.ToParentRefs(tt.refs)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ToParentRefs() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParentRefRewritingGuard(t *testing.T) {
+	tests := []struct {
+		name             string
+		gatewayHasRefs   bool
+		httpRouteHasSpec bool
+		wantRewrite      bool
+	}{
+		{
+			name:             "gateway refs + route spec -> rewrite",
+			gatewayHasRefs:   true,
+			httpRouteHasSpec: true,
+			wantRewrite:      true,
+		},
+		{
+			name:             "gateway refs + route refs (no spec) -> skip rewrite",
+			gatewayHasRefs:   true,
+			httpRouteHasSpec: false,
+			wantRewrite:      false,
+		},
+		{
+			name:             "no gateway refs + route spec -> skip rewrite",
+			gatewayHasRefs:   false,
+			httpRouteHasSpec: true,
+			wantRewrite:      false,
+		},
+		{
+			name:             "no gateway refs + no route spec -> skip rewrite",
+			gatewayHasRefs:   false,
+			httpRouteHasSpec: false,
+			wantRewrite:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gateway := &v1alpha2.GatewaySpec{}
+			if tt.gatewayHasRefs {
+				gateway.Refs = []v1alpha2.UntypedObjectReference{
+					{Name: "my-gw", Namespace: "my-ns"},
+				}
+			}
+
+			httpRoute := &v1alpha2.HTTPRouteSpec{}
+			if tt.httpRouteHasSpec {
+				httpRoute.Spec = &gwapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1.CommonRouteSpec{
+						ParentRefs: []gwapiv1.ParentReference{
+							{Name: "old-default-gateway"},
+						},
+					},
+				}
+			} else {
+				httpRoute.Refs = []corev1.LocalObjectReference{{Name: "my-route"}}
+			}
+
+			shouldRewrite := httpRoute.HasSpec() && gateway.HasRefs()
+			if shouldRewrite != tt.wantRewrite {
+				t.Errorf("expected rewrite=%v, got %v", tt.wantRewrite, shouldRewrite)
+			}
+
+			if shouldRewrite {
+				parentRefs := llmisvc.ToParentRefs(gateway.Refs)
+				if len(parentRefs) != len(gateway.Refs) {
+					t.Errorf("expected %d parent refs, got %d", len(gateway.Refs), len(parentRefs))
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -901,6 +901,119 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		})
 	})
 
+	Context("Custom Gateway Reference", func() {
+		It("should not require default gateway when custom gateway is specified", func(ctx SpecContext) {
+			// given - remove the default gateway
+			defaultGateway := &gwapiv1.Gateway{}
+			Expect(envTest.Client.Get(ctx, types.NamespacedName{
+				Name:      constants.GatewayName,
+				Namespace: constants.KServeNamespace,
+			}, defaultGateway)).To(Succeed())
+
+			gatewayToRestore := defaultGateway.DeepCopy()
+			gatewayToRestore.ResourceVersion = "" // Clear for re-creation
+
+			DeferCleanup(func(ctx context.Context) {
+				// Restore the default gateway after the test (pass or fail)
+				existing := &gwapiv1.Gateway{}
+				err := envTest.Client.Get(ctx, types.NamespacedName{
+					Name:      constants.GatewayName,
+					Namespace: constants.KServeNamespace,
+				}, existing)
+				if err == nil {
+					// Gateway already exists, no restoration needed.
+					return
+				}
+				// Whether NotFound or transient error, attempt to restore.
+				Expect(client.IgnoreAlreadyExists(envTest.Client.Create(ctx, gatewayToRestore))).To(Succeed())
+			})
+
+			Expect(envTest.Client.Delete(ctx, defaultGateway)).To(Succeed())
+
+			// Ensure the default gateway is actually deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Client.Get(ctx, types.NamespacedName{
+					Name:      constants.GatewayName,
+					Namespace: constants.KServeNamespace,
+				}, &gwapiv1.Gateway{})
+				return errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "default gateway should be deleted")
+
+			// Create test namespace
+			svcName := "test-llm-custom-gateway"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			customGatewayName := "my-custom-gateway"
+			customGateway := Gateway(customGatewayName,
+				InNamespace[*gwapiv1.Gateway](nsName),
+				WithListener(gwapiv1.HTTPProtocolType),
+				WithAddresses("203.0.113.42"),
+			)
+			Expect(envTest.Client.Create(ctx, customGateway)).To(Succeed())
+			ensureGatewayReady(ctx, envTest.Client, customGateway)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithGatewayRefs(LLMGatewayRef(customGatewayName, nsName)),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// Wait for HTTPRoute to be created and verify it references the custom gateway
+			var createdRoute *gwapiv1.HTTPRoute
+			Eventually(func(g Gomega, ctx context.Context) error {
+				routes, errList := managedRoutes(ctx, llmSvc)
+				g.Expect(errList).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				g.Expect(&routes[0]).To(HaveGatewayRefs(gwapiv1.ParentReference{
+					Name:      gwapiv1.ObjectName(customGatewayName),
+					Namespace: ptr.To(gwapiv1.Namespace(nsName)),
+				}))
+
+				createdRoute = &routes[0]
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "HTTPRoute should reference the custom gateway")
+
+			// Simulate gateway controller setting HTTPRoute status
+			ensureHTTPRouteReady(ctx, envTest.Client, createdRoute)
+
+			// then - inspect status
+			Eventually(func(g Gomega, ctx context.Context) error {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				// Check that RouterReady condition exists and is True
+				routerCondition := current.Status.GetCondition(v1alpha2.RouterReady)
+				g.Expect(routerCondition).ToNot(BeNil(), "RouterReady condition should be set")
+				g.Expect(routerCondition.IsTrue()).To(BeTrue(), "RouterReady condition should be True")
+
+				// Check that HTTPRoutesReady condition exists and is True
+				httpRoutesCondition := current.Status.GetCondition(v1alpha2.HTTPRoutesReady)
+				g.Expect(httpRoutesCondition).ToNot(BeNil(), "HTTPRoutesReady condition should be set")
+				g.Expect(httpRoutesCondition.IsTrue()).To(BeTrue(), "HTTPRoutesReady condition should be True")
+
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "LLMInferenceService should become ready with custom gateway")
+		})
+	})
+
 	Context("Reference validation", func() {
 		When("referenced Gateway does not exist", func() {
 			It("should mark RouterReady condition as False with InvalidRefs reason", func(ctx SpecContext) {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a custom gateway is specified via Gateway.Refs, the managed HTTPRoute was still referencing the default gateway from presets during validation, causing a RefsInvalid condition when the default gateway was absent. Move the gateway reference update from expectedHTTPRoute() to the config merge phase so the spec is correctly updated before reconciliation.

Port of opendatahub-io/kserve#1028.

**Release note**:
```release-note
NONE
```
