### PR TITLE
fix(controllers): gracefully handle resource deletion

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -326,7 +326,7 @@ func (r *InferenceGraphReconciler) updateStatus(ctx context.Context, desiredGrap
 	graph := &v1alpha1.InferenceGraph{}
 	namespacedName := types.NamespacedName{Name: desiredGraph.Name, Namespace: desiredGraph.Namespace}
 	if err := r.Get(ctx, namespacedName, graph); err != nil {
-		return err
+		return client.IgnoreNotFound(err)
 	}
 
 	wasReady := inferenceGraphReadiness(graph.Status)

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -239,7 +239,7 @@ func (r *LLMISVCReconciler) updateStatus(ctx context.Context, desired *v1alpha2.
 		// Always fetch the latest version to avoid conflicts
 		latest := &v1alpha2.LLMInferenceService{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(desired), latest); err != nil {
-			return err
+			return client.IgnoreNotFound(err)
 		}
 
 		// Skip update if status hasn't changed

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -416,7 +416,7 @@ func (r *InferenceServiceReconciler) updateStatus(ctx context.Context, desiredSe
 	existingService := &v1beta1.InferenceService{}
 	namespacedName := types.NamespacedName{Name: desiredService.Name, Namespace: desiredService.Namespace}
 	if err := r.Get(ctx, namespacedName, existingService); err != nil {
-		return err
+		return client.IgnoreNotFound(err)
 	}
 	wasReady := inferenceServiceReadiness(existingService.Status)
 	if inferenceServiceStatusEqual(existingService.Status, desiredService.Status, deploymentMode) {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a resource is deleted while a reconcile is in flight, the updateStatus re-fetch returns NotFound and triggers error-driven backoff requeues. These requeues are pointless - the next reconcile just finds the resource gone and returns nil - but they delay processing of the deletion event, preventing finalizer cleanup from running promptly.

Treats a missing resource in updateStatus as a no-op instead of an error, consistent with how the main Reconcile functions already handle NotFound at their entry points.

**Release note**:
```release-note
NONE
```
