### PR TITLE
feat(logger): log occurrence and record time in CloudEvents

### DIFF
--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"time"
 
 	"github.com/go-logr/logr"
 	guuid "github.com/google/uuid"
@@ -118,6 +119,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	requestTime := time.Now()
 	// Read request payload
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -156,6 +158,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Metadata:         metadata,
 			CertName:         eh.certName,
 			TlsSkipVerify:    eh.tlsSkipVerify,
+			RequestTime:      requestTime,
 		}); err != nil {
 			eh.log.Error(err, "Failed to log request")
 		}
@@ -191,6 +194,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Component:        eh.component,
 				CertName:         eh.certName,
 				TlsSkipVerify:    eh.tlsSkipVerify,
+				RequestTime:      requestTime,
 			}); err != nil {
 				eh.log.Error(err, "Failed to log response")
 			}

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -119,6 +119,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Record the time when the request arrives
 	requestTime := time.Now()
 	// Read request payload
 	body, err := io.ReadAll(r.Body)
@@ -158,7 +159,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Metadata:         metadata,
 			CertName:         eh.certName,
 			TlsSkipVerify:    eh.tlsSkipVerify,
-			RequestTime:      requestTime,
+			OccurrenceTime:   requestTime,
 		}); err != nil {
 			eh.log.Error(err, "Failed to log request")
 		}
@@ -176,6 +177,8 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		eh.log.Error(err, "Failed to read response body")
 	}
+	// Record the time when the response is received
+	responseTime := time.Now()
 	// log Response
 	if lrw.statusCode == http.StatusOK {
 		if eh.logMode == v1beta1.LogAll || eh.logMode == v1beta1.LogResponse {
@@ -194,7 +197,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Component:        eh.component,
 				CertName:         eh.certName,
 				TlsSkipVerify:    eh.tlsSkipVerify,
-				RequestTime:      requestTime,
+				OccurrenceTime:   responseTime,
 			}); err != nil {
 				eh.log.Error(err, "Failed to log response")
 			}

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -369,7 +369,7 @@ func TestLoggerWithS3Store(t *testing.T) {
 	g.Expect(res.Annotations["test-annotation"]).To(gomega.Equal("test-value"))
 }
 
