### PR TITLE
chore: change 'owners' to 'project-leads' in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-owners:
+project-leads:
   - terrytangyuan
   - yuzisun
 


### PR DESCRIPTION
Addressing feedback from CNCF:
> Term Inconsistency: The owners file uses owners:, members doc calls them Leads, and the Charter calls them Project Leads. It would be good to sort out all terms across doc doc while changing the charter.
