### PR TITLE
fix: add missing LLMIsvc deps to standard mode quickstart scripts

### DIFF
--- a/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-full-install-with-manifests.definition
+++ b/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-full-install-with-manifests.definition
@@ -8,13 +8,14 @@ TOOLS:
   
 INCLUDE_DEFINITIONS:
   - ./kserve-standard-mode-dependency-install.definition
+  - ../llmisvc/llmisvc-dependency-install.definition
     
 COMPONENTS:
   - name: kserve-kustomize
     env:
       DEPLOYMENT_MODE: Standard
-      ENABLE_LLMISVC: false
+      ENABLE_LLMISVC: true
       ENABLE_KSERVE: true
       INSTALL_RUNTIMES: true
-      INSTALL_LLMISVC_CONFIGS: false
+      INSTALL_LLMISVC_CONFIGS: true
       

--- a/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-full-install.definition
+++ b/hack/setup/quick-install/definitions/kserve-standard/kserve-standard-mode-full-install.definition
@@ -8,13 +8,14 @@ TOOLS:
   
 INCLUDE_DEFINITIONS:
   - ./kserve-standard-mode-dependency-install.definition
+  - ../llmisvc/llmisvc-dependency-install.definition
     
 COMPONENTS:
   - name: kserve-helm
     env:
       DEPLOYMENT_MODE: Standard
-      ENABLE_LLMISVC: false
+      ENABLE_LLMISVC: true
       ENABLE_KSERVE: true
       INSTALL_RUNTIMES: true
-      INSTALL_LLMISVC_CONFIGS: false
+      INSTALL_LLMISVC_CONFIGS: true
 

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -678,6 +678,11 @@ KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
 # Component-Specific Variables
 #================================================
 
+PLATFORM="${PLATFORM:-$(detect_platform)}"
+TEMPLATE_DIR="${REPO_ROOT}/hack/setup/infra/external-lb/templates"
+GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-envoy}"
+CONTROLLER_NAME="${CONTROLLER_NAME:-gateway.envoyproxy.io/gatewayclass-controller}"
+GATEWAY_NAME="kserve-ingress-gateway"
 INSTALL_MODE="helm"
 USE_LOCAL_CHARTS="${USE_LOCAL_CHARTS:-false}"
 CHARTS_DIR="${REPO_ROOT}/charts"
@@ -697,6 +702,27 @@ RUNTIME_CONFIG_CHART_NAME="kserve-runtime-configs"
 #================================================
 # Template Functions (EMBED_TEMPLATES MODE)
 #================================================
+
+# ============================================================================
+# Template Functions: external-lb
+# ============================================================================
+
+get_metallb_config() {
+    cat <<'METALLB_CONFIG_EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - {{START}}-{{END}}
+METALLB_CONFIG_EOF
+}
 
 
 
@@ -875,6 +901,126 @@ install_yq() {
 }
 
 # ----------------------------------------
