### PR TITLE
ci: bump k8s & minikube version

### DIFF
--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -21,13 +21,13 @@ runs:
     - name: Install kubectl
       uses: azure/setup-kubectl@v4.0.0
       with:
-        version: 'v1.30.7'
+        version: 'v1.34.4'
 
     - name: Setup Minikube
       uses: medyagh/setup-minikube@latest
       with:
-        minikube-version: '1.35.0'
-        kubernetes-version: 'v1.30.7'
+        minikube-version: '1.38.1'
+        kubernetes-version: 'v1.34.4'
         driver: ${{ inputs.driver }}
         wait: 'all'
         cpus: 'max'

--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -19,6 +19,7 @@ on:
       - "!python/**"
       - "!**.md"
       - ".github/workflows/agent-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 
 env:

--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -18,6 +18,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/artexplainer-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: art-explainer

--- a/.github/workflows/custom-model-grpc-publish.yml
+++ b/.github/workflows/custom-model-grpc-publish.yml
@@ -14,6 +14,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/custom-model-grpc-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: custom-model-grpc

--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -13,6 +13,7 @@ on:
       - "cmd/llmisvc/**"
       - "test/e2e/llmisvc/**"
       - ".github/workflows/e2e-test-llmisvc.yaml"
+      - ".github/actions/**"
       - "hack/setup/quick-install/llmisvc-dependency-install.sh"
 
 concurrency:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -9,6 +9,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/e2e-test.yml"
+      - ".github/actions/**"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/huggingface-cpu-docker-publish.yml
+++ b/.github/workflows/huggingface-cpu-docker-publish.yml
@@ -17,6 +17,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/huggingface-cpu-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: huggingfaceserver

--- a/.github/workflows/huggingface-docker-publish.yml
+++ b/.github/workflows/huggingface-docker-publish.yml
@@ -17,6 +17,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/huggingface-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: huggingfaceserver 

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -19,6 +19,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/kserve-controller-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: kserve-controller

--- a/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
+++ b/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
@@ -19,6 +19,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/kserve--llmisvccontroller-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: llmisvc-controller

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -19,6 +19,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/kserve-localmodel-agent-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: kserve-localmodelnode-agent

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -19,6 +19,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/kserve-localmodel-controller-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: kserve-localmodel-controller

--- a/.github/workflows/lightgbm-docker-publish.yml
+++ b/.github/workflows/lightgbm-docker-publish.yml
@@ -18,6 +18,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/lightgbm-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: lgbserver

--- a/.github/workflows/paddle-docker-publish.yml
+++ b/.github/workflows/paddle-docker-publish.yml
@@ -18,6 +18,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/paddle-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: paddleserver

--- a/.github/workflows/pmml-docker-publish.yml
+++ b/.github/workflows/pmml-docker-publish.yml
@@ -18,6 +18,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/pmml-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: pmmlserver

--- a/.github/workflows/predictiveserver-docker-publish.yml
+++ b/.github/workflows/predictiveserver-docker-publish.yml
@@ -18,6 +18,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/predictiveserver-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: predictiveserver

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,6 +12,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/python-test.yml"
+      - ".github/actions/free-up-disk-space/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/qpext-docker-publish.yml
+++ b/.github/workflows/qpext-docker-publish.yml
@@ -19,6 +19,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/qpext-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: qpext

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -19,6 +19,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/router-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: router

--- a/.github/workflows/sklearnserver-docker-publish.yml
+++ b/.github/workflows/sklearnserver-docker-publish.yml
@@ -18,6 +18,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/sklearnserver-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: sklearnserver

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -18,6 +18,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/storage-initializer-docker-publisher.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: storage-initializer

--- a/.github/workflows/tf2openapi-docker-publisher.yml
+++ b/.github/workflows/tf2openapi-docker-publisher.yml
@@ -19,6 +19,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/tf2openapi-docker-publisher.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: tf2openapi

--- a/.github/workflows/transformer-docker-publish.yml
+++ b/.github/workflows/transformer-docker-publish.yml
@@ -14,6 +14,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/transformer-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: image-transformer

--- a/.github/workflows/xgbserver-docker-publisher.yml
+++ b/.github/workflows/xgbserver-docker-publisher.yml
@@ -18,6 +18,7 @@ on:
       - "!docs/**"
       - "!**.md"
       - ".github/workflows/xgbserver-docker-publisher.yml"
+      - ".github/actions/free-up-disk-space/**"
 
 env:
   IMAGE_NAME: xgbserver


### PR DESCRIPTION


**What this PR does / why we need it**:
Bumps Outdated Kubernetes & Minikube version in CI.