### PR TITLE
refactor(llmisvc): simplify EPPServiceName guard logic

### DIFF
--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types_func.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types_func.go
@@ -30,10 +30,12 @@ func (s *SchedulerSpec) InferencePoolName(llmSvc *LLMInferenceService) string {
 }
 
 func (r *RouterSpec) EPPServiceName(llmSvc *LLMInferenceService) string {
-	if r == nil || r.Route == nil || r.Scheduler == nil || r.Scheduler.Pool == nil || !r.Scheduler.Pool.HasRef() || r.Scheduler.Pool.Spec == nil || r.Scheduler.Pool.Spec.EndpointPickerRef.Name == "" {
-		return kmeta.ChildName(llmSvc.GetName(), "-epp-service")
+	if r != nil && r.Scheduler != nil && r.Scheduler.Pool != nil &&
+		!r.Scheduler.Pool.HasRef() &&
+		r.Scheduler.Pool.Spec != nil && r.Scheduler.Pool.Spec.EndpointPickerRef.Name != "" {
+		return string(r.Scheduler.Pool.Spec.EndpointPickerRef.Name)
 	}
-	return string(r.Scheduler.Pool.Spec.EndpointPickerRef.Name)
+	return kmeta.ChildName(llmSvc.GetName(), "-epp-service")
 }
 
 func (in *GatewaySpec) HasRefs() bool {

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types_func_test.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types_func_test.go
@@ -105,7 +105,7 @@ func TestEPPServiceName(t *testing.T) {
 			router: &RouterSpec{
 				Scheduler: &SchedulerSpec{
 					Pool: &InferencePoolSpec{
-						Ref:  &corev1.LocalObjectReference{Name: "external-pool"},
+						Ref: &corev1.LocalObjectReference{Name: "external-pool"},
 						Spec: &igwapi.InferencePoolSpec{
 							EndpointPickerRef: igwapi.EndpointPickerRef{
 								Name: "should-be-ignored",

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types_func_test.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types_func_test.go
@@ -20,8 +20,178 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 )
+
+func TestEPPServiceName(t *testing.T) {
+	llmSvc := &LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-llm"},
+	}
+	defaultName := "my-llm-epp-service"
+
+	tests := []struct {
+		name     string
+		router   *RouterSpec
+		expected string
+	}{
+		{
+			name:     "nil router",
+			router:   nil,
+			expected: defaultName,
+		},
+		{
+			name:     "nil scheduler",
+			router:   &RouterSpec{},
+			expected: defaultName,
+		},
+		{
+			name: "nil pool",
+			router: &RouterSpec{
+				Scheduler: &SchedulerSpec{},
+			},
+			expected: defaultName,
+		},
+		{
+			name: "inline pool with default EndpointPickerRef name",
+			router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Spec: &igwapi.InferencePoolSpec{
+							EndpointPickerRef: igwapi.EndpointPickerRef{
+								Name: igwapi.ObjectName(defaultName),
+							},
+						},
+					},
+				},
+			},
+			expected: defaultName,
+		},
+		{
+			// This is the key case: a user overrides EndpointPickerRef.Name
+			// to a custom value in inline mode. The function should return
+			// the custom name so the EPP service matches what the
+			// InferencePool references. It previously returned the default
+			// name because !HasRef() short-circuited the condition chain
+			// before Spec was ever checked; this test guards against that regression.
+			name: "inline pool with custom EndpointPickerRef name - should use custom name",
+			router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Spec: &igwapi.InferencePoolSpec{
+							EndpointPickerRef: igwapi.EndpointPickerRef{
+								Name: "my-custom-epp",
+							},
+						},
+					},
+				},
+			},
+			expected: "my-custom-epp",
+		},
+		{
+			name: "ref pool (external) - default name for deletion lookup",
+			router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Ref: &corev1.LocalObjectReference{Name: "external-pool"},
+					},
+				},
+			},
+			expected: defaultName,
+		},
+		{
+			name: "ref pool with Spec also set - ref takes precedence",
+			router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Ref:  &corev1.LocalObjectReference{Name: "external-pool"},
+						Spec: &igwapi.InferencePoolSpec{
+							EndpointPickerRef: igwapi.EndpointPickerRef{
+								Name: "should-be-ignored",
+							},
+						},
+					},
+				},
+			},
+			expected: defaultName,
+		},
+		{
+			name: "inline pool with empty EndpointPickerRef name",
+			router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Spec: &igwapi.InferencePoolSpec{
+							EndpointPickerRef: igwapi.EndpointPickerRef{
+								Name: "",
+							},
+						},
+					},
+				},
+			},
+			expected: defaultName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.router.EPPServiceName(llmSvc)
+			if got != tt.expected {
+				t.Errorf("EPPServiceName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInferencePoolName(t *testing.T) {
+	llmSvc := &LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-llm"},
+	}
+
+	tests := []struct {
+		name      string
+		scheduler *SchedulerSpec
+		expected  string
+	}{
+		{
+			name:      "nil scheduler",
+			scheduler: nil,
+			expected:  "my-llm-inference-pool",
+		},
+		{
+			name:      "nil pool",
+			scheduler: &SchedulerSpec{},
+			expected:  "my-llm-inference-pool",
+		},
+		{
+			name: "inline pool (no ref)",
+			scheduler: &SchedulerSpec{
+				Pool: &InferencePoolSpec{
+					Spec: &igwapi.InferencePoolSpec{},
+				},
+			},
+			expected: "my-llm-inference-pool",
+		},
+		{
+			name: "ref pool",
+			scheduler: &SchedulerSpec{
+				Pool: &InferencePoolSpec{
+					Ref: &corev1.LocalObjectReference{Name: "external-pool"},
+				},
+			},
+			expected: "external-pool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scheduler.InferencePoolName(llmSvc)
+			if got != tt.expected {
+				t.Errorf("InferencePoolName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
 
 func TestIsUsingLLMInferenceServiceConfig(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

The condition chain in `EPPServiceName` mixed nil-safety guards with unrelated mode checks (`HasRef`, `Route`), making the logic hard to audit and masking a latent correctness issue: inline pool specs with a custom `EndpointPickerRef.Name` were silently ignored because `!HasRef()` short-circuited before Spec was ever evaluated.

Replaces the negated OR-chain with a straightforward positive AND-chain that reads the `EndpointPickerRef` name from `Pool.Spec` when available, falling back to the default otherwise.

No behavioral change for current users - the default preset template produces matching names - but the function now correctly handles custom EndpointPickerRef overrides in inline mode.

Adds unit tests for both `EPPServiceName` and `InferencePoolName`, covering nil paths, inline and ref modes, and custom name propagation.

**Release note**:
```release-note
NONE
```
