### PR TITLE
feat: allow configuring GatewayClass for llmisvc e2e tests

### DIFF
--- a/test/e2e/llmisvc/test_resources.py
+++ b/test/e2e/llmisvc/test_resources.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from .fixtures import KSERVE_TEST_NAMESPACE
+
+# GatewayClass name - can be overridden via GATEWAY_CLASS_NAME env var (e.g., "istio")
+GATEWAY_CLASS_NAME = os.environ.get("GATEWAY_CLASS_NAME", "envoy")
 
 ROUTER_GATEWAYS = [
     {
@@ -23,7 +28,7 @@ ROUTER_GATEWAYS = [
             "namespace": KSERVE_TEST_NAMESPACE,
         },
         "spec": {
-            "gatewayClassName": "envoy",
+            "gatewayClassName": GATEWAY_CLASS_NAME,
             "listeners": [
                 {
                     "name": "http",
@@ -46,7 +51,7 @@ ROUTER_GATEWAYS = [
             "namespace": KSERVE_TEST_NAMESPACE,
         },
         "spec": {
-            "gatewayClassName": "envoy",
+            "gatewayClassName": GATEWAY_CLASS_NAME,
             "listeners": [
                 {
                     "name": "http",


### PR DESCRIPTION
Allow configuring GW class in e2e test with GATEWAY_CLASS_NAME env variable