### PR TITLE
refactor(llmisvc): centralize test namespace management

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
@@ -43,21 +42,10 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create a basic multi-node deployment with worker spec", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithReplicas(2),
 				WithParallelism(ParallelismSpec(
@@ -75,7 +63,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then
@@ -83,7 +71,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -108,21 +96,10 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create multi-node deployment with prefill workload", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-prefill"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithReplicas(1),
 				WithParallelism(ParallelismSpec(
@@ -145,7 +122,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - Check main workload LWS
@@ -153,7 +130,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedMainLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -165,7 +142,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn-prefill",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedPrefillLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -180,21 +157,10 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create RBAC resources when prefill and decode is used", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-rbac"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithReplicas(1),
 				WithParallelism(ParallelismSpec(
@@ -212,7 +178,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - Check ServiceAccount is created
@@ -220,7 +186,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedSA)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -232,7 +198,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn-role",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedRole)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -244,7 +210,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn-rb",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedRB)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -258,7 +224,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -270,18 +236,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should delete multi-node resources when worker spec is removed", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-cleanup"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			parallelismSpec := ParallelismSpec(
 				WithDataParallelism(2),
@@ -290,7 +245,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			parallelismSpec.Expert = true
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithParallelism(parallelismSpec),
 				WithWorker(&corev1.PodSpec{}),
@@ -300,7 +255,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			lwsName := svcName + "-kserve-mn"
@@ -310,7 +265,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 				lws := &lwsapi.LeaderWorkerSet{}
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      lwsName,
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, lws)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -329,7 +284,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 				lws := &lwsapi.LeaderWorkerSet{}
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      lwsName,
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, lws)
 				g.Expect(err).To(HaveOccurred())
 				return nil
@@ -339,21 +294,10 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should delete prefill resources when prefill spec is removed", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-prefill-cleanup"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithPrefillParallelism(ParallelismSpec(
 					WithDataParallelism(2),
@@ -366,7 +310,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			prefillLWSName := kmeta.ChildName(svcName, "-kserve-mn-prefill")
@@ -376,7 +320,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 				lws := &lwsapi.LeaderWorkerSet{}
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      prefillLWSName,
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, lws)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -395,7 +339,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 				lws := &lwsapi.LeaderWorkerSet{}
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      prefillLWSName,
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, lws)
 				g.Expect(err).To(HaveOccurred())
 				return nil
@@ -407,25 +351,14 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should set correct labels and annotation", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-lws-labels"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			localQueueName := "test-local-q"
 			preemptPriority := "0"
 			testValue := "test"
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithParallelism(ParallelismSpec(
 					WithDataParallelism(1),
@@ -453,7 +386,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then
@@ -461,7 +394,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -493,23 +426,12 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should preserve externally set replicas when owner does not specify replicas", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-mn-preserve-replicas"
-			nsName := kmeta.ChildName(svcName, "-test")
-			lwsName := types.NamespacedName{Name: svcName + "-kserve-mn", Namespace: nsName}
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			lwsName := types.NamespacedName{Name: svcName + "-kserve-mn", Namespace: testNs.Name}
 
 			// Create LLMInferenceService WITHOUT specifying replicas
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithParallelism(ParallelismSpec(
 					WithDataParallelism(2),
@@ -528,7 +450,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - LeaderWorkerSet should be created with default replicas (1)
@@ -575,23 +497,12 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should override externally set replicas when owner specifies replicas", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-mn-override-replicas"
-			nsName := kmeta.ChildName(svcName, "-test")
-			lwsName := types.NamespacedName{Name: svcName + "-kserve-mn", Namespace: nsName}
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			lwsName := types.NamespacedName{Name: svcName + "-kserve-mn", Namespace: testNs.Name}
 
 			// Create LLMInferenceService WITH explicit replicas
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithParallelism(ParallelismSpec(
 					WithDataParallelism(2),
@@ -610,7 +521,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - LeaderWorkerSet should be created with owner-specified replicas (2)

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
@@ -54,7 +54,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -164,7 +164,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -223,7 +223,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -360,7 +360,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -436,7 +436,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			// Create first service
@@ -523,7 +523,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -59,32 +59,21 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should create a basic single node deployment with just base refs", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			modelConfig := LLMInferenceServiceConfig("model-fb-opt-125m",
-				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
 				WithConfigModelName("facebook/opt-125m"),
 				WithConfigModelURI("hf://facebook/opt-125m"),
 			)
 
 			routerConfig := LLMInferenceServiceConfig("router-managed",
-				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
 				WithConfigManagedRouter(),
 			)
 
 			workloadConfig := LLMInferenceServiceConfig("workload-single-cpu",
-				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
 				WithConfigWorkloadTemplate(&corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -123,7 +112,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 			// Create LLMInferenceService using baseRefs only
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithBaseRefs(
 					corev1.LocalObjectReference{Name: "model-fb-opt-125m"},
 					corev1.LocalObjectReference{Name: "router-managed"},
@@ -134,7 +123,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then
@@ -142,7 +131,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedDeployment)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -168,25 +157,14 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should propagate kueue labels and annotations to the deployment", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-kueue"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			localQueueName := "test-local-q"
 			preemptPriority := "0"
 			testValue := "test"
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithManagedRoute(),
 				WithManagedGateway(),
@@ -206,7 +184,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then
@@ -214,7 +192,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedDeployment)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -241,23 +219,12 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should preserve externally set replicas when owner does not specify replicas", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-preserve-replicas"
-			nsName := kmeta.ChildName(svcName, "-test")
-			deploymentName := types.NamespacedName{Name: svcName + "-kserve", Namespace: nsName}
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			deploymentName := types.NamespacedName{Name: svcName + "-kserve", Namespace: testNs.Name}
 
 			// Create LLMInferenceService WITHOUT specifying replicas
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithModelName("facebook/opt-125m"),
 				WithManagedRoute(),
@@ -271,7 +238,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - Deployment should be created with default replicas (1)
@@ -318,23 +285,12 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should override externally set replicas when owner specifies replicas", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-override-replicas"
-			nsName := kmeta.ChildName(svcName, "-test")
-			deploymentName := types.NamespacedName{Name: svcName + "-kserve", Namespace: nsName}
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			deploymentName := types.NamespacedName{Name: svcName + "-kserve", Namespace: testNs.Name}
 
 			// Create LLMInferenceService WITH explicit replicas
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithModelName("facebook/opt-125m"),
 				WithManagedRoute(),
@@ -348,7 +304,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - Deployment should be created with owner-specified replicas (2)
@@ -398,20 +354,10 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create routes pointing to the default gateway when both are managed", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-create-http-route"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -421,7 +367,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -483,22 +429,12 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should use referenced external InferencePool", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-create-http-route-inf-pool-ref"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 				infPoolName := kmeta.ChildName(svcName, "-my-inf-pool")
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -506,7 +442,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				)
 
 				infPool := InferencePool(infPoolName,
-					InNamespace[*igwapi.InferencePool](nsName),
+					InNamespace[*igwapi.InferencePool](testNs.Name),
 					WithSelector("app", "workload"),
 					WithTargetPort(8000),
 					WithExtensionRef("", "Service", kmeta.ChildName(svcName, "-epp-service"), 9002),
@@ -517,8 +453,8 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				Expect(envTest.Create(ctx, infPool)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
-					Expect(envTest.Delete(ctx, infPool)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
+					testNs.DeleteAndWait(ctx, infPool)
 				}()
 
 				// then
@@ -549,20 +485,10 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create routes pointing to workload service when no scheduler is configured", func(ctx SpecContext) {
 				// given
 				llmSvcName := "test-llm-create-http-route-no-scheduler"
-				nsName := kmeta.ChildName(llmSvcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(llmSvcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(llmSvcName))
 
 				llmSvc := LLMInferenceService(llmSvcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -571,7 +497,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -594,7 +520,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Eventually(func(g Gomega, ctx context.Context) error {
 					svc := &corev1.Service{}
-					err := envTest.Client.Get(ctx, client.ObjectKey{Name: svcName, Namespace: nsName}, svc)
+					err := envTest.Client.Get(ctx, client.ObjectKey{Name: svcName, Namespace: testNs.Name}, svc)
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(svc.Spec.Selector).To(Equal(llmisvc.GetWorkloadLabelSelector(llmSvc.ObjectMeta, &llmSvc.Spec)))
 					return nil
@@ -618,29 +544,19 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create HTTPRoute with defined spec", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-defined-http-route"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedGateway(),
-					WithHTTPRouteSpec(customRouteSpec(ctx, envTest.Client, nsName, "my-ingress-gateway", "my-inference-service")),
+					WithHTTPRouteSpec(customRouteSpec(ctx, envTest.Client, testNs.Name, "my-ingress-gateway", "my-inference-service")),
 				)
 
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				expectedHTTPRoute := &gwapiv1.HTTPRoute{}
@@ -673,21 +589,11 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should delete managed HTTPRoute when ref is defined", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-update-http-route"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 				// Create the Gateway that the router-managed preset references
 				gateway := Gateway("my-ingress-gateway",
-					InNamespace[*gwapiv1.Gateway](nsName),
+					InNamespace[*gwapiv1.Gateway](testNs.Name),
 					WithListener(gwapiv1.HTTPProtocolType),
 					WithAddresses("203.0.113.1"),
 					// Don't set the condition here initially
@@ -698,11 +604,11 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				ensureGatewayReady(ctx, envTest.Client, gateway)
 
 				defer func() {
-					Expect(envTest.Delete(ctx, gateway)).To(Succeed())
+					testNs.DeleteAndWait(ctx, gateway)
 				}()
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -710,7 +616,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				Eventually(func(g Gomega, ctx context.Context) error {
@@ -722,7 +628,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				}).WithContext(ctx).Should(Succeed())
 
 				customHTTPRoute := HTTPRoute("my-custom-route", []HTTPRouteOption{
-					InNamespace[*gwapiv1.HTTPRoute](nsName),
+					InNamespace[*gwapiv1.HTTPRoute](testNs.Name),
 					WithParentRef(GatewayParentRef(gateway.Name, gateway.Namespace)),
 					WithHTTPRouteRule(
 						HTTPRouteRuleWithBackendAndTimeouts(svcName+"-inference-pool", 8000, "/", "0s", "0s"),
@@ -761,29 +667,19 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should evaluate HTTPRoute readiness conditions", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-httproute-conditions"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
-				ingressGateway := DefaultGateway(nsName)
+				ingressGateway := DefaultGateway(testNs.Name)
 				Expect(envTest.Client.Create(ctx, ingressGateway)).To(Succeed())
 				ensureGatewayReady(ctx, envTest.Client, ingressGateway)
 
 				defer func() {
-					Expect(envTest.Delete(ctx, ingressGateway)).To(Succeed())
+					testNs.DeleteAndWait(ctx, ingressGateway)
 				}()
 
 				customHTTPRoute := HTTPRoute("my-custom-route", []HTTPRouteOption{
-					InNamespace[*gwapiv1.HTTPRoute](nsName),
-					WithParentRef(GatewayParentRef("kserve-ingress-gateway", nsName)),
+					InNamespace[*gwapiv1.HTTPRoute](testNs.Name),
+					WithParentRef(GatewayParentRef("kserve-ingress-gateway", testNs.Name)),
 					WithHTTPRouteRule(
 						HTTPRouteRuleWithBackendAndTimeouts(svcName+"-inference-pool", 8000, "/", "0s", "0s"),
 					),
@@ -794,7 +690,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				ensureHTTPRouteReady(ctx, envTest.Client, customHTTPRoute)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("my-custom-route")),
 				)
@@ -802,7 +698,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then - verify HTTPRoutesReady condition is set
@@ -830,20 +726,10 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				func(ctx SpecContext, testName string, initialRouterSpec *v1alpha2.RouterSpec, specMutation func(*v1alpha2.LLMInferenceService)) {
 					// given
 					svcName := "test-llm-" + testName
-					nsName := kmeta.ChildName(svcName, "-test")
-					namespace := &corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: nsName,
-						},
-					}
-					Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-					Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-					defer func() {
-						envTest.DeleteAll(namespace)
-					}()
+					testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 					llmSvc := LLMInferenceService(svcName,
-						InNamespace[*v1alpha2.LLMInferenceService](nsName),
+						InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 						WithModelURI("hf://facebook/opt-125m"),
 					)
 					llmSvc.Spec.Router = initialRouterSpec
@@ -851,7 +737,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					// when - Create LLMInferenceService
 					Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 					defer func() {
-						Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+						testNs.DeleteAndWait(ctx, llmSvc)
 					}()
 
 					// then - HTTPRoute should be created with router labels
@@ -906,28 +792,19 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should mark RouterReady condition as False with InvalidRefs reason", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-gateway-ref-not-found"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("non-existent-route")),
-					WithGatewayRefs(LLMGatewayRef("non-existent-gateway", nsName)),
+					WithGatewayRefs(LLMGatewayRef("non-existent-gateway", testNs.Name)),
 				)
 
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -940,7 +817,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					routerCondition := updatedLLMSvc.Status.GetCondition(v1alpha2.RouterReady)
 					g.Expect(routerCondition).ToNot(BeNil())
 					g.Expect(routerCondition.Reason).To(Equal(llmisvc.RefsInvalidReason))
-					g.Expect(routerCondition.Message).To(ContainSubstring(nsName + "/non-existent-gateway does not exist"))
+					g.Expect(routerCondition.Message).To(ContainSubstring(testNs.Name + "/non-existent-gateway does not exist"))
 
 					return nil
 				}).WithContext(ctx).Should(Succeed())
@@ -951,27 +828,18 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should mark RouterReady condition as False with RefsInvalid reason", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-parent-gateway-ref-not-found"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				// Create HTTPRoute spec that references a non-existent gateway
 				customRouteSpec := &HTTPRoute("temp",
-					WithParentRefs(GatewayParentRef("non-existent-parent-gateway", nsName)),
+					WithParentRefs(GatewayParentRef("non-existent-parent-gateway", testNs.Name)),
 					WithHTTPRule(
 						WithBackendRefs(ServiceRef("some-backend", 8000, 1)),
 					),
 				).Spec
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteSpec(customRouteSpec),
 				)
@@ -979,7 +847,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -992,7 +860,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					routerCondition := updatedLLMSvc.Status.GetCondition(v1alpha2.RouterReady)
 					g.Expect(routerCondition).ToNot(BeNil())
 					g.Expect(routerCondition.Reason).To(Equal(llmisvc.RefsInvalidReason))
-					g.Expect(routerCondition.Message).To(ContainSubstring(fmt.Sprintf("Managed HTTPRoute references non-existent Gateway %s/non-existent-parent-gateway", nsName)))
+					g.Expect(routerCondition.Message).To(ContainSubstring(fmt.Sprintf("Managed HTTPRoute references non-existent Gateway %s/non-existent-parent-gateway", testNs.Name)))
 
 					return nil
 				}).WithContext(ctx).Should(Succeed())
@@ -1003,19 +871,10 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should mark RouterReady condition as False with RefsInvalid reason", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-route-ref-not-found"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("non-existent-route")),
 					WithGatewayRefs(LLMGatewayRef(constants.GatewayName, constants.KServeNamespace)),
@@ -1024,7 +883,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -1037,7 +896,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					routerCondition := updatedLLMSvc.Status.GetCondition(v1alpha2.RouterReady)
 					g.Expect(routerCondition).ToNot(BeNil())
 					g.Expect(routerCondition.Reason).To(Equal(llmisvc.RefsInvalidReason))
-					g.Expect(routerCondition.Message).To(ContainSubstring(fmt.Sprintf("HTTPRoute %s/non-existent-route does not exist", nsName)))
+					g.Expect(routerCondition.Message).To(ContainSubstring(fmt.Sprintf("HTTPRoute %s/non-existent-route does not exist", testNs.Name)))
 
 					return nil
 				}).WithContext(ctx).Should(Succeed())
@@ -1050,38 +909,29 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should clear stale GatewaysReady condition when Gateway is created", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-stale-gateway-condition"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				// Create HTTPRoute first so HTTPRoute validation passes (focus on Gateway stale condition)
 				httpRoute := HTTPRoute("my-route", []HTTPRouteOption{
-					InNamespace[*gwapiv1.HTTPRoute](nsName),
+					InNamespace[*gwapiv1.HTTPRoute](testNs.Name),
 				}...)
 				Expect(envTest.Client.Create(ctx, httpRoute)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, httpRoute)).To(Succeed())
+					testNs.DeleteAndWait(ctx, httpRoute)
 				}()
 
 				// Create LLMInferenceService referencing a Gateway that doesn't exist yet
 				// Must use WithHTTPRouteRefs (custom gateway requires custom routes, not managed routes)
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("my-route")),
-					WithGatewayRefs(LLMGatewayRef("my-gateway", nsName)),
+					WithGatewayRefs(LLMGatewayRef("my-gateway", testNs.Name)),
 				)
 
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// Verify GatewaysReady is False with RefsInvalid
@@ -1100,14 +950,14 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				// when - Create the Gateway
 				gateway := Gateway("my-gateway",
-					InNamespace[*gwapiv1.Gateway](nsName),
+					InNamespace[*gwapiv1.Gateway](testNs.Name),
 					WithListener(gwapiv1.HTTPProtocolType),
 					WithAddresses("203.0.113.1"),
 				)
 				Expect(envTest.Client.Create(ctx, gateway)).To(Succeed())
 				ensureGatewayReady(ctx, envTest.Client, gateway)
 				defer func() {
-					Expect(envTest.Delete(ctx, gateway)).To(Succeed())
+					testNs.DeleteAndWait(ctx, gateway)
 				}()
 
 				// then - GatewaysReady stale condition should be cleared (no longer RefsInvalid)
@@ -1131,40 +981,31 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should clear stale HTTPRoutesReady condition when HTTPRoute is created", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-stale-httproute-condition"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				// Create the Gateway first so gateway validation passes
 				gateway := Gateway("my-gateway",
-					InNamespace[*gwapiv1.Gateway](nsName),
+					InNamespace[*gwapiv1.Gateway](testNs.Name),
 					WithListener(gwapiv1.HTTPProtocolType),
 					WithAddresses("203.0.113.1"),
 				)
 				Expect(envTest.Client.Create(ctx, gateway)).To(Succeed())
 				ensureGatewayReady(ctx, envTest.Client, gateway)
 				defer func() {
-					Expect(envTest.Delete(ctx, gateway)).To(Succeed())
+					testNs.DeleteAndWait(ctx, gateway)
 				}()
 
 				// Create LLMInferenceService referencing an HTTPRoute that doesn't exist yet
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("my-route")),
-					WithGatewayRefs(LLMGatewayRef("my-gateway", nsName)),
+					WithGatewayRefs(LLMGatewayRef("my-gateway", testNs.Name)),
 				)
 
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// Verify HTTPRoutesReady is False with RefsInvalid
@@ -1190,8 +1031,8 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				// when - Create the HTTPRoute
 				httpRoute := HTTPRoute("my-route", []HTTPRouteOption{
-					InNamespace[*gwapiv1.HTTPRoute](nsName),
-					WithParentRef(GatewayParentRef("my-gateway", nsName)),
+					InNamespace[*gwapiv1.HTTPRoute](testNs.Name),
+					WithParentRef(GatewayParentRef("my-gateway", testNs.Name)),
 					WithHTTPRouteRule(
 						HTTPRouteRuleWithBackendAndTimeouts(svcName+"-kserve-workload-svc", 8000, "/", "0s", "0s"),
 					),
@@ -1199,7 +1040,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				Expect(envTest.Client.Create(ctx, httpRoute)).To(Succeed())
 				ensureHTTPRouteReady(ctx, envTest.Client, httpRoute)
 				defer func() {
-					Expect(envTest.Delete(ctx, httpRoute)).To(Succeed())
+					testNs.DeleteAndWait(ctx, httpRoute)
 				}()
 
 				// then - HTTPRoutesReady stale condition should be cleared
@@ -1223,21 +1064,11 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should clear SchedulerWorkloadReady condition when scheduler is no longer configured", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-stale-scheduler-condition"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 				// Create LLMInferenceService with scheduler
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](nsName),
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -1246,7 +1077,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)

