### PR TITLE
feat(llmisvc): evaluate both InferencePool readiness

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/fixture/gwapi_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/gwapi_builders.go
@@ -580,34 +580,47 @@ func KuadrantControllerStatus(parentRef gwapiv1.ParentReference, generation int6
 	}
 }
 
-// GatewayAPIControllerStatus creates a RouteParentStatus for Gateway API controller
-func GatewayAPIControllerStatus(parentRef gwapiv1.ParentReference, generation int64) gwapiv1.RouteParentStatus {
-	return gwapiv1.RouteParentStatus{
-		ParentRef:      parentRef,
-		ControllerName: "openshift.io/gateway-controller/v1",
-		Conditions: []metav1.Condition{
-			{
-				Type:               string(gwapiv1.RouteConditionAccepted),
-				Status:             metav1.ConditionTrue,
-				Reason:             "Accepted",
-				Message:            "Route was valid",
-				LastTransitionTime: metav1.Now(),
-				ObservedGeneration: generation,
+// StatusFunc is a function that creates a RouteParentStatus for a given parent ref and generation.
+type StatusFunc func(parentRef gwapiv1.ParentReference, generation int64) gwapiv1.RouteParentStatus
+
+// gatewayAPIControllerStatusWith creates a StatusFunc with the given ResolvedRefs condition.
+func gatewayAPIControllerStatusWith(resolvedRefsStatus metav1.ConditionStatus, reason, message string) StatusFunc {
+	return func(parentRef gwapiv1.ParentReference, generation int64) gwapiv1.RouteParentStatus {
+		return gwapiv1.RouteParentStatus{
+			ParentRef:      parentRef,
+			ControllerName: "gateway-controller/v1",
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(gwapiv1.RouteConditionAccepted),
+					Status:             metav1.ConditionTrue,
+					Reason:             "Accepted",
+					Message:            "Route was valid",
+					LastTransitionTime: metav1.Now(),
+					ObservedGeneration: generation,
+				},
+				{
+					Type:               string(gwapiv1.RouteConditionResolvedRefs),
+					Status:             resolvedRefsStatus,
+					Reason:             reason,
+					Message:            message,
+					LastTransitionTime: metav1.Now(),
+					ObservedGeneration: generation,
+				},
 			},
-			{
-				Type:               string(gwapiv1.RouteConditionResolvedRefs),
-				Status:             metav1.ConditionTrue,
-				Reason:             "ResolvedRefs",
-				Message:            "All references resolved",
-				LastTransitionTime: metav1.Now(),
-				ObservedGeneration: generation,
-			},
-		},
+		}
 	}
 }
 
-// StatusFunc is a function that creates a RouteParentStatus for a given parent ref and generation
-type StatusFunc func(parentRef gwapiv1.ParentReference, generation int64) gwapiv1.RouteParentStatus
+var (
+	// GatewayAPIControllerStatus creates a RouteParentStatus with ResolvedRefs=True.
+	GatewayAPIControllerStatus = gatewayAPIControllerStatusWith(metav1.ConditionTrue, "ResolvedRefs", "All references resolved")
+
+	// GatewayAPIControllerStatusInvalidKind creates a RouteParentStatus with ResolvedRefs=False, Reason=InvalidKind.
+	GatewayAPIControllerStatusInvalidKind = gatewayAPIControllerStatusWith(metav1.ConditionFalse, string(gwapiv1.RouteReasonInvalidKind), "Backend kind InferencePool is not supported")
+
+	// GatewayAPIControllerStatusBackendNotFound creates a RouteParentStatus with ResolvedRefs=False, Reason=BackendNotFound.
+	GatewayAPIControllerStatusBackendNotFound = gatewayAPIControllerStatusWith(metav1.ConditionFalse, string(gwapiv1.RouteReasonBackendNotFound), "Backend not found")
+)
 
 // WithHTTPRouteMultipleControllerStatus sets HTTPRoute status with multiple controllers
 // This simulates real-world scenarios where policy controllers and gateway controllers

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/network"
@@ -35,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	igwapiv1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -505,7 +507,9 @@ func (r *LLMISVCReconciler) EvaluateHTTPRouteConditions(ctx context.Context, llm
 }
 
 // EvaluateInferencePoolConditions evaluates the readiness of all Inference Pools in the LLMInferenceService
-// and updates the InferencePoolReady condition accordingly
+// and updates the InferencePoolReady condition accordingly.
+// During the v1alpha2 to v1 migration, it checks both pool versions for managed pools
+// and considers the pool ready if at least one is ready.
 func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
 	logger := log.FromContext(ctx).WithName("EvaluateInferencePoolConditions")
 
@@ -521,27 +525,103 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 		return nil
 	}
 
