### PR TITLE
feat: add offset_mapping output for HuggingFace token classification

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/__main__.py
+++ b/python/huggingfaceserver/huggingfaceserver/__main__.py
@@ -140,6 +140,12 @@ parser.add_argument(
 parser.add_argument(
     "--return_token_type_ids", action="store_true", help="Return token type ids"
 )
+parser.add_argument(
+    "--return_offsets_mapping",
+    action="store_true",
+    default=False,
+    help="Return start/end character offsets for each token (token_classification only).",
+)
 
 # Create a mutually exclusive group for output format options
 # This group allows the user to choose between returning probabilities or disabling postprocessing.
@@ -312,6 +318,7 @@ def load_model():
                 tensor_input_names=kwargs.get("tensor_input_names", None),
                 return_token_type_ids=kwargs.get("return_token_type_ids", None),
                 request_logger=request_logger,
+                return_offsets_mapping=kwargs.get("return_offsets_mapping", False),
                 return_probabilities=kwargs.get("return_probabilities", False),
                 return_raw_logits=kwargs.get("return_raw_logits", False),
             )

--- a/python/huggingfaceserver/huggingfaceserver/encoder_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/encoder_model.py
@@ -305,7 +305,7 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
             try:
                 with torch.no_grad():
                     outputs = self._model(**input_batch, return_dict=True)
-                    if self.task == MLTask.text_embedding.value:
+                    if self.task == MLTask.text_embeddin:
                         # last_hidden_state contains all token embeddings
                         outputs = outputs.last_hidden_state
                     else:

--- a/python/huggingfaceserver/huggingfaceserver/encoder_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/encoder_model.py
@@ -20,6 +20,8 @@ import struct
 import time
 import torch
 import torch.nn.functional as F
+import numpy as np
+from kserve import InferOutput
 from accelerate import init_empty_weights
 from kserve import Model
 from kserve.logging import logger
@@ -98,6 +100,7 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
         model_revision: Optional[str] = None,
         tokenizer_revision: Optional[str] = None,
         trust_remote_code: bool = False,
+        return_offsets_mapping: bool = False,
         return_probabilities: bool = False,
         request_logger: Optional[RequestLogger] = None,
         return_raw_logits: bool = False,
@@ -114,6 +117,7 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
         self.model_revision = model_revision
         self.tokenizer_revision = tokenizer_revision
         self.trust_remote_code = trust_remote_code
+        self.return_offsets_mapping = return_offsets_mapping
         self.return_probabilities = return_probabilities
         self.return_raw_logits = return_raw_logits
         self.request_logger = request_logger
@@ -214,6 +218,15 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
         context: Dict[str, Any],
     ) -> Union[BatchEncoding, InferRequest]:
         instances = get_predict_input(payload)
+        need_offsets = (self.task == MLTask.token_classification) and getattr(
+            self, "return_offsets_mapping", False
+        )
+
+        if need_offsets and not getattr(self._tokenizer, "is_fast", False):
+            raise ValueError(
+                "return_offsets_mapping requires a fast tokenizer (tokenizers backend)."
+            )
+
         if isinstance(payload, InferRequest):
             request_id = payload.id
         else:
@@ -230,7 +243,13 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
                 return_token_type_ids=self.return_token_type_ids,
                 padding=True,
                 truncation=True,
+                return_offsets_mapping=need_offsets,
             )
+            if need_offsets:
+                offset_mapping = inputs.pop("offset_mapping", None)
+                if offset_mapping is not None and hasattr(offset_mapping, "tolist"):
+                    offset_mapping = offset_mapping.tolist()
+                context["offset_mapping"] = offset_mapping
             context["payload"] = payload
             context["input_ids"] = inputs["input_ids"]
             if self.task == MLTask.text_embedding:
@@ -258,7 +277,13 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
                 return_token_type_ids=self.return_token_type_ids,
                 padding=True,
                 truncation=True,
+                return_offsets_mapping=need_offsets,
             )
+            if need_offsets:
+                offset_mapping = inputs.pop("offset_mapping", None)
+                if offset_mapping is not None and hasattr(offset_mapping, "tolist"):
+                    offset_mapping = offset_mapping.tolist()
+                context["offset_mapping"] = offset_mapping
             context["payload"] = payload
             context["input_ids"] = inputs["input_ids"]
             if self.task == MLTask.text_embedding:
@@ -280,7 +305,7 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
             try:
                 with torch.no_grad():
                     outputs = self._model(**input_batch, return_dict=True)
-                    if self.task == MLTask.text_embedding:
+                    if self.task == MLTask.text_embedding.value:
                         # last_hidden_state contains all token embeddings
                         outputs = outputs.last_hidden_state
                     else:
@@ -314,6 +339,31 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
             return get_predict_response(request, inferences, self.name)
         elif self.task == MLTask.token_classification:
             inferences = self._process_token_classification(normalized_outputs)
