### PR TITLE
feat(e2e/llmisvc): configurable test environment and new endpoint coverage

### DIFF
--- a/test/e2e/common/http_retry.py
+++ b/test/e2e/common/http_retry.py
@@ -9,6 +9,43 @@ DEFAULT_RETRY_TOTAL = 8
 DEFAULT_RETRY_BACKOFF_FACTOR = 2.0
 
 
+def _retry_session(
+    allowed_methods,
+    total_retries=DEFAULT_RETRY_TOTAL,
+    backoff_factor=DEFAULT_RETRY_BACKOFF_FACTOR,
+    retry_status_codes=DEFAULT_RETRY_STATUS_CODES,
+) -> requests.Session:
+    retry = Retry(
+        total=total_retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=retry_status_codes,
+        allowed_methods=allowed_methods,
+        raise_on_status=False,
+    )
+    session = requests.Session()
+    session.mount("http://", HTTPAdapter(max_retries=retry))
+    session.mount("https://", HTTPAdapter(max_retries=retry))
+    return session
+
+
+def get_with_retry(
+    url: str,
+    *,
+    headers: Dict = None,
+    timeout: float = None,
+    total_retries: int = DEFAULT_RETRY_TOTAL,
+    backoff_factor: float = DEFAULT_RETRY_BACKOFF_FACTOR,
+    retry_status_codes=DEFAULT_RETRY_STATUS_CODES,
+) -> requests.Response:
+    """
+    Send GET request with retries for transient HTTP and network failures.
+    """
+    with _retry_session(
+        ["GET"], total_retries, backoff_factor, retry_status_codes
+    ) as session:
+        return session.get(url, headers=headers, timeout=timeout)
+
+
 def post_with_retry(
     url: str,
     *,
@@ -27,16 +64,9 @@ def post_with_retry(
     if json_data is not None and data is not None:
         raise ValueError("Only one of json_data or data can be provided.")
 
-    retry = Retry(
-        total=total_retries,
-        backoff_factor=backoff_factor,
-        status_forcelist=retry_status_codes,
-        allowed_methods=["POST"],
-        raise_on_status=False,
-    )
-    with requests.Session() as session:
-        session.mount("http://", HTTPAdapter(max_retries=retry))
-        session.mount("https://", HTTPAdapter(max_retries=retry))
+    with _retry_session(
+        ["POST"], total_retries, backoff_factor, retry_status_codes
+    ) as session:
         return session.post(
             url,
             json=json_data,

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -14,6 +14,8 @@
 
 import hashlib
 import os
+import re
+
 import pytest
 from ..common.gw_api import (
     create_or_update_gateway,
@@ -917,16 +919,20 @@ def _get_model_name_from_configs(config_names):
     return "default/model"
 
 
+_NON_DNS_CHARS = re.compile(r"[^a-z0-9]+")
+
+
+def _sanitize_for_dns(s: str) -> str:
+    """Replace non-DNS characters with hyphens, mirrors sanitizeForDNS in test_namespace.go."""
+    return _NON_DNS_CHARS.sub("-", s.lower()).strip("-")
+
+
 def generate_k8s_safe_suffix(
     base_name: str, extra_parts: Optional[List[str]] = None
 ) -> str:
     """Generate a Kubernetes-safe name suffix with hash."""
-    if extra_parts:
-        full_name = f"{base_name}-{'-'.join(sorted(extra_parts))}"
-    else:
-        full_name = base_name
-
-    full_name = full_name.lower().replace("_", "-")
+    raw = f"{base_name}-{'-'.join(sorted(extra_parts))}" if extra_parts else base_name
+    full_name = _sanitize_for_dns(raw)
 
     name_hash = hashlib.sha256(full_name.encode()).hexdigest()[:8]
 

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -122,6 +122,12 @@ LLMINFERENCESERVICE_CONFIGS = {
     "model-fb-opt-125m": {
         "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
     },
+    "model-qwen2.5-0.5b": {
+        "model": {
+            "uri": "hf://Qwen/Qwen2.5-0.5B-Instruct",
+            "name": "Qwen/Qwen2.5-0.5B-Instruct",
+        },
+    },
     "model-deepseek-v2-lite": {
         "model": {
             "uri": "hf://deepseek-ai/DeepSeek-V2-Lite-Chat",

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -145,6 +145,12 @@ LLMINFERENCESERVICE_CONFIGS = {
     "model-fb-opt-125m": {
         "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
     },
+    "model-qwen2.5-0.5b": {
+        "model": {
+            "uri": "hf://Qwen/Qwen2.5-0.5B-Instruct",
+            "name": "Qwen/Qwen2.5-0.5B-Instruct",
+        },
+    },
     "model-deepseek-v2-lite": {
         "model": {
             "uri": "hf://deepseek-ai/DeepSeek-V2-Lite-Chat",

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1117,7 +1117,8 @@ def test_case(request):
             )
         if not tc.service_name:
             tc.service_name = generate_service_name(request.node.name, tc.base_refs)
-        tc.model_name = _get_model_name_from_configs(tc.base_refs)
+        if tc.model_name == "default/model":
+            tc.model_name = _get_model_name_from_configs(tc.base_refs)
 
         # Create unique configs for this test
         unique_base_refs = []

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -14,6 +14,8 @@
 
 import hashlib
 import os
+import re
+
 import pytest
 from ..common.gw_api import (
     create_or_update_gateway,
@@ -1174,16 +1176,20 @@ def _get_model_name_from_configs(config_names):
     return "default/model"
 
 
+_NON_DNS_CHARS = re.compile(r"[^a-z0-9]+")
+
+
+def _sanitize_for_dns(s: str) -> str:
+    """Replace non-DNS characters with hyphens, mirrors sanitizeForDNS in test_namespace.go."""
+    return _NON_DNS_CHARS.sub("-", s.lower()).strip("-")
+
+
 def generate_k8s_safe_suffix(
     base_name: str, extra_parts: Optional[List[str]] = None
 ) -> str:
     """Generate a Kubernetes-safe name suffix with hash."""
-    if extra_parts:
-        full_name = f"{base_name}-{'-'.join(sorted(extra_parts))}"
-    else:
-        full_name = base_name
-
-    full_name = full_name.lower().replace("_", "-")
+    raw = f"{base_name}-{'-'.join(sorted(extra_parts))}" if extra_parts else base_name
+    full_name = _sanitize_for_dns(raw)
 
     name_hash = hashlib.sha256(full_name.encode()).hexdigest()[:8]
 

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -39,8 +39,8 @@ from .test_resources import (
     ROUTER_GATEWAYS,
     ROUTER_ROUTES,
 )
-from .logging import log_execution
-from ..common.http_retry import post_with_retry
+from .logging import log_execution, logger
+from ..common.http_retry import get_with_retry, post_with_retry
 
 KSERVE_PLURAL_LLMINFERENCESERVICE = "llminferenceservices"
 
@@ -88,7 +88,7 @@ class TestCase:
 
     __test__ = False  # So pytest will not try to execute it.
     base_refs: List[str]
-    prompt: str
+    prompt: Optional[str] = None
     service_name: Optional[str] = None
     endpoint: str = "/v1/completions"
     max_tokens: int = 100
@@ -148,6 +148,7 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 pytest.mark.cluster_cpu,
                 pytest.mark.cluster_single_node,
                 pytest.mark.llmd_simulator,
+                pytest.mark.custom_gateway,
             ],
         ),
         pytest.param(
@@ -193,7 +194,11 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                     )
                 ],
             ),
-            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.custom_gateway,
+            ],
         ),
         pytest.param(
             TestCase(
@@ -241,7 +246,11 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                     )
                 ],
             ),
-            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.custom_gateway,
+            ],
         ),
         pytest.param(
             TestCase(
@@ -332,6 +341,25 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
             ),
             marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
         ),
+        # Chat completions endpoint coverage
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-llmd-simulator",
+                    "model-qwen2.5-0.5b",
+                ],
+                endpoint="/v1/chat/completions",
+                prompt="What is KServe?",
+                payload_formatter=chat_completions_payload,
+                response_assertion=create_response_assertion(with_field="choices"),
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+        ),
         pytest.param(
             TestCase(
                 base_refs=[
@@ -375,6 +403,22 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 pytest.mark.llmd_simulator,
             ],
         ),
+        # Models endpoint coverage
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-llmd-simulator",
+                ],
+                endpoint="/v1/models",
+                response_assertion=create_response_assertion(with_field="data"),
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+        ),
     ],
     indirect=["test_case"],
     ids=generate_test_id,
