### PR TITLE
fix(localmodel): use ObjectOld in node update predicate

### DIFF
--- a/pkg/controller/v1alpha1/localmodel/node_watch_test.go
+++ b/pkg/controller/v1alpha1/localmodel/node_watch_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localmodel
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ = Describe("Node Ready Predicate", func() {
+	var pred predicate.Funcs
+
+	BeforeEach(func() {
+		pred = nodeReadyPredicate()
+	})
+
+	Describe("UpdateFunc", func() {
+		Context("when a node transitions from NotReady to Ready", func() {
+			It("should return true", func() {
+				oldNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}
+				newNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				result := pred.Update(event.UpdateEvent{
+					ObjectOld: oldNode,
+					ObjectNew: newNode,
+				})
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("when a node transitions from no conditions (new node) to Ready", func() {
+			It("should return true", func() {
+				oldNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status:     corev1.NodeStatus{},
+				}
+				newNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				result := pred.Update(event.UpdateEvent{
+					ObjectOld: oldNode,
+					ObjectNew: newNode,
+				})
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("when a node stays Ready", func() {
+			It("should return false", func() {
+				oldNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				newNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+
+				result := pred.Update(event.UpdateEvent{
+					ObjectOld: oldNode,
+					ObjectNew: newNode,
+				})
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when a node transitions from Ready to NotReady", func() {
+			It("should return false", func() {
+				oldNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				newNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}
+
+				result := pred.Update(event.UpdateEvent{
+					ObjectOld: oldNode,
+					ObjectNew: newNode,
+				})
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when a node stays NotReady", func() {
+			It("should return false", func() {
+				oldNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}
+				newNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}
+
+				result := pred.Update(event.UpdateEvent{
+					ObjectOld: oldNode,
+					ObjectNew: newNode,
+				})
+				Expect(result).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("CreateFunc", func() {
+		It("should return true for any node creation", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+			}
+			result := pred.Create(event.CreateEvent{
+				Object: node,
+			})
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	Describe("DeleteFunc", func() {
+		It("should return false for any node deletion", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+			}
+			result := pred.Delete(event.DeleteEvent{
+				Object: node,
+			})
+			Expect(result).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes a copy-paste bug in `nodePredicates.UpdateFunc` where `e.ObjectNew` was used for both `oldNode` and `newNode`, causing the NotReady→Ready transition check to always return `false`
- This prevented `LocalModelCache` reconciliation when nodes dynamically join the cluster (e.g., via cluster autoscaler), so `LocalModelNode` resources were never created for new nodes

**Which issue(s) this PR fixes**: #4771

**Details**:

In `pkg/controller/v1alpha1/localmodel/controller.go`, the node update predicate was:
```go
oldNode := e.ObjectNew.(*corev1.Node) // BUG: should be e.ObjectOld
newNode := e.ObjectNew.(*corev1.Node)
return !isNodeReady(*oldNode) && isNodeReady(*newNode)
```

Since both variables reference the same (new) object, `!isNodeReady(X) && isNodeReady(X)` is always `false`. The fix changes `oldNode` to use `e.ObjectOld`.

**Feature/Issue validation/testing**:
- The fix compiles successfully
- Existing unit/webhook tests pass
- The integration tests require envtest infrastructure (etcd/kubebuilder) and are unaffected by this change

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

**Release note**:
```release-note
NONE
```