### PR TITLE
fix(keda): delete legacy KServe-owned HPA before creating ScaledObject

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 
@@ -281,8 +282,49 @@ func semanticScaledObjectEquals(desired, existing *kedav1alpha1.ScaledObject) bo
 	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec)
 }
 
+// cleanupLegacyHPA deletes a KServe-owned HPA with the same name as the ScaledObject, if one exists.
+// This handles the migration case: when the autoscalerClass annotation is changed from "hpa" to "keda",
+// the HPA reconciler is no longer invoked (a KedaReconciler is created instead), so the old HPA would
+// never be cleaned up. The old HPA must be removed before KEDA's admission webhook will accept the
+// new ScaledObject targeting the same Deployment.
+func (r *KedaReconciler) cleanupLegacyHPA(ctx context.Context, name, namespace string) error {
+	existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, existingHPA)
+	if apierr.IsNotFound(err) {
+		return nil // nothing to clean up
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get legacy HPA %s/%s: %w", namespace, name, err)
+	}
+
+	// Only delete HPAs that are owned by an InferenceService to avoid touching user-managed HPAs.
+	isOwnedByKServe := false
+	for _, ref := range existingHPA.OwnerReferences {
+		if strings.HasPrefix(ref.APIVersion, "serving.kserve.io") && ref.Kind == "InferenceService" {
+			isOwnedByKServe = true
+			break
+		}
+	}
+	if !isOwnedByKServe {
+		return nil
+	}
+
+	log.Info("Deleting legacy HPA before creating KEDA ScaledObject", "namespace", namespace, "name", name)
+	if err := r.client.Delete(ctx, existingHPA); err != nil && !apierr.IsNotFound(err) {
+		return fmt.Errorf("failed to delete legacy HPA %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
 func (r *KedaReconciler) Reconcile(ctx context.Context) error {
 	desired := r.ScaledObject
+
+	// Clean up any legacy KServe-managed HPA left over from before the autoscalerClass was changed
+	// to "keda". The HPA reconciler is not called when autoscalerClass=keda, so without this step
+	// the old HPA would block KEDA's admission webhook from accepting the new ScaledObject.
+	if err := r.cleanupLegacyHPA(ctx, desired.Name, desired.Namespace); err != nil {
+		return err
+	}
 
 	existing := &kedav1alpha1.ScaledObject{}
 	getExistingErr := r.client.Get(ctx, types.NamespacedName{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -1014,4 +1015,130 @@ func TestGetOriginalStringMQ(t *testing.T) {
 			assert.Equal(t, tt.expectedOut, result)
 		})
 	}
+}
+
+// newKServeOwnedHPA constructs a minimal HPA whose owner reference points to an InferenceService,
+// mimicking what the HPA reconciler creates for a KServe-managed ISVC.
+func newKServeOwnedHPA(name, namespace string) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "serving.kserve.io/v1beta1",
+					Kind:       "InferenceService",
+					Name:       name,
+				},
+			},
+		},
+	}
+}
+
+// TestCleanupLegacyHPA verifies the three branches of cleanupLegacyHPA:
+//  1. No HPA exists        → no-op, no error
+//  2. HPA exists but not owned by an InferenceService → not deleted
+//  3. HPA exists and is owned by an InferenceService  → deleted
+func TestCleanupLegacyHPA(t *testing.T) {
+	_ = kedav1alpha1.AddToScheme(scheme.Scheme)
+
+	tests := []struct {
+		name          string
+		setupHPA      func(*fake.ClientBuilder) *fake.ClientBuilder
+		expectHPALeft bool
+	}{
+		{
+			name:          "no HPA exists - no-op",
+			setupHPA:      func(c *fake.ClientBuilder) *fake.ClientBuilder { return c },
+			expectHPALeft: false,
+		},
+		{
+			name: "HPA exists but not owned by KServe - not deleted",
+			setupHPA: func(c *fake.ClientBuilder) *fake.ClientBuilder {
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-component",
+						Namespace: "test-namespace",
+					},
+				}
+				return c.WithObjects(hpa)
+			},
+			expectHPALeft: true,
+		},
+		{
+			name: "HPA exists and is KServe-owned - deleted",
+			setupHPA: func(c *fake.ClientBuilder) *fake.ClientBuilder {
+				return c.WithObjects(newKServeOwnedHPA("test-component", "test-namespace"))
+			},
+			expectHPALeft: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			cb = tt.setupHPA(cb)
+			fakeClient := cb.Build()
+
+			r := &KedaReconciler{client: fakeClient, scheme: scheme.Scheme}
+			err := r.cleanupLegacyHPA(t.Context(), "test-component", "test-namespace")
+			require.NoError(t, err)
+
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+			getErr := fakeClient.Get(t.Context(), types.NamespacedName{
+				Name:      "test-component",
+				Namespace: "test-namespace",
+			}, hpa)
+
+			if tt.expectHPALeft {
+				require.NoError(t, getErr, "HPA should still exist")
+			} else {
+				require.True(t, apierr.IsNotFound(getErr), "HPA should have been deleted (or never existed)")
+			}
+		})
+	}
+}
+
+// TestReconcile_MigrateFromHPAToKeda is an integration-style test for the HPA→KEDA migration
+// scenario: when autoscalerClass changes to "keda" while a KServe-owned HPA already exists,
+// Reconcile() should delete the HPA first and then create the ScaledObject without error.
+func TestReconcile_MigrateFromHPAToKeda(t *testing.T) {
+	_ = kedav1alpha1.AddToScheme(scheme.Scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(newKServeOwnedHPA("test-component", "test-namespace")).
+		Build()
+
+	componentMeta := metav1.ObjectMeta{
+		Name:      "test-component",
+		Namespace: "test-namespace",
+	}
+	componentExt := &v1beta1.ComponentExtensionSpec{
+		MinReplicas: ptr.To(int32(1)),
+		MaxReplicas: 3,
+	}
+
+	r, err := NewKedaReconciler(fakeClient, scheme.Scheme, componentMeta, componentExt, &corev1.ConfigMap{})
+	require.NoError(t, err)
+
+	err = r.Reconcile(t.Context())
+	require.NoError(t, err)
+
+	// Legacy HPA must be gone.
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      "test-component",
+		Namespace: "test-namespace",
+	}, hpa)
+	require.True(t, apierr.IsNotFound(err), "legacy HPA should have been deleted during migration")
+
+	// ScaledObject must be created.
+	scaledObject := &kedav1alpha1.ScaledObject{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      "test-component",
+		Namespace: "test-namespace",
+	}, scaledObject)
+	require.NoError(t, err)
+	assert.Equal(t, "test-component", scaledObject.Name)
 }


