### PR TITLE
fix: avoid storage-initializer rollout on operator upgrade

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node_serviceaccount_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node_serviceaccount_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
@@ -42,6 +43,7 @@ func TestReconcileMultiNodeMainServiceAccount_UseExisting_SkipsManagedSA(t *test
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(lwsapi.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
 
@@ -112,6 +114,7 @@ func TestReconcileMultiNodeMainServiceAccount_Default_CreatesManagedSA(t *testin
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(lwsapi.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
 
@@ -161,6 +164,7 @@ func TestReconcileMultiNodeMainServiceAccount_Default_WhenWorkerNil_DeletesManag
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(lwsapi.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
 
@@ -218,6 +222,7 @@ func TestReconcileMultiNodePrefillServiceAccount_UseExisting_SkipsManagedSA(t *t
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(lwsapi.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
 
@@ -286,6 +291,7 @@ func TestReconcileMultiNodePrefillServiceAccount_Default_CreatesManagedSA(t *tes
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(lwsapi.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
 
@@ -335,6 +341,7 @@ func TestReconcileMultiNodePrefillServiceAccount_Default_WhenWorkerNil_DeletesMa
 
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(lwsapi.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
 

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -136,7 +136,11 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 			}
 		}
 
-		if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, &d.Spec.Template.Spec, config); err != nil {
+		curr := &appsv1.Deployment{}
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(d), curr); err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get current deployment %s/%s: %w", d.GetNamespace(), d.GetName(), err)
+		}
+		if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, curr.Spec.Template.Spec, &d.Spec.Template.Spec, config); err != nil {
 			return nil, fmt.Errorf("failed to attach model artifacts to main deployment: %w", err)
 		}
 	}
@@ -217,7 +221,11 @@ func (r *LLMISVCReconciler) expectedPrefillMainDeployment(ctx context.Context, l
 			}
 		}
 
-		if err := r.attachModelArtifacts(ctx, existingServiceAccount, llmSvc, &d.Spec.Template.Spec, config); err != nil {
+		curr := &appsv1.Deployment{}
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(d), curr); err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get current prefill deployment %s/%s: %w", d.GetNamespace(), d.GetName(), err)
+		}
+		if err := r.attachModelArtifacts(ctx, existingServiceAccount, llmSvc, curr.Spec.Template.Spec, &d.Spec.Template.Spec, config); err != nil {
 			return nil, fmt.Errorf("failed to attach model artifacts to prefill deployment: %w", err)
 		}
 	}

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node_serviceaccount_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node_serviceaccount_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,6 +44,7 @@ func TestReconcileSingleNodeMainServiceAccount_UseExisting_SkipsManagedSA(t *tes
 	ctx := t.Context()
 
 	scheme := runtime.NewScheme()
+	g.Expect(appsv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
@@ -111,6 +113,7 @@ func TestReconcileSingleNodeMainServiceAccount_Default_DeletesManagedSA(t *testi
 	ctx := t.Context()
 
 	scheme := runtime.NewScheme()
+	g.Expect(appsv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
@@ -167,6 +170,7 @@ func TestReconcileSingleNodeMainServiceAccount_RoutingEnabled_UseExisting_SkipsM
 	ctx := t.Context()
 
 	scheme := runtime.NewScheme()
+	g.Expect(appsv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
@@ -234,6 +238,7 @@ func TestReconcileSingleNodeMainServiceAccount_RoutingEnabled_Default_DeletesMan
 	ctx := t.Context()
 
 	scheme := runtime.NewScheme()
+	g.Expect(appsv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -53,7 +53,7 @@ const CaBundleVolumeName = "cabundle-cert"
 // Returns:
 //
 //	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, podSpec *corev1.PodSpec, config *Config) error {
+func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, curr corev1.PodSpec, podSpec *corev1.PodSpec, config *Config) error {
 	modelUri := llmSvc.Spec.Model.URI.String()
 	schema, _, sepFound := strings.Cut(modelUri, "://")
 
@@ -83,10 +83,10 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 		return r.attachOciModelArtifact(modelUri, podSpec, config.StorageConfig)
 
 	case constants.HfURIPrefix:
-		return r.attachHfModelArtifact(ctx, serviceAccount, llmSvc, modelUri, podSpec, config.StorageConfig, config.CredentialConfig)
+		return r.attachHfModelArtifact(ctx, serviceAccount, llmSvc, modelUri, curr, podSpec, config.StorageConfig, config.CredentialConfig)
 
 	case constants.S3URIPrefix:
-		return r.attachS3ModelArtifact(ctx, serviceAccount, llmSvc, modelUri, podSpec, config.StorageConfig, config.CredentialConfig)
+		return r.attachS3ModelArtifact(ctx, serviceAccount, llmSvc, modelUri, curr, podSpec, config.StorageConfig, config.CredentialConfig)
 	}
 
 	return fmt.Errorf("unsupported schema in model URI: %s", modelUri)
@@ -161,8 +161,8 @@ func (r *LLMISVCReconciler) attachPVCModelArtifact(modelUri string, podSpec *cor
 // Returns:
 //
 //	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig) error {
-	if err := r.attachStorageInitializer(modelUri, podSpec, storageConfig); err != nil {
+func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig) error {
+	if err := r.attachStorageInitializer(modelUri, curr, podSpec, storageConfig); err != nil {
 		return err
 	}
 	if initContainer := utils.GetInitContainerWithName(podSpec, constants.StorageInitializerContainerName); initContainer != nil {
@@ -208,8 +208,8 @@ func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAc
 // Returns:
 //
 //	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig) error {
-	if err := r.attachStorageInitializer(modelUri, podSpec, storageConfig); err != nil {
+func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig) error {
+	if err := r.attachStorageInitializer(modelUri, curr, podSpec, storageConfig); err != nil {
 		return err
 	}
 	if initContainer := utils.GetInitContainerWithName(podSpec, constants.StorageInitializerContainerName); initContainer != nil {
@@ -249,7 +249,7 @@ func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, serviceAc
 // Returns:
 //
 //	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig) error {
+func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig) error {
 	containerArgs := []string{
 		modelUri,
 		constants.DefaultModelLocalMountPath,
@@ -259,7 +259,18 @@ func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, podSpec *c
 		VolumeName: constants.StorageInitializerVolumeName,
 		ReadOnly:   false,
 	}
-	initContainer := utils.CreateInitContainerWithConfig(storageConfig, containerArgs)
+
+	// Preserve the existing storage-initializer image from the current deployment
+	// to avoid unnecessary pod restarts during operator upgrades when the model
+	// hasn't changed.
+	copied := *storageConfig
+	for _, initContainer := range curr.InitContainers {
+		if initContainer.Name == constants.StorageInitializerContainerName {
+			copied.Image = initContainer.Image
+		}
+	}
+
+	initContainer := utils.CreateInitContainerWithConfig(&copied, containerArgs)
 	podSpec.InitContainers = append(podSpec.InitContainers, *initContainer)
 
 	utils.AddModelMount(storageMountParams, initContainer.Name, podSpec)


### PR DESCRIPTION
**What this PR does / why we need it**:

Preserve the existing storage-initializer container image when reconciling deployments and LeaderWorkerSets. During operator upgrades, the new storage-initializer image from the operator config would cause all pods to restart even when the model hasn't changed.

The fix fetches the current deployment/LWS before reconciliation and reuses the existing storage-init container image, avoiding unnecessary pod rollouts.

Port of opendatahub-io/kserve#1105

**Release note**:
```release-note
NONE
```