-	curr := &igwapi.InferencePool{}
-
+	// For referenced pools (external), only check that pool
 	if llmSvc.Spec.Router.Scheduler.Pool != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref.Name != "" {
 		poolRef := llmSvc.Spec.Router.Scheduler.Pool.Ref
+		curr := &igwapi.InferencePool{}
 		err := r.Get(ctx, types.NamespacedName{Namespace: llmSvc.Namespace, Name: poolRef.Name}, curr)
 		if err != nil {
 			err := fmt.Errorf("failed to fetch referenced Inference Pool %s/%s: %w", llmSvc.Namespace, poolRef.Name, err)
 			llmSvc.MarkInferencePoolNotReady("InferencePoolFetchError", err.Error())
 			return err
 		}
-	} else {
-		expected := r.expectedSchedulerInferencePool(ctx, llmSvc)
-		err := r.Get(ctx, types.NamespacedName{Namespace: expected.Namespace, Name: expected.Name}, curr)
-		if err != nil {
-			err := fmt.Errorf("failed to fetch embedded Inference Pool %s/%s: %w", llmSvc.Namespace, llmSvc.Name, err)
-			llmSvc.MarkInferencePoolNotReady("InferencePoolFetchError", err.Error())
-			return err
-		}
+		return r.evaluateSingleInferencePoolCondition(ctx, llmSvc, curr)
 	}
 
