### PR TITLE
feat: centralize storage initializer dependencies

### DIFF
--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -4,9 +4,11 @@ ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
 
-# Install all system dependencies first
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Install all system dependencies first (including Kerberos libs required by krbcontext and requests-kerberos)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-dev curl build-essential \
+    gcc libkrb5-dev krb5-config \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     ln -s /root/.local/bin/uv /usr/local/bin/uv
@@ -23,20 +25,6 @@ RUN cd storage && uv sync --active --no-cache
 
 COPY storage storage
 RUN cd storage && uv pip install . --no-cache 
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y \
-    gcc \
-    libkrb5-dev \
-    krb5-config \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Kerberos-related packages
-RUN uv pip install --no-cache \
-    krbcontext==0.10 \
-    hdfs~=2.6.0 \
-    requests-kerberos==0.14.0
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml

--- a/python/storage/pyproject.toml
+++ b/python/storage/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "huggingface-hub[hf-transfer]>=0.32.0",
     "dulwich>=0.21.0",
     "cryptography>=46.0.5", # CVE-2026-26007 cryptography Subgroup Attack Due to Missing Subgroup Validation for SECT Curves
+    # Kerberos/HDFS dependencies - centralizing dependencies, moved from Containerfile
+    "krbcontext==0.10",
+    "hdfs~=2.6.0",
+    "requests-kerberos==0.14.0",
 ]
 name = "kserve-storage"
 version = "0.17.0rc1"


### PR DESCRIPTION
chore:  Move the Python dependencies from the storageInitializer.Dockerfile to its pyproject.toml.
        It facilitates de dependency management.



**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
<!--  Write your release note:

-->
```release-note
NONE
```
