### PR TITLE
feat: support path based routing in raw deployment mode

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1045,6 +1045,18 @@ jobs:
         run: |
           ./test/scripts/gh-actions/run-e2e-tests.sh "raw" "6" ${{ matrix.network-layer }}
 
+      - name: Patch inferenceservice config for ingress path based routing
+        if: matrix.network-layer == 'istio-ingress'
+        run: |
+          kubectl patch configmaps -n kserve inferenceservice-config --patch-file config/overlays/test/configmap/inferenceservice-ingress-path-template.yaml
+          kubectl describe configmaps -n kserve inferenceservice-config
+
+      - name: Run E2E tests with ingress path based routing
+        if: matrix.network-layer == 'istio-ingress'
+        timeout-minutes: 30
+        run: |
+          ./test/scripts/gh-actions/run-e2e-tests.sh "raw" "6" ${{ matrix.network-layer }}
+
       - name: Patch inferenceservice config for cluster ip none
         run: |
           kubectl patch configmaps -n kserve inferenceservice-config --patch-file config/overlays/test/configmap/inferenceservice-enable-cluster-ip.yaml

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -365,11 +365,11 @@ data:
            # NOTE: This configuration only applicable for raw deployment.
            "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
 
-           # ingressPathTemplate to expose all InferenceServices in a cluster behind a single domain by combining the following variables:
+           # ingressPathTemplate specifies the template for generating the path of url's for each inference service by combining variables from:
            # Name of the inference service  ( {{ .Name}} )
            # Namespace of the inference service ( {{ .Namespace }} )
-           # If not set or empty: the root path is used
-           # NOTE: This configuration only applicable for raw deployment.
+           # If not set or empty: the root path is used.
+           # NOTE: This configuration only applicable for raw deployment with Gateway API disabled.
            "ingressPathTemplate": "/namespaces/{{ .Namespace }}/endpoints/{{ .Name }}",
 
            # urlScheme specifies the url scheme to use for inference service and inference graph.

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -94,13 +94,13 @@ data:
         "resource": {
            # cpuLimit is the limits.cpu to set for the inference service.
            "cpuLimit": "1",
-    
+
            # memoryLimit is the limits.memory to set for the inference service.
            "memoryLimit": "2Gi",
-    
+
            # cpuRequest is the requests.cpu to set for the inference service.
            "cpuRequest": "1",
-    
+
            # memoryRequest is the requests.memory to set for the inference service.
            "memoryRequest": "2Gi"
         }
@@ -364,7 +364,14 @@ data:
            # If domain template is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }} is used.
            # NOTE: This configuration only applicable for raw deployment.
            "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-     
+
+           # ingressPathTemplate to expose all InferenceServices in a cluster behind a single domain by combining the following variables:
+           # Name of the inference service  ( {{ .Name}} )
+           # Namespace of the inference service ( {{ .Namespace }} )
+           # If not set or empty: the root path is used
+           # NOTE: This configuration only applicable for raw deployment.
+           "ingressPathTemplate": "/namespaces/{{ .Namespace }}/endpoints/{{ .Name }}",
+
            # urlScheme specifies the url scheme to use for inference service and inference graph.
            # If urlScheme is empty then by default http is used.
            "urlScheme": "http",

--- a/config/overlays/test/configmap/inferenceservice-ingress-path-template.yaml
+++ b/config/overlays/test/configmap/inferenceservice-ingress-path-template.yaml
@@ -15,5 +15,5 @@ data:
         "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
         "urlScheme": "http",
         "ingressPathTemplate": "/endpoints/{{ .Namespace }}/{{ .Name }}/",
-        "ingressDomain": "mydomain.com",
+        "ingressDomain": "mydomain.com"
     }

--- a/config/overlays/test/configmap/inferenceservice-ingress-path-template.yaml
+++ b/config/overlays/test/configmap/inferenceservice-ingress-path-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inferenceservice-config
+  namespace: kserve
+data:
+  ingress: |-
+    {   
+        "enableGatewayApi": false,
+        "kserveIngressGateway": "kserve/kserve-ingress-gateway",
+        "ingressGateway": "knative-serving/knative-ingress-gateway",
+        "localGateway": "knative-serving/knative-local-gateway",
+        "localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
+        "ingressClassName": "istio",
+        "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
+        "urlScheme": "http",
+        "ingressPathTemplate": "/endpoints/{{ .Namespace }}/{{ .Name }}/",
+        "ingressDomain": "mydomain.com",
+    }

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -365,11 +365,11 @@ data:
            # NOTE: This configuration only applicable for raw deployment.
            "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
 
-           # ingressPathTemplate to expose all InferenceServices in a cluster behind a single domain by combining the following variables:
+           # ingressPathTemplate specifies the template for generating the path of url's for each inference service by combining variables from:
            # Name of the inference service  ( {{ .Name}} )
            # Namespace of the inference service ( {{ .Namespace }} )
