### PR TITLE
fix(pytest): check readiness before sleeping

### DIFF
--- a/python/kserve/kserve/api/kserve_client.py
+++ b/python/kserve/kserve/api/kserve_client.py
@@ -404,7 +404,6 @@ class KServeClient(object):
             )
         else:
             for _ in range(round(timeout_seconds / polling_interval)):
-                time.sleep(polling_interval)
                 if self.is_isvc_ready(
                     name,
                     namespace=namespace,
@@ -412,6 +411,7 @@ class KServeClient(object):
                     expected_generation=expected_generation,
                 ):
                     return
+                time.sleep(polling_interval)
 
             current_isvc = self.get(name, namespace=namespace, version=version)
             if expected_generation is None:
@@ -667,9 +667,9 @@ class KServeClient(object):
         :return:
         """
         for _ in range(round(timeout_seconds / polling_interval)):
-            time.sleep(polling_interval)
             if self.is_ig_ready(name, namespace, version):
                 return
+            time.sleep(polling_interval)
 
         current_ig = self.get_inference_graph(
             name, namespace=namespace, version=version


### PR DESCRIPTION
**What this PR does / why we need it**:

Reorder the polling loop to check readiness first, then sleep. This avoids an unnecessary initial delay when the resource is already ready, reducing test execution time by one polling interval per wait call.

**Release note**:
```release-note
NONE
```