### PR DESCRIPTION
Prevents KEDA webhook conflict when switching autoscalerClass from hpa to keda on a live InferenceService



**What this PR does / why we need it**:

Related to the issue I filed above. Since there's been no discussion yet, I went ahead and implemented a fix based on my understanding of the root cause — happy to iterate on the approach if the community has other thoughts.

What this does: 
Adds `cleanupLegacyHPA()` in KedaReconciler.Reconcile() to delete any KServe-owned HPA with the same name before creating the `ScaledObject`. This prevents the KEDA admission webhook from rejecting the new `ScaledObject` when autoscalerClass is switched from hpa to keda on a live InferenceService.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5196 


**Feature/Issue validation/testing**:

Added unit tests in [keda_reconciler_test.go](cci:7://file:///Users/yuan/Dev/alauda/aml/kserve.io/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go:0:0-0:0) covering the new [cleanupLegacyHPA](cci:1://file:///Users/yuan/Dev/alauda/aml/kserve.io/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go:284:0-316:1) logic:
- `TestCleanupLegacyHPA/no_HPA_exists`: no-op when there is no pre-existing HPA
- `TestCleanupLegacyHPA/HPA_exists_but_not_owned_by_KServe`: HPA created by the user (no `InferenceService` owner reference) is not touched
- `TestCleanupLegacyHPA/HPA_exists_and_is_KServe-owned`: a KServe-managed HPA is deleted before the ScaledObject is created
- [TestReconcile_MigrateFromHPAToKeda](cci:1://file:///Users/yuan/Dev/alauda/aml/kserve.io/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go:1101:0-1143:1): end-to-end migration path — [Reconcile()](cci:1://file:///Users/yuan/Dev/alauda/aml/kserve.io/kserve/pkg/controller/v1beta1/inferenceservice/components/predictor.go:82:0-258:1) with a pre-existing KServe HPA succeeds, the HPA is deleted, and the ScaledObject is created
All tests pass:
```text
go test ./pkg/controller/v1beta1/inferenceservice/reconcilers/keda/... -run 'TestCleanupLegacyHPA|TestReconcile_MigrateFromHPAToKeda' -v
--- PASS: TestCleanupLegacyHPA (0.00s)
--- PASS: TestReconcile_MigrateFromHPAToKeda (0.00s)
```

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? 
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

NONE
