### PR TITLE
feat(llmisvc): add extra_headers to wait_for_model_response

### DIFF
--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -82,6 +82,7 @@ def create_response_assertion(
 @dataclass
 class TestCase:
     """Test case configuration for LLM inference service tests."""
+
     __test__ = False  # So pytest will not try to execute it.
     base_refs: List[str]
     prompt: str
@@ -456,6 +457,7 @@ def wait_for_model_response(
     kserve_client: KServeClient,
     test_case: TestCase,  # noqa: F811
     timeout_seconds: int = 900,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> str:
     def assert_model_responds():
         try:
@@ -464,6 +466,10 @@ def wait_for_model_response(
             raise AssertionError(f"❌ Failed to get service URL: {e}") from e
 
         model_url = service_url + test_case.endpoint
+
+        headers = {"Content-Type": "application/json"}
+        if extra_headers:
+            headers.update(extra_headers)
 
         if test_case.payload_formatter is not None:
             test_payload = test_case.payload_formatter(test_case)
@@ -474,13 +480,11 @@ def wait_for_model_response(
                 "max_tokens": test_case.max_tokens,
             }
 
-        logger.info(
-            f"Calling LLM service at {model_url} with payload {test_payload}"
-        )
+        logger.info(f"Calling LLM service at {model_url} with payload {test_payload}")
         try:
             response = post_with_retry(
                 model_url,
-                headers={"Content-Type": "application/json"},
+                headers=headers,
                 json_data=test_payload,
                 timeout=test_case.response_timeout,
             )


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an optional `extra_headers` parameter to `wait_for_model_response` in the LLMInferenceService E2E test helpers. This allows callers to inject custom HTTP headers (e.g. `Authorization`) into the retry loop, which is needed for testing authenticated inference endpoints.

Existing callers are unaffected -- the parameter defaults to `None`.

**Type of changes**

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

- No behavioral change to existing tests (default `extra_headers=None` skips the merge)
- Used downstream (ODH) in auth E2E tests to pass `Authorization: Bearer <token>` through the retry loop

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?

```release-note
NONE
```

Made with [Cursor](https://cursor.com)