--- a/pkg/controller/v1alpha2/llmisvc/fixture/test_namespace.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/test_namespace.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"regexp"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pkgtest "github.com/kserve/kserve/pkg/testing"
+)
+
+// TestNamespace encapsulates a test namespace with its lifecycle management.
+// It ensures proper setup and cleanup ordering.
+type TestNamespace struct {
+	Name      string
+	Namespace *corev1.Namespace
+	client    *pkgtest.Client
+	// resources tracks all resources created via options for cleanup
+	resources []client.Object
+}
+
+// TestNamespaceOption configures a TestNamespace during creation
+type TestNamespaceOption func(ctx context.Context, tn *TestNamespace)
+
+// WithIstioShadowService creates an Istio shadow service in the namespace.
+// This is required for tests that verify Istio integration.
+func WithIstioShadowService(svcName string) TestNamespaceOption {
+	return func(ctx context.Context, tn *TestNamespace) {
+		svc := IstioShadowService(svcName, tn.Name)
+		gomega.Expect(tn.client.Create(ctx, svc)).To(gomega.Succeed())
+		tn.resources = append(tn.resources, svc)
+	}
+}
+
+// WithDefaultServiceAccount creates the default ServiceAccount.
+// This is automatically applied but can be explicitly added for clarity.
+// Note: envtest doesn't run kube-controller-manager, so default SA isn't auto-created.
+func WithDefaultServiceAccount() TestNamespaceOption {
+	return func(ctx context.Context, tn *TestNamespace) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default",
+				Namespace: tn.Name,
+			},
+		}
+		err := tn.client.Create(ctx, sa)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		if err == nil {
+			tn.resources = append(tn.resources, sa)
+		}
+	}
+}
+
+// WithServiceAccount creates a custom ServiceAccount in the namespace.
+func WithServiceAccount(name string) TestNamespaceOption {
+	return func(ctx context.Context, tn *TestNamespace) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: tn.Name,
+			},
+		}
+		err := tn.client.Create(ctx, sa)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		if err == nil {
+			tn.resources = append(tn.resources, sa)
+		}
+	}
+}
+
+// NewTestNamespace creates a namespace for testing with proper cleanup registered.
+//
+// It automatically:
+//   - Creates the namespace with name derived from current Ginkgo test info
+//   - Creates default ServiceAccount when using envtest (real clusters auto-create it)
+//   - Registers cleanup via DeferCleanup (ensures proper ordering)
+//
+// Example usage:
+//
+//	testNs := NewTestNamespace(ctx, envTest,
+//	    WithIstioShadowService("my-service"),
+//	)
+func NewTestNamespace(ctx context.Context, c *pkgtest.Client, opts ...TestNamespaceOption) *TestNamespace {
+	nsName := generateNamespaceName(ginkgo.CurrentSpecReport())
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	}
+
+	gomega.Expect(c.Create(ctx, namespace)).To(gomega.Succeed())
+
+	tn := &TestNamespace{
+		Name:      nsName,
+		Namespace: namespace,
+		client:    c,
+	}
+
+	// Create default ServiceAccount only for envtest (real clusters auto-create it)
+	if !c.UsingExistingCluster() {
+		WithDefaultServiceAccount()(ctx, tn)
+	}
+
+	// Apply additional options
+	for _, opt := range opts {
+		opt(ctx, tn)
+	}
+
+	// Register cleanup via DeferCleanup - this ensures it runs AFTER any
+	// inline defers registered after this call (LIFO order)
+	// Note: envtest has no GC, so we must explicitly delete all resources
+	ginkgo.DeferCleanup(func(ctx context.Context) {
+		// Delete tracked resources in reverse order (LIFO)
+		for i := len(tn.resources) - 1; i >= 0; i-- {
+			if err := c.Delete(ctx, tn.resources[i]); err != nil && !apierrors.IsNotFound(err) {
+				// Log but don't fail - cleanup should be best-effort
+				fmt.Fprintf(ginkgo.GinkgoWriter, "Warning: failed to delete resource %v: %v\n",
+					client.ObjectKeyFromObject(tn.resources[i]), err)
+			}
+		}
+		c.DeleteAll(ctx, namespace)
+	})
+
+	return tn
+}
+
+// DeleteAndWait deletes the given object and waits for it to be fully removed.
+// This should be called for objects with finalizers (like LLMInferenceService)
+// before namespace cleanup to avoid race conditions.
+func (tn *TestNamespace) DeleteAndWait(ctx context.Context, obj client.Object) {
+	err := tn.client.Delete(ctx, obj)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Wait for the object to be fully deleted (including finalizer processing)
+	gomega.Eventually(func(g gomega.Gomega) {
+		getErr := tn.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		g.Expect(apierrors.IsNotFound(getErr)).To(gomega.BeTrue(),
+			"expected object to be deleted, got: %v", getErr)
+	}).WithContext(ctx).Should(gomega.Succeed())
+}
+
+// generateNamespaceName creates a DNS-safe namespace name from test info.
+// Uses full test hierarchy (Describe/Context/It) for stable namespace name.
+//
+// Example: Describe("Controller") > Context("Reconciliation") > It("should create")
+// becomes: "test-controller-reconciliation-should-create"
+// (or "test-controller-reconci-a1b2c3d4" if exceeds 63 chars)
+func generateNamespaceName(spec ginkgo.SpecReport) string {
+	texts := make([]string, len(spec.ContainerHierarchyTexts)+1)
+	copy(texts, spec.ContainerHierarchyTexts)
+	texts[len(spec.ContainerHierarchyTexts)] = spec.LeafNodeText
+	fullPath := strings.Join(texts, "-")
+	return truncateWithHash("test-"+sanitizeForDNS(fullPath), 63)
+}
+
+var nonDNSChars = regexp.MustCompile(`[^a-z0-9]+`)
+
+func sanitizeForDNS(s string) string {
+	return strings.Trim(nonDNSChars.ReplaceAllString(strings.ToLower(s), "-"), "-")
+}
+
+// truncateWithHash returns name as-is if it fits in maxLen,
+// otherwise truncates and appends a hash suffix for uniqueness.
+func truncateWithHash(name string, maxLen int) string {
+	if len(name) <= maxLen {
+		return name
+	}
+	hash := fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(name)))
+	// hash (8 chars) + separator (1 char) = 9 chars reserved for suffix
+	truncateAt := max(maxLen-9, 0)
+	return strings.TrimRight(name[:truncateAt], "-") + "-" + hash
+}

