### PR TITLE
fix(test): ensures GinkgoRecover is used correctly

### DIFF
--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -69,7 +69,6 @@ var _ = Describe("Watcher", func() {
 	Describe("Sync models config on startup", func() {
 		Context("Getting new model events", func() {
 			It("should download and load the new models", func() {
-				defer GinkgoRecover()
 				logger.Printf("Sync model config using temp dir %v\n", modelDir)
 				modelConfigs := modelconfig.ModelConfigs{
 					{
@@ -144,7 +143,6 @@ var _ = Describe("Watcher", func() {
 	Describe("Watch model config changes", func() {
 		Context("When new models are added", func() {
 			It("Should download and load the new models", func() {
-				defer GinkgoRecover()
 				logger.Printf("Sync model config using temp dir %v\n", modelDir)
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
 				puller := Puller{
@@ -190,7 +188,6 @@ var _ = Describe("Watcher", func() {
 
 		Context("When models are deleted from config", func() {
 			It("Should remove the model dir and unload the models", func() {
-				defer GinkgoRecover()
 				logger.Printf("Sync delete models using temp dir %v\n", modelDir)
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
 				puller := Puller{
@@ -248,7 +245,6 @@ var _ = Describe("Watcher", func() {
 
 		Context("When models uri are updated in config", func() {
 			It("Should download and reload the model", func() {
-				defer GinkgoRecover()
 				logger.Printf("Sync update models using temp dir %v\n", modelDir)
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
 				puller := Puller{
@@ -315,7 +311,6 @@ var _ = Describe("Watcher", func() {
 
 		Context("When model download fails", func() {
 			It("Should not create the success file", func() {
-				defer GinkgoRecover()
 				logger.Printf("Using temp dir %v\n", modelDir)
 				errs := make([]s3manager.Error, 0, 1)
 				errs = append(errs, s3manager.Error{
@@ -361,8 +356,6 @@ var _ = Describe("Watcher", func() {
 	Describe("Use GCS Downloader", func() {
 		Context("Download Mocked Model", func() {
 			It("should download test model and write contents", func() {
-				defer GinkgoRecover()
-
 				logger.Printf("Creating mock GCS Client")
 				ctx := context.Background()
 				client := mocks.NewMockClient()
@@ -394,8 +387,6 @@ var _ = Describe("Watcher", func() {
 
 		Context("Model Download Failure", func() {
 			It("should fail out if the model does not exist in the bucket", func() {
-				defer GinkgoRecover()
-
 				logger.Printf("Creating mock GCS Client")
 				ctx := context.Background()
 				client := mocks.NewMockClient()
@@ -454,7 +445,6 @@ var _ = Describe("Watcher", func() {
 
 		Context("Getting new model events", func() {
 			It("should download and load the new models", func() {
-				defer GinkgoRecover()
 				logger.Printf("Sync model config using temp dir %v\n", modelDir)
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
 				modelConfigs := modelconfig.ModelConfigs{
@@ -517,7 +507,6 @@ var _ = Describe("Watcher", func() {
 
 		Context("Puller Waits Before Initializing", func() {
 			It("should download all models before allowing watcher to add new events", func() {
-				defer GinkgoRecover()
 				logger.Printf("Sync model config using temp dir %v\n", modelDir)
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
 				puller := Puller{

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -28,12 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
-	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -1267,67 +1262,4 @@ func createTestPVC(ctx context.Context, pvcName, namespace, pvName string, cache
 	}
 	Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
 	return pvc
-}
-
-func genericSetup(ctx context.Context, configs map[string]string, clusterStorageContainerSpec v1alpha1.StorageContainerSpec) (*corev1.ConfigMap,
-	*v1alpha1.ClusterStorageContainer,
-) {
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.InferenceServiceConfigMapName,
-			Namespace: constants.KServeNamespace,
-		},
-		Data: configs,
-	}
-	Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
-
-	clusterStorageContainer := &v1alpha1.ClusterStorageContainer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-		},
-		Spec: clusterStorageContainerSpec,
-	}
-	Expect(k8sClient.Create(ctx, clusterStorageContainer)).Should(Succeed())
-
-	return configMap, clusterStorageContainer
-}
-
-func initializeManager(ctx context.Context, cfg *rest.Config) {
-	clientset, err := kubernetes.NewForConfig(cfg)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(clientset).ToNot(BeNil())
-	Expect(testScheme).ToNot(BeNil())
-
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: testScheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0",
-		},
-		Controller: crconfig.Controller{
-			SkipNameValidation: ptr.To(true),
-		},
-	})
-	Expect(err).ToNot(HaveOccurred())
-
-	k8sClient = k8sManager.GetClient()
-	Expect(k8sClient).ToNot(BeNil())
-	//nolint: contextcheck
-	err = (&LocalModelReconciler{
-		Client:    k8sClient,
-		Clientset: clientset,
-		Scheme:    testScheme,
-		Log:       ctrl.Log.WithName("v1alpha1LocalModelController"),
-	}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred())
-	}()
-	// Wait for cache to start
-	// Ping the ConfigMap to ensure the cache is started
-	Eventually(func() bool {
-		return k8sClient.Get(ctx, types.NamespacedName{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace}, &corev1.ConfigMap{}) == nil
-	}).Should(BeTrue())
 }

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -28,7 +28,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -1331,4 +1331,3 @@ func initializeManager(ctx context.Context, cfg *rest.Config) {
 		return k8sClient.Get(ctx, types.NamespacedName{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace}, &corev1.ConfigMap{}) == nil
 	}).Should(BeTrue())
 }
-

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -121,7 +121,6 @@ var _ = Describe("CachedModel controller", func() {
 
 	Context("When creating a local model", func() {
 		It("Should create pv, pvc, localmodelnode, and update status from localmodelnode", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -273,7 +272,6 @@ var _ = Describe("CachedModel controller", func() {
 		})
 
 		It("Should create pvs and pvcs for inference services", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 			nodeGroup1 := &v1alpha1.LocalModelNodeGroup{
@@ -425,7 +423,6 @@ var _ = Describe("CachedModel controller", func() {
 
 	Context("When DisableVolumeManagement is set to true", func() {
 		It("Should NOT create/delete pvs and pvcs if localmodel config value DisableVolumeManagement is true", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -488,7 +485,6 @@ var _ = Describe("CachedModel controller", func() {
 	Context("When creating multiple localModels", func() {
 		// With two nodes and two local models, each node should have both local models
 		It("Should create localModelNode correctly", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 			nodeGroup1 := &v1alpha1.LocalModelNodeGroup{
@@ -1267,3 +1263,67 @@ func createTestPVC(ctx context.Context, pvcName, namespace, pvName string, cache
 	Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
 	return pvc
 }
+
+func genericSetup(ctx context.Context, configs map[string]string, clusterStorageContainerSpec v1alpha1.StorageContainerSpec) (*corev1.ConfigMap,
+	*v1alpha1.ClusterStorageContainer,
+) {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.InferenceServiceConfigMapName,
+			Namespace: constants.KServeNamespace,
+		},
+		Data: configs,
+	}
+	Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+
+	clusterStorageContainer := &v1alpha1.ClusterStorageContainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: clusterStorageContainerSpec,
+	}
+	Expect(k8sClient.Create(ctx, clusterStorageContainer)).Should(Succeed())
+
+	return configMap, clusterStorageContainer
+}
+
+func initializeManager(ctx context.Context, cfg *rest.Config) {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(clientset).ToNot(BeNil())
+	Expect(testScheme).ToNot(BeNil())
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: testScheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+		Controller: crconfig.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	k8sClient = k8sManager.GetClient()
+	Expect(k8sClient).ToNot(BeNil())
+	//nolint: contextcheck
+	err = (&LocalModelReconciler{
+		Client:    k8sClient,
+		Clientset: clientset,
+		Scheme:    testScheme,
+		Log:       ctrl.Log.WithName("v1alpha1LocalModelController"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+	// Wait for cache to start
+	// Ping the ConfigMap to ensure the cache is started
+	Eventually(func() bool {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace}, &corev1.ConfigMap{}) == nil
+	}).Should(BeTrue())
+}
+

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -652,7 +652,6 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 
 	Context("When creating a namespace-scoped local model", func() {
 		It("Should create pv, pvc, localmodelnode, and update status from localmodelnode", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -763,7 +762,6 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 		})
 
 		It("Should create pvs and pvcs for inference services in the same namespace only", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -879,7 +877,6 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 		})
 
 		It("Should delete LocalModelNamespaceCache and run finalizer cleanup", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -944,7 +941,6 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 		})
 
 		It("Should track both cluster-scoped and namespace-scoped models on LocalModelNode", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -1033,7 +1029,6 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 		})
 
 		It("Should create download PV for LocalModelNamespaceCache and verify finalizer is set", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 
@@ -1096,7 +1091,6 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 		})
 
 		It("Should create serving PV/PVC for ISVC and update status when ISVC is removed", func() {
-			defer GinkgoRecover()
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Move defer `GinkgoRecover()` inside goroutines where it belongs (it must run in the same goroutine as the panicking code). Remove unnecessary `GinkgoRecover()` calls from `It()` blocks which already have Ginkgo's built-in panic recovery.

**Release note**:
```release-note
NONE
```
