### PR TITLE
fix: surface failure conditions in InferenceService status

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -428,7 +428,9 @@ func (ss *InferenceServiceStatus) PropagateRawStatus(
 
 	ss.SetCondition(readyCondition, componentReadyCondition)
 	ss.Components[component] = statusSpec
-	ss.ObservedGeneration = deploymentList[0].Status.ObservedGeneration
+	if len(deploymentList) > 0 {
+		ss.ObservedGeneration = deploymentList[0].Status.ObservedGeneration
+	}
 }
 
 func getDeploymentCondition(deploymentList []*appsv1.Deployment, conditionType appsv1.DeploymentConditionType) *apis.Condition {

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -132,10 +132,12 @@ func (e *Explainer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	// Here we allow switch between knative and vanilla deployment
 	if e.deploymentMode == constants.Standard {
 		if err := e.reconcileExplainerRawDeployment(ctx, isvc, &objectMeta, &podSpec); err != nil {
+			isvc.Status.PropagateRawStatusWithMessages(v1beta1.ExplainerComponent, "ReconcileFailed", err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
 	} else {
 		if err := e.reconcileExplainerKnativeDeployment(ctx, isvc, &objectMeta, &podSpec); err != nil {
+			isvc.Status.PropagateRawStatusWithMessages(v1beta1.ExplainerComponent, "ReconcileFailed", err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -191,6 +191,7 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 		podLabelKey = constants.RawDeploymentAppLabel
 		// This is main RawKubeReconciler to create objects (deployment, svc, scaler)
 		if err := p.reconcileRawDeployment(ctx, isvc, objectMeta, workerObjectMeta, &podSpec, workerPodSpec); err != nil {
+			isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, "ReconcileFailed", err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
 	} else {
@@ -198,6 +199,7 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 		podLabelKey = constants.RevisionLabel
 
 		if kstatus, err = p.reconcileKnativeDeployment(ctx, isvc, &objectMeta, &podSpec); err != nil {
+			isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, "ReconcileFailed", err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -161,10 +161,12 @@ func (p *Transformer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServ
 	// Here we allow switch between knative and vanilla deployment
 	if p.deploymentMode == constants.Standard {
 		if err := p.reconcileTransformerRawDeployment(ctx, isvc, &objectMeta, &podSpec); err != nil {
+			isvc.Status.PropagateRawStatusWithMessages(v1beta1.TransformerComponent, "ReconcileFailed", err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
 	} else {
 		if err := p.reconcileTransformerKnativeDeployment(ctx, isvc, &objectMeta, &podSpec); err != nil {
+			isvc.Status.PropagateRawStatusWithMessages(v1beta1.TransformerComponent, "ReconcileFailed", err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -9822,9 +9822,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 //
 // Bug 2: Previously, DeploymentReconciler.Reconcile returned the in-memory desired
 // deployment (no .Status.Conditions) instead of the server-side existing deployment.
-// As a result, a ReplicaFailure condition (e.g. from an admission-webhook like BCSIdentity
-// denying pod creation) was silently lost.  After the fix the ISVC PredictorReady condition
-// must carry the reason and message from the deployment's ReplicaFailure condition.
+// As a result, a ReplicaFailure condition (e.g. from an admission webhook denying pod
+// creation) was silently lost.  After the fix the ISVC PredictorReady condition must
+// carry the reason and message from the deployment's ReplicaFailure condition.
 var _ = Context("When a Standard-mode predictor deployment develops a ReplicaFailure", func() {
 	It("should surface the failure reason in the InferenceService PredictorReady condition", func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -9873,7 +9873,7 @@ var _ = Context("When a Standard-mode predictor deployment develops a ReplicaFai
 		}, timeout, interval).Should(Succeed())
 
 		By("patching the deployment status with a ReplicaFailure condition (simulating webhook denial)")
-		replicaFailureMsg := `admission webhook "pod.bcsidentity.identity.bloomberg.com" denied the request: BCSIdentity "kserve-workshop" not found`
+		replicaFailureMsg := `admission webhook "pod-policy.example.com" denied the request: identity "my-identity" not found`
 		updatedDeployment := actualDeployment.DeepCopy()
 		updatedDeployment.Status.Conditions = []appsv1.DeploymentCondition{
 			{

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -9813,6 +9813,105 @@ var _ = Describe("v1beta1 inference service controller", func() {
 	})
 })
 
+// TestDeploymentReplicaFailurePropagatedToIsvcStatus is an integration test that covers
+// the combined fix for Bug 1 and Bug 2 from issue #5113.
+//
+// Bug 1: Without InitializeConditions on early paths the ISVC status could be completely
+// empty. After the fix the status section must always contain at least the "Ready"
+// condition once the first reconciliation cycle completes.
+//
+// Bug 2: Previously, DeploymentReconciler.Reconcile returned the in-memory desired
+// deployment (no .Status.Conditions) instead of the server-side existing deployment.
+// As a result, a ReplicaFailure condition (e.g. from an admission-webhook like BCSIdentity
+// denying pod creation) was silently lost.  After the fix the ISVC PredictorReady condition
+// must carry the reason and message from the deployment's ReplicaFailure condition.
+var _ = Context("When a Standard-mode predictor deployment develops a ReplicaFailure", func() {
+	It("should surface the failure reason in the InferenceService PredictorReady condition", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+
+		By("setting up configmap and serving runtime")
+		configs := getRawKubeTestConfigs()
+		configMap := createInferenceServiceConfigMap(configs)
+		Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, configMap) })
+
+		servingRuntime := getServingRuntime("tf-serving-raw", "default")
+		Expect(k8sClient.Create(ctx, &servingRuntime)).To(Or(Succeed(), MatchError(ContainSubstring("already exists"))))
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, &servingRuntime) })
+
+		By("creating the InferenceService")
+		serviceName := "raw-replica-failure-test"
+		serviceKey := types.NamespacedName{Name: serviceName, Namespace: "default"}
+
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        serviceKey.Name,
+				Namespace:   serviceKey.Namespace,
+				Annotations: getDefaultAnnotations(constants.AutoscalerClassNone),
+			},
+			Spec: v1beta1.InferenceServiceSpec{
+				Predictor: v1beta1.PredictorSpec{
+					Tensorflow: &v1beta1.TFServingSpec{
+						PredictorExtensionSpec: getCommonPredictorExtensionSpec(),
+					},
+				},
+			},
+		}
+		isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil)
+		Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, isvc) })
+
+		By("waiting for the controller to create the predictor deployment")
+		predictorDeploymentKey := types.NamespacedName{
+			Name:      constants.PredictorServiceName(serviceKey.Name),
+			Namespace: serviceKey.Namespace,
+		}
+		actualDeployment := &appsv1.Deployment{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, predictorDeploymentKey, actualDeployment)
+		}, timeout, interval).Should(Succeed())
+
+		By("patching the deployment status with a ReplicaFailure condition (simulating webhook denial)")
+		replicaFailureMsg := `admission webhook "pod.bcsidentity.identity.bloomberg.com" denied the request: BCSIdentity "kserve-workshop" not found`
+		updatedDeployment := actualDeployment.DeepCopy()
+		updatedDeployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Type:    appsv1.DeploymentReplicaFailure,
+				Status:  corev1.ConditionTrue,
+				Reason:  "FailedCreate",
+				Message: replicaFailureMsg,
+			},
+			{
+				Type:    appsv1.DeploymentAvailable,
+				Status:  corev1.ConditionFalse,
+				Reason:  "MinimumReplicasUnavailable",
+				Message: "Deployment does not have minimum availability.",
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, updatedDeployment)).NotTo(HaveOccurred())
+
+		By("verifying the ISVC PredictorReady condition reflects ReplicaFailure (Bug 2 fix)")
+		updatedIsvc := &v1beta1.InferenceService{}
+		Eventually(func() bool {
+			if err := k8sClient.Get(ctx, serviceKey, updatedIsvc); err != nil {
+				return false
+			}
+			cond := updatedIsvc.Status.GetCondition(v1beta1.PredictorReady)
+			return cond != nil &&
+				cond.IsFalse() &&
+				cond.Reason == "FailedCreate" &&
+				cond.Message == replicaFailureMsg
+		}, timeout, interval).Should(BeTrue(),
+			"PredictorReady condition should be False with FailedCreate reason from ReplicaFailure")
+
+		By("verifying the ISVC status section is never completely empty (Bug 1 fix)")
+		// The overall Ready condition must exist regardless of deployment state.
+		Expect(updatedIsvc.Status.GetCondition(apis.ConditionReady)).NotTo(BeNil(),
+			"ConditionReady must be present: status section should not be empty after reconciliation")
+	})
+})
+
 func verifyEnvKeyValueDeployments(actualDefaultDeployment *appsv1.Deployment, envKey string, expectedEnvValue string) {
 	// default deployment
 	if envValue, exists := utils.GetEnvVarValue(actualDefaultDeployment.Spec.Template.Spec.Containers[0].Env, envKey); exists {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -1091,7 +1091,7 @@ func TestDeploymentReconciler_Reconcile(t *testing.T) {
 		Type:    appsv1.DeploymentReplicaFailure,
 		Status:  corev1.ConditionTrue,
 		Reason:  "FailedCreate",
-		Message: `admission webhook "pod.bcsidentity.identity.bloomberg.com" denied the request: BCSIdentity "kserve-workshop" not found`,
+		Message: `admission webhook "pod-policy.example.com" denied the request: identity "my-identity" not found`,
 	}
 	availableFalseCondition := appsv1.DeploymentCondition{
 		Type:    appsv1.DeploymentAvailable,
@@ -1119,7 +1119,7 @@ func TestDeploymentReconciler_Reconcile(t *testing.T) {
 			wantErr:              false,
 		},
 		{
-			name: "deployment exists with ReplicaFailure (BCSIdentity not found): existingDep returned so conditions are visible",
+			name: "deployment exists with ReplicaFailure (admission webhook denied): existingDep returned so conditions are visible",
 			serverDeployment: func() *appsv1.Deployment {
 				d := makeDeployment("test-predictor", "test-ns")
 				d.Status.Conditions = []appsv1.DeploymentCondition{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -1011,6 +1011,194 @@ func TestCheckDeploymentExist(t *testing.T) {
 	}
 }
 
+// mockClientForReconcile is a mock client used to test DeploymentReconciler.Reconcile.
+// It records which operations were called and allows configuring Get/Create/Patch/Delete behaviour.
+type mockClientForReconcile struct {
+	kclient.Client
+	// getDeployment is returned by Get calls; nil means "not found".
+	getDeployment *appsv1.Deployment
+	// getErr, if non-nil, is returned by Get instead.
+	getErr error
+	// createErr, patchErr, deleteErr allow injecting failures.
+	createErr error
+	patchErr  error
+	deleteErr error
+}
+
+func (m *mockClientForReconcile) Get(ctx context.Context, key kclient.ObjectKey, obj kclient.Object, opts ...kclient.GetOption) error {
+	if m.getErr != nil {
+		return m.getErr
+	}
+	if m.getDeployment == nil {
+		return errors.NewNotFound(appsv1.Resource("deployment"), key.Name)
+	}
+	d := obj.(*appsv1.Deployment)
+	*d = *m.getDeployment.DeepCopy()
+	return nil
+}
+
+func (m *mockClientForReconcile) Update(_ context.Context, _ kclient.Object, _ ...kclient.UpdateOption) error {
+	// Simulate dry-run update: always succeeds.
+	return nil
+}
+
+func (m *mockClientForReconcile) Create(_ context.Context, _ kclient.Object, _ ...kclient.CreateOption) error {
+	return m.createErr
+}
+
+func (m *mockClientForReconcile) Patch(_ context.Context, _ kclient.Object, _ kclient.Patch, _ ...kclient.PatchOption) error {
+	return m.patchErr
+}
+
+func (m *mockClientForReconcile) Delete(_ context.Context, _ kclient.Object, _ ...kclient.DeleteOption) error {
+	return m.deleteErr
+}
+
+func (m *mockClientForReconcile) Scheme() *runtime.Scheme { return runtime.NewScheme() }
+
+// makeDeployment is a helper that builds a minimal Deployment for tests.
+func makeDeployment(name, namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				constants.AutoscalerClass: string(constants.AutoscalerClassNone),
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: constants.InferenceServiceContainerName, Image: "test-image"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestDeploymentReconciler_Reconcile verifies that Reconcile returns the server-side
+// deployment (with live .Status.Conditions) rather than the in-memory desired deployment
+// (which has no status). This is the fix for Bug 2: deployment conditions such as
+// ReplicaFailure were previously invisible to PropagateRawStatus.
+func TestDeploymentReconciler_Reconcile(t *testing.T) {
+	replicaFailureCondition := appsv1.DeploymentCondition{
+		Type:    appsv1.DeploymentReplicaFailure,
+		Status:  corev1.ConditionTrue,
+		Reason:  "FailedCreate",
+		Message: `admission webhook "pod.bcsidentity.identity.bloomberg.com" denied the request: BCSIdentity "kserve-workshop" not found`,
+	}
+	availableFalseCondition := appsv1.DeploymentCondition{
+		Type:    appsv1.DeploymentAvailable,
+		Status:  corev1.ConditionFalse,
+		Reason:  "MinimumReplicasUnavailable",
+		Message: "Deployment does not have minimum availability.",
+	}
+
+	tests := []struct {
+		name string
+		// serverDeployment is the deployment returned by Get (nil = not found).
+		serverDeployment *appsv1.Deployment
+		// wantStatusConditions is the expected Conditions on the first returned deployment.
+		wantStatusConditions []appsv1.DeploymentCondition
+		// wantCreate is true when we expect Create to be called (new deployment).
+		wantCreate bool
+		wantErr    bool
+	}{
+		{
+			name:             "deployment does not exist: Create is called, desiredDep returned with empty status",
+			serverDeployment: nil,
+			// Newly created deployment has no conditions yet.
+			wantStatusConditions: nil,
+			wantCreate:           true,
+			wantErr:              false,
+		},
+		{
+			name: "deployment exists with ReplicaFailure (BCSIdentity not found): existingDep returned so conditions are visible",
+			serverDeployment: func() *appsv1.Deployment {
+				d := makeDeployment("test-predictor", "test-ns")
+				d.Status.Conditions = []appsv1.DeploymentCondition{
+					replicaFailureCondition,
+					availableFalseCondition,
+				}
+				d.Status.ObservedGeneration = 1
+				return d
+			}(),
+			// Bug 2 fix: ReplicaFailure MUST appear in the returned deployment.
+			wantStatusConditions: []appsv1.DeploymentCondition{
+				replicaFailureCondition,
+				availableFalseCondition,
+			},
+			wantCreate: false,
+			wantErr:    false,
+		},
+		{
+			name: "deployment exists and spec is unchanged (CheckResultExisted): existingDep with conditions returned",
+			serverDeployment: func() *appsv1.Deployment {
+				d := makeDeployment("test-predictor", "test-ns")
+				d.Status.Conditions = []appsv1.DeploymentCondition{
+					{
+						Type:    appsv1.DeploymentAvailable,
+						Status:  corev1.ConditionTrue,
+						Reason:  "MinimumReplicasAvailable",
+						Message: "Deployment has minimum availability.",
+					},
+				}
+				d.Status.ObservedGeneration = 2
+				return d
+			}(),
+			wantStatusConditions: []appsv1.DeploymentCondition{
+				{
+					Type:    appsv1.DeploymentAvailable,
+					Status:  corev1.ConditionTrue,
+					Reason:  "MinimumReplicasAvailable",
+					Message: "Deployment has minimum availability.",
+				},
+			},
+			wantCreate: false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desiredDep := makeDeployment("test-predictor", "test-ns")
+
+			mockClient := &mockClientForReconcile{
+				getDeployment: tt.serverDeployment,
+			}
+
+			r := &DeploymentReconciler{
+				client:         mockClient,
+				DeploymentList: []*appsv1.Deployment{desiredDep},
+			}
+
+			resultList, err := r.Reconcile(t.Context())
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, resultList, 1, "resultList should contain exactly one deployment")
+
+			gotConditions := resultList[0].Status.Conditions
+			if len(tt.wantStatusConditions) == 0 {
+				assert.Empty(t, gotConditions,
+					"expected no status conditions on newly created deployment")
+			} else {
+				assert.Equal(t, tt.wantStatusConditions, gotConditions,
+					"returned deployment should carry the server-side status conditions")
+			}
+		})
+	}
+}
+
 func TestNewDeploymentReconciler(t *testing.T) {
 	type fields struct {
 		client       kclient.Client


### PR DESCRIPTION
Fixes: #5113

Two root causes fixed:

Bug 1 - Status section empty on early reconciliation failures:
- Call InitializeConditions() early in Reconcile() before any early-return path.
- Add updateStatus() before every early-return error path in controller.go.
- Call PropagateRawStatusWithMessages() on reconcile failure in predictor.go, transformer.go, and explainer.go for both Standard and Knative modes.
- Guard against empty deploymentList in PropagateRawStatus() to prevent panic.

Bug 2 - Deployment failure conditions silently lost in Standard mode:
- DeploymentReconciler.Reconcile() was returning in-memory desired-state deployments (empty .Status) instead of the server-side existing deployments (with live .Status.Conditions like ReplicaFailure). Introduce resultList to return the correct server-side object per reconcile outcome.

Tests added:
- Unit: TestDeploymentReconciler_Reconcile
- Unit: TestPropagateRawStatus_EmptyDeploymentList
- Unit: TestPropagateRawStatusWithMessages_AllComponents
- Integration: replica failure condition (e.g. admission webhook denial) propagated to InferenceService PredictorReady condition