+# CLI/Component: external-lb
+# ----------------------------------------
+
+uninstall_external_lb() {
+    log_info "Uninstalling External LoadBalancer for platform: ${PLATFORM}"
+
+    case "${PLATFORM}" in
+        kind)
+            if pgrep -f cloud-provider-kind > /dev/null; then
+                log_info "Stopping cloud-provider-kind..."
+                pkill -f cloud-provider-kind || true
+                log_success "cloud-provider-kind stopped"
+            else
+                log_info "cloud-provider-kind is not running"
+            fi
+            ;;
+
+        minikube)
+            log_info "Disabling MetalLB addon..."
+            minikube addons disable metallb 2>/dev/null || true
+            log_success "MetalLB disabled"
+            ;;
+
+        openshift|kubernetes)
+            log_info "Platform ${PLATFORM} does not require external LB teardown. Skipping."
+            ;;
+    esac
+
+    log_success "External LoadBalancer uninstalled for ${PLATFORM}!"
+}
+
+install_external_lb() {
+    if [ "$REINSTALL" = true ]; then
+        log_info "Reinstalling External LoadBalancer..."
+        uninstall_external_lb
+    fi
+
+    log_info "Setting up External LoadBalancer for platform: ${PLATFORM}"
+
+    case "${PLATFORM}" in
+        kind)
+            log_info "Installing cloud-provider-kind for KIND cluster..."
+
+            if ! command_exists cloud-provider-kind; then
+                log_info "Installing cloud-provider-kind..."
+                go install sigs.k8s.io/cloud-provider-kind@latest
+
+                if ! command_exists cloud-provider-kind; then
+                    log_error "Failed to install cloud-provider-kind. Make sure GOPATH/bin is in your PATH."
+                    exit 1
+                fi
+            fi
+
+            if pgrep -f cloud-provider-kind > /dev/null; then
+                log_info "cloud-provider-kind is already running"
+            else
+                log_info "Starting cloud-provider-kind..."
+                nohup cloud-provider-kind > /dev/null 2>&1 &
+                sleep 2
+
+                if pgrep -f cloud-provider-kind > /dev/null; then
+                    log_success "cloud-provider-kind started successfully"
+                else
+                    log_error "Failed to start cloud-provider-kind"
+                    exit 1
+                fi
+            fi
+            ;;
+
+        minikube)
+            log_info "Setting up MetalLB for Minikube cluster..."
+
+            log_info "Enabling MetalLB addon..."
+            minikube addons enable metallb
+            kubectl wait --for=condition=ready pod -l app=metallb -n metallb-system --timeout=60s
+
+            MINIKUBE_IP=$(minikube ip)
+            if [[ -z "${MINIKUBE_IP}" ]]; then
+                log_error "Failed to get minikube IP"
+                exit 1
+            fi
+
+            log_info "Minikube IP: ${MINIKUBE_IP}"
+
+            PREFIX=${MINIKUBE_IP%.*}
+            START=${METALLB_IP_RANGE_START:-${PREFIX}.200}
+            END=${METALLB_IP_RANGE_END:-${PREFIX}.235}
+
+            log_info "Configuring MetalLB IP range: ${START}-${END}"
+
+            if [ "$EMBED_TEMPLATES" = "true" ]; then
+                get_metallb_config | \
+                    sed -e "s/{{START}}/${START}/g" -e "s/{{END}}/${END}/g" | \
+                    kubectl apply -f -
+            else
+                sed -e "s/{{START}}/${START}/g" -e "s/{{END}}/${END}/g" \
+                    "${TEMPLATE_DIR}/metallb-config.yaml.tmpl" | kubectl apply -f -
+            fi
+
+            kubectl rollout restart deployment controller -n metallb-system
+            kubectl rollout status deployment controller -n metallb-system --timeout=60s
+
+            log_success "MetalLB configured successfully with IP range: ${START}-${END}"
+            ;;
+
+        openshift|kubernetes)
+            log_info "Platform ${PLATFORM} does not require external LB setup. Skipping."
+            return 0
+            ;;
+
+        *)
+            log_error "Unknown platform: ${PLATFORM}"
+            exit 1
+            ;;
+    esac
+
+    log_success "External LoadBalancer setup completed for ${PLATFORM}!"
+}
+
+# ----------------------------------------
 # CLI/Component: cert-manager
 # ----------------------------------------
 
