### PR TITLE
fix(llmisvc): handle JSON marshal error in ReplaceVariables

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -370,7 +370,10 @@ func ToParentRefs(gatewayRefs []v1alpha2.UntypedObjectReference) []gwapiv1.Paren
 // ReplaceVariables processes the configuration as a Go template to substitute
 // variables with values from the LLM service and global configuration.
 func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.LLMInferenceServiceConfig, reconcilerConfig *Config) (*v1alpha2.LLMInferenceServiceConfig, error) {
-	templateBytes, _ := json.Marshal(llmSvcCfg)
+	templateBytes, err := json.Marshal(llmSvcCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal config for template processing: %w", err)
+	}
 	buf := bytes.NewBuffer(nil)
 	config := struct {
 		*v1alpha2.LLMInferenceService


### PR DESCRIPTION
**What this PR does / why we need it**:

`ReplaceVariables` discarded the `json.Marshal(llmSvcCfg)` error on line 351. While marshaling a well-typed Kubernetes struct practically never fails, discarding the error means any failure would surface as a confusing "failed to unmarshal config from template" error from the downstream `json.Unmarshal` call, making debugging harder than necessary.

**Release note**:
```release-note
NONE
```