--- a/pkg/controller/v1alpha2/llmisvc/validation_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/validation_int_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package llmisvc_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -66,11 +67,11 @@ var _ = Describe("LLMInferenceService webhook validation", func() {
 		)
 		Expect(envTest.Client.Create(ctx, httpRoute)).To(Succeed())
 
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			httpRoute := httpRoute
 			gateway := gateway
 			ns := ns
-			envTest.DeleteAll(httpRoute, gateway, ns)
+			envTest.DeleteAll(ctx, httpRoute, gateway, ns)
 		})
 	})
 
@@ -398,9 +399,9 @@ var _ = Describe("LLMInferenceService API validation", func() {
 		}
 		Expect(envTest.Client.Create(ctx, ns)).To(Succeed())
 
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			ns := ns
-			envTest.DeleteAll(ns)
+			envTest.DeleteAll(ctx, ns)
 		})
 	})
 	Context("scheduler config validation", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Integration tests repeated the same namespace setup and cleanup pattern, leading to code duplication and inconsistent behavior.

The existing approach had several issues with envtest: missing garbage collection meant resources weren't cleaned up when the namespace was deleted, and the default ServiceAccount wasn't auto-created, causing noisy error logs.

```
2025-12-29T14:28:09+01:00       ERROR   LLMInferenceService.reconcile.reconcileWorkload Failed to find default service account     {"controller": "llminferenceservice", "controllerGroup": "serving.kserve.io", "controllerKind": "LLMInferenceService", "LLMInferenceService": {"name":"test-llm-lws-labels","namespace":"test-llm-lws-labels-test"}, "namespace": "test-llm-lws-labels-test", "name": "test-llm-lws-labels", "reconcileID": "376d6481-c47b-412a-92a9-6de510a592cd", "namespace": "test-llm-lws-labels-test", "error": "ServiceAccount \"default\" not found"}
```

This PR introduces a `TestNamespace` fixture that standardizes namespace lifecycle management. It tracks all created resources for explicit cleanup via `ginkgo.DeferCleanup`, and automatically provisions the `default` `ServiceAccount` that envtest doesn't provide.

Port of opendatahub-io/kserve#1030

**Release note**:
```release-note
NONE
```