@@ -914,6 +1060,242 @@ install_cert_manager() {
     wait_for_pods "cert-manager" "app in (cert-manager,webhook,cainjector)" "180s"
 
     log_success "cert-manager is ready!"
+}
+
+# ----------------------------------------
+# CLI/Component: gateway-api-extension-crd
+# ----------------------------------------
+
+uninstall_gateway_api_extension_crd() {
+    log_info "Uninstalling Gateway Inference Extension CRDs..."
+    kubectl delete -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
+    log_success "Gateway Inference Extension CRDs uninstalled"
+}
+
+install_gateway_api_extension_crd() {
+    if kubectl get crd inferencepools.inference.networking.x-k8s.io &>/dev/null; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "Gateway Inference Extension CRDs are already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling Gateway Inference Extension CRDs..."
+            uninstall_gateway_api_extension_crd
+        fi
+    fi
+
+    log_info "Installing Gateway Inference Extension CRDs ${GIE_VERSION}..."
+    kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GIE_VERSION}/manifests.yaml"
+
+    log_success "Successfully installed Gateway Inference Extension CRDs ${GIE_VERSION}"
+
+    wait_for_crds "60s" \
+        "inferencepools.inference.networking.x-k8s.io" \
+        "inferenceobjectives.inference.networking.x-k8s.io"
+
+    log_success "Gateway Inference Extension CRDs are ready!"
+}
+
+# ----------------------------------------
+# CLI/Component: envoy-gateway
+# ----------------------------------------
+
+uninstall_envoy_gateway() {
+    log_info "Uninstalling Envoy Gateway..."
+    kubectl delete gatewayclass envoy --ignore-not-found=true --force --grace-period=0 2>/dev/null || true
+    helm uninstall eg -n envoy-gateway-system 2>/dev/null || true
+    kubectl delete all --all -n envoy-gateway-system --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace envoy-gateway-system --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    log_success "Envoy Gateway uninstalled"
+}
+
+install_envoy_gateway() {
+    if helm list -n envoy-gateway-system 2>/dev/null | grep -q "eg"; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "Envoy Gateway is already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling Envoy Gateway..."
+            uninstall_envoy_gateway
+        fi
+    fi
+
+    log_info "Installing Envoy Gateway ${ENVOY_GATEWAY_VERSION}..."
+    helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
+        --version "${ENVOY_GATEWAY_VERSION}" \
+        -n envoy-gateway-system \
+        --create-namespace \
+        --wait
+
+    log_success "Successfully installed Envoy Gateway ${ENVOY_GATEWAY_VERSION} via Helm"
+
+    wait_for_pods "envoy-gateway-system" "control-plane=envoy-gateway" "300s"
+
+    log_success "Envoy Gateway is ready!"
+}
+
+# ----------------------------------------
+# CLI/Component: envoy-ai-gateway
+# ----------------------------------------
+
+uninstall_envoy_ai_gateway() {
+    log_info "Uninstalling Envoy AI Gateway..."
+    helm uninstall aieg -n envoy-ai-gateway-system 2>/dev/null || true
+    helm uninstall aieg-crd -n envoy-ai-gateway-system 2>/dev/null || true
+    kubectl delete all --all -n envoy-ai-gateway-system --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace envoy-ai-gateway-system --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    kubectl delete all --all -n redis-system --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace redis-system --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    log_success "Envoy AI Gateway uninstalled"
+}
+
+install_envoy_ai_gateway() {
+    if helm list -n envoy-ai-gateway-system 2>/dev/null | grep -q "aieg"; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "Envoy AI Gateway is already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling Envoy AI Gateway..."
+            uninstall_envoy_ai_gateway
+        fi
+    fi
+
+    log_info "Updating Envoy Gateway ${ENVOY_GATEWAY_VERSION}...to add inference pool addons for Envoy AI Gateway"
+    helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
+        --version "${ENVOY_GATEWAY_VERSION}" \
+        -n envoy-gateway-system \
+        --create-namespace \
+        -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/${ENVOY_AI_GATEWAY_VERSION}/manifests/envoy-gateway-values.yaml \
+        -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/${ENVOY_AI_GATEWAY_VERSION}/examples/inference-pool/envoy-gateway-values-addon.yaml \
+        --wait
+
+    log_success "Successfully Updated Envoy Gateway ${ENVOY_GATEWAY_VERSION} for Envoy AI Gateway"
+
+    log_info "Installing Envoy AI Gateway CRDs ${ENVOY_AI_GATEWAY_VERSION}..."
+    helm upgrade -i aieg-crd oci://docker.io/envoyproxy/ai-gateway-crds-helm \
+        --version "${ENVOY_AI_GATEWAY_VERSION}" \
+        --namespace envoy-ai-gateway-system \
+        --create-namespace
+
+    log_info "Installing Envoy AI Gateway ${ENVOY_AI_GATEWAY_VERSION}..."
+    helm upgrade -i aieg oci://docker.io/envoyproxy/ai-gateway-helm \
+        --version "${ENVOY_AI_GATEWAY_VERSION}" \
+        --namespace envoy-ai-gateway-system \
+        --create-namespace
+
+    kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-controller --for=condition=Available
+    log_success "Envoy AI Gateway ${ENVOY_AI_GATEWAY_VERSION} is ready!"
+}
+
+# ----------------------------------------
+# CLI/Component: gateway-api-gwclass
+# ----------------------------------------
+
+uninstall_gateway_api_gwclass() {
+    log_info "Deleting GatewayClass '${GATEWAYCLASS_NAME}'..."
+    kubectl delete gatewayclass "${GATEWAYCLASS_NAME}" --ignore-not-found=true --force --grace-period=0 2>/dev/null || true
+    log_success "GatewayClass '${GATEWAYCLASS_NAME}' deleted"
+}
+
+install_gateway_api_gwclass() {
+    if kubectl get gatewayclass "${GATEWAYCLASS_NAME}" &>/dev/null; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "GatewayClass '${GATEWAYCLASS_NAME}' already exists. Use --reinstall to recreate."
+            return 0
+        else
+            log_info "Recreating GatewayClass '${GATEWAYCLASS_NAME}'..."
+            uninstall_gateway_api_gwclass
+        fi
+    fi
+
+    log_info "Creating GatewayClass '${GATEWAYCLASS_NAME}'..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ${GATEWAYCLASS_NAME}
+spec:
+  controllerName: ${CONTROLLER_NAME}
+EOF
+
+    log_success "GatewayClass '${GATEWAYCLASS_NAME}' created successfully!"
+}
+
+# ----------------------------------------
+# CLI/Component: gateway-api-gw
+# ----------------------------------------
+
+uninstall_gateway_api_gw() {
+    log_info "Deleting KServe Gateway '${GATEWAY_NAME}' in namespace '${GATEWAY_NAMESPACE}'..."
+    kubectl delete gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" --ignore-not-found=true --force --grace-period=0 2>/dev/null || true
+    log_success "KServe Gateway '${GATEWAY_NAME}' deleted"
+}
+
+install_gateway_api_gw() {
+    create_or_skip_namespace "${GATEWAY_NAMESPACE}"
+
+    if kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "KServe Gateway '${GATEWAY_NAME}' already exists in namespace '${GATEWAY_NAMESPACE}'. Use --reinstall to recreate."
+            return 0
+        else
+            log_info "Recreating KServe Gateway '${GATEWAY_NAME}'..."
+            uninstall_gateway_api_gw
+        fi
+    fi
+
+    log_info "Creating KServe Gateway '${GATEWAY_NAME}' in namespace '${GATEWAY_NAMESPACE}'..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${GATEWAY_NAME}
+  namespace: ${GATEWAY_NAMESPACE}
+spec:
+  gatewayClassName: ${GATEWAYCLASS_NAME}
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+  infrastructure:
+    labels:
+      serving.kserve.io/gateway: ${GATEWAY_NAME}
+EOF
+
+    log_success "KServe Gateway '${GATEWAY_NAME}' created successfully!"
+}
+
+# ----------------------------------------
+# CLI/Component: lws-operator
+# ----------------------------------------
+
+uninstall_lws_operator() {
+    log_info "Uninstalling LeaderWorkerSet (LWS)..."
+    kubectl delete -f "https://github.com/kubernetes-sigs/lws/releases/download/${LWS_VERSION}/manifests.yaml" --ignore-not-found=true 2>/dev/null || true
+    log_success "LWS uninstalled"
+}
+
+install_lws_operator() {
+    if kubectl get deployment lws-controller-manager -n lws-system &>/dev/null; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "LWS is already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling LWS..."
+            uninstall_lws_operator
+        fi
+    fi
+
+    log_info "Installing LWS ${LWS_VERSION}..."
+    kubectl apply --server-side -f "https://github.com/kubernetes-sigs/lws/releases/download/${LWS_VERSION}/manifests.yaml"
+
+    log_success "Successfully installed LWS ${LWS_VERSION}"
+
+    wait_for_pods "lws-system" "control-plane=controller-manager" "300s"
+
+    log_success "LWS is ready!"
 }
 
 # ----------------------------------------