@@ -390,6 +434,7 @@ def test_llm_inference_service(test_case: TestCase):  # noqa: F811
 
     service_name = test_case.llm_service.metadata.name
 
+    test_failed = False
     try:
         create_llmisvc(kserve_client, test_case.llm_service)
         wait_for_llm_isvc_ready(
@@ -397,19 +442,12 @@ def test_llm_inference_service(test_case: TestCase):  # noqa: F811
         )
         wait_for_model_response(kserve_client, test_case, test_case.wait_timeout)
     except Exception as e:
+        test_failed = True
         print(f"❌ ERROR: Failed to call llm inference service {service_name}: {e}")
         _collect_diagnostics(kserve_client, test_case.llm_service)
         raise
     finally:
-        try:
-            if os.getenv("SKIP_RESOURCE_DELETION", "False").lower() in (
-                "false",
-                "0",
-                "f",
-            ):
-                delete_llmisvc(kserve_client, test_case.llm_service)
-        except Exception as e:
-            print(f"⚠️ Warning: Failed to cleanup service {service_name}: {e}")
+        maybe_delete_llmisvc(kserve_client, test_case.llm_service, test_failed)
 
 
 @log_execution
@@ -448,6 +486,41 @@ def delete_llmisvc(kserve_client: KServeClient, llm_isvc: V1alpha1LLMInferenceSe
             f"❌ Exception when calling CustomObjectsApi->"
             f"delete_namespaced_custom_object for LLMInferenceService: {e}"
         ) from e
