### PR TITLE
feat(llmisvc): enhance Gateway API URL discovery

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_loader.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader.go
@@ -35,6 +35,7 @@ type Config struct {
 	SystemNamespace         string `json:"systemNamespace,omitempty"`
 	IngressGatewayName      string `json:"ingressGatewayName,omitempty"`
 	IngressGatewayNamespace string `json:"ingressGatewayNamespace,omitempty"`
+	UrlScheme               string `json:"urlScheme,omitempty"`
 
 	// Storage and credential configs are excluded from JSON serialization
 	// as they contain sensitive information
@@ -59,6 +60,7 @@ func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *types.Storag
 		SystemNamespace:         constants.KServeNamespace,
 		IngressGatewayNamespace: igwNs,
 		IngressGatewayName:      igwName,
+		UrlScheme:               ingressConfig.UrlScheme,
 		StorageConfig:           storageConfig,
 		CredentialConfig:        credentialConfig,
 	}

--- a/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
@@ -119,6 +119,14 @@ func DefaultGatewayClass() *gwapiv1.GatewayClass {
 }
 
 func InferenceServiceCfgMap(ns string) *corev1.ConfigMap {
+	return InferenceServiceCfgMapWithUrlScheme(ns, "")
+}
+
+func InferenceServiceCfgMapWithUrlScheme(ns, urlScheme string) *corev1.ConfigMap {
+	urlSchemeConfig := ""
+	if urlScheme != "" {
+		urlSchemeConfig = `,"urlScheme": "` + urlScheme + `"`
+	}
 	configs := map[string]string{
 		"ingress": `{
 				"enableGatewayApi": true,
@@ -126,7 +134,7 @@ func InferenceServiceCfgMap(ns string) *corev1.ConfigMap {
 				"ingressGateway": "knative-serving/knative-ingress-gateway",
 				"localGateway": "knative-serving/knative-local-gateway",
 				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
-				"additionalIngressDomains": ["additional.example.com"]
+				"additionalIngressDomains": ["additional.example.com"]` + urlSchemeConfig + `
 			}`,
 		"storageInitializer": `{
 				"memoryRequest": "100Mi",

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -273,6 +273,9 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 		return nil
 	}
 
+	// TODO: LoadConfig fetches the configmap from the API server on every
+	// reconciliation. Consider caching with an informer-based watch to reduce
+	// API server pressure under high reconciliation load.
 	cfg, err := LoadConfig(ctx, r.Clientset)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -273,10 +273,15 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 		return nil
 	}
 
+	cfg, err := LoadConfig(ctx, r.Clientset)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
 	var urls []*apis.URL
 	for _, route := range routes {
-		discoverURL, err := DiscoverURLs(ctx, r.Client, route)
-		if IgnoreExternalAddressNotFound(err) != nil {
+		discoverURL, err := DiscoverURLs(ctx, r.Client, route, cfg.UrlScheme)
+		if IgnoreNoURLsDiscovered(err) != nil {
 			return fmt.Errorf("failed to discover URL for route %s/%s: %w", route.GetNamespace(), route.GetName(), err)
 		}
 		if discoverURL != nil {
@@ -298,8 +303,10 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 
 	llmSvc.Status.Addresses = make([]duckv1.Addressable, 0, len(urls))
 	for _, url := range urls {
+		addressType := AddressTypeName(url)
 		llmSvc.Status.Addresses = append(llmSvc.Status.Addresses, duckv1.Addressable{
-			URL: url,
+			Name: &addressType,
+			URL:  url,
 		})
 	}
 
@@ -331,7 +338,7 @@ func (r *LLMISVCReconciler) EvaluateGatewayConditions(ctx context.Context, llmSv
 	}
 
 	// If no router or gateway configuration, mark as ready to clear any previous stopped state
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Gateway == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
+	if llmSvc.Spec.Router == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
 		logger.Info("No Gateway references found, skipping Gateway condition evaluation")
 		llmSvc.MarkGatewaysReadyUnset()
 		return nil
@@ -368,7 +375,7 @@ func (r *LLMISVCReconciler) EvaluateGatewayConditions(ctx context.Context, llmSv
 
 // CollectReferencedGateways retrieves all Gateway objects referenced in the LLMInferenceService spec
 func (r *LLMISVCReconciler) CollectReferencedGateways(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) ([]*gwapiv1.Gateway, error) {
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Gateway == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
+	if llmSvc.Spec.Router == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
 		return nil, nil
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -17,12 +17,13 @@ limitations under the License.
 package llmisvc
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"slices"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -96,6 +97,13 @@ func DiscoverGatewayServiceHost(ctx context.Context, c client.Client, gateway *g
 		return "", fmt.Errorf("failed to list services for gateway %s/%s: %w", gateway.Namespace, gateway.Name, err)
 	}
 	if len(svcList.Items) > 0 {
+		if len(svcList.Items) > 1 {
+			logger.Info("Multiple services found with gateway label, using first alphabetically",
+				"gateway", gateway.Name, "count", len(svcList.Items))
+			slices.SortFunc(svcList.Items, func(a, b corev1.Service) int {
+				return cmp.Compare(a.Name, b.Name)
+			})
+		}
 		svc := &svcList.Items[0]
 		host := network.GetServiceHostname(svc.Name, svc.Namespace)
 		logger.V(1).Info("Discovered gateway service via label", "gateway", gateway.Name, "service", svc.Name, "host", host)
@@ -166,7 +174,10 @@ func DiscoverURLs(ctx context.Context, c client.Client, route *gwapiv1.HTTPRoute
 			return nil, fmt.Errorf("failed to discover gateway service host for %s/%s: %w", g.gateway.Namespace, g.gateway.Name, err)
 		}
 		if internalHost != "" {
-			// Use first listener's scheme and port - internal service matches Gateway listener
+			// Use preferred (first) listener's scheme and port for the internal URL.
+			// Internal services typically expose a single protocol, so generating one
+			// URL (matching the preferred scheme) is sufficient. External URLs are
+			// generated for all listeners because clients may need either protocol.
 			listener := listeners[0]
 			internalURLs, err := combineIntoURLs([]string{internalHost}, schemeForProtocol(listener.Protocol), listener.Port, path)
 			if err != nil {
@@ -209,51 +220,59 @@ func extractHostnamesForListener(route *gwapiv1.HTTPRoute, listener *gwapiv1.Lis
 	return hostnames
 }
 
-// extractRoutePath extracts the path from the HTTPRoute rules.
-// Returns the shortest path (by slash count) from rules referencing a Service backend.
+// extractRoutePath selects the base URL path from an HTTPRoute's rules.
+// It assumes paths form a hierarchy (e.g. /ns/name, /ns/name/v1/completions)
+// where the shallowest path is the logical base URL to advertise in status.
+// Paths from rules with a Service backend take priority over others (e.g. InferencePool).
+// Among candidates, the path with the fewest "/" segments is chosen, with
+// string length as a tiebreaker.
+// Note: this only handles PathPrefix matches correctly; Exact and RegularExpression
+// match types are not distinguished.
 func extractRoutePath(route *gwapiv1.HTTPRoute) string {
-	serviceKind := gwapiv1.Kind("Service")
-	servicePaths := []string{}
-	paths := []string{}
+	var servicePaths, otherPaths []string
 	for _, rule := range route.Spec.Rules {
-		serviceFound := false
-		for _, backendRef := range rule.BackendRefs {
-			if ptr.Deref(backendRef.Kind, serviceKind) == serviceKind {
-				serviceFound = true
-				break
-			}
-		}
+		svc := hasServiceBackend(rule)
 		for _, match := range rule.Matches {
 			if match.Path == nil {
 				continue
 			}
-			if serviceFound {
-				servicePaths = append(servicePaths, ptr.Deref(match.Path.Value, "/"))
+			p := ptr.Deref(match.Path.Value, "/")
+			if svc {
+				servicePaths = append(servicePaths, p)
 			} else {
-				paths = append(paths, ptr.Deref(match.Path.Value, "/"))
+				otherPaths = append(otherPaths, p)
 			}
 		}
 	}
 
-	// Paths set in rules referencing a Service as the backend will take priority
-	if len(servicePaths) > 0 {
-		paths = servicePaths
-	}
-
-	// If any paths are set in rules for the route, return the highest level path with the shortest length
 	// TODO how do we deal with regexp
 	// TODO how do we intelligently handle multiple rules
-	shortestPath := "/"
-	minSlashes := math.MaxInt
-	for _, path := range paths {
-		pathSlashes := strings.Count(path, "/")
-		if pathSlashes < minSlashes || (pathSlashes == minSlashes && len(path) < len(shortestPath)) {
-			shortestPath = path
-			minSlashes = pathSlashes
-		}
+	paths := servicePaths
+	if len(paths) == 0 {
+		paths = otherPaths
+	}
+	if len(paths) == 0 {
+		return "/"
 	}
 
-	return shortestPath
+	return slices.MinFunc(paths, func(a, b string) int {
+		if d := strings.Count(a, "/") - strings.Count(b, "/"); d != 0 {
+			return d
+		}
+		return len(a) - len(b)
+	})
+}
+
+// hasServiceBackend returns true if the rule has at least one backendRef with Kind "Service"
+// or with no Kind set (defaults to Service per Gateway API spec).
+func hasServiceBackend(rule gwapiv1.HTTPRouteRule) bool {
+	for _, ref := range rule.BackendRefs {
+		kind := ptr.Deref(ref.Kind, gwapiv1.Kind("Service"))
+		if kind == "Service" {
+			return true
+		}
+	}
+	return false
 }
 
 // schemeForProtocol returns the URL scheme for a Gateway API protocol.
@@ -367,7 +386,7 @@ func combineIntoURLs(hostnames []string, scheme string, port gwapiv1.PortNumber,
 			urlStr = fmt.Sprintf("%s://%s%s", scheme, joinHostPort(hostname, &port), path)
 		} else {
 			// Use standard port - omit from URL for cleaner appearance
-			urlStr = fmt.Sprintf("%s://%s%s", scheme, hostname, path)
+			urlStr = fmt.Sprintf("%s://%s%s", scheme, joinHostPort(hostname, nil), path)
 		}
 
 		url, err := apis.ParseURL(urlStr)
@@ -383,10 +402,14 @@ func combineIntoURLs(hostnames []string, scheme string, port gwapiv1.PortNumber,
 
 // joinHostPort safely combines a hostname and port into a host:port string
 // Uses net.JoinHostPort to handle IPv6 addresses correctly with brackets
-// Returns just the host if port is nil or zero
+// Returns just the host if port is nil or zero (with IPv6 bracket wrapping)
 func joinHostPort(host string, port *gwapiv1.PortNumber) string {
 	if port != nil && *port != 0 {
-		return net.JoinHostPort(host, fmt.Sprint(*port))
+		return net.JoinHostPort(host, strconv.Itoa(int(*port)))
+	}
+	// IPv6 addresses need brackets in URLs even without an explicit port
+	if strings.Contains(host, ":") {
+		return "[" + host + "]"
 	}
 	return host
 }
@@ -482,7 +505,7 @@ func IsHTTPRouteReady(route *gwapiv1.HTTPRoute) bool {
 	// Multiple controllers may write separate status entries for the same ParentRef,
 	// so we only require that at least one entry exists per spec ref.
 	for _, specRef := range route.Spec.ParentRefs {
-		if !hasMatchingParentStatus(specRef, route.Status.Parents) {
+		if !hasMatchingParentStatus(specRef, route.Status.Parents, gwapiv1.Namespace(route.Namespace)) {
 			return false
 		}
 	}
@@ -495,9 +518,9 @@ func IsHTTPRouteReady(route *gwapiv1.HTTPRoute) bool {
 // controller (i.e., has the Accepted condition set). Policy or extension
 // controllers may also write status entries for the same ParentRef but without
 // setting the Accepted condition, so those entries alone are not sufficient.
-func hasMatchingParentStatus(specRef gwapiv1.ParentReference, parents []gwapiv1.RouteParentStatus) bool {
+func hasMatchingParentStatus(specRef gwapiv1.ParentReference, parents []gwapiv1.RouteParentStatus, defaultNS gwapiv1.Namespace) bool {
 	for i := range parents {
-		if parentRefMatches(specRef, parents[i].ParentRef) &&
+		if parentRefMatches(specRef, parents[i].ParentRef, defaultNS) &&
 			meta.FindStatusCondition(parents[i].Conditions, string(gwapiv1.RouteConditionAccepted)) != nil {
 			return true
 		}
@@ -507,13 +530,13 @@ func hasMatchingParentStatus(specRef gwapiv1.ParentReference, parents []gwapiv1.
 
 // parentRefMatches returns true when two ParentReferences identify the same parent,
 // applying Gateway API defaulting rules for optional fields.
-// Note: Namespace comparison uses empty string default. In practice, both spec and status
-// refs should have consistent namespace handling (either both explicit or both implicit).
-func parentRefMatches(a, b gwapiv1.ParentReference) bool {
+// defaultNS is used when Namespace is omitted (nil) from a ParentReference, which
+// per Gateway API spec defaults to the route's own namespace.
+func parentRefMatches(a, b gwapiv1.ParentReference, defaultNS gwapiv1.Namespace) bool {
 	return a.Name == b.Name &&
 		ptr.Deref(a.Group, gwapiv1.GroupName) == ptr.Deref(b.Group, gwapiv1.GroupName) &&
 		ptr.Deref(a.Kind, "Gateway") == ptr.Deref(b.Kind, "Gateway") &&
-		ptr.Deref(a.Namespace, "") == ptr.Deref(b.Namespace, "") &&
+		ptr.Deref(a.Namespace, defaultNS) == ptr.Deref(b.Namespace, defaultNS) &&
 		ptr.Deref(a.SectionName, "") == ptr.Deref(b.SectionName, "") &&
 		ptr.Deref(a.Port, 0) == ptr.Deref(b.Port, 0)
 }
@@ -523,7 +546,7 @@ func parentRefMatches(a, b gwapiv1.ParentReference) bool {
 // Status entries without the Accepted condition (e.g. from policy controllers) are skipped.
 // A condition is stale when its ObservedGeneration is less than the route's Generation.
 func areGatewayConditionsReady(route *gwapiv1.HTTPRoute) bool {
-	if route == nil {
+	if route == nil || len(route.Status.Parents) == 0 {
 		return false
 	}
 	for _, parent := range route.Status.Parents {
@@ -565,7 +588,14 @@ func findNonReadyGatewayCondition(route *gwapiv1.HTTPRoute) *metav1.Condition {
 		}
 		resolvedRefCond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionResolvedRefs))
 		if resolvedRefCond == nil {
-			continue
+			// ResolvedRefs not yet reported — areGatewayConditionsReady treats this as not-ready,
+			// so surface a synthesized condition for diagnostics.
+			return &metav1.Condition{
+				Type:    string(gwapiv1.RouteConditionResolvedRefs),
+				Status:  metav1.ConditionUnknown,
+				Reason:  "ConditionMissing",
+				Message: "ResolvedRefs condition not yet reported by gateway controller",
+			}
 		}
 		stale = resolvedRefCond.ObservedGeneration > 0 && resolvedRefCond.ObservedGeneration < route.Generation
 		if resolvedRefCond.Status != metav1.ConditionTrue || stale {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -224,6 +224,9 @@ func extractRoutePath(route *gwapiv1.HTTPRoute) string {
 			}
 		}
 		for _, match := range rule.Matches {
+			if match.Path == nil {
+				continue
+			}
 			if serviceFound {
 				servicePaths = append(servicePaths, ptr.Deref(match.Path.Value, "/"))
 			} else {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -20,15 +20,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"slices"
-	"strconv"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/network"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,9 +79,53 @@ func DiscoverGateways(ctx context.Context, c client.Client, route *gwapiv1.HTTPR
 	return gateways, nil
 }
 
+// DiscoverGatewayServiceHost attempts to find the cluster-local hostname
+// for the Service backing a Gateway.
+// Returns empty string if no backing service is found (not an error).
+func DiscoverGatewayServiceHost(ctx context.Context, c client.Client, gateway *gwapiv1.Gateway) (string, error) {
+	logger := log.FromContext(ctx)
+
+	// Look for Service with known gateway label first
+	svcList := &corev1.ServiceList{}
+	if err := c.List(ctx, svcList,
+		client.InNamespace(gateway.Namespace),
+		client.MatchingLabels{
+			"gateway.networking.k8s.io/gateway-name": gateway.Name,
+		},
+	); err != nil {
+		return "", fmt.Errorf("failed to list services for gateway %s/%s: %w", gateway.Namespace, gateway.Name, err)
+	}
+	if len(svcList.Items) > 0 {
+		svc := &svcList.Items[0]
+		host := network.GetServiceHostname(svc.Name, svc.Namespace)
+		logger.V(1).Info("Discovered gateway service via label", "gateway", gateway.Name, "service", svc.Name, "host", host)
+		return host, nil
+	}
+
+	// Fallback: Look for Service with the same name as Gateway
+	svc := &corev1.Service{}
+	err := c.Get(ctx, types.NamespacedName{
+		Namespace: gateway.Namespace,
+		Name:      gateway.Name,
+	}, svc)
+	if err == nil {
+		host := network.GetServiceHostname(svc.Name, svc.Namespace)
+		logger.V(1).Info("Discovered gateway service via name match", "gateway", gateway.Name, "service", svc.Name, "host", host)
+		return host, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("failed to get service %s/%s: %w", gateway.Namespace, gateway.Name, err)
+	}
+
+	// No backing service found - not an error - we are guessing here
+	logger.V(1).Info("No backing service found for gateway", "gateway", fmt.Sprintf("%s/%s", gateway.Namespace, gateway.Name))
+	return "", nil
+}
+
 // DiscoverURLs extracts accessible URLs from an HTTPRoute by examining its gateways
-// It constructs URLs based on gateway listeners and addresses
-func DiscoverURLs(ctx context.Context, c client.Client, route *gwapiv1.HTTPRoute) ([]*apis.URL, error) {
+// It constructs URLs based on gateway listeners and addresses, and also discovers
+// internal URLs from backing services
+func DiscoverURLs(ctx context.Context, c client.Client, route *gwapiv1.HTTPRoute, preferredUrlScheme string) ([]*apis.URL, error) {
 	var urls []*apis.URL
 
 	gateways, err := DiscoverGateways(ctx, c, route)
@@ -86,142 +133,189 @@ func DiscoverURLs(ctx context.Context, c client.Client, route *gwapiv1.HTTPRoute
 		return nil, fmt.Errorf("failed to discover gateways: %w", err)
 	}
 
-	// Extract URLs from each gateway based on its listeners and addresses
 	for _, g := range gateways {
-		listener, err := selectListener(g.gateway, g.parentRef.SectionName)
+		listeners, err := selectListeners(g.gateway, g.parentRef.SectionName, preferredUrlScheme)
 		if err != nil {
-			return nil, fmt.Errorf("failed to select listener for Gateway %s/%s: %w", g.gateway.Namespace, g.gateway.Name, err)
-		}
-		scheme := extractSchemeFromListener(listener)
-		port := listener.Port
-
-		addresses := g.gateway.Status.Addresses
-		if len(addresses) == 0 {
-			return nil, &ExternalAddressNotFoundError{
-				GatewayNamespace: g.gateway.Namespace,
-				GatewayName:      g.gateway.Name,
-			}
-		}
-
-		hostnames := extractRouteHostnames(route)
-		// If Hostname is set in the spec, use the Hostname specified.
-		// Using the LoadBalancer addresses in `Gateway.Status.Addresses` will return 404 in those cases.
-		if len(hostnames) == 0 && listener.Hostname != nil && *listener.Hostname != "" {
-			if host, isWildcard := strings.CutPrefix(string(*listener.Hostname), "*."); isWildcard {
-				// Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
-				// as a suffix match. That means that a match for `*.example.com` would match
-				// both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
-				hostnames = append(hostnames, fmt.Sprintf("%s.%s", wildcardHostname, host))
-			} else {
-				hostnames = []string{host}
-			}
-		}
-		if len(hostnames) == 0 {
-			hostnames = extractAddressValues(addresses)
+			return nil, fmt.Errorf("failed to select listeners for gateway %s/%s: %w", g.gateway.Namespace, g.gateway.Name, err)
 		}
 
 		path := extractRoutePath(route)
+		addresses := g.gateway.Status.Addresses
 
-		gatewayURLs, err := combineIntoURLs(hostnames, scheme, port, path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to combine URLs for Gateway %s/%s: %w", g.gateway.Namespace, g.gateway.Name, err)
+		// Discover external URLs from Gateway status addresses (if available)
+		if len(addresses) > 0 {
+			for _, listener := range listeners {
+				scheme, err := resolveScheme(listener)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve scheme for gateway %s/%s listener %s: %w",
+						g.gateway.Namespace, g.gateway.Name, listener.Name, err)
+				}
+
+				hostnames := extractHostnamesForListener(route, listener, addresses)
+				gatewayURLs, err := combineIntoURLs(hostnames, scheme, listener.Port, path)
+				if err != nil {
+					return nil, fmt.Errorf("failed to combine URLs for Gateway %s/%s: %w", g.gateway.Namespace, g.gateway.Name, err)
+				}
+				urls = append(urls, gatewayURLs...)
+			}
 		}
 
-		urls = append(urls, gatewayURLs...)
+		// Discover internal URL from Gateway backing service
+		internalHost, err := DiscoverGatewayServiceHost(ctx, c, g.gateway)
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover gateway service host for %s/%s: %w", g.gateway.Namespace, g.gateway.Name, err)
+		}
+		if internalHost != "" {
+			// Use first listener's scheme and port - internal service matches Gateway listener
+			listener := listeners[0]
+			internalURLs, err := combineIntoURLs([]string{internalHost}, schemeForProtocol(listener.Protocol), listener.Port, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build internal URL for Gateway %s/%s: %w", g.gateway.Namespace, g.gateway.Name, err)
+			}
+			urls = append(urls, internalURLs...)
+		}
+	}
+
+	// Error only if no URLs discovered at all (neither external nor internal)
+	if len(urls) == 0 && len(gateways) > 0 {
+		g := gateways[0]
+		return nil, &NoURLsDiscoveredError{
+			GatewayNamespace: g.gateway.Namespace,
+			GatewayName:      g.gateway.Name,
+		}
 	}
 
 	return urls, nil
 }
 
-// extractRoutePath extracts the most appropriate path from an HTTPRoute for URL construction.
-// When an HTTPRoute contains multiple rules with different backend types (e.g., InferencePool
-// for completions endpoints and Service for catch-all), this function prefers the path from
-// Service-backed rules as they represent the base path for the service.
-// If no Service-backed rule is found, it falls back to the shortest path from any rule.
-func extractRoutePath(route *gwapiv1.HTTPRoute) string {
-	if len(route.Spec.Rules) == 0 {
-		return "/"
+// extractHostnamesForListener determines the hostnames to use for URL generation
+func extractHostnamesForListener(route *gwapiv1.HTTPRoute, listener *gwapiv1.Listener, addresses []gwapiv1.GatewayStatusAddress) []string {
+	hostnames := extractRouteHostnames(route)
+	// If Hostname is set in the spec, use the Hostname specified.
+	// Using the LoadBalancer addresses in `Gateway.Status.Addresses` will return 404 in those cases.
+	if len(hostnames) == 0 && listener.Hostname != nil && *listener.Hostname != "" {
+		if host, isWildcard := strings.CutPrefix(string(*listener.Hostname), "*."); isWildcard {
+			// Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+			// as a suffix match. That means that a match for `*.example.com` would match
+			// both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+			hostnames = append(hostnames, fmt.Sprintf("%s.%s", wildcardHostname, host))
+		} else {
+			hostnames = []string{host}
+		}
 	}
+	if len(hostnames) == 0 {
+		hostnames = extractAddressValues(addresses)
+	}
+	return hostnames
+}
 
-	// Look for the path from a rule backed by a Service (not InferencePool).
-	// This is the catch-all/base path that should be used for URL construction.
-	var shortestServicePath string
-	var shortestAnyPath string
-
+// extractRoutePath extracts the path from the HTTPRoute rules.
+// Returns the shortest path (by slash count) from rules referencing a Service backend.
+func extractRoutePath(route *gwapiv1.HTTPRoute) string {
+	serviceKind := gwapiv1.Kind("Service")
+	servicePaths := []string{}
+	paths := []string{}
 	for _, rule := range route.Spec.Rules {
-		if len(rule.Matches) == 0 {
-			continue
+		serviceFound := false
+		for _, backendRef := range rule.BackendRefs {
+			if ptr.Deref(backendRef.Kind, serviceKind) == serviceKind {
+				serviceFound = true
+				break
+			}
 		}
-
-		match := rule.Matches[0]
-		if match.Path == nil {
-			continue
-		}
-		path := ptr.Deref(match.Path.Value, "/")
-
-		// Track shortest path from any rule as fallback
-		if shortestAnyPath == "" || len(path) < len(shortestAnyPath) {
-			shortestAnyPath = path
-		}
-
-		// Check if this rule is backed by a Service (not InferencePool)
-		if hasServiceBackend(rule) {
-			if shortestServicePath == "" || len(path) < len(shortestServicePath) {
-				shortestServicePath = path
+		for _, match := range rule.Matches {
+			if serviceFound {
+				servicePaths = append(servicePaths, ptr.Deref(match.Path.Value, "/"))
+			} else {
+				paths = append(paths, ptr.Deref(match.Path.Value, "/"))
 			}
 		}
 	}
 
-	if shortestServicePath != "" {
-		return shortestServicePath
+	// Paths set in rules referencing a Service as the backend will take priority
+	if len(servicePaths) > 0 {
+		paths = servicePaths
 	}
-	if shortestAnyPath != "" {
-		return shortestAnyPath
-	}
-	return "/"
-}
 
-// hasServiceBackend returns true if the rule has at least one backendRef with Kind "Service"
-// or with no Kind set (defaults to Service per Gateway API spec).
-func hasServiceBackend(rule gwapiv1.HTTPRouteRule) bool {
-	for _, ref := range rule.BackendRefs {
-		kind := ptr.Deref(ref.Kind, gwapiv1.Kind("Service"))
-		if kind == "Service" {
-			return true
+	// If any paths are set in rules for the route, return the highest level path with the shortest length
+	// TODO how do we deal with regexp
+	// TODO how do we intelligently handle multiple rules
+	shortestPath := "/"
+	minSlashes := math.MaxInt
+	for _, path := range paths {
+		pathSlashes := strings.Count(path, "/")
+		if pathSlashes < minSlashes || (pathSlashes == minSlashes && len(path) < len(shortestPath)) {
+			shortestPath = path
+			minSlashes = pathSlashes
 		}
 	}
-	return false
+
+	return shortestPath
 }
 
-// selectListener chooses the appropriate listener from a Gateway.
-// If a specific sectionName is provided, it searches for that listener by name
-// and returns an error if no match is found. Otherwise, it defaults to the
-// first listener. Returns an error if the Gateway has no listeners.
-func selectListener(gateway *gwapiv1.Gateway, sectionName *gwapiv1.SectionName) (*gwapiv1.Listener, error) {
-	if len(gateway.Spec.Listeners) == 0 {
-		return nil, fmt.Errorf("gateway %s/%s has no listeners", gateway.Namespace, gateway.Name)
+// schemeForProtocol returns the URL scheme for a Gateway API protocol.
+// Returns empty string for protocols that don't support HTTP routing.
+func schemeForProtocol(protocol gwapiv1.ProtocolType) string {
+	switch protocol {
+	case gwapiv1.HTTPProtocolType, gwapiv1.HTTPSProtocolType:
+		return strings.ToLower(string(protocol))
+	case gwapiv1.TLSProtocolType:
+		return "https"
+	default:
+		return ""
 	}
+}
 
+// selectListeners returns the applicable listeners for URL generation.
+// - If sectionName is provided, returns only that specific listener
+// - Otherwise, returns ALL HTTP-capable listeners sorted by: preferredScheme first, then HTTPS, then HTTP
+func selectListeners(gateway *gwapiv1.Gateway, sectionName *gwapiv1.SectionName, preferredScheme string) ([]*gwapiv1.Listener, error) {
+	// If sectionName provided, find exact match (single listener)
 	if sectionName != nil {
 		for i := range gateway.Spec.Listeners {
 			if gateway.Spec.Listeners[i].Name == *sectionName {
-				return &gateway.Spec.Listeners[i], nil
+				return []*gwapiv1.Listener{&gateway.Spec.Listeners[i]}, nil
 			}
 		}
-		return nil, fmt.Errorf("gateway %s/%s has no listener named %q", gateway.Namespace, gateway.Name, *sectionName)
+		return nil, fmt.Errorf("listener %q not found in gateway %s/%s", *sectionName, gateway.Namespace, gateway.Name)
 	}
 
-	return &gateway.Spec.Listeners[0], nil
+	// Collect all HTTP-capable listeners
+	var listeners []*gwapiv1.Listener
+	for i := range gateway.Spec.Listeners {
+		if scheme := schemeForProtocol(gateway.Spec.Listeners[i].Protocol); scheme != "" {
+			listeners = append(listeners, &gateway.Spec.Listeners[i])
+		}
+	}
+	if len(listeners) == 0 {
+		return nil, fmt.Errorf("no HTTP-capable listener found in gateway %s/%s", gateway.Namespace, gateway.Name)
+	}
+
+	// Sort: preferredScheme first, then HTTPS before HTTP
+	precedence := func(l *gwapiv1.Listener) int {
+		scheme := schemeForProtocol(l.Protocol)
+		if scheme == preferredScheme {
+			return 0
+		}
+		if scheme == "https" {
+			return 1
+		}
+		return 2
+	}
+	slices.SortFunc(listeners, func(a, b *gwapiv1.Listener) int {
+		return precedence(a) - precedence(b)
+	})
+
+	return listeners, nil
 }
 
-// extractSchemeFromListener determines the URL scheme (http/https) based on the listener protocol
-// This is essential for constructing valid URLs that match the Gateway's configuration
-func extractSchemeFromListener(listener *gwapiv1.Listener) string {
-	if listener.Protocol == gwapiv1.HTTPSProtocolType {
-		return "https"
+// resolveScheme returns the URL scheme derived from the listener's protocol.
+func resolveScheme(listener *gwapiv1.Listener) (string, error) {
+	scheme := schemeForProtocol(listener.Protocol)
+	if scheme == "" {
+		return "", fmt.Errorf("listener %q uses unsupported protocol %s for HTTP routing", listener.Name, listener.Protocol)
 	}
-	// Default to HTTP for all other protocols (HTTP, TCP, etc.)
-	return "http"
+	return scheme, nil
 }
 
 // extractRouteHostnames extracts valid hostnames from an HTTPRoute specification
@@ -289,35 +383,35 @@ func combineIntoURLs(hostnames []string, scheme string, port gwapiv1.PortNumber,
 // Returns just the host if port is nil or zero
 func joinHostPort(host string, port *gwapiv1.PortNumber) string {
 	if port != nil && *port != 0 {
-		return net.JoinHostPort(host, strconv.Itoa(int(*port)))
+		return net.JoinHostPort(host, fmt.Sprint(*port))
 	}
 	return host
 }
 
-// ExternalAddressNotFoundError indicates that a Gateway has no external addresses
-// This typically occurs when the Gateway is not yet provisioned by the infrastructure
-type ExternalAddressNotFoundError struct {
+// NoURLsDiscoveredError indicates that no URLs could be discovered for a Gateway
+// (neither external addresses nor internal backing service found)
+type NoURLsDiscoveredError struct {
 	GatewayNamespace string
 	GatewayName      string
 }
 
-func (e *ExternalAddressNotFoundError) Error() string {
-	return fmt.Sprintf("Gateway %s/%s has no external address found", e.GatewayNamespace, e.GatewayName)
+func (e *NoURLsDiscoveredError) Error() string {
+	return fmt.Sprintf("no URLs discovered for Gateway %s/%s (no external addresses and no backing service found)", e.GatewayNamespace, e.GatewayName)
 }
 
-// IgnoreExternalAddressNotFound converts ExternalAddressNotFoundError to nil
-// This is useful when external addresses are optional or may not be immediately available
-func IgnoreExternalAddressNotFound(err error) error {
-	if IsExternalAddressNotFound(err) {
+// IgnoreNoURLsDiscovered converts NoURLsDiscoveredError to nil
+// This is useful when URLs may not be immediately available during provisioning
+func IgnoreNoURLsDiscovered(err error) error {
+	if IsNoURLsDiscovered(err) {
 		return nil
 	}
 	return err
 }
 
-// IsExternalAddressNotFound checks if an error is of type ExternalAddressNotFoundError
-func IsExternalAddressNotFound(err error) bool {
-	var externalAddrNotFoundErr *ExternalAddressNotFoundError
-	return errors.As(err, &externalAddrNotFoundErr)
+// IsNoURLsDiscovered checks if an error is of type NoURLsDiscoveredError
+func IsNoURLsDiscovered(err error) bool {
+	var noURLsErr *NoURLsDiscoveredError
+	return errors.As(err, &noURLsErr)
 }
 
 // EvaluateGatewayReadiness checks the readiness status of Gateways and returns those that are not ready

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_filter.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_filter.go
@@ -62,6 +62,27 @@ func isInternalIP(addr string) bool {
 	return false
 }
 
+// IsClusterLocalURL returns true if the URL uses a Kubernetes cluster-local hostname
+// (e.g., service.namespace.svc.cluster.local)
+func IsClusterLocalURL(url *apis.URL) bool {
+	host := strings.ToLower(url.URL().Hostname())
+	return strings.HasSuffix(host, network.GetClusterDomainName())
+}
+
+// AddressTypeName returns the type name for a URL to be used in Addressable.Name:
+// - "gateway-external" for public addresses
+// - "gateway-internal" for cluster-local gateway service URLs
+// - "internal" for private IPs or other internal hostnames
+func AddressTypeName(url *apis.URL) string {
+	if IsClusterLocalURL(url) {
+		return "gateway-internal"
+	}
+	if IsInternalURL(url) {
+		return "internal"
+	}
+	return "gateway-external"
+}
+
 // isInternalHostname checks if a hostname appears to be internal
 // This includes cluster-local domains and localhost variants
 func isInternalHostname(hostname string) bool {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,23 +35,48 @@ import (
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 )
 
+// expectURLs returns an assert function that expects no error and exact URL match
+func expectURLs(expected ...string) func(g Gomega, urls []string, err error) {
+	return func(g Gomega, urls []string, err error) {
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(urls).To(Equal(expected))
+	}
+}
+
+// expectURLsContain returns an assert function that expects no error and URLs containing the expected elements
+func expectURLsContain(expected ...string) func(g Gomega, urls []string, err error) {
+	return func(g Gomega, urls []string, err error) {
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(urls).To(ContainElements(expected))
+	}
+}
+
+// expectError returns an assert function that expects an error matching the predicate
+func expectError(check func(error) bool) func(g Gomega, urls []string, err error) {
+	return func(g Gomega, urls []string, err error) {
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(check(err)).To(BeTrue(), "Error check failed for: %v", err)
+	}
+}
+
 func TestDiscoverURLs(t *testing.T) {
 	tests := []struct {
 		name               string
 		route              *gwapiv1.HTTPRoute
-		gateway            *gwapiv1.Gateway
-		additionalGateways []*gwapiv1.Gateway // Additional gateways for multiple parent refs test
-		expectedURLs       []string           // Always expect multiple URLs, single URL cases will have length 1
-		expectedErrorCheck func(error) bool
+		gateways           []*gwapiv1.Gateway
+		services           []*corev1.Service
+		preferredUrlScheme string
+		assert             func(g Gomega, urls []string, err error)
 	}{
+		// ===== Basic address resolution =====
 		{
 			name: "basic external address resolution",
 			route: HTTPRoute("test-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway:      HTTPGateway("test-gateway", "test-ns", "203.0.113.1"),
-			expectedURLs: []string{"http://203.0.113.1/"},
+			gateways: []*gwapiv1.Gateway{HTTPGateway("test-gateway", "test-ns", "203.0.113.1")},
+			assert:   expectURLs("http://203.0.113.1/"),
 		},
 		{
 			name: "address ordering consistency - same addresses different order",
@@ -58,47 +84,35 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("consistency-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("consistency-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses([]string{"203.0.113.200", "203.0.113.100"}...),
-			),
-			expectedURLs: []string{
-				"http://203.0.113.100/",
-				"http://203.0.113.200/",
+			gateways: []*gwapiv1.Gateway{
+				Gateway("consistency-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.200", "203.0.113.100"),
+				),
 			},
+			assert: expectURLs("http://203.0.113.100/", "http://203.0.113.200/"),
 		},
+		// ===== Hostname handling =====
 		{
-			name: "mixed internal and external addresses - deterministic selection",
-			route: HTTPRoute("mixed-route",
-				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("mixed-gateway", RefInNamespace("test-ns"))),
-			),
-			gateway: Gateway("mixed-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("192.168.1.10", "203.0.113.50", "10.0.0.20", "203.0.113.25"),
-			),
-			expectedURLs: []string{
-				"http://10.0.0.20/",
-				"http://192.168.1.10/",
-				"http://203.0.113.25/",
-				"http://203.0.113.50/",
-			},
-		},
-		{
-			name: "route hostname override",
+			name: "route hostname within listener wildcard",
 			route: HTTPRoute("hostname-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("hostname-gateway", RefInNamespace("test-ns"))),
 				WithHostnames("api.example.com"),
 			),
-			gateway: Gateway("hostname-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses([]string{"203.0.113.1"}...),
-			),
-			expectedURLs: []string{"http://api.example.com/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("hostname-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gwapiv1.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://api.example.com/"),
 		},
 		{
 			name: "route wildcard hostname - use gateway address",
@@ -107,43 +121,46 @@ func TestDiscoverURLs(t *testing.T) {
 				WithParentRef(GatewayRef("wildcard-gateway", RefInNamespace("test-ns"))),
 				WithHostnames("*"),
 			),
-			gateway: Gateway("wildcard-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.100"),
-			),
-			expectedURLs: []string{"http://203.0.113.100/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("wildcard-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.100"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.100/"),
 		},
 		{
 			name: "multiple hostnames - generates multiple URLs",
 			route: HTTPRoute("multi-hostname-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("multi-hostname-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("*", "", "api.example.com", "alt.example.com"),
+				WithHostnames("api.example.com", "alt.example.com"),
 			),
-			gateway: Gateway("multi-hostname-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{
-				"http://alt.example.com/",
-				"http://api.example.com/",
+			gateways: []*gwapiv1.Gateway{
+				Gateway("multi-hostname-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gwapiv1.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
 			},
+			assert: expectURLs("http://alt.example.com/", "http://api.example.com/"),
 		},
+
+		// ===== Path handling =====
 		{
 			name: "custom path extraction",
 			route: HTTPRoute("path-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("path-gateway", RefInNamespace("test-ns"))),
-				WithPath("/api/v1/models"),
+				WithPath("/api/v1"),
 			),
-			gateway: Gateway("path-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/api/v1/models"},
+			gateways: []*gwapiv1.Gateway{HTTPGateway("path-gateway", "test-ns", "203.0.113.1")},
+			assert:   expectURLs("http://203.0.113.1/api/v1"),
 		},
 		{
 			name: "multi-rule path extraction - prefers Service-backed rule path",
@@ -163,12 +180,14 @@ func TestDiscoverURLs(t *testing.T) {
 					WithBackendRefs(BackendRefService("svc")),
 				),
 			),
-			gateway: Gateway("multi-rule-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/ns/name"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("multi-rule-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1/ns/name"),
 		},
 		{
 			name: "multi-rule path extraction - falls back to shortest when no Service backend",
@@ -184,12 +203,14 @@ func TestDiscoverURLs(t *testing.T) {
 					WithBackendRefs(BackendRefInferencePool("pool")),
 				),
 			),
-			gateway: Gateway("no-svc-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/ns/name/v1/completions"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("no-svc-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1/ns/name/v1/completions"),
 		},
 		{
 			name: "multi-rule path extraction - Service with default Kind (nil)",
@@ -213,22 +234,37 @@ func TestDiscoverURLs(t *testing.T) {
 					}),
 				),
 			),
-			gateway: Gateway("default-kind-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/ns/name"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("default-kind-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1/ns/name"),
 		},
+		{
+			name: "empty route rules - default path",
+			route: HTTPRoute("empty-rules-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("empty-rules-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{HTTPGateway("empty-rules-gateway", "test-ns", "203.0.113.1")},
+			assert:   expectURLs("http://203.0.113.1/"),
+		},
+
+		// ===== Scheme from listener =====
 		{
 			name: "HTTPS scheme from gateway listener",
 			route: HTTPRoute("https-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("https-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway:      HTTPSGateway("https-gateway", "test-ns", "203.0.113.1"),
-			expectedURLs: []string{"https://203.0.113.1/"},
+			gateways: []*gwapiv1.Gateway{HTTPSGateway("https-gateway", "test-ns", "203.0.113.1")},
+			assert:   expectURLs("https://203.0.113.1/"),
 		},
+
+		// ===== Multiple parent refs =====
 		{
 			name: "multiple parent refs - sorted selection",
 			route: HTTPRoute("multi-parent-route",
@@ -239,12 +275,12 @@ func TestDiscoverURLs(t *testing.T) {
 					GatewayRef("b-gateway", RefInNamespace("a-namespace")),
 				),
 			),
-			gateway: Gateway("a-gateway",
-				InNamespace[*gwapiv1.Gateway]("a-namespace"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses([]string{"203.0.113.1"}...),
-			),
-			additionalGateways: []*gwapiv1.Gateway{
+			gateways: []*gwapiv1.Gateway{
+				Gateway("a-gateway",
+					InNamespace[*gwapiv1.Gateway]("a-namespace"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.1"),
+				),
 				Gateway("z-gateway",
 					InNamespace[*gwapiv1.Gateway]("z-namespace"),
 					WithListener(gwapiv1.HTTPProtocolType),
@@ -256,191 +292,182 @@ func TestDiscoverURLs(t *testing.T) {
 					WithAddresses("203.0.113.3"),
 				),
 			},
-			expectedURLs: []string{
+			assert: expectURLs(
 				"http://203.0.113.2/",
 				"http://203.0.113.1/",
 				"http://203.0.113.3/",
+			),
+		},
+		{
+			name: "route with multiple parent refs to different gateways",
+			route: HTTPRoute("multi-gateway-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRefs(
+					gwapiv1.ParentReference{
+						Name:      "gateway-a",
+						Namespace: ptr.To(gwapiv1.Namespace("gw-ns")),
+						Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+					},
+					gwapiv1.ParentReference{
+						Name:      "gateway-b",
+						Namespace: ptr.To(gwapiv1.Namespace("gw-ns")),
+						Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+					},
+				),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("gateway-a",
+					InNamespace[*gwapiv1.Gateway]("gw-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "https",
+						Protocol: gwapiv1.HTTPSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("gateway-a.example.com"),
+				),
+				Gateway("gateway-b",
+					InNamespace[*gwapiv1.Gateway]("gw-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     8080,
+					}),
+					WithAddresses("gateway-b.example.com"),
+				),
 			},
+			assert: expectURLsContain(
+				"https://gateway-a.example.com/",
+				"http://gateway-b.example.com:8080/",
+			),
 		},
 		{
 			name: "parent ref without namespace - use route namespace",
 			route: HTTPRoute("no-ns-route",
 				InNamespace[*gwapiv1.HTTPRoute]("route-ns"),
-				WithParentRef(GatewayRefWithoutNamespace("no-ns-gateway")),
+				WithParentRef(GatewayRef("same-ns-gateway")),
 			),
-			gateway: Gateway("no-ns-gateway",
-				InNamespace[*gwapiv1.Gateway]("route-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/"},
+			gateways: []*gwapiv1.Gateway{HTTPGateway("same-ns-gateway", "route-ns", "203.0.113.1")},
+			assert:   expectURLs("http://203.0.113.1/"),
 		},
+
+		// ===== Address types =====
 		{
-			name: "no external addresses - custom ExternalAddressNotFoundError",
-			route: HTTPRoute("no-external-route",
+			name: "private addresses only - still returns URLs",
+			route: HTTPRoute("private-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("no-external-addresses-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("private-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("no-external-addresses-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("192.168.1.10", "10.0.0.20"),
-			),
-			expectedURLs: []string{
-				"http://10.0.0.20/",
-				"http://192.168.1.10/",
+			gateways: []*gwapiv1.Gateway{
+				Gateway("private-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("192.168.1.100", "10.0.0.50"),
+				),
 			},
+			assert: expectURLs("http://10.0.0.50/", "http://192.168.1.100/"),
 		},
-		{
-			name: "gateway not found should cause not found error",
-			route: HTTPRoute("missing-gw-route",
-				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("missing-gateway", RefInNamespace("test-ns"))),
-			),
-			expectedErrorCheck: apierrors.IsNotFound,
-		},
-		{
-			name: "empty route rules - default path",
-			route: HTTPRoute("empty-rules-route",
-				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("empty-rules-gateway", RefInNamespace("test-ns"))),
-				WithRules(), // Empty rules
-			),
-			gateway: Gateway("empty-rules-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/"},
-		},
-		// Hostname address type tests
 		{
 			name: "hostname addresses - basic resolution",
-			route: HTTPRoute("hostname-route",
+			route: HTTPRoute("hostname-addr-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("hostname-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("hostname-addr-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("hostname-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithHostnameAddresses("api.example.com"),
-			),
-			expectedURLs: []string{"http://api.example.com/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("hostname-addr-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithHostnameAddresses("api.example.com", "lb.example.com"),
+				),
+			},
+			assert: expectURLs("http://api.example.com/", "http://lb.example.com/"),
 		},
 		{
 			name: "mixed hostname and IP addresses - deterministic selection",
-			route: HTTPRoute("mixed-types-route",
+			route: HTTPRoute("mixed-addr-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("mixed-types-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("mixed-addr-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("mixed-types-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithMixedAddresses(
-					HostnameAddress("z.example.com"),
-					IPAddress("203.0.113.1"),
-					HostnameAddress("api.example.com"),
-					IPAddress("198.51.100.1"),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("mixed-addr-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithMixedAddresses(
+						IPAddress("203.0.113.1"),
+						HostnameAddress("api.example.com"),
+						HostnameAddress("lb.example.com"),
+					),
 				),
-			),
-			expectedURLs: []string{
-				"http://198.51.100.1/",
+			},
+			assert: expectURLs(
 				"http://203.0.113.1/",
 				"http://api.example.com/",
-				"http://z.example.com/",
-			},
+				"http://lb.example.com/",
+			),
+		},
+		// ===== Error cases =====
+		{
+			name: "gateway not found should cause not found error",
+			route: HTTPRoute("nonexistent-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("nonexistent-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: nil,
+			assert:   expectError(apierrors.IsNotFound),
 		},
 		{
-			name: "hostname addresses with internal hostnames filtered",
-			route: HTTPRoute("internal-hostname-route",
+			name: "no addresses at all - NoURLsDiscoveredError",
+			route: HTTPRoute("no-addr-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("internal-hostname-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("no-addr-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("internal-hostname-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithMixedAddresses(
-					HostnameAddress("localhost"),
-					HostnameAddress("service.local"),
-					HostnameAddress("app.internal"),
-					HostnameAddress("api.example.com"),
-					HostnameAddress("backup.example.com"),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("no-addr-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
 				),
-			),
-			expectedURLs: []string{
-				"http://api.example.com/",
-				"http://app.internal/",
-				"http://backup.example.com/",
-				"http://localhost/",
-				"http://service.local/",
 			},
+			assert: expectError(llmisvc.IsNoURLsDiscovered),
 		},
 		{
-			name: "only internal addresses (IP + hostnames) - ExternalAddressNotFoundError",
-			route: HTTPRoute("only-internal-route",
+			name: "gateway with only TCP listeners returns error",
+			route: HTTPRoute("test-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("only-internal-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("only-internal-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithMixedAddresses(
-					IPAddress("192.168.1.10"),
-					IPAddress("10.0.0.20"),
-					HostnameAddress("localhost"),
-					HostnameAddress("app.local"),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "tcp-listener",
+						Protocol: gwapiv1.TCPProtocolType,
+						Port:     9000,
+					}),
+					WithAddresses("203.0.113.1"),
 				),
-			),
-			expectedURLs: []string{
-				"http://10.0.0.20/",
-				"http://192.168.1.10/",
-				"http://app.local/",
-				"http://localhost/",
 			},
+			assert: expectError(func(err error) bool { return err != nil }),
 		},
-		{
-			name: "backwards compatibility - nil Type defaults to IP behavior",
-			route: HTTPRoute("nil-type-route",
-				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("nil-type-gateway", RefInNamespace("test-ns"))),
-			),
-			gateway: Gateway("nil-type-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1", "192.168.1.10"),
-			),
-			expectedURLs: []string{
-				"http://192.168.1.10/",
-				"http://203.0.113.1/",
-			},
-		},
-		{
-			name: "no addresses at all - ExternalAddressNotFoundError",
-			route: HTTPRoute("no-addresses-route",
-				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("no-addresses-gateway", RefInNamespace("test-ns"))),
-			),
-			gateway: Gateway("no-addresses-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-			),
-			expectedErrorCheck: llmisvc.IsExternalAddressNotFound,
-		},
+
+		// ===== Port handling =====
 		{
 			name: "custom port handling - non-standard HTTP port",
 			route: HTTPRoute("custom-port-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("custom-port-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("custom-port-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     8080,
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1:8080/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("custom-port-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     8080,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1:8080/"),
 		},
 		{
 			name: "custom port handling - non-standard HTTPS port",
@@ -449,15 +476,17 @@ func TestDiscoverURLs(t *testing.T) {
 				WithParentRef(GatewayRef("custom-https-port-gateway", RefInNamespace("test-ns"))),
 				WithHostnames("secure.example.com"),
 			),
-			gateway: Gateway("custom-https-port-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPSProtocolType,
-					Port:     8443,
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"https://secure.example.com:8443/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("custom-https-port-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPSProtocolType,
+						Port:     8443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("https://secure.example.com:8443/"),
 		},
 		{
 			name: "standard ports omitted - HTTP port 80",
@@ -465,64 +494,85 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("standard-http-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("standard-http-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     80,
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("standard-http-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1/"),
 		},
 		{
 			name: "standard ports omitted - HTTPS port 443",
 			route: HTTPRoute("standard-https-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("standard-https-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("secure.example.com"),
 			),
-			gateway: Gateway("standard-https-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPSProtocolType,
-					Port:     443,
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"https://secure.example.com/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("standard-https-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("https://203.0.113.1/"),
 		},
+
+		// ===== sectionName listener selection =====
 		{
-			name: "sectionName selects specific listener",
-			route: HTTPRoute("section-route",
+			name: "sectionName isolates to specific listener - no leakage from other listeners",
+			route: HTTPRoute("test-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(gwapiv1.ParentReference{
 					Name:        "multi-listener-gateway",
-					Namespace:   ptr.To(gwapiv1.Namespace("test-ns")),
-					SectionName: ptr.To(gwapiv1.SectionName("https-listener")),
+					Namespace:   ptr.To(gwapiv1.Namespace("gw-ns")),
+					SectionName: ptr.To(gwapiv1.SectionName("http")),
 					Group:       ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
 					Kind:        ptr.To(gwapiv1.Kind("Gateway")),
 				}),
-				WithHostnames("secure.example.com"),
 			),
-			gateway: Gateway("multi-listener-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(
-					gwapiv1.Listener{
-						Name:     "http-listener",
-						Protocol: gwapiv1.HTTPProtocolType,
-						Port:     80,
-					},
-					gwapiv1.Listener{
-						Name:     "https-listener",
-						Protocol: gwapiv1.HTTPSProtocolType,
-						Port:     443,
-					},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("multi-listener-gateway",
+					InNamespace[*gwapiv1.Gateway]("gw-ns"),
+					WithListeners(
+						gwapiv1.Listener{
+							Name:     "http",
+							Protocol: gwapiv1.HTTPProtocolType,
+							Port:     80,
+							Hostname: ptr.To(gwapiv1.Hostname("http.example.com")),
+						},
+						gwapiv1.Listener{
+							Name:     "https",
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Port:     443,
+							Hostname: ptr.To(gwapiv1.Hostname("https.example.com")),
+						},
+						gwapiv1.Listener{
+							Name:     "internal",
+							Protocol: gwapiv1.HTTPProtocolType,
+							Port:     8080,
+							Hostname: ptr.To(gwapiv1.Hostname("internal.example.com")),
+						},
+					),
+					WithAddresses("203.0.113.1"),
 				),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"https://secure.example.com/"},
+			},
+			assert: func(g Gomega, urls []string, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(urls).To(Equal([]string{"http://http.example.com/"}))
+				g.Expect(urls).ToNot(ContainElement(ContainSubstring("https.example.com")))
+				g.Expect(urls).ToNot(ContainElement(ContainSubstring("internal.example.com")))
+			},
 		},
+
+		// ===== Comprehensive URL generation =====
 		{
 			name: "sectionName does not match any listener - should error, not silently use wrong listener",
 			route: HTTPRoute("mismatched-section-route",
@@ -580,143 +630,157 @@ func TestDiscoverURLs(t *testing.T) {
 			route: HTTPRoute("comprehensive-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("comprehensive-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("api.example.com", "backup.example.com", "primary.example.com"),
+				WithHostnames("api.example.com", "v2.example.com"),
 			),
-			gateway: Gateway("comprehensive-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListener(gwapiv1.HTTPProtocolType),
-				WithAddresses("203.0.113.1", "198.51.100.1"),
-			),
-			expectedURLs: []string{
-				"http://api.example.com/",
-				"http://backup.example.com/",
-				"http://primary.example.com/",
+			gateways: []*gwapiv1.Gateway{
+				Gateway("comprehensive-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.1", "203.0.113.2"),
+				),
 			},
+			assert: expectURLs("http://api.example.com/", "http://v2.example.com/"),
 		},
+
+		// ===== Listener hostname fallback =====
 		{
 			name: "listener hostname fallback - no route hostnames",
 			route: HTTPRoute("listener-hostname-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("listener-hostname-gateway", RefInNamespace("test-ns"))),
-				// No hostnames specified in route
 			),
-			gateway: Gateway("listener-hostname-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gwapiv1.Hostname("listener.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://listener.example.com/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("listener-hostname-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gwapiv1.Hostname("listener.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://listener.example.com/"),
 		},
 		{
 			name: "listener hostname fallback - route has wildcard hostname",
-			route: HTTPRoute("listener-hostname-wildcard-route",
-				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("listener-hostname-wildcard-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("*"), // Wildcard should be filtered out
-			),
-			gateway: Gateway("listener-hostname-wildcard-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gwapiv1.Hostname("fallback.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://fallback.example.com/"},
-		},
-		{
-			name: "listener hostname fallback - route hostname takes precedence",
-			route: HTTPRoute("route-hostname-precedence",
-				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("route-hostname-precedence-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("route.example.com"),
-			),
-			gateway: Gateway("route-hostname-precedence-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gwapiv1.Hostname("listener.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://route.example.com/"}, // Route hostname should be used, not listener
-		},
-		{
-			name: "listener hostname fallback - empty listener hostname uses addresses",
-			route: HTTPRoute("empty-listener-hostname-route",
-				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("empty-listener-hostname-gateway", RefInNamespace("test-ns"))),
-				// No hostnames specified in route
-			),
-			gateway: Gateway("empty-listener-hostname-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gwapiv1.Hostname("")), // Empty hostname
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/"}, // Should fall back to addresses
-		},
-		{
-			name: "listener wildcard hostname - basic wildcard expansion",
 			route: HTTPRoute("wildcard-listener-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("wildcard-listener-gateway", RefInNamespace("test-ns"))),
-				// No hostnames specified in route
+				WithHostnames("*"),
 			),
-			gateway: Gateway("wildcard-listener-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gwapiv1.Hostname("*.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("wildcard-listener-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gwapiv1.Hostname("listener.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://listener.example.com/"),
+		},
+		{
+			name: "listener hostname fallback - route hostname takes precedence",
+			route: HTTPRoute("precedence-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("precedence-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("route.example.com"),
 			),
-			expectedURLs: []string{"http://inference.example.com/"}, // Should expand wildcard to inference.example.com
+			gateways: []*gwapiv1.Gateway{
+				Gateway("precedence-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gwapiv1.Hostname("listener.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://route.example.com/"),
+		},
+		{
+			name: "listener hostname fallback - empty listener hostname uses addresses",
+			route: HTTPRoute("empty-listener-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("empty-listener-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("empty-listener-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1/"),
+		},
+
+		// ===== Listener wildcard hostname =====
+		{
+			name: "listener wildcard hostname - basic wildcard expansion",
+			route: HTTPRoute("wildcard-expansion-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("wildcard-expansion-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("wildcard-expansion-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gwapiv1.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			// Wildcards are expanded to inference.example.com
+			assert: expectURLs("http://inference.example.com/"),
 		},
 		{
 			name: "listener wildcard hostname - wildcard with subdomain",
-			route: HTTPRoute("wildcard-subdomain-route",
+			route: HTTPRoute("subdomain-wildcard-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("wildcard-subdomain-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("subdomain-wildcard-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("wildcard-subdomain-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gwapiv1.Hostname("*.api.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://inference.api.example.com/"}, // Should expand to inference.api.example.com
+			gateways: []*gwapiv1.Gateway{
+				Gateway("subdomain-wildcard-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gwapiv1.Hostname("*.api.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			// Wildcards are expanded to inference.api.example.com
+			assert: expectURLs("http://inference.api.example.com/"),
 		},
 		{
 			name: "listener wildcard hostname - route hostname takes precedence over wildcard",
-			route: HTTPRoute("route-over-wildcard-route",
+			route: HTTPRoute("wildcard-precedence-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("route-over-wildcard-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("custom.example.com"),
+				WithParentRef(GatewayRef("wildcard-precedence-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("specific.example.com"),
 			),
-			gateway: Gateway("route-over-wildcard-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gwapiv1.Hostname("*.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://custom.example.com/"}, // Route hostname should take precedence
+			gateways: []*gwapiv1.Gateway{
+				Gateway("wildcard-precedence-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gwapiv1.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://specific.example.com/"),
 		},
 		{
 			name: "listener wildcard hostname - HTTPS with wildcard",
@@ -724,16 +788,19 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("https-wildcard-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("https-wildcard-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPSProtocolType,
-					Port:     443,
-					Hostname: ptr.To(gwapiv1.Hostname("*.secure.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"https://inference.secure.example.com/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("https-wildcard-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPSProtocolType,
+						Port:     443,
+						Hostname: ptr.To(gwapiv1.Hostname("*.secure.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			// HTTPS with wildcard expanded to inference.secure.example.com
+			assert: expectURLs("https://inference.secure.example.com/"),
 		},
 		{
 			name: "listener wildcard hostname - custom port with wildcard",
@@ -741,37 +808,489 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("custom-port-wildcard-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("custom-port-wildcard-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(gwapiv1.Listener{
-					Protocol: gwapiv1.HTTPProtocolType,
-					Port:     8080,
-					Hostname: ptr.To(gwapiv1.Hostname("*.apps.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("custom-port-wildcard-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     8080,
+						Hostname: ptr.To(gwapiv1.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			// Custom port with wildcard expanded
+			assert: expectURLs("http://inference.example.com:8080/"),
+		},
+
+		// ===== preferredUrlScheme =====
+		{
+			name: "preferredUrlScheme=https prioritizes HTTPS listener",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
 			),
-			expectedURLs: []string{"http://inference.apps.example.com:8080/"},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(
+						gwapiv1.Listener{
+							Name:     "http-listener",
+							Protocol: gwapiv1.HTTPProtocolType,
+							Port:     80,
+						},
+						gwapiv1.Listener{
+							Name:     "https-listener",
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "https",
+			assert:             expectURLs("https://203.0.113.1/", "http://203.0.113.1/"),
+		},
+		{
+			name: "preferredUrlScheme=http prioritizes HTTP listener",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(
+						gwapiv1.Listener{
+							Name:     "http-listener",
+							Protocol: gwapiv1.HTTPProtocolType,
+							Port:     80,
+						},
+						gwapiv1.Listener{
+							Name:     "https-listener",
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "http",
+			assert:             expectURLs("http://203.0.113.1/", "https://203.0.113.1/"),
+		},
+		{
+			name: "preferredUrlScheme mismatch falls back to available listener",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http-listener",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "https",
+			assert:             expectURLs("http://203.0.113.1/"),
+		},
+		{
+			name: "preferredUrlScheme matching listener preserves non-standard port",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "https-listener",
+						Protocol: gwapiv1.HTTPSProtocolType,
+						Port:     8443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "https",
+			assert:             expectURLs("https://203.0.113.1:8443/"),
+		},
+		{
+			name: "empty preferredUrlScheme returns ALL listeners (HTTPS first)",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(
+						gwapiv1.Listener{
+							Name:     "http-listener",
+							Protocol: gwapiv1.HTTPProtocolType,
+							Port:     80,
+						},
+						gwapiv1.Listener{
+							Name:     "https-listener",
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "",
+			assert:             expectURLs("https://203.0.113.1/", "http://203.0.113.1/"),
+		},
+		{
+			name: "empty preferredUrlScheme falls back to HTTP if no HTTPS",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http-listener",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     8080,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "",
+			assert:             expectURLs("http://203.0.113.1:8080/"),
+		},
+		{
+			name: "sectionName takes precedence over preferredUrlScheme",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(gwapiv1.ParentReference{
+					Name:        "test-gateway",
+					Namespace:   ptr.To(gwapiv1.Namespace("test-ns")),
+					SectionName: ptr.To(gwapiv1.SectionName("http-listener")),
+					Group:       ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+					Kind:        ptr.To(gwapiv1.Kind("Gateway")),
+				}),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(
+						gwapiv1.Listener{
+							Name:     "http-listener",
+							Protocol: gwapiv1.HTTPProtocolType,
+							Port:     80,
+						},
+						gwapiv1.Listener{
+							Name:     "https-listener",
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "https", // ignored because sectionName is set
+			assert:             expectURLs("http://203.0.113.1/"),
+		},
+		{
+			name: "gateway with multiple HTTP-capable listeners - all listeners advertised",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("multi-listener-gateway", RefInNamespace("gw-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("multi-listener-gateway",
+					InNamespace[*gwapiv1.Gateway]("gw-ns"),
+					WithListeners(
+						gwapiv1.Listener{
+							Name:     "http",
+							Protocol: gwapiv1.HTTPProtocolType,
+							Port:     80,
+							Hostname: ptr.To(gwapiv1.Hostname("api.example.com")),
+						},
+						gwapiv1.Listener{
+							Name:     "https",
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Port:     443,
+							Hostname: ptr.To(gwapiv1.Hostname("api.example.com")),
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("https://api.example.com/", "http://api.example.com/"),
+		},
+
+		// ===== Internal service discovery =====
+		{
+			name: "discovers internal URL via gateway label",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gwapiv1.Gateway]("gateway-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-service",
+						Namespace: "gateway-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "my-gateway",
+						},
+					},
+				},
+			},
+			assert: expectURLs(
+				"http://203.0.113.1/",
+				"http://gateway-service.gateway-ns.svc.cluster.local/",
+			),
+		},
+		{
+			name: "discovers internal URL via same-name service fallback",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gwapiv1.Gateway]("gateway-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-gateway", // Same name as gateway
+						Namespace: "gateway-ns",
+					},
+				},
+			},
+			assert: expectURLs(
+				"http://203.0.113.1/",
+				"http://my-gateway.gateway-ns.svc.cluster.local/",
+			),
+		},
+		{
+			name: "internal URL includes non-standard port",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gwapiv1.Gateway]("gateway-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http-alt",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     8080,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-service",
+						Namespace: "gateway-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "my-gateway",
+						},
+					},
+				},
+			},
+			assert: expectURLs(
+				"http://203.0.113.1:8080/",
+				"http://gateway-service.gateway-ns.svc.cluster.local:8080/",
+			),
+		},
+		{
+			name: "internal URL uses same scheme as gateway listener",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gwapiv1.Gateway]("gateway-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "https",
+						Protocol: gwapiv1.HTTPSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-service",
+						Namespace: "gateway-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "my-gateway",
+						},
+					},
+				},
+			},
+			// Internal URL matches the listener's scheme and port
+			assert: expectURLs(
+				"https://203.0.113.1/",
+				"https://gateway-service.gateway-ns.svc.cluster.local/",
+			),
+		},
+		{
+			name: "no internal URL without backing service",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gwapiv1.Gateway]("gateway-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: nil,
+			assert:   expectURLs("http://203.0.113.1/"),
+		},
+		{
+			name: "no external addresses but backing service exists - returns internal URL only",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gwapiv1.Gateway]("gateway-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     8080,
+					}),
+					// No addresses - LoadBalancer pending
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-service",
+						Namespace: "gateway-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "my-gateway",
+						},
+					},
+				},
+			},
+			assert: expectURLs("http://gateway-service.gateway-ns.svc.cluster.local:8080/"),
+		},
+		{
+			name: "multiple gateways with backing services - each gets internal URL",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRefs(
+					gwapiv1.ParentReference{
+						Name:      "gateway-a",
+						Namespace: ptr.To(gwapiv1.Namespace("gw-ns")),
+						Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+					},
+					gwapiv1.ParentReference{
+						Name:      "gateway-b",
+						Namespace: ptr.To(gwapiv1.Namespace("gw-ns")),
+						Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+					},
+				),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("gateway-a",
+					InNamespace[*gwapiv1.Gateway]("gw-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "https",
+						Protocol: gwapiv1.HTTPSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("gw-a.example.com"),
+				),
+				Gateway("gateway-b",
+					InNamespace[*gwapiv1.Gateway]("gw-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "http",
+						Protocol: gwapiv1.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("gw-b.example.com"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-a",
+						Namespace: "gw-ns",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-b-svc",
+						Namespace: "gw-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "gateway-b",
+						},
+					},
+				},
+			},
+			assert: expectURLsContain(
+				"https://gw-a.example.com/",
+				"https://gateway-a.gw-ns.svc.cluster.local/",
+				"http://gw-b.example.com/",
+				"http://gateway-b-svc.gw-ns.svc.cluster.local/",
+			),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			ctx := t.Context()
 
 			scheme := runtime.NewScheme()
-			err := gwapiv1.Install(scheme)
-			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(gwapiv1.Install(scheme)).To(Succeed())
+			g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 			var objects []client.Object
-			if tt.gateway != nil {
-				objects = append(objects, tt.gateway)
-			}
 			if tt.route != nil {
 				objects = append(objects, tt.route)
 			}
-			for _, gw := range tt.additionalGateways {
+			for _, gw := range tt.gateways {
 				objects = append(objects, gw)
+			}
+			for _, svc := range tt.services {
+				objects = append(objects, svc)
 			}
 			objects = append(objects, DefaultGatewayClass())
 
@@ -780,23 +1299,14 @@ func TestDiscoverURLs(t *testing.T) {
 				WithObjects(objects...).
 				Build()
 
-			urls, err := llmisvc.DiscoverURLs(ctx, fakeClient, tt.route)
+			urls, err := llmisvc.DiscoverURLs(ctx, fakeClient, tt.route, tt.preferredUrlScheme)
 
-			if tt.expectedErrorCheck != nil {
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(tt.expectedErrorCheck(err)).To(BeTrue(), "Error check function failed for error: %v", err)
-			} else {
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(urls).To(HaveLen(len(tt.expectedURLs)))
-
-				// Convert to strings for easier comparison
-				var actualURLs []string
-				for _, url := range urls {
-					actualURLs = append(actualURLs, url.String())
-				}
-
-				g.Expect(actualURLs).To(Equal(tt.expectedURLs))
+			var actualURLs []string
+			for _, url := range urls {
+				actualURLs = append(actualURLs, url.String())
 			}
+
+			tt.assert(g, actualURLs, err)
 		})
 	}
 }
@@ -1063,6 +1573,56 @@ func TestFilterURLs(t *testing.T) {
 			isExternal := llmisvc.IsExternalURL(url)
 
 			g.Expect(isInternal).To(Equal(!isExternal), "URL %s should be either internal or external, not both", urlStr)
+		}
+	})
+
+	t.Run("AddressTypeName", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			url      string
+			expected string
+		}{
+			{
+				name:     "external hostname",
+				url:      "https://api.example.com/",
+				expected: "gateway-external",
+			},
+			{
+				name:     "external IP",
+				url:      "http://203.0.113.1/",
+				expected: "gateway-external",
+			},
+			{
+				name:     "private IP",
+				url:      "http://192.168.1.100/",
+				expected: "internal",
+			},
+			{
+				name:     "localhost",
+				url:      "http://localhost/",
+				expected: "internal",
+			},
+			{
+				name:     "cluster-local service",
+				url:      "http://my-service.default.svc.cluster.local/",
+				expected: "gateway-internal",
+			},
+			{
+				name:     "cluster-local with port",
+				url:      "http://gateway.ns.svc.cluster.local:8080/",
+				expected: "gateway-internal",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewGomegaWithT(t)
+				parsedURL, err := apis.ParseURL(tt.url)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				result := llmisvc.AddressTypeName(parsedURL)
+				g.Expect(result).To(Equal(tt.expected))
+			})
 		}
 	})
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
@@ -244,6 +244,35 @@ func TestDiscoverURLs(t *testing.T) {
 			assert: expectURLs("http://203.0.113.1/ns/name"),
 		},
 		{
+			name: "multi-rule path extraction - nil match.Path is skipped",
+			route: HTTPRoute("nil-path-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("nil-path-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					Matches(gwapiv1.HTTPRouteMatch{
+						// No Path set - header-only match
+						Headers: []gwapiv1.HTTPHeaderMatch{{
+							Name:  "x-custom",
+							Value: "val",
+						}},
+					}),
+					WithBackendRefs(BackendRefService("svc")),
+				),
+				WithHTTPRule(
+					Matches(PathPrefixMatch("/ns/name")),
+					WithBackendRefs(BackendRefService("svc")),
+				),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("nil-path-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListener(gwapiv1.HTTPProtocolType),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1/ns/name"),
+		},
+		{
 			name: "empty route rules - default path",
 			route: HTTPRoute("empty-rules-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
@@ -292,6 +292,34 @@ func TestDiscoverURLs(t *testing.T) {
 			gateways: []*gwapiv1.Gateway{HTTPSGateway("https-gateway", "test-ns", "203.0.113.1")},
 			assert:   expectURLs("https://203.0.113.1/"),
 		},
+		{
+			name: "TLS protocol listener uses HTTPS scheme",
+			route: HTTPRoute("tls-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("tls-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{
+				Gateway("tls-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(gwapiv1.Listener{
+						Name:     "tls",
+						Protocol: gwapiv1.TLSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("https://203.0.113.1/"),
+		},
+		{
+			name: "IPv6 gateway address - brackets in URL",
+			route: HTTPRoute("ipv6-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("ipv6-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gwapiv1.Gateway{HTTPGateway("ipv6-gateway", "test-ns", "2001:db8::1")},
+			assert:   expectURLs("http://[2001:db8::1]/"),
+		},
 
 		// ===== Multiple parent refs =====
 		{
@@ -615,28 +643,26 @@ func TestDiscoverURLs(t *testing.T) {
 				}),
 				WithHostnames("api.example.com"),
 			),
-			gateway: Gateway("mismatched-section-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				WithListeners(
-					gwapiv1.Listener{
-						Name:     "http-listener",
-						Protocol: gwapiv1.HTTPProtocolType,
-						Port:     80,
-					},
-					gwapiv1.Listener{
-						Name:     "https-listener",
-						Protocol: gwapiv1.HTTPSProtocolType,
-						Port:     443,
-					},
+			gateways: []*gwapiv1.Gateway{
+				Gateway("mismatched-section-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					WithListeners(
+						gwapiv1.Listener{
+							Name:     "http-listener",
+							Protocol: gwapiv1.HTTPProtocolType,
+							Port:     80,
+						},
+						gwapiv1.Listener{
+							Name:     "https-listener",
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
 				),
-				WithAddresses("203.0.113.1"),
-			),
-			// The current behavior silently falls through to Listeners[0] (HTTP/80),
-			// producing "http://api.example.com/" instead of erroring. This is wrong
-			// because the caller explicitly asked for "nonexistent-listener" and should
-			// be told it doesn't exist rather than getting a URL from the wrong listener.
-			expectedErrorCheck: func(err error) bool {
-				return err != nil
+			},
+			assert: func(g Gomega, urls []string, err error) {
+				g.Expect(err).To(HaveOccurred())
 			},
 		},
 		{
@@ -645,13 +671,15 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("no-listener-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("no-listener-gateway",
-				InNamespace[*gwapiv1.Gateway]("test-ns"),
-				// No WithListener — Gateway has empty Listeners slice
-				WithAddresses("203.0.113.1"),
-			),
-			expectedErrorCheck: func(err error) bool {
-				return err != nil
+			gateways: []*gwapiv1.Gateway{
+				Gateway("no-listener-gateway",
+					InNamespace[*gwapiv1.Gateway]("test-ns"),
+					// No WithListener — Gateway has empty Listeners slice
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: func(g Gomega, urls []string, err error) {
+				g.Expect(err).To(HaveOccurred())
 			},
 		},
 		{

--- a/pkg/controller/v1alpha2/llmisvc/router_validation.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_validation.go
@@ -117,7 +117,7 @@ func (r *LLMISVCReconciler) validateGatewayReferences(ctx context.Context, llmSv
 	logger := log.FromContext(ctx).WithName("validateGatewayReferences")
 
 	// If no router or gateway configuration, skip validation
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Gateway == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
+	if llmSvc.Spec.Router == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Rewrite URL discovery to support multiple Gateway listeners (HTTP/HTTPS), preferred URL scheme selection, wildcard hostname expansion, and internal cluster-local service discovery via gateway-backing Services. Add AddressTypeName classification for Addressable entries and rename error types for clarity (NoURLsDiscoveredError).

Port of opendatahub-io/kserve#1046

Additions on top of downstream:

#### guard against nil match.Path in `extractRoutePath`

HTTPRoute rules can contain matches with only header conditions and no path specification. The existing code unconditionally dereferenced match.Path.Value, causing a nil pointer panic for header-only matches.

Adds a nil check to skip matches without a path and a corresponding unit test exercising the header-only match scenario.

#### Additional hardening

Deterministic service selection when multiple services match the gateway label:

- sorts alphabetically and logs a warning
- guards against empty parent status in HTTPRoute readiness checks
- fixes namespace comparison in parentRef matching by threading the
route's own namespace as default
- synthesizes a condition when ResolvedRefs is missing from gateway
controller status
-f ixes IPv6 address handling in URL construction where
standard-port paths bypassed bracket wrapping
- adds TLS protocol listener test coverage

**Release note**:
```release-note
NONE
```