+	// For managed pools, check both v1 and v1alpha2 pools during migration.
+	// Both pool versions are created by the scheduler reconciler - they live in different
+	// API groups and can coexist. During migration, the gateway may only accept one version.
+	expected := r.expectedSchedulerInferencePool(ctx, llmSvc)
+	poolName := expected.Name
+	poolNamespace := expected.Namespace
+
+	// Check v1 pool
+	v1Pool := &igwapi.InferencePool{}
+	v1Err := r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: poolName}, v1Pool)
+	v1Ready := v1Err == nil && IsInferencePoolReady(v1Pool)
+
+	// Check v1alpha2 pool - treat CRD-not-installed as "version unavailable" (not an error)
+	v1alpha2Pool := &igwapiv1alpha2.InferencePool{}
+	v1alpha2Err := r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: poolName}, v1alpha2Pool)
+	v1alpha2Ready := v1alpha2Err == nil && IsInferencePoolV1Alpha2Ready(v1alpha2Pool)
+
+	logger.V(2).Info("Checking InferencePool readiness",
+		"pool", poolNamespace+"/"+poolName,
+		"v1Ready", v1Ready,
+		"v1Err", v1Err,
+		"v1alpha2Ready", v1alpha2Ready,
+		"v1alpha2Err", v1alpha2Err,
+	)
+
+	// If at least one is ready, mark as ready
+	if v1Ready || v1alpha2Ready {
+		llmSvc.MarkInferencePoolReady()
+		logger.V(2).Info("Inference Pool is ready", "v1Ready", v1Ready, "v1alpha2Ready", v1alpha2Ready)
+		return nil
+	}
+
+	// Neither is ready - report status from the one that exists (prefer v1 since it's the target)
+	if v1Err == nil {
+		return r.evaluateSingleInferencePoolCondition(ctx, llmSvc, v1Pool)
+	}
+
+	if v1alpha2Err == nil {
+		if len(v1alpha2Pool.Status.Parents) == 0 {
+			llmSvc.MarkInferencePoolNotReady("WaitingForGateway",
+				"Inference Pool %s/%s exists but no Gateway controller has accepted it yet", poolNamespace, poolName)
+			return nil
+		}
+		topLevelCondition, _ := nonReadyInferencePoolV1Alpha2TopLevelCondition(v1alpha2Pool)
+		if topLevelCondition != nil {
+			llmSvc.MarkInferencePoolNotReady("InferencePoolNotReady", fmt.Sprintf(
+				"%s/%s: %v=%#v (reason %q, message %q)",
+				poolNamespace,
+				poolName,
+				topLevelCondition.Type,
+				topLevelCondition.Status,
+				topLevelCondition.Reason,
+				topLevelCondition.Message,
+			))
+		} else {
+			llmSvc.MarkInferencePoolNotReady("InferencePoolNotReady", fmt.Sprintf("The inference pool %s/%s is not ready", poolNamespace, poolName))
+		}
+		return nil
+	}
+
+	// Both failed to fetch - distinguish between "not found" and transient errors
+	if (apierrors.IsNotFound(v1Err) || meta.IsNoMatchError(v1Err)) &&
+		(apierrors.IsNotFound(v1alpha2Err) || meta.IsNoMatchError(v1alpha2Err)) {
+		llmSvc.MarkInferencePoolNotReady("InferencePoolFetchError",
+			fmt.Sprintf("Inference Pool %s/%s not found (checked v1 and v1alpha2)", poolNamespace, poolName))
+		return nil
+	}
+
+	// At least one was a transient error - return it so the controller requeues
+	err := fmt.Errorf("failed to fetch Inference Pool %s/%s: v1: %w, v1alpha2: %w", poolNamespace, poolName, v1Err, v1alpha2Err)
+	llmSvc.MarkInferencePoolNotReady("InferencePoolFetchError", err.Error())
+	return err
+}
+
+// evaluateSingleInferencePoolCondition evaluates a single v1 InferencePool and updates the condition.
+func (r *LLMISVCReconciler) evaluateSingleInferencePoolCondition(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, curr *igwapi.InferencePool) error {
 	if !IsInferencePoolReady(curr) {
+		if len(curr.Status.Parents) == 0 {
+			// Pool exists but no Gateway controller has claimed it yet.
+			// The Owns() watch will trigger re-reconciliation when the Gateway updates the pool's status.
+			llmSvc.MarkInferencePoolNotReady("WaitingForGateway",
+				"Inference Pool %s/%s exists but no Gateway controller has accepted it yet", curr.Namespace, curr.Name)
+			return nil
+		}
 		topLevelCondition, _ := nonReadyInferencePoolTopLevelCondition(curr)
 		if topLevelCondition != nil {
 			llmSvc.MarkInferencePoolNotReady("InferencePoolNotReady", fmt.Sprintf(
@@ -560,6 +640,6 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 	}
 
 	llmSvc.MarkInferencePoolReady()
-	logger.V(2).Info("Inference Pool is ready", "pool", curr)
+	log.FromContext(ctx).V(2).Info("Inference Pool is ready", "pool", curr)
 	return nil
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	igwapiv1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kserve/kserve/pkg/constants"
@@ -605,19 +606,18 @@ func findNonReadyGatewayCondition(route *gwapiv1.HTTPRoute) *metav1.Condition {
 	return nil
 }
 
-// IsInferencePoolReady checks if an InferencePool has been accepted by all parents
-// InferencePools manage collections of inference workloads for load balancing
-// They must be accepted by their parent Gateways to be considered operational
+// IsInferencePoolReady checks if an InferencePool has been accepted by all parents.
+// An InferencePool is only considered ready when at least one Gateway has claimed it
+// and all parent conditions report Accepted=True. If no parents have been set
+// (no Gateway controller has reconciled the pool yet), it is not ready.
 func IsInferencePoolReady(pool *igwapi.InferencePool) bool {
 	if pool == nil {
 		return false
 	}
 
-	// If no parents have been set, consider the pool ready if it exists and has a valid spec
-	// This handles cases where no Gateway controller is populating the status
+	// No Gateway has claimed this pool yet - not ready for traffic
 	if len(pool.Status.Parents) == 0 {
-		// Pool is ready if it exists with a valid selector and target ports
-		return len(pool.Spec.Selector.MatchLabels) > 0 && len(pool.Spec.TargetPorts) > 0
+		return false
 	}
 
 	// Check for any non-ready conditions across all parents
@@ -644,6 +644,47 @@ func nonReadyInferencePoolTopLevelCondition(pool *igwapi.InferencePool) (*metav1
 			return nil, true
 		}
 		// Check if condition is stale (based on older generation)
+		staleCondition := cond.ObservedGeneration > 0 && cond.ObservedGeneration < pool.Generation
+		if cond.Status != metav1.ConditionTrue || staleCondition {
+			return cond, false
+		}
+	}
+
+	return nil, false
+}
+
+// IsInferencePoolV1Alpha2Ready checks if a v1alpha2 InferencePool has been accepted by all parents.
+// This mirrors IsInferencePoolReady but for the v1alpha2 InferencePool type, which has a different
+// status structure (PoolStatus instead of ParentStatus).
+func IsInferencePoolV1Alpha2Ready(pool *igwapiv1alpha2.InferencePool) bool {
+	if pool == nil {
+		return false
+	}
+
+	// No Gateway has claimed this pool yet - not ready for traffic
+	if len(pool.Status.Parents) == 0 {
+		return false
+	}
+
+	if cond, missing := nonReadyInferencePoolV1Alpha2TopLevelCondition(pool); cond != nil || missing {
+		return false
+	}
+
+	return true
+}
+
+// nonReadyInferencePoolV1Alpha2TopLevelCondition checks for any non-ready conditions in a v1alpha2 InferencePool.
+// Returns the first problematic condition or indicates missing conditions.
+func nonReadyInferencePoolV1Alpha2TopLevelCondition(pool *igwapiv1alpha2.InferencePool) (*metav1.Condition, bool) {
+	if pool == nil {
+		return nil, true
+	}
+
+	for _, parent := range pool.Status.Parents {
+		cond := meta.FindStatusCondition(parent.Conditions, string(igwapiv1alpha2.InferencePoolConditionAccepted))
+		if cond == nil {
+			return nil, true
+		}
 		staleCondition := cond.ObservedGeneration > 0 && cond.ObservedGeneration < pool.Generation
 		if cond.Status != metav1.ConditionTrue || staleCondition {
 			return cond, false

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_migration_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_migration_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+func TestIsInferencePoolV1Supported(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    *gwapiv1.HTTPRoute
+		expected metav1.ConditionStatus
+	}{
+		{
+			name:     "nil route returns Unknown",
+			route:    nil,
+			expected: metav1.ConditionUnknown,
+		},
+		{
+			name: "route without InferencePool backendRef returns Unknown",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefService("my-service")),
+				),
+				WithHTTPRouteReadyStatus("gateway-controller/v1"),
+			),
+			expected: metav1.ConditionUnknown,
+		},
+		{
+			name: "route with v1alpha2 InferencePool backendRef returns Unknown (not v1)",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePoolV1Alpha2("my-pool")),
+				),
+				WithHTTPRouteReadyStatus("gateway-controller/v1"),
+			),
+			expected: metav1.ConditionUnknown,
+		},
+		{
+			name: "route with v1 InferencePool and ResolvedRefs=True returns True",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePool("my-pool")),
+				),
+				WithHTTPRouteReadyStatus("gateway-controller/v1"),
+			),
+			expected: metav1.ConditionTrue,
+		},
+		{
+			name: "route with v1 InferencePool and ResolvedRefs=False InvalidKind returns False",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePool("my-pool")),
+				),
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayRef("test-gateway", RefInNamespace("test-ns")),
+					GatewayAPIControllerStatusInvalidKind,
+				),
+			),
+			expected: metav1.ConditionFalse,
+		},
+		{
+			name: "route with v1 InferencePool and ResolvedRefs=False BackendNotFound returns True (kind is supported)",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePool("my-pool")),
+				),
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayRef("test-gateway", RefInNamespace("test-ns")),
+					GatewayAPIControllerStatusBackendNotFound,
+				),
+			),
+			expected: metav1.ConditionTrue,
+		},
+		{
+			name: "route with v1 InferencePool and no status returns Unknown",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePool("my-pool")),
+				),
+				// No status set
+			),
+			expected: metav1.ConditionUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := llmisvc.IsInferencePoolV1Supported(tt.route)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestIsInferencePoolSupportedWithMultipleParents(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    *gwapiv1.HTTPRoute
+		expected metav1.ConditionStatus
+	}{
+		{
+			name: "route with both Gateway and Kuadrant controllers - Gateway has ResolvedRefs=True",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePool("my-pool")),
+				),
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayRef("test-gateway", RefInNamespace("test-ns")),
+					GatewayAPIControllerStatus,
+					KuadrantControllerStatus,
+				),
+			),
+			expected: metav1.ConditionTrue,
+		},
+		{
+			name: "route with both Gateway and Kuadrant controllers - Gateway has ResolvedRefs=False InvalidKind",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePool("my-pool")),
+				),
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayRef("test-gateway", RefInNamespace("test-ns")),
+					GatewayAPIControllerStatusInvalidKind,
+					KuadrantControllerStatus,
+				),
+			),
+			expected: metav1.ConditionFalse,
+		},
+		{
+			name: "route with only Kuadrant controller (no ResolvedRefs condition) returns Unknown",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePool("my-pool")),
+				),
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayRef("test-gateway", RefInNamespace("test-ns")),
+					KuadrantControllerStatus, // Only Kuadrant, no Gateway controller
+				),
+			),
+			expected: metav1.ConditionUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := llmisvc.IsInferencePoolV1Supported(tt.route)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_pool_readiness_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_pool_readiness_test.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	igwapiv1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
+
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+)
+
+func TestIsInferencePoolReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pool     *igwapi.InferencePool
+		expected bool
+	}{
+		{
+			name:     "nil pool is not ready",
+			pool:     nil,
+			expected: false,
+		},
+		{
+			name: "pool with no parents is not ready",
+			pool: &igwapi.InferencePool{
+				Spec: igwapi.InferencePoolSpec{
+					Selector: igwapi.LabelSelector{
+						MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{"app": "vllm"},
+					},
+					TargetPorts: []igwapi.Port{{Number: 8080}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pool with Accepted=True parent is ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(igwapi.InferencePoolConditionAccepted),
+									Status: metav1.ConditionTrue,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pool with Accepted=False parent is not ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(igwapi.InferencePoolConditionAccepted),
+									Status: metav1.ConditionFalse,
+									Reason: "NotSupportedByGateway",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pool with missing Accepted condition is not ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							Conditions: []metav1.Condition{
+								{
+									Type:   "SomeOtherCondition",
+									Status: metav1.ConditionTrue,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pool with stale Accepted condition is not ready",
+			pool: &igwapi.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 5,
+				},
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							Conditions: []metav1.Condition{
+								{
+									Type:               string(igwapi.InferencePoolConditionAccepted),
+									Status:             metav1.ConditionTrue,
+									ObservedGeneration: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pool with multiple parents all accepted is ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pool with one parent not accepted among multiple is not ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llmisvc.IsInferencePoolReady(tt.pool)
+			if got != tt.expected {
+				t.Errorf("IsInferencePoolReady() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsInferencePoolV1Alpha2Ready(t *testing.T) {
+	tests := []struct {
+		name     string
+		pool     *igwapiv1alpha2.InferencePool
+		expected bool
+	}{
+		{
+			name:     "nil pool is not ready",
+			pool:     nil,
+			expected: false,
+		},
+		{
+			name: "pool with no parents is not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Spec: igwapiv1alpha2.InferencePoolSpec{
+					Selector:         map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm"},
+					TargetPortNumber: 8080,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pool with Accepted=True parent is ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Spec: igwapiv1alpha2.InferencePoolSpec{
+					Selector:         map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm"},
+					TargetPortNumber: 8080,
+				},
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(igwapiv1alpha2.InferencePoolConditionAccepted),
+									Status: metav1.ConditionTrue,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pool with Accepted=False parent is not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Spec: igwapiv1alpha2.InferencePoolSpec{
+					Selector:         map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm"},
+					TargetPortNumber: 8080,
+				},
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(igwapiv1alpha2.InferencePoolConditionAccepted),
+									Status: metav1.ConditionFalse,
+									Reason: "NotSupportedByGateway",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pool with missing Accepted condition is not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Spec: igwapiv1alpha2.InferencePoolSpec{
+					Selector:         map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm"},
+					TargetPortNumber: 8080,
+				},
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							Conditions: []metav1.Condition{
+								{
+									Type:   "SomeOtherCondition",
+									Status: metav1.ConditionTrue,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pool with stale Accepted condition is not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 5,
+				},
+				Spec: igwapiv1alpha2.InferencePoolSpec{
+					Selector:         map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm"},
+					TargetPortNumber: 8080,
+				},
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							Conditions: []metav1.Condition{
+								{
+									Type:               string(igwapiv1alpha2.InferencePoolConditionAccepted),
+									Status:             metav1.ConditionTrue,
+									ObservedGeneration: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pool with multiple parents all accepted is ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Spec: igwapiv1alpha2.InferencePoolSpec{
+					Selector:         map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm"},
+					TargetPortNumber: 8080,
+				},
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pool with one parent not accepted among multiple is not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Spec: igwapiv1alpha2.InferencePoolSpec{
+					Selector:         map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm"},
+					TargetPortNumber: 8080,
+				},
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llmisvc.IsInferencePoolV1Alpha2Ready(tt.pool)
+			if got != tt.expected {
+				t.Errorf("IsInferencePoolV1Alpha2Ready() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

During the `v1alpha2` to `v1` `InferencePool` migration, the controller creates both pool versions. However, `EvaluateInferencePoolConditions` only checked the v1 pool - if the gateway only accepts `v1alpha2`, this reports "not ready" even though the `v1alpha2` pool IS ready.

For managed pools (not referenced), check both v1 and v1alpha2 InferencePool readiness and consider the pool ready if at least one version is accepted by the gateway. This prevents false "not ready" status during migration.

Uses typed clients for both pool versions (upstream already has igwapi v1 and igwapiv1alpha2 typed imports).

Additionally, rework `IsInferencePoolReady` (`v1` and `v1alpha2`) to no longer treat pools with empty `Status.Parents` as ready. A pool without any gateway claiming it is not ready for traffic - the `Owns()` watch ensures re-reconciliation when a gateway populates the status, and the `WaitingForGateway` reason provides clear observability.

Port of opendatahub-io/kserve#1099, opendatahub-io/kserve#1090

**Release note**:
```release-note
NONE
```