-func TestLoggerRequestTimestamp(t *testing.T) {
+func TestLoggerCloudEventTimestamps(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	predictorRequest := []byte(`{"instances":[[0,0,0]]}`)
@@ -383,9 +383,12 @@ func TestLoggerRequestTimestamp(t *testing.T) {
 		_, err = rw.Write([]byte(`ok`))
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 
-		// Verify requesttimestamp is present and uses the same RFC3339 format as ce-time
-		g.Expect(req.Header.Get("Ce-Requesttimestamp")).ToNot(gomega.BeEmpty())
-		g.Expect(req.Header.Get("Ce-Requesttimestamp")).To(gomega.MatchRegexp(
+		// Verify CE time (occurrence/request arrival) and recordedtime (CE creation) are present
+		g.Expect(req.Header.Get("Ce-Time")).ToNot(gomega.BeEmpty())
+		g.Expect(req.Header.Get("Ce-Time")).To(gomega.MatchRegexp(
+			`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`))
+		g.Expect(req.Header.Get("Ce-Recordedtime")).ToNot(gomega.BeEmpty())
+		g.Expect(req.Header.Get("Ce-Recordedtime")).To(gomega.MatchRegexp(
 			`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`))
 	}))
 	defer logSvc.Close()

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -368,3 +368,58 @@ func TestLoggerWithS3Store(t *testing.T) {
 	g.Expect(res.Annotations).To(gomega.HaveLen(1))
 	g.Expect(res.Annotations["test-annotation"]).To(gomega.Equal("test-value"))
 }
+
+func TestLoggerRequestTimestamp(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	predictorRequest := []byte(`{"instances":[[0,0,0]]}`)
+	predictorResponse := []byte(`{"instances":[[4,5,6]]}`)
+
+	responseChan := make(chan string)
+	logSvc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		b, err := io.ReadAll(req.Body)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		responseChan <- string(b)
+		_, err = rw.Write([]byte(`ok`))
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Verify requesttimestamp is present and uses the same RFC3339 format as ce-time
+		g.Expect(req.Header.Get("Ce-Requesttimestamp")).ToNot(gomega.BeEmpty())
+		g.Expect(req.Header.Get("Ce-Requesttimestamp")).To(gomega.MatchRegexp(
+			`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`))
+	}))
+	defer logSvc.Close()
+
+	predictor := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		b, err := io.ReadAll(req.Body)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(b).To(gomega.Or(gomega.Equal(predictorRequest), gomega.Equal(predictorResponse)))
+		_, err = rw.Write(predictorResponse)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+	}))
+	defer predictor.Close()
+
+	reader := bytes.NewReader(predictorRequest)
+	r := httptest.NewRequest(http.MethodPost, "http://a", reader)
+	w := httptest.NewRecorder()
+	logger, _ := pkglogging.NewLogger("", "INFO")
+	logf.SetLogger(zap.New())
+	logSvcUrl, err := url.Parse(logSvc.URL)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	sourceUri, err := url.Parse("http://localhost:9081/")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	targetUri, err := url.Parse(predictor.URL)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	StartDispatcher(5, &MockStore{}, &ImmediateBatch{}, logger)
+	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
+	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default",
+		"default", httpProxy, nil, "", nil, true)
+
+	oh.ServeHTTP(w, r)
+
+	// get logRequest
+	<-responseChan
+	// get logResponse
+	<-responseChan
+}

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 	pkglogging "knative.dev/pkg/logging"
@@ -375,21 +376,33 @@ func TestLoggerCloudEventTimestamps(t *testing.T) {
 	predictorRequest := []byte(`{"instances":[[0,0,0]]}`)
 	predictorResponse := []byte(`{"instances":[[4,5,6]]}`)
 
-	responseChan := make(chan string)
+	type ceTimestamps struct {
+		ceTime       time.Time
+		recordedTime time.Time
+	}
+	reqTimestampChan := make(chan ceTimestamps, 1)
+	resTimestampChan := make(chan ceTimestamps, 1)
+
 	logSvc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		b, err := io.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		g.Expect(err).ToNot(gomega.HaveOccurred())
-		responseChan <- string(b)
 		_, err = rw.Write([]byte(`ok`))
 		g.Expect(err).ToNot(gomega.HaveOccurred())
 
-		// Verify CE time (occurrence/request arrival) and recordedtime (CE creation) are present
-		g.Expect(req.Header.Get("Ce-Time")).ToNot(gomega.BeEmpty())
-		g.Expect(req.Header.Get("Ce-Time")).To(gomega.MatchRegexp(
-			`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`))
-		g.Expect(req.Header.Get("Ce-Recordedtime")).ToNot(gomega.BeEmpty())
-		g.Expect(req.Header.Get("Ce-Recordedtime")).To(gomega.MatchRegexp(
-			`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}`))
+		ceTime, err := time.Parse(time.RFC3339Nano, req.Header.Get("Ce-Time"))
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		recordedTime, err := time.Parse(time.RFC3339Nano, req.Header.Get("Ce-Recordedtime"))
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// recordedtime (CE creation) should be >= time (occurrence)
+		g.Expect(recordedTime.After(ceTime) || recordedTime.Equal(ceTime)).To(gomega.BeTrue())
+
+		ts := ceTimestamps{ceTime: ceTime, recordedTime: recordedTime}
+		if req.Header.Get("Ce-Type") == CEInferenceRequest {
+			reqTimestampChan <- ts
+		} else {
+			resTimestampChan <- ts
+		}
 	}))
 	defer logSvc.Close()
 
@@ -421,8 +434,10 @@ func TestLoggerCloudEventTimestamps(t *testing.T) {
 
 	oh.ServeHTTP(w, r)
 
-	// get logRequest
-	<-responseChan
-	// get logResponse
-	<-responseChan
+	reqTimestamps := <-reqTimestampChan
+	resTimestamps := <-resTimestampChan
+
+	// Response occurrence time should be >= request occurrence time
+	g.Expect(resTimestamps.ceTime.After(reqTimestamps.ceTime) ||
+		resTimestamps.ceTime.Equal(reqTimestamps.ceTime)).To(gomega.BeTrue())
 }

--- a/pkg/logger/types.go
+++ b/pkg/logger/types.go
@@ -36,5 +36,5 @@ type LogRequest struct {
 	Annotations      map[string]string   `json:"annotations,omitempty"`
 	CertName         string              `json:"certName,omitempty"`
 	TlsSkipVerify    bool                `json:"tlsSkipVerify,omitempty"`
-	RequestTime      time.Time           `json:"requestTime"`
+	OccurrenceTime   time.Time           `json:"occurrenceTime"`
 }

