### PR TITLE
feat(llmisvc): add platform hooks for networking and manager cfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,9 @@ manifests: controller-gen kustomize yq
 	@$(CONTROLLER_GEN) rbac:roleName=kserve-llmisvc-manager-role paths=./pkg/controller/v1alpha2/llmisvc output:rbac:artifacts:config=config/rbac/llmisvc
 	@$(CONTROLLER_GEN) rbac:roleName=kserve-localmodel-manager-role paths=./pkg/controller/v1alpha1/localmodel output:rbac:artifacts:config=config/rbac/localmodel
 	@$(CONTROLLER_GEN) rbac:roleName=kserve-localmodelnode-agent-role paths=./pkg/controller/v1alpha1/localmodelnode output:rbac:artifacts:config=config/rbac/localmodelnode
-	
+	# Hook for distro-specific manifest generation (override via Makefile.overrides.mk).
+	@$(MAKE) manifests-distro
+
 	# DO NOT COPY to helm chart. It needs to be created before the Envoy Gateway or you will need to restart the Envoy Gateway controller.
 	# The llmisvc helm chart needs to be installed after the Envoy Gateway as well, so it needs to be created before the llmisvc helm chart.
 	$(KUSTOMIZE) build https://github.com/kubernetes-sigs/gateway-api-inference-extension.git/config/crd?ref=$(GIE_VERSION) > config/llmisvc/gateway-inference-extension.yaml
@@ -608,6 +610,10 @@ apidocs:
 .PHONY: check-doc-links
 check-doc-links:
 	@python3 hack/verify-doc-links.py && echo "$@: OK"
+
+# Extension point for distro-specific manifest generation.
+.PHONY: manifests-distro
+manifests-distro:
 
 # Optional local/downstream overrides (ignored if absent)
 -include Makefile.overrides.mk

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -167,7 +167,7 @@ func main() {
 
 	llmSvcCacheSelector, _ := metav1.LabelSelectorAsSelector(&llmisvc.ChildResourcesLabelSelector)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOpts := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: options.webhookPort, TLSOpts: tlsOpts}),
@@ -193,7 +193,13 @@ func main() {
 				},
 			},
 		},
-	})
+	}
+
+	if err := customizeManagerOptions(&mgrOpts); err != nil {
+		setupLog.Error(err, "failed to apply distribution-specific manager options")
+		os.Exit(1)
+	}
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/cmd/llmisvc/manager_options_default.go
+++ b/cmd/llmisvc/manager_options_default.go
@@ -1,0 +1,25 @@
+//go:build !distro
+
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import ctrl "sigs.k8s.io/controller-runtime"
+
+// customizeManagerOptions is a hook for distribution-specific manager configuration
+// such as adding extra cache watches or modifying controller options.
+func customizeManagerOptions(_ *ctrl.Options) error { return nil }

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -276,6 +276,10 @@ func (r *LLMISVCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueOnLLMInferenceServicePods),
 			builder.WithPredicates(PodStatusPredicate()))
 