-           # If not set or empty: the root path is used
-           # NOTE: This configuration only applicable for raw deployment.
+           # If not set or empty: the root path is used.
+           # NOTE: This configuration only applicable for raw deployment with Gateway API disabled.
            "ingressPathTemplate": "/namespaces/{{ .Namespace }}/endpoints/{{ .Name }}",
 
            # urlScheme specifies the url scheme to use for inference service and inference graph.

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -94,13 +94,13 @@ data:
         "resource": {
            # cpuLimit is the limits.cpu to set for the inference service.
            "cpuLimit": "1",
-    
+
            # memoryLimit is the limits.memory to set for the inference service.
            "memoryLimit": "2Gi",
-    
+
            # cpuRequest is the requests.cpu to set for the inference service.
            "cpuRequest": "1",
-    
+
            # memoryRequest is the requests.memory to set for the inference service.
            "memoryRequest": "2Gi"
         }
@@ -364,7 +364,14 @@ data:
            # If domain template is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }} is used.
            # NOTE: This configuration only applicable for raw deployment.
            "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-     
+
+           # ingressPathTemplate to expose all InferenceServices in a cluster behind a single domain by combining the following variables:
+           # Name of the inference service  ( {{ .Name}} )
+           # Namespace of the inference service ( {{ .Namespace }} )
+           # If not set or empty: the root path is used
+           # NOTE: This configuration only applicable for raw deployment.
+           "ingressPathTemplate": "/namespaces/{{ .Namespace }}/endpoints/{{ .Name }}",
+
            # urlScheme specifies the url scheme to use for inference service and inference graph.
            # If urlScheme is empty then by default http is used.
            "urlScheme": "http",

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -38191,16 +38191,21 @@ data:
     }} )\n       # IngressDomain ( {{ .IngressDomain }} )\n       # If domain template
     is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}
     is used.\n       # NOTE: This configuration only applicable for raw deployment.\n
-    \      \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n
-    \n       # urlScheme specifies the url scheme to use for inference service and
-    inference graph.\n       # If urlScheme is empty then by default http is used.\n
-    \      \"urlScheme\": \"http\",\n \n       # disableIstioVirtualHost controls
-    whether to use istio as network layer.\n       # By default istio is used as the
-    network layer. When DisableIstioVirtualHost is true, KServe does not\n       #
-    create the top level virtual service thus Istio is no longer required for serverless
-    mode.\n       # By setting this field to true, user can use other networking layers
-    supported by knative.\n       # For more info https://github.com/kserve/kserve/pull/2380,
-    https://kserve.github.io/website/master/admin/serverless/kourier_networking/.\n
+    \      \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n\n
+    \      # ingressPathTemplate to expose all InferenceServices in a cluster behind
+    a single domain by combining the following variables:\n       # Name of the inference
+    service  ( {{ .Name}} )\n       # Namespace of the inference service ( {{ .Namespace
+    }} )\n       # If not set or empty: the root path is used\n       # NOTE: This
+    configuration only applicable for raw deployment.\n       \"ingressPathTemplate\":
+    \"/namespaces/{{ .Namespace }}/endpoints/{{ .Name }}\",\n\n       # urlScheme
+    specifies the url scheme to use for inference service and inference graph.\n       #
+    If urlScheme is empty then by default http is used.\n       \"urlScheme\": \"http\",\n
+    \n       # disableIstioVirtualHost controls whether to use istio as network layer.\n
+    \      # By default istio is used as the network layer. When DisableIstioVirtualHost
+    is true, KServe does not\n       # create the top level virtual service thus Istio
+    is no longer required for serverless mode.\n       # By setting this field to
+    true, user can use other networking layers supported by knative.\n       # For
+    more info https://github.com/kserve/kserve/pull/2380, https://kserve.github.io/website/master/admin/serverless/kourier_networking/.\n
     \      # NOTE: This configuration is only applicable to serverless deployment.\n
     \      \"disableIstioVirtualHost\": false,\n\n       # disableIngressCreation
     controls whether to disable ingress creation for raw deployment mode.\n       \"disableIngressCreation\":

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -37777,16 +37777,21 @@ data:
     }} )\n       # IngressDomain ( {{ .IngressDomain }} )\n       # If domain template
     is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}
     is used.\n       # NOTE: This configuration only applicable for raw deployment.\n