--- a/pkg/logger/types.go
+++ b/pkg/logger/types.go
@@ -18,6 +18,7 @@ package logger
 
 import (
 	"net/url"
+	"time"
 )
 
 type LogRequest struct {
@@ -35,4 +36,5 @@ type LogRequest struct {
 	Annotations      map[string]string   `json:"annotations,omitempty"`
 	CertName         string              `json:"certName,omitempty"`
 	TlsSkipVerify    bool                `json:"tlsSkipVerify,omitempty"`
+	RequestTime      time.Time           `json:"requestTime"`
 }

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -122,7 +122,7 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetID(logReq.Id)
 	event.SetType(logReq.ReqType)
-	event.SetTime(logReq.RequestTime)
+	event.SetTime(logReq.OccurrenceTime)
 	event.SetExtension(RecordedTimeAttr, time.Now())
 
 	event.SetExtension(InferenceServiceAttr, logReq.InferenceService)

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
@@ -45,9 +46,9 @@ const (
 	ComponentAttr        = "component"
 	MetadataAttr         = "metadata"
 	// endpoint would be either default or canary
-	EndpointAttr    = "endpoint"
-	AnnotationAttr  = "annotations"
-	RequestTimeAttr = "requesttimestamp"
+	EndpointAttr     = "endpoint"
+	AnnotationAttr   = "annotations"
+	RecordedTimeAttr = "recordedtime"
 
 	LoggerWorkerQueueSize = 100
 	CloudEventsIdHeader   = "Ce-Id"
@@ -114,21 +115,20 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 		}
 	}
 
-	c, err := cloudevents.NewClient(t,
-		cloudevents.WithTimeNow(),
-	)
+	c, err := cloudevents.NewClient(t)
 	if err != nil {
 		return fmt.Errorf("while creating new cloudevents client: %w", err)
 	}
 	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetID(logReq.Id)
 	event.SetType(logReq.ReqType)
+	event.SetTime(logReq.RequestTime)
+	event.SetExtension(RecordedTimeAttr, time.Now())
 
 	event.SetExtension(InferenceServiceAttr, logReq.InferenceService)
 	event.SetExtension(NamespaceAttr, logReq.Namespace)
 	event.SetExtension(ComponentAttr, logReq.Component)
 	event.SetExtension(EndpointAttr, logReq.Endpoint)
-	event.SetExtension(RequestTimeAttr, logReq.RequestTime)
 
 	encodedMetadata, err := json.Marshal(logReq.Metadata)
 	if err != nil {

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -45,8 +45,9 @@ const (
 	ComponentAttr        = "component"
 	MetadataAttr         = "metadata"
 	// endpoint would be either default or canary
-	EndpointAttr   = "endpoint"
-	AnnotationAttr = "annotations"
+	EndpointAttr    = "endpoint"
+	AnnotationAttr  = "annotations"
+	RequestTimeAttr = "requesttimestamp"
 
 	LoggerWorkerQueueSize = 100
 	CloudEventsIdHeader   = "Ce-Id"
@@ -127,6 +128,7 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 	event.SetExtension(NamespaceAttr, logReq.Namespace)
 	event.SetExtension(ComponentAttr, logReq.Component)
 	event.SetExtension(EndpointAttr, logReq.Endpoint)
+	event.SetExtension(RequestTimeAttr, logReq.RequestTime)
 
 	encodedMetadata, err := json.Marshal(logReq.Metadata)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The logger's CloudEvent `time` attribute was previously set at worker dispatch time via `WithTimeNow()`, not when the request actually arrived at the handler. Under heavy load, the worker queue delay makes `ce-time` unreliable for precise chronological analysis and latency debugging.

This PR adopts the standard CloudEvents `recordedtime` extension to support bitemporal tracking:

- `ce-time` (Occurrence Time): Now accurately captures when the request arrived at the handler (for request CEs) or when the response was received (for response CEs).
- `ce-recordedtime` (Recorded Time): Captures the time when the CloudEvent was actually created and dispatched by the worker.

**Feature/Issue validation/testing**:

- [x] Added `TestLoggerCloudEventTimestamps` verifying:
  - Both `ce-time` and `ce-recordedtime` headers are present and follow RFC3339 format.
  - `recordedtime` $\ge$ `time` for each CloudEvent.
  - Response occurrence time $\ge$ request occurrence time.
- [x] Verified all existing logger unit tests pass.

**Special notes for your reviewer**:

- `recordedtime` is a recognized [CloudEvents standard extension](https://www.google.com/search?q=https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/recordedtime.md) — no custom attributes are introduced.
- Downstream consumers that do not support `recordedtime` will simply ignore it, ensuring backward compatibility.
- `omitempty` is intentionally omitted for the time fields as it does not affect `time.Time` structs during JSON encoding in Go.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

**Release note**:
```release-note
Use standard CloudEvents `recordedtime` extension for bitemporal tracking of request/response occurrence time and event creation time in the logger.
```