+	if err := extendControllerSetup(mgr, b); err != nil {
+		return fmt.Errorf("failed to extend controller setup: %w", err)
+	}
+
 	if ok, err := utils.IsCrdAvailable(mgr.GetConfig(), gwapiv1.GroupVersion.String(), "HTTPRoute"); ok && err == nil {
 		b = b.Owns(&gwapiv1.HTTPRoute{}, builder.WithPredicates(childResourcesPredicate)).
 			Watches(&gwapiv1.HTTPRoute{}, r.enqueueOnHttpRouteChange(logger))

--- a/pkg/controller/v1alpha2/llmisvc/controller_setup_default.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_setup_default.go
@@ -1,0 +1,30 @@
+//go:build !distro
+
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// extendControllerSetup is a hook for distribution-specific controller setup such as
+// registering additional API schemes or adding ownership watches for platform-specific resources.
+func extendControllerSetup(_ manager.Manager, _ *builder.Builder) error {
+	return nil
+}

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -99,6 +99,12 @@ func (r *LLMISVCReconciler) reconcileRouter(ctx context.Context, llmSvc *v1alpha
 		return fmt.Errorf("failed to reconcile HTTP routes: %w", err)
 	}
 
+	// Reconcile platform-specific networking resources
+	if err := r.reconcileRouterPlatformNetworking(ctx, llmSvc); err != nil {
+		llmSvc.MarkHTTPRoutesNotReady("PlatformNetworkingReconcileError", "Failed to reconcile platform networking: %v", err.Error())
+		return fmt.Errorf("failed to reconcile router platform networking: %w", err)
+	}
+
 	// Evaluate the subconditions to determine overall router health
 	if err := r.EvaluateInferencePoolConditions(ctx, llmSvc); err != nil {
 		return fmt.Errorf("failed to evaluate Inference Pool conditions: %w", err)

--- a/pkg/controller/v1alpha2/llmisvc/router_platform_networking_default.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_platform_networking_default.go
@@ -1,0 +1,31 @@
+//go:build !distro
+
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+// reconcileRouterPlatformNetworking is a hook for distribution-specific networking setup
+// required by the router (e.g. Istio DestinationRules for TLS origination).
+func (r *LLMISVCReconciler) reconcileRouterPlatformNetworking(_ context.Context, _ *v1alpha2.LLMInferenceService) error {
+	return nil
+}

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_cert_default.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_cert_default.go
@@ -1,0 +1,34 @@
+//go:build !distro
+
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import "context"
+
+// createWorkloadCertificate returns a createCertFunc that generates a self-signed TLS certificate.
+// Because the certificate signs itself (issuer = subject, same key pair), it is its own CA -
+// ca.crt is therefore identical to tls.crt.
+func (r *LLMISVCReconciler) createWorkloadCertificate(_ context.Context, dnsNames []string, ips []string) createCertFunc {
+	return func() (*certBundle, error) {
+		keyBytes, certBytes, err := createSelfSignedTLSCertificate(dnsNames, ips)
+		if err != nil {
+			return nil, err
+		}
+		return &certBundle{Key: keyBytes, Cert: certBytes, CACert: certBytes}, nil
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"maps"
 	"math/big"
@@ -67,12 +68,10 @@ func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, 
 
 	// Generating a new certificate is quite slow and expensive as it generates a new certificate, check if the current
 	// self-signed certificate (if any) is expired before creating a new one.
-	var certFunc createCertFunc = func() ([]byte, []byte, error) {
-		return createSelfSignedTLSCertificate(dnsNames, ips)
-	}
+	certFunc := r.createWorkloadCertificate(ctx, dnsNames, ips)
 	if curr := r.getExistingSelfSignedCertificate(ctx, llmSvc); curr != nil && !ShouldRecreateCertificate(curr, dnsNames, ips, schedulerConfig.ExpirationAnnotations) {
-		certFunc = func() ([]byte, []byte, error) {
-			return curr.Data["tls.key"], curr.Data["tls.crt"], nil
+		certFunc = func() (*certBundle, error) {
+			return &certBundle{Key: curr.Data["tls.key"], Cert: curr.Data["tls.crt"], CACert: curr.Data["ca.crt"]}, nil
 		}
 	}
 
@@ -91,12 +90,42 @@ func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, 
 	return nil
 }
 
-type createCertFunc func() ([]byte, []byte, error)
+// certBundle holds TLS certificate material.
+// CACert holds the CA certificate. For self-signed certs it equals Cert (the cert is its own CA).
+// Distro hooks may supply a separate CA cert.
+type certBundle struct {
+	Key    []byte
+	Cert   []byte
+	CACert []byte
+}
+
+func (b *certBundle) Validate() error {
+	if len(b.Key) == 0 {
+		return errors.New("certificate bundle is missing private key")
+	}
+	if len(b.Cert) == 0 {
+		return errors.New("certificate bundle is missing certificate")
+	}
+	return nil
+}
+
+type createCertFunc func() (*certBundle, error)
 
 func (r *LLMISVCReconciler) expectedSelfSignedCertsSecret(llmSvc *v1alpha2.LLMInferenceService, certFunc createCertFunc, schedulerConfig *SchedulerConfig) (*corev1.Secret, error) {
-	keyBytes, certBytes, err := certFunc()
+	bundle, err := certFunc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create self-signed TLS certificate: %w", err)
+	}
+	if err := bundle.Validate(); err != nil {
+		return nil, err
+	}
+
+	secretData := map[string][]byte{
+		"tls.key": bundle.Key,
+		"tls.crt": bundle.Cert,
+	}
+	if len(bundle.CACert) > 0 {
+		secretData["ca.crt"] = bundle.CACert
 	}
 
 	expected := &corev1.Secret{
@@ -117,10 +146,7 @@ func (r *LLMISVCReconciler) expectedSelfSignedCertsSecret(llmSvc *v1alpha2.LLMIn
 				*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
 			},
 		},
-		Data: map[string][]byte{
-			"tls.crt": certBytes,
-			"tls.key": keyBytes,
-		},
+		Data: secretData,
 		Type: corev1.SecretTypeTLS,
 	}
 	return expected, nil

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed_test.go
@@ -95,6 +95,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				Data: map[string][]byte{
 					"tls.key": validKey,
 					"tls.crt": validCert,
+					"ca.crt":  validCert,
 				},
 			},
 			want: true,
@@ -109,6 +110,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					"tls.crt": validCert,
+					"ca.crt":  validCert,
 				},
 			},
 			want: true,