-    \      \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n
-    \n       # urlScheme specifies the url scheme to use for inference service and
-    inference graph.\n       # If urlScheme is empty then by default http is used.\n
-    \      \"urlScheme\": \"http\",\n \n       # disableIstioVirtualHost controls
-    whether to use istio as network layer.\n       # By default istio is used as the
-    network layer. When DisableIstioVirtualHost is true, KServe does not\n       #
-    create the top level virtual service thus Istio is no longer required for serverless
-    mode.\n       # By setting this field to true, user can use other networking layers
-    supported by knative.\n       # For more info https://github.com/kserve/kserve/pull/2380,
-    https://kserve.github.io/website/master/admin/serverless/kourier_networking/.\n
+    \      \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n\n
+    \      # ingressPathTemplate to expose all InferenceServices in a cluster behind
+    a single domain by combining the following variables:\n       # Name of the inference
+    service  ( {{ .Name}} )\n       # Namespace of the inference service ( {{ .Namespace
+    }} )\n       # If not set or empty: the root path is used\n       # NOTE: This
+    configuration only applicable for raw deployment.\n       \"ingressPathTemplate\":
+    \"/namespaces/{{ .Namespace }}/endpoints/{{ .Name }}\",\n\n       # urlScheme
+    specifies the url scheme to use for inference service and inference graph.\n       #
+    If urlScheme is empty then by default http is used.\n       \"urlScheme\": \"http\",\n
+    \n       # disableIstioVirtualHost controls whether to use istio as network layer.\n
+    \      # By default istio is used as the network layer. When DisableIstioVirtualHost
+    is true, KServe does not\n       # create the top level virtual service thus Istio
+    is no longer required for serverless mode.\n       # By setting this field to
+    true, user can use other networking layers supported by knative.\n       # For
+    more info https://github.com/kserve/kserve/pull/2380, https://kserve.github.io/website/master/admin/serverless/kourier_networking/.\n
     \      # NOTE: This configuration is only applicable to serverless deployment.\n
     \      \"disableIstioVirtualHost\": false,\n\n       # disableIngressCreation
     controls whether to disable ingress creation for raw deployment mode.\n       \"disableIngressCreation\":

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -127,10 +127,10 @@ type IngressConfig struct {
 	// This field has been added to prevent enabling path based routing by default in RawDeployment without GatewayAPI
 	//
 	// If using any other mode, use IngressConfig.PathTemplate
-	IngressPathTemplate     string `json:"ingressPathTemplate,omitempty"`
-	UrlScheme               string `json:"urlScheme,omitempty"`
-	EnableLLMInferenceServiceTLS bool      `json:"enableLLMInferenceServiceTLS,omitempty"`
-	DisableIstioVirtualHost bool   `json:"disableIstioVirtualHost,omitempty"`
+	IngressPathTemplate          string `json:"ingressPathTemplate,omitempty"`
+	UrlScheme                    string `json:"urlScheme,omitempty"`
+	EnableLLMInferenceServiceTLS bool   `json:"enableLLMInferenceServiceTLS,omitempty"`
+	DisableIstioVirtualHost      bool   `json:"disableIstioVirtualHost,omitempty"`
 	// Specifies the template for generating path based url's for InferenceServices in Serverless and GatewayAPI modes.
 	//
 	// If using RawDeployment without GatewayAPI, use IngressConfig.IngressPathTemplate

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -112,22 +112,30 @@ type MultiNodeConfig struct {
 
 // +kubebuilder:object:generate=false
 type IngressConfig struct {
-	EnableGatewayAPI             bool      `json:"enableGatewayApi,omitempty"`
-	KserveIngressGateway         string    `json:"kserveIngressGateway,omitempty"`
-	IngressGateway               string    `json:"ingressGateway,omitempty"`
-	KnativeLocalGatewayService   string    `json:"knativeLocalGatewayService,omitempty"`
-	LocalGateway                 string    `json:"localGateway,omitempty"`
-	LocalGatewayServiceName      string    `json:"localGatewayService,omitempty"`
-	IngressDomain                string    `json:"ingressDomain,omitempty"`
-	IngressClassName             *string   `json:"ingressClassName,omitempty"`
-	AdditionalIngressDomains     *[]string `json:"additionalIngressDomains,omitempty"`
-	DomainTemplate               string    `json:"domainTemplate,omitempty"`
-	IngressPathTemplate          string    `json:"ingressPathTemplate,omitempty"`
-	UrlScheme                    string    `json:"urlScheme,omitempty"`
+	EnableGatewayAPI           bool      `json:"enableGatewayApi,omitempty"`
+	KserveIngressGateway       string    `json:"kserveIngressGateway,omitempty"`
+	IngressGateway             string    `json:"ingressGateway,omitempty"`
+	KnativeLocalGatewayService string    `json:"knativeLocalGatewayService,omitempty"`
+	LocalGateway               string    `json:"localGateway,omitempty"`
+	LocalGatewayServiceName    string    `json:"localGatewayService,omitempty"`
+	IngressDomain              string    `json:"ingressDomain,omitempty"`
+	IngressClassName           *string   `json:"ingressClassName,omitempty"`
+	AdditionalIngressDomains   *[]string `json:"additionalIngressDomains,omitempty"`
+	DomainTemplate             string    `json:"domainTemplate,omitempty"`
+	// Specifies the template for generating path based url's in the RawDeployment mode with GatewayAPI disabled.
+	//
+	// This field has been added to prevent enabling path based routing by default in RawDeployment without GatewayAPI
+	//
+	// If using any other mode, use IngressConfig.PathTemplate
+	IngressPathTemplate     string `json:"ingressPathTemplate,omitempty"`
+	UrlScheme               string `json:"urlScheme,omitempty"`
 	EnableLLMInferenceServiceTLS bool      `json:"enableLLMInferenceServiceTLS,omitempty"`
-	DisableIstioVirtualHost      bool      `json:"disableIstioVirtualHost,omitempty"`
-	PathTemplate                 string    `json:"pathTemplate,omitempty"`
-	DisableIngressCreation       bool      `json:"disableIngressCreation,omitempty"`
+	DisableIstioVirtualHost bool   `json:"disableIstioVirtualHost,omitempty"`
+	// Specifies the template for generating path based url's for InferenceServices in Serverless and GatewayAPI modes.
+	//
+	// If using RawDeployment without GatewayAPI, use IngressConfig.IngressPathTemplate
+	PathTemplate           string `json:"pathTemplate,omitempty"`
+	DisableIngressCreation bool   `json:"disableIngressCreation,omitempty"`
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -52,9 +52,10 @@ const (
 )
 
 const (
-	DefaultDomainTemplate = "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"
-	DefaultIngressDomain  = "example.com"
-	DefaultUrlScheme      = "http"
+	DefaultDomainTemplate      = "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"
+	DefaultIngressPathTemplate = ""
+	DefaultIngressDomain       = "example.com"
+	DefaultUrlScheme           = "http"
 )
 
 // Error messages
@@ -121,6 +122,7 @@ type IngressConfig struct {
 	IngressClassName             *string   `json:"ingressClassName,omitempty"`
 	AdditionalIngressDomains     *[]string `json:"additionalIngressDomains,omitempty"`
 	DomainTemplate               string    `json:"domainTemplate,omitempty"`
+	IngressPathTemplate          string    `json:"ingressPathTemplate,omitempty"`
 	UrlScheme                    string    `json:"urlScheme,omitempty"`
 	EnableLLMInferenceServiceTLS bool      `json:"enableLLMInferenceServiceTLS,omitempty"`
 	DisableIstioVirtualHost      bool      `json:"disableIstioVirtualHost,omitempty"`

--- a/pkg/apis/serving/v1beta1/configmap_test.go
+++ b/pkg/apis/serving/v1beta1/configmap_test.go
@@ -669,6 +669,7 @@ func TestNewIngressConfig_Validation(t *testing.T) {
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
 		g.Expect(cfg).ShouldNot(gomega.BeNil())
 		g.Expect(cfg.DomainTemplate).To(gomega.Equal(DefaultDomainTemplate))
+		g.Expect(cfg.IngressPathTemplate).To(gomega.Equal(DefaultIngressPathTemplate))
 		g.Expect(cfg.IngressDomain).To(gomega.Equal(DefaultIngressDomain))
 		g.Expect(cfg.UrlScheme).To(gomega.Equal(DefaultUrlScheme))
 	})

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"strings"
 	"text/template"
 
@@ -64,6 +65,35 @@ func GenerateDomainName(name string, obj metav1.ObjectMeta, ingressConfig *v1bet
 	}
 
 	return buf.String(), nil
+}
+
+// GenerateIngressPath generate URL path using template configured in IngressConfig
+func GenerateIngressPath(name string, obj metav1.ObjectMeta, ingressConfig *v1beta1.IngressConfig) (string, error) {
+	if ingressConfig.IngressPathTemplate == "" {
+		return "", nil
+	}
+
+	values := DomainTemplateValues{
+		Name:      name,
+		Namespace: obj.Namespace,
+	}
+
+	tpl, err := template.New("ingress-path-template").Parse(ingressConfig.IngressPathTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	buf := bytes.Buffer{}
+	if err := tpl.Execute(&buf, values); err != nil {
+		return "", fmt.Errorf("error rendering the ingress path template: %w", err)
+	}
+
+	url, err := url.ParseRequestURI(buf.String())
+	if err != nil {
+		return "", fmt.Errorf("invalid url %q: %w", buf.String(), err)
+	}
+
+	return url.Path, nil
 }
 
 func GenerateInternalDomainName(name string, obj metav1.ObjectMeta, ingressConfig *v1beta1.IngressConfig) (string, error) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain.go
@@ -19,7 +19,6 @@ package ingress
 import (
 	"bytes"
 	"fmt"
-	"net/url"
 	"strings"
 	"text/template"
 
@@ -88,12 +87,12 @@ func GenerateIngressPath(name string, obj metav1.ObjectMeta, ingressConfig *v1be
 		return "", fmt.Errorf("error rendering the ingress path template: %w", err)
 	}
 
-	url, err := url.ParseRequestURI(buf.String())
-	if err != nil {
-		return "", fmt.Errorf("invalid url %q: %w", buf.String(), err)
+	path := buf.String()
+	if !strings.HasPrefix(path, "/") {
+		return "", fmt.Errorf("invalid rendered ingress path %s, should start with a forward slash", path)
 	}
 
-	return url.Path, nil
+	return path, nil
 }
 
 func GenerateInternalDomainName(name string, obj metav1.ObjectMeta, ingressConfig *v1beta1.IngressConfig) (string, error) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain_test.go
@@ -137,6 +137,83 @@ func TestGenerateDomainName(t *testing.T) {
 	}
 }
 
+func TestGenerateIngressPath(t *testing.T) {
+	type args struct {
+		name          string
+		obj           metav1.ObjectMeta
+		ingressConfig *v1beta1.IngressConfig
+	}
+
+	obj := metav1.ObjectMeta{
+		Name:      "model",
+		Namespace: "test",
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "default ingress path template",
+			args: args{
+				name: "model",
+				obj:  obj,
+				ingressConfig: &v1beta1.IngressConfig{
+					IngressPathTemplate: v1beta1.DefaultIngressPathTemplate,
+				},
+			},
+			want: "",
+		},
+		{
+			name: "template with no variables",
+			args: args{
+				name: "model",
+				obj:  obj,
+				ingressConfig: &v1beta1.IngressConfig{
+					IngressPathTemplate: "/",
+				},
+			},
+			want: "/",
+		},
+		{
+			name: "template with namespace and name",
+			args: args{
+				name: "model",
+				obj:  obj,
+				ingressConfig: &v1beta1.IngressConfig{
+					IngressPathTemplate: "/namespaces/{{.Namespace}}/endpoints/{{.Name}}",
+				},
+			},
+			want: "/namespaces/test/endpoints/model",
+		},
+		{
+			name: "unknown variable",
+			args: args{
+				name: "model",
+				obj:  obj,
+				ingressConfig: &v1beta1.IngressConfig{
+					IngressPathTemplate: "/cluster/{{.Cluster}}/namespaces/{{.Namespace}}/endpoints/{{.Name}}",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateIngressPath(tt.args.name, tt.args.obj, tt.args.ingressConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateIngressPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Test %q unexpected ingress path (-want +got): %v", tt.name, diff)
+			}
+		})
+	}
+}
+
 func TestGetAdditionalHosts(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/domain_test.go
@@ -199,6 +199,17 @@ func TestGenerateIngressPath(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid template",
+			args: args{
+				name: "model",
+				obj:  obj,
+				ingressConfig: &v1beta1.IngressConfig{
+					IngressPathTemplate: "this/should-not/work",
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -81,10 +81,6 @@ func createRawURL(isvc *v1beta1.InferenceService,
 	if err != nil {
 		return nil, err
 	}
-	url.Path, err = GenerateIngressPath(isvc.Name, isvc.ObjectMeta, ingressConfig)
-	if err != nil {
-		return nil, err
-	}
 
 	return url, nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -81,6 +81,10 @@ func createRawURL(isvc *v1beta1.InferenceService,
 	if err != nil {
 		return nil, err
 	}
+	url.Path, err = GenerateIngressPath(isvc.Name, isvc.ObjectMeta, ingressConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	return url, nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -107,6 +107,22 @@ func TestCreateRawURL(t *testing.T) {
 			expectedURL:     "",
 			isErrorExpected: true,
 		},
+		"basic case with ingress path template": {
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-isvc",
+					Namespace: "default",
+				},
+			},
+			ingressConfig: &v1beta1.IngressConfig{
+				IngressDomain:       "example.com",
+				UrlScheme:           "http",
+				DomainTemplate:      "{{.IngressDomain}}",
+				IngressPathTemplate: "/namespaces/{{.Namespace}}/endpoints/{{.Name}}",
+			},
+			isErrorExpected: false,
+			expectedURL:     "http://example.com/namespaces/default/endpoints/test-isvc",
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -107,22 +107,6 @@ func TestCreateRawURL(t *testing.T) {
 			expectedURL:     "",
 			isErrorExpected: true,
 		},
-		"basic case with ingress path template": {
-			isvc: &v1beta1.InferenceService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-isvc",
-					Namespace: "default",
-				},
-			},
-			ingressConfig: &v1beta1.IngressConfig{
-				IngressDomain:       "example.com",
-				UrlScheme:           "http",
-				DomainTemplate:      "{{.IngressDomain}}",
-				IngressPathTemplate: "/namespaces/{{.Namespace}}/endpoints/{{.Name}}",
-			},
-			isErrorExpected: false,
-			expectedURL:     "http://example.com/namespaces/default/endpoints/test-isvc",
-		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -233,6 +233,29 @@ func generateIngressHost(ingressConfig *v1beta1.IngressConfig,
 	}
 }
 
+// generateIngressHost return the path to be used when an configmap.IngressPathTemplate is set
+func generateIngressPath(ingressConfig *v1beta1.IngressConfig,
+	isvc *v1beta1.InferenceService,
+	isvcConfig *v1beta1.InferenceServicesConfig,
+	componentType string,
+	topLevelFlag bool,
+	name string,
+) (path string, err error) {
+	metadata := generateMetadata(isvc, constants.InferenceServiceComponent(componentType), name, isvcConfig)
+	if !topLevelFlag {
+		path, err = GenerateIngressPath(metadata.Name, isvc.ObjectMeta, ingressConfig)
+	} else {
+		path, err = GenerateIngressPath(isvc.Name, isvc.ObjectMeta, ingressConfig)
+	}
+	if err != nil {
+		return "", err
+	}
+	if path == "" {
+		return "/", nil
+	}
+	return path, nil
+}
+
 func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1.InferenceService,
 	ingressConfig *v1beta1.IngressConfig, isvcConfig *v1beta1.InferenceServicesConfig,
 ) (*netv1.Ingress, error) {
@@ -262,20 +285,34 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1.InferenceService,
 		if err != nil {
 			return nil, fmt.Errorf("failed creating top level transformer ingress host: %w", err)
 		}
+		path, err := generateIngressPath(ingressConfig, isvc, isvcConfig, string(constants.Transformer), true, predictorName)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating top level transformer ingress path: %w", err)
+		}
+
 		transformerHost, err := generateIngressHost(ingressConfig, isvc, isvcConfig, string(constants.Transformer), false, transformerName)
 		if err != nil {
 			return nil, fmt.Errorf("failed creating transformer ingress host: %w", err)
 		}
+		transformerPath, err := generateIngressPath(ingressConfig, isvc, isvcConfig, string(constants.Transformer), false, transformerName)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating transformer ingress path: %w", err)
+		}
+
 		if isvc.Spec.Explainer != nil {
 			explainerHost, err := generateIngressHost(ingressConfig, isvc, isvcConfig, string(constants.Explainer), false, transformerName)
 			if err != nil {
 				return nil, fmt.Errorf("failed creating explainer ingress host: %w", err)
 			}
-			rules = append(rules, generateRule(explainerHost, explainerName, "/", constants.CommonDefaultHttpPort))
+			explainerPath, err := generateIngressPath(ingressConfig, isvc, isvcConfig, string(constants.Explainer), false, transformerName)
+			if err != nil {
+				return nil, fmt.Errorf("failed creating explainer ingress path: %w", err)
+			}
+			rules = append(rules, generateRule(explainerHost, explainerName, explainerPath, constants.CommonDefaultHttpPort))
 		}
 		// :predict routes to the transformer when there are both predictor and transformer
-		rules = append(rules, generateRule(host, transformerName, "/", constants.CommonDefaultHttpPort))
-		rules = append(rules, generateRule(transformerHost, predictorName, "/", constants.CommonDefaultHttpPort))
+		rules = append(rules, generateRule(host, transformerName, path, constants.CommonDefaultHttpPort))
+		rules = append(rules, generateRule(transformerHost, predictorName, transformerPath, constants.CommonDefaultHttpPort))
 	case isvc.Spec.Explainer != nil:
 		if !isvc.Status.IsConditionReady(v1beta1.ExplainerReady) {
 			isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
@@ -290,26 +327,45 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1.InferenceService,
 		if err != nil {
 			return nil, fmt.Errorf("failed creating top level explainer ingress host: %w", err)
 		}
+		path, err := generateIngressPath(ingressConfig, isvc, isvcConfig, string(constants.Explainer), true, predictorName)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating top level explainer ingress path: %w", err)
+		}
+
 		explainerHost, err := generateIngressHost(ingressConfig, isvc, isvcConfig, string(constants.Explainer), false, explainerName)
 		if err != nil {
 			return nil, fmt.Errorf("failed creating explainer ingress host: %w", err)
 		}
+		explainerPath, err := generateIngressPath(ingressConfig, isvc, isvcConfig, string(constants.Explainer), false, explainerName)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating explainer ingress path: %w", err)
+		}
+
 		// :predict routes to the predictor when there is only predictor and explainer
-		rules = append(rules, generateRule(host, predictorName, "/", constants.CommonDefaultHttpPort))
-		rules = append(rules, generateRule(explainerHost, explainerName, "/", constants.CommonDefaultHttpPort))
+		rules = append(rules, generateRule(host, predictorName, path, constants.CommonDefaultHttpPort))
+		rules = append(rules, generateRule(explainerHost, explainerName, explainerPath, constants.CommonDefaultHttpPort))
 	default:
 		host, err := generateIngressHost(ingressConfig, isvc, isvcConfig, string(constants.Predictor), true, predictorName)
 		if err != nil {
 			return nil, fmt.Errorf("failed creating top level predictor ingress host: %w", err)
 		}
-		rules = append(rules, generateRule(host, predictorName, "/", constants.CommonDefaultHttpPort))
+		path, err := generateIngressPath(ingressConfig, isvc, isvcConfig, string(constants.Predictor), true, predictorName)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating top level predictor ingress path: %w", err)
+		}
+
+		rules = append(rules, generateRule(host, predictorName, path, constants.CommonDefaultHttpPort))
 	}
 	// add predictor rule
 	predictorHost, err := generateIngressHost(ingressConfig, isvc, isvcConfig, string(constants.Predictor), false, predictorName)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating predictor ingress host: %w", err)
 	}
-	rules = append(rules, generateRule(predictorHost, predictorName, "/", constants.CommonDefaultHttpPort))
+	predictorPath, err := generateIngressPath(ingressConfig, isvc, isvcConfig, string(constants.Predictor), false, predictorName)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating predictor ingress path: %w", err)
+	}
+	rules = append(rules, generateRule(predictorHost, predictorName, predictorPath, constants.CommonDefaultHttpPort))
 
 	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -233,7 +233,7 @@ func generateIngressHost(ingressConfig *v1beta1.IngressConfig,
 	}
 }
 
