### PR TITLE
docs: add minimum system requirements for standalone local setup

### DIFF
--- a/docs/sys_requirement.md
+++ b/docs/sys_requirement.md
@@ -1,0 +1,21 @@
+# Minimum System Requirements for Running KServe Standalone (Local Setup)
+
+This document provides recommended minimum hardware requirements to run KServe standalone on a single-node Kubernetes cluster such as Minikube for development and testing purposes.
+
+## Recommended Minimum Hardware
+
+For local experimentation and basic model serving workloads:
+
+- **CPU**: 4 vCPUs
+- **Memory (RAM)**: 8 GB minimum (16 GB recommended for smoother experience)
+- **Disk**: 20 GB available space
+- **Kubernetes Version**: v1.24+ recommended
+
+> Note: Lower configurations may work for lightweight examples, but performance may degrade when running inference services with multiple replicas or larger models.
+
+## Starting Minikube
+
+Example command to start Minikube with recommended resources:
+
+```bash
+minikube start --cpus=4 --memory=8192 --disk-size=20g


### PR DESCRIPTION
This PR adds documentation describing recommended minimum hardware
requirements for running KServe standalone on a single-node Minikube cluster.

The guidance includes:
- CPU and memory recommendations
- Example minikube start command
- Notes regarding scaling and resource limits

This addresses the feature request for documenting minimum system requirements.

Reference: Similar hardware recommendations are provided in Istio and Kubeflow documentation.
https://istio.io/latest/docs/