### PR TITLE
fix(ci): configure git identity for merge commits in CI workflows

### DIFF
--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -44,6 +44,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/custom-model-grpc-publish.yml
+++ b/.github/workflows/custom-model-grpc-publish.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -40,6 +40,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
       - uses: dorny/paths-filter@v3
         id: filter
@@ -74,6 +76,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -127,6 +131,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,6 +40,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
       - uses: dorny/paths-filter@v3
         id: filter
@@ -74,6 +76,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -154,6 +158,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -266,6 +272,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -303,6 +311,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -356,6 +366,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -434,6 +446,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -541,6 +555,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -637,6 +653,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -754,6 +772,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -841,6 +861,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -909,6 +931,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -1051,6 +1075,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -1152,6 +1178,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -1258,6 +1286,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -1333,6 +1363,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables
@@ -1408,6 +1440,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Load KServe environment variables

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,8 @@ jobs:
               run: |
                 git fetch --unshallow origin
                 git fetch origin ${{ github.event.pull_request.base.ref }}
+                git config user.email "ci@kserve.io"
+                git config user.name "CI Bot"
                 git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
             - name: Set up Go 1.x
@@ -84,6 +86,8 @@ jobs:
               run: |
                 git fetch --unshallow origin
                 git fetch origin ${{ github.event.pull_request.base.ref }}
+                git config user.email "ci@kserve.io"
+                git config user.name "CI Bot"
                 git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
             - name: Download cover profile artifact

--- a/.github/workflows/huggingface-cpu-docker-publish.yml
+++ b/.github/workflows/huggingface-cpu-docker-publish.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/huggingface-docker-publish.yml
+++ b/.github/workflows/huggingface-docker-publish.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
+++ b/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/lightgbm-docker-publish.yml
+++ b/.github/workflows/lightgbm-docker-publish.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/paddle-docker-publish.yml
+++ b/.github/workflows/paddle-docker-publish.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/pmml-docker-publish.yml
+++ b/.github/workflows/pmml-docker-publish.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/precommit-check.yml
+++ b/.github/workflows/precommit-check.yml
@@ -21,6 +21,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Setup Go

--- a/.github/workflows/predictiveserver-docker-publish.yml
+++ b/.github/workflows/predictiveserver-docker-publish.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/qpext-docker-publish.yml
+++ b/.github/workflows/qpext-docker-publish.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/scheduled-go-security-scan.yml
+++ b/.github/workflows/scheduled-go-security-scan.yml
@@ -21,6 +21,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Run Gosec Security Scanner

--- a/.github/workflows/sklearnserver-docker-publish.yml
+++ b/.github/workflows/sklearnserver-docker-publish.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/tf2openapi-docker-publisher.yml
+++ b/.github/workflows/tf2openapi-docker-publisher.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space

--- a/.github/workflows/transformer-docker-publish.yml
+++ b/.github/workflows/transformer-docker-publish.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space
@@ -131,6 +133,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Setup Docker Buildx

--- a/.github/workflows/xgbserver-docker-publisher.yml
+++ b/.github/workflows/xgbserver-docker-publisher.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           git fetch --unshallow origin
           git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
           git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space


### PR DESCRIPTION
The 'Merge target branch' steps fail when the PR branch has diverged from the base branch because git needs a committer identity to create merge commits. This adds git config user.email/name before git merge in all workflow files.