-// generateIngressHost return the path to be used when an configmap.IngressPathTemplate is set
+// generateIngressPath return the path to be used when an configmap.IngressPathTemplate is set
 func generateIngressPath(ingressConfig *v1beta1.IngressConfig,
 	isvc *v1beta1.InferenceService,
 	isvcConfig *v1beta1.InferenceServicesConfig,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
@@ -1,0 +1,505 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+)
+
+func TestCreateRawIngressWithPathTemplate(t *testing.T) {
+	g := NewGomegaWithT(t)
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	_ = netv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	ingressClassName := "istio"
+	ingressConfig := &v1beta1.IngressConfig{
+		IngressDomain:       "example.com",
+		DomainTemplate:      "{{.IngressDomain}}",
+		IngressClassName:    &ingressClassName,
+		IngressPathTemplate: "/namespace/{{.Namespace}}/endpoint/{{.Name}}",
+	}
+
+	pathTypePrefix := netv1.PathTypePrefix
+
+	testCases := map[string]struct {
+		isvc          *v1beta1.InferenceService
+		expectedRules []netv1.IngressRule
+		shouldFail    bool
+	}{
+		"Predictor not ready": {
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{},
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Type:   v1beta1.PredictorReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			expectedRules: nil,
+			shouldFail:    false,
+		},
+		"Predictor ready": {
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{},
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Type:   v1beta1.PredictorReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedRules: []netv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-predictor",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc-predictor",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-predictor",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		"Transformer defined but not ready": {
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor:   v1beta1.PredictorSpec{},
+					Transformer: &v1beta1.TransformerSpec{},
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Type:   v1beta1.PredictorReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   v1beta1.TransformerReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			expectedRules: nil,
+			shouldFail:    false,
+		},
+		"Transformer ready": {
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor:   v1beta1.PredictorSpec{},
+					Transformer: &v1beta1.TransformerSpec{},
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Type:   v1beta1.PredictorReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   v1beta1.TransformerReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedRules: []netv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-transformer",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc-transformer",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-predictor",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc-predictor",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-predictor",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		"Explainer defined but not ready": {
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{},
+					Explainer: &v1beta1.ExplainerSpec{},
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Type:   v1beta1.PredictorReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   v1beta1.ExplainerReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			expectedRules: nil,
+			shouldFail:    false,
+		},
+		"Explainer ready (no transformer)": {
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{},
+					Explainer: &v1beta1.ExplainerSpec{},
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Type:   v1beta1.PredictorReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   v1beta1.ExplainerReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedRules: []netv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-predictor",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc-explainer",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-explainer",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc-predictor",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-predictor",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		"Transformer and Explainer{ ready": {
+			isvc: &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-isvc",
+					Namespace: "default",
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor:   v1beta1.PredictorSpec{},
+					Transformer: &v1beta1.TransformerSpec{},
+					Explainer:   &v1beta1.ExplainerSpec{},
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					Status: duckv1.Status{
+						Conditions: []apis.Condition{
+							{
+								Type:   v1beta1.PredictorReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   v1beta1.TransformerReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedRules: []netv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc-transformer",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-explainer",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-transformer",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc-transformer",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-predictor",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path:     "/namespace/default/endpoint/my-isvc-predictor",
+									PathType: &pathTypePrefix,
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "my-isvc-predictor",
+											Port: netv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+	}
+
+	// tests := []struct {
+	// 	name          string
+	// 	isvc          *v1beta1.InferenceService
+	// 	expectedRules []netv1.IngressRule
+	// 	shouldFail    bool
+	// }{
+
+	// }
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ingress, err := createRawIngress(scheme, tc.isvc, ingressConfig, &v1beta1.InferenceServicesConfig{})
+			if tc.shouldFail {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				if tc.expectedRules == nil {
+					g.Expect(ingress).To(BeNil())
+				} else {
+					g.Expect(ingress).ToNot(BeNil())
+					g.Expect(ingress.Name).To(BeComparableTo(tc.isvc.Name))
+					g.Expect(ingress.Namespace).To(BeComparableTo(tc.isvc.Namespace))
+					g.Expect(ingress.Spec.IngressClassName).To(BeComparableTo(ingressConfig.IngressClassName))
+					g.Expect(ingress.Spec.Rules).To(HaveLen(len(tc.expectedRules)))
+					g.Expect(ingress.Spec.Rules).To(BeComparableTo(tc.expectedRules))
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
@@ -365,7 +365,7 @@ func TestCreateRawIngressWithPathTemplate(t *testing.T) {
 			},
 			shouldFail: false,
 		},
-		"Transformer and Explainer{ ready": {
+		"Transformer and Explainer ready": {
 			isvc: &v1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-isvc",
@@ -472,15 +472,6 @@ func TestCreateRawIngressWithPathTemplate(t *testing.T) {
 			shouldFail: false,
 		},
 	}
-
-	// tests := []struct {
-	// 	name          string
-	// 	isvc          *v1beta1.InferenceService
-	// 	expectedRules []netv1.IngressRule
-	// 	shouldFail    bool
-	// }{
-
-	// }
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6788,6 +6788,12 @@ func schema_pkg_apis_serving_v1beta1_IngressConfig(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"ingressPathTemplate": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"urlScheme": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -3734,6 +3734,9 @@
         "ingressGateway": {
           "type": "string"
         },
+        "ingressPathTemplate": {
+          "type": "string"
+        },
         "knativeLocalGatewayService": {
           "type": "string"
         },

--- a/python/kserve/docs/V1beta1IngressConfig.md
+++ b/python/kserve/docs/V1beta1IngressConfig.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **ingress_class_name** | **str** |  | [optional] 
 **ingress_domain** | **str** |  | [optional] 
 **ingress_gateway** | **str** |  | [optional] 
+**ingress_path_template** | **str** |  | [optional] 
 **knative_local_gateway_service** | **str** |  | [optional] 
 **kserve_ingress_gateway** | **str** |  | [optional] 
 **local_gateway** | **str** |  | [optional] 

--- a/python/kserve/kserve/models/v1beta1_ingress_config.py
+++ b/python/kserve/kserve/models/v1beta1_ingress_config.py
@@ -56,6 +56,7 @@ class V1beta1IngressConfig(object):
         'ingress_class_name': 'str',
         'ingress_domain': 'str',
         'ingress_gateway': 'str',
+        "ingress_path_template": "str",
         'knative_local_gateway_service': 'str',
         'kserve_ingress_gateway': 'str',
         'local_gateway': 'str',
@@ -74,6 +75,7 @@ class V1beta1IngressConfig(object):
         'ingress_class_name': 'ingressClassName',
         'ingress_domain': 'ingressDomain',
         'ingress_gateway': 'ingressGateway',
+        "ingress_path_template": "ingressPathTemplate",
         'knative_local_gateway_service': 'knativeLocalGatewayService',
         'kserve_ingress_gateway': 'kserveIngressGateway',
         'local_gateway': 'localGateway',
@@ -82,7 +84,7 @@ class V1beta1IngressConfig(object):
         'url_scheme': 'urlScheme'
     }
 
-    def __init__(self, additional_ingress_domains=None, disable_ingress_creation=None, disable_istio_virtual_host=None, domain_template=None, enable_gateway_api=None, enable_llm_inference_service_tls=None, ingress_class_name=None, ingress_domain=None, ingress_gateway=None, knative_local_gateway_service=None, kserve_ingress_gateway=None, local_gateway=None, local_gateway_service=None, path_template=None, url_scheme=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, additional_ingress_domains=None, disable_ingress_creation=None, disable_istio_virtual_host=None, domain_template=None, enable_gateway_api=None, enable_llm_inference_service_tls=None, ingress_class_name=None, ingress_domain=None, ingress_gateway=None, ingress_path_template=None, knative_local_gateway_service=None, kserve_ingress_gateway=None, local_gateway=None, local_gateway_service=None, path_template=None, url_scheme=None, local_vars_configuration=None):  # noqa: E501
         """V1beta1IngressConfig - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -97,6 +99,7 @@ class V1beta1IngressConfig(object):
         self._ingress_class_name = None
         self._ingress_domain = None
         self._ingress_gateway = None
+        self._ingress_path_template = None
         self._knative_local_gateway_service = None
         self._kserve_ingress_gateway = None
         self._local_gateway = None
@@ -123,6 +126,8 @@ class V1beta1IngressConfig(object):
             self.ingress_domain = ingress_domain
         if ingress_gateway is not None:
             self.ingress_gateway = ingress_gateway
+        if ingress_path_template is not None:
+            self.ingress_path_template = ingress_path_template
         if knative_local_gateway_service is not None:
             self.knative_local_gateway_service = knative_local_gateway_service
         if kserve_ingress_gateway is not None:
@@ -326,6 +331,27 @@ class V1beta1IngressConfig(object):
         self._ingress_gateway = ingress_gateway
 
     @property
+    def ingress_path_template(self):
+        """Gets the ingress_path_template of this V1beta1IngressConfig.  # noqa: E501
+
+
+        :return: The ingress_path_template of this V1beta1IngressConfig.  # noqa: E501
+        :rtype: str
+        """
+        return self._ingress_path_template
+
+    @ingress_path_template.setter
+    def ingress_path_template(self, ingress_path_template):
+        """Sets the ingress_path_template of this V1beta1IngressConfig.
+
+
+        :param ingress_path_template: The ingress_path_template of this V1beta1IngressConfig.  # noqa: E501
+        :type: str
+        """
+
+        self._ingress_path_template = ingress_path_template
+
+    @property
     def knative_local_gateway_service(self):
         """Gets the knative_local_gateway_service of this V1beta1IngressConfig.  # noqa: E501
 
@@ -458,18 +484,22 @@ class V1beta1IngressConfig(object):
         for attr, _ in six.iteritems(self.openapi_types):
             value = getattr(self, attr)
             if isinstance(value, list):
-                result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    value
-                ))
+                result[attr] = list(
+                    map(lambda x: x.to_dict() if hasattr(x, "to_dict") else x, value)
+                )
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()
             elif isinstance(value, dict):
-                result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
-                    if hasattr(item[1], "to_dict") else item,
-                    value.items()
-                ))
+                result[attr] = dict(
+                    map(
+                        lambda item: (
+                            (item[0], item[1].to_dict())
+                            if hasattr(item[1], "to_dict")
+                            else item
+                        ),
+                        value.items(),
+                    )
+                )
             else:
                 result[attr] = value
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability for the person deploying KServe to set up path based routing via the `ingressPathTemplate` field in the `inferenceservice-config` configmap:
```yaml
ingress: |-
    {   
      "ingressPathTemplate": "/namespaces/{{ .Namespace }}/endpoints/{{ .Name }}"
    }
```
This allows users to put all inference services behind a single domain and increases feature parity between the RawDeployment and Serverless mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4888 

**Feature/Issue validation/testing**:
`make test` passed without issues

**Special notes for your reviewer**:
- In the original issue (#4888) the author suggested to use `pathTemplate` to configure the path template for RawDeployment mode, this however would result in a breaking change for RawDeployment users since the default is already set to a non empty value which would change the ingress prefixes in those deployments of KServe.
- I'm not familiar with the GatewayAPI that's why path based routing hasn't been implemented for RawDeployment's with GatewayAPI enabled

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Added path based routing to `InferenceServices` deployed in `RawDeployment` mode. Users are able to configure the path template via `ingressPathTemplate` under the `ingress` key of the `inferenceservice-config` config map.
```
