### PR TITLE
feat: route only completions through InferencePool

### DIFF
--- a/config/llmisvcconfig/config-llm-router-route.yaml
+++ b/config/llmisvcconfig/config-llm-router-route.yaml
@@ -26,6 +26,47 @@ spec:
                 - path:
                     type: PathPrefix
                     value: |-
+                      /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/completions
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /v1/completions
+              timeouts:
+                backendRequest: 0s
+                request: 0s
+            - backendRefs:
+                - group: inference.networking.k8s.io
+                  kind: InferencePool
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
+                      /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/chat/completions
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /v1/chat/completions
+              timeouts:
+                backendRequest: 0s
+                request: 0s
+            - backendRefs:
+                - kind: Service
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
                       /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}
               filters:
                 - type: URLRewrite

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -437,11 +437,12 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Expect(expectedHTTPRoute).To(BeControlledBy(llmSvc))
 				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gwapiv1.ParentReference{Name: "kserve-ingress-gateway"}))
-				Expect(expectedHTTPRoute).To(Not(HaveBackendRefs(BackendRefService(svcName + "-kserve-workload-svc"))))
+				// With completions-only routing, the catch-all rule uses a Service backend
+				Expect(expectedHTTPRoute).To(HaveBackendRefs(BackendRefService(svcName + "-kserve-workload-svc")))
 
 				ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
 
-				// HTTPRoute uses v1alpha2 backendRef when both CRDs are available
+				// HTTPRoute uses v1alpha2 backendRef for InferencePool rules when both CRDs are available
 				Eventually(func(g Gomega, ctx context.Context) {
 					routes, errList := managedRoutes(ctx, llmSvc)
 					g.Expect(errList).ToNot(HaveOccurred())
@@ -535,7 +536,8 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				Expect(expectedHTTPRoute).To(BeControlledBy(llmSvc))
 				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gwapiv1.ParentReference{Name: "kserve-ingress-gateway"}))
 				Expect(expectedHTTPRoute).To(HaveBackendRefs(BackendRefInferencePool(infPoolName)))
-				Expect(expectedHTTPRoute).To(Not(HaveBackendRefs(BackendRefService(svcName + "-kserve-workload-svc"))))
+				// With completions-only routing, the catch-all rule uses a Service backend
+				Expect(expectedHTTPRoute).To(HaveBackendRefs(BackendRefService(svcName + "-kserve-workload-svc")))
 
 				ensureInferencePoolReady(ctx, envTest.Client, infPool)
 				ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)

--- a/pkg/testing/httproute_matchers.go
+++ b/pkg/testing/httproute_matchers.go
@@ -100,7 +100,8 @@ func (matcher *haveGatewayRefsMatcher) NegatedFailureMessage(actual any) string 
 		actual, matcher.expectedGatewayNames)
 }
 
-// HaveBackendRefs returns a matcher that checks if an HTTPRoute has the specified backend refs.
+// HaveBackendRefs returns a matcher that checks if an HTTPRoute contains the specified backend refs.
+// It uses "contains" semantics: the route may have additional backend refs beyond those listed.
 func HaveBackendRefs(backends ...gwapiv1.HTTPBackendRef) types.GomegaMatcher {
 	return &haveBackendRefsMatcher{
 		expectedBackendRefs: backends,
@@ -120,10 +121,6 @@ func (matcher *haveBackendRefsMatcher) Match(actual any) (success bool, err erro
 
 	for _, rule := range httpRoute.Spec.Rules {
 		matcher.actualBackendRefs = append(matcher.actualBackendRefs, rule.BackendRefs...)
-	}
-
-	if len(matcher.actualBackendRefs) != len(matcher.expectedBackendRefs) {
-		return false, nil
 	}
 
 	for _, want := range matcher.expectedBackendRefs {


### PR DESCRIPTION
**What this PR does / why we need it**:

Split the single catch-all HTTPRoute rule into three specific rules:
- /v1/completions -> InferencePool (with URL rewrite)
- /v1/chat/completions -> InferencePool (with URL rewrite)
- catch-all base path -> Service (direct backend)

This ensures only completion endpoints are routed through the InferencePool for intelligent load balancing, while other traffic (health checks, model info, etc.) goes directly to the Service.

The extractRoutePath function is updated to prefer Service-backed rule paths for URL construction, falling back to the shortest path from any rule when no Service backend exists.

Port of opendatahub-io/kserve#938

**Release note**:
```release-note
NONE
```