+
+
+def maybe_delete_llmisvc(
+    kserve_client: KServeClient,
+    llm_isvc: V1alpha1LLMInferenceService,
+    test_failed: bool = False,
+):
+    """Delete LLMInferenceService unless env vars instruct otherwise.
+
+    Respects SKIP_RESOURCE_DELETION (skip always) and
+    SKIP_DELETION_ON_FAILURE (skip only when test_failed is True).
+    """
+    service_name = llm_isvc.metadata.name
+    try:
+        skip_all = os.getenv(
+            "SKIP_RESOURCE_DELETION", "False"
+        ).lower() in ("true", "1", "t")
+        skip_on_failure = os.getenv(
+            "SKIP_DELETION_ON_FAILURE", "False"
+        ).lower() in ("true", "1", "t")
+
+        should_skip = skip_all or (skip_on_failure and test_failed)
+
+        if not should_skip:
+            delete_llmisvc(kserve_client, llm_isvc)
+        elif skip_all:
+            print(
+                f"⏭️  Skipping deletion of {service_name} (SKIP_RESOURCE_DELETION=True)"
+            )
+        elif test_failed and skip_on_failure:
+            print(
+                f"⏭️  Skipping deletion of {service_name} due to test failure (SKIP_DELETION_ON_FAILURE=True)"
+            )
+    except Exception as e:
+        print(f"⚠️ Warning: Failed to cleanup service {service_name}: {e}")
 
 
 @log_execution
