### PR TITLE
fix(make): increase test timeout from 20m to 30m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ clean:
 
 # Run tests
 test: fmt vet manifests envtest test-qpext
-	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test --timeout 20m $$(go list ./pkg/...) ./cmd/... -coverprofile coverage.out -coverpkg ./pkg/... ./cmd...
+	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test --timeout 30m $$(go list ./pkg/...) ./cmd/... -coverprofile coverage.out -coverpkg ./pkg/... ./cmd...
 
 test-qpext:
 	cd qpext && go test -v ./... -cover


### PR DESCRIPTION
**What this PR does / why we need it**:

Increases the `make test` timeout from 20 minutes to 30 minutes. The current timeout is too tight for the full test suite, especially on slower CI runners where controller tests occasionally time out before completion.

**Release note**:
```release-note
NONE
```