### PR TITLE
fix(llmisvc): allow multi-node ISVC without ServingRuntime

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -475,6 +475,21 @@ func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *
 	var workerPodSpec *corev1.PodSpec
 	var err error
 
+	// If no ServingRuntime was passed, we still want to support WorkerSpec provided directly on the InferenceService.
+	// Seeting empty WorkerSpec here allows us to avoid having nil dereference errors in the code below when we try to
+	// access WorkerSpec fields (like annotations, lables, pipelineParallelSize, tensorParallelSize) in reconcileWorker
+	// and multinodeProcess functions. The code will use the values from ISVC's WorkerSpec if ServingRuntime one is
+	// empty
+	if sRuntime.WorkerSpec == nil {
+		sRuntime.WorkerSpec = &v1alpha1.WorkerSpec{}
+	}
+	// If the runtime didn't define worker containers, prefer containers specified on the InferenceService WorkerSpec.
+	// This allows multi-node InferenceService to work even when no ServingRuntime is specified, as long as the user
+	// provides the necessary worker container spec directly on the InferenceService
+	if len(sRuntime.WorkerSpec.Containers) == 0 && isvc.Spec.Predictor.WorkerSpec != nil {
+		sRuntime.WorkerSpec.Containers = isvc.Spec.Predictor.WorkerSpec.Containers
+	}
+
 	sRuntimeWorkerAnnotations := sRuntime.WorkerSpec.Annotations
 	sRuntimeWorkerLabels := sRuntime.WorkerSpec.Labels
 
@@ -525,21 +540,6 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	// Set the TensorParallelSize from InferenceService to ServingRuntime workerSpec.TensorParallelSize
 	if isvc.Spec.Predictor.WorkerSpec.TensorParallelSize != nil {
 		sRuntime.WorkerSpec.TensorParallelSize = isvc.Spec.Predictor.WorkerSpec.TensorParallelSize
-	}
-
-	if sRuntime.WorkerSpec == nil {
-		errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
-		isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
-		return nil, errors.New(errMsg)
-	}
-	// Check if workerSpec in ServingRuntime does not have worker containers information, it should return errors
-	if len(sRuntime.WorkerSpec.Containers) == 0 {
-		errMsg := "No workerSpec container configuration found in selected serving runtime"
-		isvc.Status.UpdateModelTransitionStatus(v1beta1.InvalidSpec, &v1beta1.FailureInfo{
-			Reason:  v1beta1.InvalidPredictorSpec,
-			Message: errMsg,
-		})
-		return nil, errors.New(errMsg)
 	}
 
 	targetisvcContainer := corev1.Container{}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -476,10 +476,10 @@ func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *
 	var err error
 
 	// If no ServingRuntime was passed, we still want to support WorkerSpec provided directly on the InferenceService.
-	// Seeting empty WorkerSpec here allows us to avoid having nil dereference errors in the code below when we try to
-	// access WorkerSpec fields (like annotations, lables, pipelineParallelSize, tensorParallelSize) in reconcileWorker
-	// and multinodeProcess functions. The code will use the values from ISVC's WorkerSpec if ServingRuntime one is
-	// empty
+	// Setting an empty WorkerSpec here avoids nil dereference errors in the code below when we try to
+	// access WorkerSpec fields (like annotations, labels, pipelineParallelSize, tensorParallelSize) in reconcileWorker
+	// and multiNodeProcess functions. The code will use the values from the ISVC's WorkerSpec if the ServingRuntime one
+	// is empty
 	if sRuntime.WorkerSpec == nil {
 		sRuntime.WorkerSpec = &v1alpha1.WorkerSpec{}
 	}
@@ -524,6 +524,21 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	var workerContainer *corev1.Container
 	var mergedWorkerPodSpec *corev1.PodSpec
 	var err error
+
+	if sRuntime.WorkerSpec == nil {
+		errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
+		isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
+		return nil, errors.New(errMsg)
+	}
+	// Check if workerSpec in ServingRuntime does not have worker containers information, it should return errors
+	if len(sRuntime.WorkerSpec.Containers) == 0 {
+		errMsg := "No workerSpec container configuration found in selected serving runtime"
+		isvc.Status.UpdateModelTransitionStatus(v1beta1.InvalidSpec, &v1beta1.FailureInfo{
+			Reason:  v1beta1.InvalidPredictorSpec,
+			Message: errMsg,
+		})
+		return nil, errors.New(errMsg)
+	}
 
 	// Initialize PipelineParallelSize and TensorParallelSize if not set
 	if sRuntime.WorkerSpec.PipelineParallelSize == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Enables deploying an InferenceService with WorkerSpec (multi-node) even when no ServingRuntime is specified.
- Previously, ISVCs with WorkerSpec but without a matching ServingRuntime would cause a nil pointer dereference (as in #4539 issue, where kserve controller error log is attached) and fail to reconcile.
- Now, if no ServingRuntime is found and multi-node is requested, the controller falls back to using the WorkerSpec provided directly in the ISVC..

**Which issue(s) this PR fixes**:
Fixes #4539


**Feature/Issue validation/testing**:

I have tested deploying an ISVC with only WorkerSpec and no ServingRuntime, and confirmed that it works as expected (sanity test).

**Release note**:

```release-note
Support deploying multi-node InferenceService with WorkerSpec without requiring a ServingRuntime.
Fixes nil pointer panic in controller for this scenario.
```
