### PR TITLE
chore: add MAINTAINERS.md for LFX Insights

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,23 @@
+# KServe Maintainers
+
+This list is a copy of the active maintainers from [MAINTAINERS.md file in kserve/community repo](https://github.com/kserve/community/blob/main/MAINTAINERS.md) to make it easy for [the LFX Insights](https://insights.linuxfoundation.org/docs/introduction/maintainers/) to crawl and index.
+
+## Maintainers
+
+| Maintainer             | GitHub ID                                             | Project Roles        | Affiliation |
+|------------------------|-------------------------------------------------------|----------------------|-------------|
+| Dan Sun                | [yuzisun](https://github.com/yuzisun)                 | Project Lead - KServe        | Bloomberg   |
+| Yuan Tang              | [terrytangyuan](https://github.com/terrytangyuan)     | Project Lead - KServe        | Red Hat     |
+| Lize Cai               | [lizzzcai](https://github.com/lizzzcai)               | Approver - KServe    | SAP         |
+| Sivanantham Chinnaiyan | [sivanantha321](https://github.com/sivanantha321)     | Approver - KServe    | Ideas2IT    |
+| Jooho Lee              | [Jooho](https://github.com/Jooho)                     | Approver - KServe    | Red Hat     |
+| Andrews Arokiam        | [andyi2it](https://github.com/andyi2it)               | Reviewer - KServe    | Ideas2IT    |
+| Cory Johannsen         | [cjohannsen-cloudera](https://github.com/cjohannsen-cloudera) | Reviewer - KServe | Cloudera |
+| Curtis Maddalozzo      | [cmaddalozzo](https://github.com/cmaddalozzo)         | Reviewer - KServe    | Bloomberg   |
+| Datta Nimmaturi        | [Datta0](https://github.com/Datta0)                   | Reviewer - KServe    | Nutanix     |
+| Gavrish Prabhu         | [gavrissh](https://github.com/gavrissh)               | Reviewer - KServe    | Nutanix     |
+| Jin Dong               | [greenmoon55](https://github.com/greenmoon55)         | Reviewer - KServe    | Bloomberg   |
+| Edgar Hernández        | [israel-hdez](https://github.com/israel-hdez)         | Reviewer - KServe    | Red Hat     |
+| Johnu George           | [johnugeorge](https://github.com/johnugeorge)         | Reviewer - KServe    | Nutanix     |
+| Filippe Spolti         | [spolti](https://github.com/spolti)                   | Reviewer - KServe    | Red Hat     |
+| Pierangelo Di Pilato   | [pierDipi](https://github.com/pierDipi)               | Reviewer - KServe    | Red Hat     |


### PR DESCRIPTION
Updated the MAINTAINERS.md file to clarify the source of the maintainers list and its purpose for LFX Insights.

See https://github.com/kserve/kserve/issues/4894 for context.