@@ -1109,7 +1491,14 @@ main() {
         echo "Uninstalling components..."
         echo "=========================================="
         uninstall_kserve_helm
+        uninstall_lws_operator
+        uninstall_gateway_api_gw
+        uninstall_gateway_api_gwclass
+        uninstall_envoy_ai_gateway
+        uninstall_envoy_gateway
+        uninstall_gateway_api_extension_crd
         uninstall_cert_manager
+        uninstall_external_lb
         
         
         
@@ -1128,13 +1517,20 @@ main() {
     install_helm
     install_kustomize
     install_yq
+    install_external_lb
     install_cert_manager
+    install_gateway_api_extension_crd
+    install_envoy_gateway
+    install_envoy_ai_gateway
+    install_gateway_api_gwclass
+    install_gateway_api_gw
+    install_lws_operator
     (
         set_env_with_priority "DEPLOYMENT_MODE" "Standard" "" ""
-        set_env_with_priority "ENABLE_LLMISVC" "False" "" ""
+        set_env_with_priority "ENABLE_LLMISVC" "True" "" ""
         set_env_with_priority "ENABLE_KSERVE" "True" "" "true"
         set_env_with_priority "INSTALL_RUNTIMES" "True" "" ""
-        set_env_with_priority "INSTALL_LLMISVC_CONFIGS" "False" "" ""
+        set_env_with_priority "INSTALL_LLMISVC_CONFIGS" "True" "" ""
         determine_shared_resources_config "${INSTALL_MODE}" "${ENABLE_KSERVE}" "${ENABLE_LLMISVC}"
         
         if [ "${SET_KSERVE_VERSION}" != "" ]; then


### PR DESCRIPTION


**What this PR does / why we need it**:

The `kserve-standard-mode quickstart` definition files were missing the `llmisvc-dependency-install.definition` include and had `ENABLE_LLMISVC` and `INSTALL_LLMISVC_CONFIGS` set to false.

This PR adds the missing include and enables LLMIsvc in both the kustomize/manifests and helm variants of the standard mode full install definitions, then regenerates the scripts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5128


**Feature/Issue validation/testing**:


- [x] Regenerated all quick-install scripts successfully, confirmed the standard mode scripts now include all LLMIsvc dependencies
- [x] Cross-checked install list against `llmisvc-full-install-with-manifests.sh` to confirm parity

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
