### PR TITLE
refactor(test): migrate pod webhook suite to centralized envtest setup

### DIFF
--- a/pkg/testing/config.go
+++ b/pkg/testing/config.go
@@ -103,17 +103,10 @@ func (e *Config) WithManagerOptions(opts ...ManagerOption) *Config {
 	return e
 }
 
-// Start wires controller-runtime manager with controllers which are subject of the tests
-// and starts Kubernetes EnvTest to verify their behavior.
-func (e *Config) Start(ctx context.Context) *Client {
-	ctx, cancel := context.WithCancel(ctx)
-
-	opts := zap.Options{
-		Development: true,
-		TimeEncoder: zapcore.TimeEncoderOfLayout(time.RFC3339),
-	}
-	logf.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseFlagOptions(&opts)))
-
+// BuildEnvironment constructs the envtest.Environment from the configured options
+// without starting it. This is intended for TestMain-based suites that manage
+// the environment lifecycle directly, since Start() depends on Ginkgo.
+func (e *Config) BuildEnvironment() *envtest.Environment {
 	envTest := &envtest.Environment{
 		CRDInstallOptions: envtest.CRDInstallOptions{
 			ErrorIfPathMissing: true,
@@ -129,6 +122,22 @@ func (e *Config) Start(ctx context.Context) *Client {
 	for _, opt := range e.envTestOptions {
 		opt(envTest)
 	}
+
+	return envTest
+}
+
+// Start wires controller-runtime manager with controllers which are subject of the tests
+// and starts Kubernetes EnvTest to verify their behavior.
+func (e *Config) Start(ctx context.Context) *Client {
+	ctx, cancel := context.WithCancel(ctx)
+
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.TimeEncoderOfLayout(time.RFC3339),
+	}
+	logf.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseFlagOptions(&opts)))
+
+	envTest := e.BuildEnvironment()
 
 	// Take exclusive ownership of SIGINT/SIGTERM so that envtest child
 	// processes (etcd, kube-apiserver) are force-killed before the test

--- a/pkg/webhook/admission/pod/suite_test.go
+++ b/pkg/webhook/admission/pod/suite_test.go
@@ -18,16 +18,13 @@ package pod
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	pkgtest "github.com/kserve/kserve/pkg/testing"
 )
 
@@ -38,29 +35,27 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	crdDirectoryPaths := []string{
-		filepath.Join(pkgtest.ProjectRoot(), "test", "crds"),
-	}
-	t := pkgtest.SetupEnvTest(crdDirectoryPaths)
+	testEnv := pkgtest.NewEnvTest().BuildEnvironment()
 
-	err := v1alpha1.AddToScheme(scheme.Scheme)
-	if err != nil {
-		klog.Error(err, "Failed to add v1alpha1 to scheme")
+	var err error
+	if cfg, err = testEnv.Start(); err != nil {
+		klog.Errorf("Failed to start test environment: %v", err)
+		os.Exit(1)
 	}
 
-	if cfg, err = t.Start(); err != nil {
-		klog.Error(err, "Failed to start testing panel")
-	}
-
-	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
-		klog.Error(err, "Failed to start client")
+	if c, err = client.New(cfg, client.Options{Scheme: testEnv.Scheme}); err != nil {
+		klog.Errorf("Failed to create client: %v", err)
+		os.Exit(1)
 	}
 
 	if clientset, err = kubernetes.NewForConfig(cfg); err != nil {
-		klog.Error(err, "Failed to create clientset")
+		klog.Errorf("Failed to create clientset: %v", err)
+		os.Exit(1)
 	}
 
 	code := m.Run()
-	_ = t.Stop()
+	if err := testEnv.Stop(); err != nil {
+		klog.Errorf("Failed to stop test environment: %v", err)
+	}
 	os.Exit(code)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrates the pod webhook test suite (`pkg/webhook/admission/pod/suite_test.go`) from the
legacy `SetupEnvTest` helper to the centralized `NewEnvTest` builder introduced in #5068.

This eliminates manual CRD path construction, per-suite scheme registration, and global
`scheme.Scheme` mutation - replacing them with the shared configuration that already handles
all KServe and Kubernetes schemes.

Also introduces `BuildEnvironment()` on `Config` so that `TestMain`-based suites (which
cannot use Ginkgo's `DeferCleanup`) can obtain a configured `envtest.Environment` without
starting a manager.

**Which issue(s) this PR fixes**:
Follow-up to #5068

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```