### PR TITLE
fix(llmisvc): add missing os.Exit(1) after controller setup failure

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -205,6 +205,7 @@ func main() {
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMInferenceService")
+		os.Exit(1)
 	}
 
 	v1alpha1ConfigValidator := &v1alpha1.LLMInferenceServiceConfigValidator{


### PR DESCRIPTION
Closes #5241 

Added missing `os.Exit(1)` after `LLMISVCReconciler.SetupWithManager` failure in `cmd/llmisvc/main.go`, consistent with all other setup blocks in the file.