### PR TITLE
fix: skip _folder to package helm chart

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -37,7 +37,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package helm charts
-        run: for dir in ./*/; do helm package $dir; done
+        run: |
+          for dir in ./*/; do
+            # Skip directories starting with underscore (e.g., _common)
+            [[ $(basename "$dir") == _* ]] && continue
+            helm package "$dir"
+          done
         working-directory: ${{ env.HELM_CHARTS_PATH }}
 
       - name: Push Charts to GHCR


### PR DESCRIPTION
**What this PR does / why we need it**:
The issue caused by the newly changed chart structure has been fixed. The _common directory under charts, which contains shared components, is now skipped.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note

```