@@ -123,9 +125,27 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					"tls.key": validKey,
+					"ca.crt":  validCert,
 				},
 			},
 			want: true,
+		},
+		{
+			name: "missing ca.crt - no recreation needed, will be added on next cert renewal",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						llmisvc.DefaultExpirationAnnotations[0]: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+					},
+				},
+				Data: map[string][]byte{
+					"tls.key": validKey,
+					"tls.crt": validCert,
+				},
+			},
+			expectedDNSNames: []string{"localhost"},
+			expectedIPs:      []string{"127.0.0.1"},
+			want:             false,
 		},
 		{
 			name: "invalid cert PEM",
@@ -138,6 +158,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				Data: map[string][]byte{
 					"tls.key": validKey,
 					"tls.crt": []byte("not-a-pem"),
+					"ca.crt":  validCert,
 				},
 			},
 			want: true,
@@ -153,6 +174,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				Data: map[string][]byte{
 					"tls.key": []byte("not-a-pem"),
 					"tls.crt": validCert,
+					"ca.crt":  validCert,
 				},
 			},
 			want: true,
@@ -168,6 +190,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				Data: map[string][]byte{
 					"tls.key": validKey,
 					"tls.crt": validCert,
+					"ca.crt":  validCert,
 				},
 			},
 			expectedDNSNames: []string{"localhost", "svc.cluster.local", "new-dns-name.example.com"},
@@ -185,6 +208,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				Data: map[string][]byte{
 					"tls.key": validKey,
 					"tls.crt": validCert,
+					"ca.crt":  validCert,
 				},
 			},
 			expectedDNSNames: []string{"localhost"},
@@ -202,6 +226,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				Data: map[string][]byte{
 					"tls.key": validKey,
 					"tls.crt": validCert,
+					"ca.crt":  validCert,
 				},
 			},
 			expectedDNSNames: []string{"localhost"},
@@ -219,6 +244,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 				Data: map[string][]byte{
 					"tls.key": validKey,
 					"tls.crt": validCert,
+					"ca.crt":  validCert,
 				},
 			},
 			expectedDNSNames: []string{"localhost"},
@@ -278,6 +304,7 @@ func TestShouldRecreateCertificate(t *testing.T) {
 					Data: map[string][]byte{
 						"tls.key": key,
 						"tls.crt": cert,
+						"ca.crt":  cert,
 					},
 				}
 			}(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #5217. Adds more build-tag extension points so distribution builds can plug in platform-specific behavior without touching upstream files.

New hooks:
- `createWorkloadCertificate` - lets distributions provide CA-signed TLS certs instead of self-signed ones, using a `certBundle` struct that cleanly separates key, cert, and optional CA material
- `reconcileRouterPlatformNetworking` - platform-specific networking setup after HTTP route reconciliation
- `extendControllerSetup` - platform-specific scheme registration and ownership watches during controller init
- `customizeManagerOptions` - distributions can extend the manager's cache configuration without modifying `main.go`

Also adds a `manifests-distro` Makefile hook for distribution-specific manifest generation.

Each hook follows the established `_default.go` (`//go:build !distro`) companion file pattern. Upstream files are no-ops; distribution builds provide the real implementations behind `//go:build distro`.

**Special notes for your reviewer**:

This PR only adds upstream no-op hooks - the actual platform implementations live behind `//go:build distro` in distribution forks.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Add build-tag extension points for distribution-specific TLS certificate creation, router networking, controller setup, and manager options configuration in the LLMInferenceService controller.
```