### PR TITLE
refactor: change kserve chart name to kserve-resources

### DIFF
--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -1,16 +1,28 @@
 # kserve-llmisvc-resources
 
+![Version: v0.17.0-rc0](https://img.shields.io/badge/Version-v0.17.0--rc0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.0-rc0](https://img.shields.io/badge/AppVersion-v0.17.0--rc0-informational?style=flat-square)
+
 Helm chart for deploying KServe LLMInferenceService resources
 
-![Version: v0.17.0-rc0](https://img.shields.io/badge/Version-v0.17.0--rc0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.0-rc0](https://img.shields.io/badge/AppVersion-v0.17.0--rc0-informational?style=flat-square)
+**Homepage:** <https://kserve.github.io/website/>
 
 ## Installing the Chart
 
 To install the chart, run the following:
 
 ```console
-$ helm install kserve-llmisvc oci://ghcr.io/kserve/charts/kserve-llmisvc-resources --version v0.17.0-rc0
+$ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmisvc-resources --version v0.17.0-rc0
 ```
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| KServe Team |  | <https://github.com/kserve/kserve> |
+
+## Source Code
+
+* <https://github.com/kserve/kserve>
 
 ## Values
 

--- a/charts/kserve-localmodel-resources/README.md
+++ b/charts/kserve-localmodel-resources/README.md
@@ -6,6 +6,14 @@ KServe LocalModel - Local Model Storage and Caching for Edge and On-Premise Depl
 
 **Homepage:** <https://kserve.github.io/website/>
 
+## Installing the Chart
+
+To install the chart, run the following:
+
+```console
+$ helm install kserve-localmodel-resources oci://ghcr.io/kserve/charts/kserve-localmodel-resources --version v0.17.0-rc0
+```
+
 ## Maintainers
 
 | Name | Email | Url |
@@ -38,4 +46,3 @@ KServe LocalModel - Local Model Storage and Caching for Edge and On-Premise Depl
 | kserve.localmodelnode.controller.tag | string | `""` |  |
 | kserve.localmodelnode.controller.tolerations | list | `[]` |  |
 | kserve.version | string | `"v0.17.0-rc0"` |  |
-

--- a/charts/kserve-localmodel-resources/README.md.gotmpl
+++ b/charts/kserve-localmodel-resources/README.md.gotmpl
@@ -11,7 +11,7 @@
 To install the chart, run the following:
 
 ```console
-$ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmisvc-resources --version {{ template "chart.version" . }}
+$ helm install kserve-localmodel-resources oci://ghcr.io/kserve/charts/kserve-localmodel-resources --version {{ template "chart.version" . }}
 ```
 
 {{ template "chart.maintainersSection" . }}

--- a/charts/kserve-resources/Chart.yaml
+++ b/charts/kserve-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: kserve
+name: kserve-resources
 version: v0.17.0-rc0
 appVersion: v0.17.0-rc0
 description: Helm chart for deploying kserve resources

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -1,4 +1,4 @@
-# kserve
+# kserve-resources
 
 Helm chart for deploying kserve resources
 
@@ -9,7 +9,7 @@ Helm chart for deploying kserve resources
 To install the chart, run the following:
 
 ```console
-$ helm install kserve oci://ghcr.io/kserve/charts/kserve --version v0.17.0-rc0
+$ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --version v0.17.0-rc0
 ```
 
 ## Values

--- a/charts/kserve-resources/README.md.gotmpl
+++ b/charts/kserve-resources/README.md.gotmpl
@@ -8,7 +8,7 @@
 To install the chart, run the following:
 
 ```console
-$ helm install kserve oci://ghcr.io/kserve/charts/kserve --version {{ template "chart.version" . }}
+$ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --version {{ template "chart.version" . }}
 ```
 
 {{ template "chart.requirementsSection" . }}

--- a/charts/kserve-runtime-configs/README.md
+++ b/charts/kserve-runtime-configs/README.md
@@ -6,6 +6,14 @@ KServe Runtime Configurations - ClusterServingRuntimes and LLM Inference Configs
 
 **Homepage:** <https://kserve.github.io/website/>
 
+## Installing the Chart
+
+To install the chart, run the following:
+
+```console
+$ helm install kserve-runtime-configs oci://ghcr.io/kserve/charts/kserve-runtime-configs --set kserve.servingruntime.enabled=true --set kserve.llmisvcConfigs.enabled=true --version v0.17.0-rc0
+```
+
 ## Maintainers
 
 | Name | Email | Url |
@@ -157,4 +165,3 @@ KServe Runtime Configurations - ClusterServingRuntimes and LLM Inference Configs
 | kserve.servingruntime.xgbserver.securityContext.runAsNonRoot | bool | `true` |  |
 | kserve.servingruntime.xgbserver.tag | string | `""` |  |
 | kserve.version | string | `"v0.17.0-rc0"` |  |
-

--- a/charts/kserve-runtime-configs/README.md.gotmpl
+++ b/charts/kserve-runtime-configs/README.md.gotmpl
@@ -11,7 +11,7 @@
 To install the chart, run the following:
 
 ```console
-$ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmisvc-resources --version {{ template "chart.version" . }}
+$ helm install kserve-runtime-configs oci://ghcr.io/kserve/charts/kserve-runtime-configs --set kserve.servingruntime.enabled=true --set kserve.llmisvcConfigs.enabled=true --version {{ template "chart.version" . }}
 ```
 
 {{ template "chart.maintainersSection" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr changed the chart name of kserve to kserve-resources based on the recent chart restructure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note

```
