### PR TITLE
fix(llmisvc): restricts GlobalConfig fields for templates

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -367,17 +367,34 @@ func ToParentRefs(gatewayRefs []v1alpha2.UntypedObjectReference) []gwapiv1.Paren
 	return parentRefs
 }
 
+// templateGlobalConfig exposes only the non-sensitive fields of Config to templates.
+// StorageConfig and CredentialConfig are intentionally excluded to prevent template
+// injection from accessing internal controller configuration.
+type templateGlobalConfig struct {
+	SystemNamespace         string
+	IngressGatewayName      string
+	IngressGatewayNamespace string
+}
+
 // ReplaceVariables processes the configuration as a Go template to substitute
 // variables with values from the LLM service and global configuration.
 func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.LLMInferenceServiceConfig, reconcilerConfig *Config) (*v1alpha2.LLMInferenceServiceConfig, error) {
 	templateBytes, _ := json.Marshal(llmSvcCfg)
 	buf := bytes.NewBuffer(nil)
+	var gc templateGlobalConfig
+	if reconcilerConfig != nil {
+		gc = templateGlobalConfig{
+			SystemNamespace:         reconcilerConfig.SystemNamespace,
+			IngressGatewayName:      reconcilerConfig.IngressGatewayName,
+			IngressGatewayNamespace: reconcilerConfig.IngressGatewayNamespace,
+		}
+	}
 	config := struct {
 		*v1alpha2.LLMInferenceService
-		GlobalConfig *Config
+		GlobalConfig templateGlobalConfig
 	}{
 		LLMInferenceService: llmSvc,
-		GlobalConfig:        reconcilerConfig,
+		GlobalConfig:        gc,
 	}
 	t, err := template.New("config").
 		Funcs(map[string]any{


### PR DESCRIPTION
**What this PR does / why we need it**:

- Replaces the full `Config` pointer in the template data context with a restricted `templateGlobalConfig` struct exposing only `SystemNamespace`, `IngressGatewayName`, and `IngressGatewayNamespace`
- Previously the entire `Config` struct (including `CredentialConfig` and `StorageConfig`) was reachable through Go template expressions despite `json:"-"` tags, since `text/template` traverses struct fields directly
- In practice the severity is low — `CredentialConfig` holds metadata (secret names, S3 endpoints) not actual credentials, and users who can create `LLMInferenceService` CRs can already run arbitrary containers. This is a "defense-in-depth" fix

**Release note**:
```release-note
NONE
```