+            resp = get_predict_response(request, inferences, self.name)
+            if getattr(self, "return_offsets_mapping", False):
+                offset_mapping = context.get("offset_mapping")
+                if offset_mapping is not None:
+                    offsets_np = np.asarray(offset_mapping, dtype=np.int64)
+                    if offsets_np.ndim == 2:
+                        offsets_np = offsets_np[None, :, :]
+                    offset_out = InferOutput(
+                        name="offset_mapping",
+                        datatype=from_np_dtype(offsets_np.dtype),
+                        shape=list(offsets_np.shape),
+                        data=offsets_np,
+                    )
+                    if hasattr(resp, "outputs") and isinstance(resp.outputs, list):
+                        resp.outputs.append(offset_out)
+                    elif isinstance(resp, dict):
+                        resp.setdefault("outputs", []).append(
+                            {
+                                "name": "offset_mapping",
+                                "datatype": from_np_dtype(offsets_np.dtype),
+                                "shape": list(offsets_np.shape),
+                                "data": offsets_np.flatten().tolist(),
+                            }
+                        )
+                return resp
             return get_predict_response(request, inferences, self.name)
         elif self.task == MLTask.text_embedding:
             inferences = self._process_text_embedding(

--- a/python/huggingfaceserver/huggingfaceserver/encoder_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/encoder_model.py
@@ -305,7 +305,7 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
             try:
                 with torch.no_grad():
                     outputs = self._model(**input_batch, return_dict=True)
-                    if self.task == MLTask.text_embeddin:
+                    if self.task == MLTask.text_embedding:
                         # last_hidden_state contains all token embeddings
                         outputs = outputs.last_hidden_state
                     else:

--- a/python/huggingfaceserver/tests/test_token_classification_offsets.py
+++ b/python/huggingfaceserver/tests/test_token_classification_offsets.py
@@ -1,0 +1,65 @@
+# Copyright 2023 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from huggingfaceserver.encoder_model import HuggingfaceEncoderModel
+
+
+@pytest.fixture(scope="module")
+def bert_token_classification_return_offsets_mapping():
+    model = HuggingfaceEncoderModel(
+        "bert-large-cased-finetuned-conll03-english",
+        model_id_or_path="dbmdz/bert-large-cased-finetuned-conll03-english",
+        do_lower_case=True,
+        add_special_tokens=False,
+        dtype=torch.float32,
+        return_offsets_mapping=True,
+    )
+    model.load()
+    yield model
+    model.stop()
+
+
+@pytest.mark.asyncio
+async def test_bert_token_classification_return_offsets_mapping(
+    bert_token_classification_return_offsets_mapping,
+):
+    request = "HuggingFace is a company based in Paris and New York"
+    response, _ = await bert_token_classification_return_offsets_mapping(
+        {"instances": [request, request]}, headers={}
+    )
+
+    assert "predictions" in response
+    assert len(response["predictions"]) == 2
+
+    assert "outputs" in response
+    offset_out = next(
+        (o for o in response["outputs"] if o.get("name") == "offset_mapping"),
+        None,
+    )
+    assert offset_out is not None
+
+    assert offset_out["datatype"] in ("INT64", "INT32")
+    assert offset_out["shape"][0] == 2
+    assert offset_out["shape"][-1] == 2
+
+    seq_len_pred = len(response["predictions"][0][0])
+    seq_len_offs = offset_out["shape"][1]
+    assert seq_len_offs == seq_len_pred
+
+    data = offset_out["data"]
+    assert len(data) == 2 * seq_len_offs * 2
+    assert all(isinstance(x, int) for x in data)


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds support for returning `offset_mapping` for HuggingFace token classification models.

The HuggingFace tokenizer can optionally return `offset_mapping`, which provides the start and end character positions of each token in the original input text. This information is useful for downstream tasks such as:

- Named Entity Recognition (NER)
- Token-level alignment
- Highlighting model predictions in the original text

Currently, the KServe HuggingFace encoder model does not expose this information in the inference response.  
This PR introduces an optional flag to enable returning offset mappings.

Changes include:

- Add CLI flag `--return_offsets_mapping`
- Pass `return_offsets_mapping` to the tokenizer during preprocessing
- Store `offset_mapping` in the request context
- Return `offset_mapping` via the KServe V2 `outputs` field
- Add a new pytest to validate the functionality

---

### Which issue(s) this PR fixes

Fixes #4528

---

### Feature/Issue validation/testing

The following validation steps were performed:

- Added a new test `test_token_classification_offsets.py`
- Verified that predictions are still returned correctly
- Verified that `offset_mapping` is included in the response `outputs`
- Validated output shape `[batch_size, sequence_length, 2]`
- Confirmed that returned values are integer start/end character offsets

Run the test with:

```bash
cd python/huggingfaceserver
python -m pytest -q tests/test_token_classification_offsets.py
```
Test result: **1 passed**