@@ -493,21 +566,30 @@ def wait_for_model_response(
 
         if test_case.payload_formatter is not None:
             test_payload = test_case.payload_formatter(test_case)
-        else:
+        elif test_case.prompt is not None:
             test_payload = {
                 "model": test_case.model_name,
                 "prompt": test_case.prompt,
                 "max_tokens": test_case.max_tokens,
             }
+        else:
+            test_payload = None
 
         logger.info(f"Calling LLM service at {model_url} with payload {test_payload}")
         try:
-            response = post_with_retry(
-                model_url,
-                headers=headers,
-                json_data=test_payload,
-                timeout=test_case.response_timeout,
-            )
+            if test_payload is not None:
+                response = post_with_retry(
+                    model_url,
+                    headers={"Content-Type": "application/json"},
+                    json_data=test_payload,
+                    timeout=test_case.response_timeout,
+                )
+            else:
+                response = get_with_retry(
+                    model_url,
+                    headers={"Accept": "application/json"},
+                    timeout=test_case.response_timeout,
+                )
         except Exception as e:
             logger.error(f"❌ Failed to call model: {e}")
             raise AssertionError(f"❌ Failed to call model: {e}") from e

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import time
 
 import os
@@ -43,8 +42,6 @@ from .logging import log_execution, logger
 from ..common.http_retry import get_with_retry, post_with_retry
 
 KSERVE_PLURAL_LLMINFERENCESERVICE = "llminferenceservices"
-
-logger = logging.getLogger(__name__)
 
 
 def assert_200(response: requests.Response) -> None:
@@ -500,12 +497,16 @@ def maybe_delete_llmisvc(
     """
     service_name = llm_isvc.metadata.name
     try:
-        skip_all = os.getenv(
-            "SKIP_RESOURCE_DELETION", "False"
-        ).lower() in ("true", "1", "t")
-        skip_on_failure = os.getenv(
-            "SKIP_DELETION_ON_FAILURE", "False"
-        ).lower() in ("true", "1", "t")
+        skip_all = os.getenv("SKIP_RESOURCE_DELETION", "False").lower() in (
+            "true",
+            "1",
+            "t",
+        )
+        skip_on_failure = os.getenv("SKIP_DELETION_ON_FAILURE", "False").lower() in (
+            "true",
+            "1",
+            "t",
+        )
 
         should_skip = skip_all or (skip_on_failure and test_failed)
 

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -346,6 +346,7 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                     "workload-llmd-simulator",
                     "model-qwen2.5-0.5b",
                 ],
+                model_name="Qwen/Qwen2.5-0.5B-Instruct",
                 endpoint="/v1/chat/completions",
                 prompt="What is KServe?",
                 payload_formatter=chat_completions_payload,

--- a/test/e2e/llmisvc/test_llm_inference_service_stop.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_stop.py
@@ -27,8 +27,8 @@ from .logging import log_execution
 from .test_llm_inference_service import (
     TestCase,
     create_llmisvc,
-    delete_llmisvc,
     get_llmisvc,
+    maybe_delete_llmisvc,
     wait_for,
     wait_for_llm_isvc_ready,
 )
@@ -124,34 +124,7 @@ def test_llm_stop_feature(test_case: TestCase):
         print(f"❌ ERROR: Stop feature test failed for {service_name}: {e}")
         raise
     finally:
-        try:
-            skip_all_deletion = os.getenv(
-                "SKIP_RESOURCE_DELETION", "False"
-            ).lower() in (
-                "true",
-                "1",
-                "t",
-            )
-            skip_deletion_on_failure = os.getenv(
-                "SKIP_DELETION_ON_FAILURE", "False"
-            ).lower() in (
-                "true",
-                "1",
-                "t",
-            )
-
-            should_skip_deletion = skip_all_deletion or (
-                skip_deletion_on_failure and test_failed
-            )
-
-            if not should_skip_deletion:
-                delete_llmisvc(kserve_client, test_case.llm_service)
-            elif test_failed and skip_deletion_on_failure:
-                print(
-                    f"⏭️  Skipping deletion of {service_name} due to test failure (SKIP_DELETION_ON_FAILURE=True)"
-                )
-        except Exception as e:
-            print(f"⚠️ Warning: Failed to cleanup service {service_name}: {e}")
+        maybe_delete_llmisvc(kserve_client, test_case.llm_service, test_failed)
 
 
 @log_execution

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -31,5 +31,9 @@ markers =
     cluster_nvidia_roce: test targeting cluster with NVIDIA ROCe
     cluster_single_node: test targeting single node cluster
     cluster_multi_node: test targeting multi node cluster
+    cluster_gpu: test targeting cluster with GPU
+    no_scheduler: test without scheduler
+    custom_gateway: test creating custom gateway resources
+    auth: test requiring authentication setup
     llmd_simulator: test using llm-d simulator
     dual_protocol: test for dual protocol gRPC and REST predictor for Standard mode with Gateway API

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -28,4 +28,9 @@ markers =
     cluster_nvidia: test targeting cluster with NVIDIA
     cluster_nvidia_roce: test targeting cluster with NVIDIA ROCe
     cluster_single_node: test targeting single node cluster
+    cluster_multi_node: test targeting multi node cluster
+    cluster_gpu: test targeting cluster with GPU
+    no_scheduler: test without scheduler
+    custom_gateway: test creating custom gateway resources
+    auth: test requiring authentication setup
     llmd_simulator: test using llm-d simulator


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #5093 (next part of port).

Adds configurability and new endpoint coverage to the LLMInferenceService e2e test suite:

- **`GATEWAY_CLASS_NAME`** env var in `test_resources.py` (default `envoy`) so downstream deployments can override the gateway class without forking
- **`SKIP_DELETION_ON_FAILURE`** env var and shared `maybe_delete_llmisvc()` helper for debugging failed tests (keeps resources around for inspection)
- **`custom_gateway`** marker on router tests that create their own Gateway resources
- New **chat-completions** test case exercising `POST /v1/chat/completions` with `model-qwen2.5-0.5b`
- New **models-endpoint** test case exercising `GET /v1/models`
- Additional pytest markers in `pytest.ini`: `cluster_multi_node`, `cluster_gpu`, `no_scheduler`, `custom_gateway`, `auth`

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] Existing e2e test suite passes (no behavioral changes to existing tests)
- [x] New test cases validated with llm-d simulator

**Special notes for your reviewer**:

Builds on the flexible endpoint testing framework from #5093. The `payload_formatter` and `endpoint` fields introduced there are now exercised by the new chat-completions and models-endpoint test cases.

Port of opendatahub-io/kserve#938, opendatahub-io/kserve#1062, opendatahub-io/kserve#832, opendatahub-io/kserve#935.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```