### PR TITLE
fix(llmisvc): return nil instead of empty InferencePoolSpec

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_conversion.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_conversion.go
@@ -339,8 +339,9 @@ func convertInferencePoolSpecToV1(src *igwapiv1alpha2.InferencePoolSpec) *igwapi
 	dstPool := &igwapiv1.InferencePool{}
 
 	if err := srcPool.ConvertTo(dstPool); err != nil {
-		// Fallback: return empty spec on error (should not happen in practice)
-		return &igwapiv1.InferencePoolSpec{}
+		// Return nil rather than an empty spec — callers nil-check Pool.Spec, and an
+		// empty spec would bypass those guards with invalid zero-value fields.
+		return nil
 	}
 
 	return &dstPool.Spec
@@ -411,8 +412,9 @@ func convertInferencePoolSpecFromV1(src *igwapiv1.InferencePoolSpec) *igwapiv1al
 	dstPool := &igwapiv1alpha2.InferencePool{}
 
 	if err := dstPool.ConvertFrom(srcPool); err != nil {
-		// Fallback: return empty spec on error (should not happen in practice)
-		return &igwapiv1alpha2.InferencePoolSpec{}
+		// Return nil rather than an empty spec — callers nil-check Pool.Spec, and an
+		// empty spec would bypass those guards with invalid zero-value fields.
+		return nil
 	}
 
 	return &dstPool.Spec

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_conversion_test.go
@@ -21,8 +21,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
+	igwapiv1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	igwapiv1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
@@ -258,4 +262,123 @@ func TestLLMInferenceServiceConversion_PreservesExistingAnnotations(t *testing.T
 	// Verify criticality annotation is cleaned up
 	_, hasAnnotation := restored.Annotations[ModelCriticalityAnnotationKey]
 	assert.False(t, hasAnnotation, "Criticality annotation should be cleaned up")
+}
+
+func TestLLMInferenceServiceConversion_PreservesInferencePoolSpec(t *testing.T) {
+	modelName := "test-model"
+	eppGroup := igwapiv1alpha2.Group("")
+	eppKind := igwapiv1alpha2.Kind("Service")
+	eppPort := igwapiv1alpha2.PortNumber(9002)
+	eppFailureMode := igwapiv1alpha2.ExtensionFailureMode("FailClose")
+
+	src := &LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-llm-isvc-pool",
+			Namespace: "default",
+		},
+		Spec: LLMInferenceServiceSpec{
+			Model: LLMModelSpec{
+				URI:  apis.URL{Scheme: "hf", Host: "meta-llama/Llama-2-7b"},
+				Name: &modelName,
+			},
+			Router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Replicas: ptr.To(int32(1)),
+					Pool: &InferencePoolSpec{
+						Spec: &igwapiv1alpha2.InferencePoolSpec{
+							Selector: map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{
+								"app": "vllm",
+							},
+							TargetPortNumber: 8000,
+							ExtensionRef: igwapiv1alpha2.Extension{
+								Group:       &eppGroup,
+								Kind:        &eppKind,
+								Name:        "my-epp",
+								PortNumber:  &eppPort,
+								FailureMode: &eppFailureMode,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Convert to v1alpha2 (hub)
+	dst := &v1alpha2.LLMInferenceService{}
+	err := src.ConvertTo(dst)
+	require.NoError(t, err)
+
+	// Verify the pool spec was converted to GIE v1 format
+	require.NotNil(t, dst.Spec.Router)
+	require.NotNil(t, dst.Spec.Router.Scheduler)
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool)
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool.Spec, "Pool.Spec must not be nil after conversion")
+
+	v1Spec := dst.Spec.Router.Scheduler.Pool.Spec
+	assert.Equal(t, igwapiv1.PortNumber(8000), v1Spec.TargetPorts[0].Number)
+	assert.Equal(t, igwapiv1.LabelValue("vllm"), v1Spec.Selector.MatchLabels["app"])
+	assert.Equal(t, igwapiv1.ObjectName("my-epp"), v1Spec.EndpointPickerRef.Name)
+
+	// Convert back to v1alpha1
+	restored := &LLMInferenceService{}
+	err = restored.ConvertFrom(dst)
+	require.NoError(t, err)
+
+	// Verify the pool spec round-trips correctly back to GIE v1alpha2 format
+	require.NotNil(t, restored.Spec.Router)
+	require.NotNil(t, restored.Spec.Router.Scheduler)
+	require.NotNil(t, restored.Spec.Router.Scheduler.Pool)
+	require.NotNil(t, restored.Spec.Router.Scheduler.Pool.Spec, "Pool.Spec must not be nil after round-trip")
+
+	v1a2Spec := restored.Spec.Router.Scheduler.Pool.Spec
+	assert.Equal(t, int32(8000), v1a2Spec.TargetPortNumber)
+	assert.Equal(t, igwapiv1alpha2.LabelValue("vllm"), v1a2Spec.Selector["app"])
+	assert.Equal(t, igwapiv1alpha2.ObjectName("my-epp"), v1a2Spec.ExtensionRef.Name)
+}
+
+func TestLLMInferenceServiceConversion_PreservesPoolRef(t *testing.T) {
+	modelName := "test-model"
+
+	src := &LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-llm-isvc-pool-ref",
+			Namespace: "default",
+		},
+		Spec: LLMInferenceServiceSpec{
+			Model: LLMModelSpec{
+				URI:  apis.URL{Scheme: "hf", Host: "meta-llama/Llama-2-7b"},
+				Name: &modelName,
+			},
+			Router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Ref: &corev1.LocalObjectReference{
+							Name: "external-pool",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Convert to v1alpha2 (hub)
+	dst := &v1alpha2.LLMInferenceService{}
+	err := src.ConvertTo(dst)
+	require.NoError(t, err)
+
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool)
+	assert.Nil(t, dst.Spec.Router.Scheduler.Pool.Spec, "Pool.Spec must be nil when using Ref")
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool.Ref)
+	assert.Equal(t, "external-pool", dst.Spec.Router.Scheduler.Pool.Ref.Name)
+
+	// Convert back to v1alpha1
+	restored := &LLMInferenceService{}
+	err = restored.ConvertFrom(dst)
+	require.NoError(t, err)
+
+	require.NotNil(t, restored.Spec.Router.Scheduler.Pool)
+	assert.Nil(t, restored.Spec.Router.Scheduler.Pool.Spec, "Pool.Spec must remain nil after round-trip")
+	require.NotNil(t, restored.Spec.Router.Scheduler.Pool.Ref)
+	assert.Equal(t, "external-pool", restored.Spec.Router.Scheduler.Pool.Ref.Name)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The `convertInferencePoolSpecToV1` and `convertInferencePoolSpecFromV1` functions returned `&InferencePoolSpec{}` on conversion error. While the upstream GIE conversion errors currently cannot trigger in practice (all error paths require nil inputs that kserve never provides), the empty struct fallback is semantically wrong:

- all downstream consumers nil-check `Pool.Spec` before use
- an empty spec bypasses those guards and would propagate zero-value fields (empty selector, no ports, missing endpoint picker) into the scheduler reconciliation

**Release note**:
```release-note
NONE
```