### PR TITLE
ci: improvements for setup-uv and build-graph image

### DIFF
--- a/test/scripts/gh-actions/build-graph-tests-images.sh
+++ b/test/scripts/gh-actions/build-graph-tests-images.sh
@@ -25,6 +25,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 source "${PROJECT_ROOT}/kserve-images.sh"
 
+BUILDER="${BUILDER:-docker}"
+if command -v podman &>/dev/null && ! command -v docker &>/dev/null; then
+  BUILDER="podman"
+fi
+
 if [ -d "${DOCKER_IMAGES_PATH}" ]; then
   mkdir -p "${DOCKER_IMAGES_PATH}"  
 fi
@@ -35,11 +40,11 @@ ERROR_404_ISVC_IMG_TAG=${KO_DOCKER_REPO}/${ERROR_404_ISVC_IMG}:${TAG}
 
 pushd python >/dev/null
 echo "Building success_200_isvc image"
-docker buildx build -t "${SUCCESS_200_ISVC_IMG_TAG}" -f success_200_isvc.Dockerfile \
+${BUILDER} buildx build -t "${SUCCESS_200_ISVC_IMG_TAG}" -f success_200_isvc.Dockerfile \
   -o type=docker,dest="${DOCKER_IMAGES_PATH}/${SUCCESS_200_ISVC_IMG}-${TAG}",compression-level=0 .
 echo "Done building success_200_isvc image"
 echo "Building error_404_isvc image"
-docker buildx build -t "${ERROR_404_ISVC_IMG_TAG}" -f error_404_isvc.Dockerfile \
+${BUILDER} buildx build -t "${ERROR_404_ISVC_IMG_TAG}" -f error_404_isvc.Dockerfile \
   -o type=docker,dest="${DOCKER_IMAGES_PATH}/${ERROR_404_ISVC_IMG}-${TAG}",compression-level=0 .
 echo "Done building error_404_isvc image"
 popd

--- a/test/scripts/gh-actions/setup-uv.sh
+++ b/test/scripts/gh-actions/setup-uv.sh
@@ -32,6 +32,6 @@ if [ -n "${GITHUB_PATH:-}" ]; then
 fi
 
 echo "Creating virtual environment..."
-uv venv
+uv venv --clear
 source .venv/bin/activate
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add `--clear` flag to uv venv to ensure a clean virtual environment even when a stale .venv directory already exists
- Add `BUILDER` variable to support podman as an alternative to docker, with automatic detection when only podman is available

Both changes align upstream with opendatahub-io/kserve CI practices. The --clear flag avoids flaky CI runs caused by leftover venvs, and podman support enables building images in environments where docker is not installed - a common setup in Red Hat CI infrastructure.

**Release note**:
```release-note
NONE
```
