### PR TITLE
chore: support for merge queue

### DIFF
--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -20,6 +20,9 @@ on:
       - "!**.md"
       - ".github/workflows/agent-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 
 env:

--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -19,6 +19,9 @@ on:
       - "!**.md"
       - ".github/workflows/artexplainer-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: art-explainer

--- a/.github/workflows/custom-model-grpc-publish.yml
+++ b/.github/workflows/custom-model-grpc-publish.yml
@@ -15,6 +15,9 @@ on:
       - "!**.md"
       - ".github/workflows/custom-model-grpc-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: custom-model-grpc

--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -15,6 +15,8 @@ on:
       - ".github/workflows/e2e-test-llmisvc.yaml"
       - ".github/actions/**"
       - "hack/setup/quick-install/llmisvc-dependency-install.sh"
+  merge_group:
+    types: [ checks_requested ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,6 +10,8 @@ on:
       - "!**.md"
       - ".github/workflows/e2e-test.yml"
       - ".github/actions/**"
+  merge_group:
+    types: [ checks_requested ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,8 @@ on:
           - "!docs/**"
           - "!**.md"
           - ".github/workflows/go.yml"
+    merge_group:
+      types: [ checks_requested ]
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/huggingface-cpu-docker-publish.yml
+++ b/.github/workflows/huggingface-cpu-docker-publish.yml
@@ -18,6 +18,9 @@ on:
       - "!**.md"
       - ".github/workflows/huggingface-cpu-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: huggingfaceserver

--- a/.github/workflows/huggingface-docker-publish.yml
+++ b/.github/workflows/huggingface-docker-publish.yml
@@ -18,6 +18,9 @@ on:
       - "!**.md"
       - ".github/workflows/huggingface-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: huggingfaceserver 

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -20,6 +20,9 @@ on:
       - "!**.md"
       - ".github/workflows/kserve-controller-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: kserve-controller

--- a/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
+++ b/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
@@ -20,6 +20,9 @@ on:
       - "!**.md"
       - ".github/workflows/kserve--llmisvccontroller-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: llmisvc-controller

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -20,6 +20,9 @@ on:
       - "!**.md"
       - ".github/workflows/kserve-localmodel-agent-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: kserve-localmodelnode-agent

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -20,6 +20,9 @@ on:
       - "!**.md"
       - ".github/workflows/kserve-localmodel-controller-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: kserve-localmodel-controller

--- a/.github/workflows/lightgbm-docker-publish.yml
+++ b/.github/workflows/lightgbm-docker-publish.yml
@@ -19,6 +19,9 @@ on:
       - "!**.md"
       - ".github/workflows/lightgbm-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: lgbserver

--- a/.github/workflows/paddle-docker-publish.yml
+++ b/.github/workflows/paddle-docker-publish.yml
@@ -19,6 +19,9 @@ on:
       - "!**.md"
       - ".github/workflows/paddle-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: paddleserver

--- a/.github/workflows/pmml-docker-publish.yml
+++ b/.github/workflows/pmml-docker-publish.yml
@@ -19,6 +19,9 @@ on:
       - "!**.md"
       - ".github/workflows/pmml-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: pmmlserver

--- a/.github/workflows/pr-style-check.yml
+++ b/.github/workflows/pr-style-check.yml
@@ -6,6 +6,9 @@ on:
       - opened
       - edited
       - synchronize
+  # This check is not applicable to merge queue
+  # merge_group:
+  #   types: [ checks_requested ]
 
 permissions:
   contents: read

--- a/.github/workflows/precommit-check.yml
+++ b/.github/workflows/precommit-check.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+  merge_group:
+    types: [ checks_requested ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/predictiveserver-docker-publish.yml
+++ b/.github/workflows/predictiveserver-docker-publish.yml
@@ -19,6 +19,9 @@ on:
       - "!**.md"
       - ".github/workflows/predictiveserver-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: predictiveserver

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -4,6 +4,10 @@
 name: "Prow remove lgtm label"
 on: pull_request
 
+# This workflow is not applicable to merge queue
+# merge_group:
+#   types: [ checks_requested ]
+
 jobs:
   remove-lgtm:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,6 +13,8 @@ on:
       - "!**.md"
       - ".github/workflows/python-test.yml"
       - ".github/actions/free-up-disk-space/**"
+  merge_group:
+    types: [ checks_requested ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/qpext-docker-publish.yml
+++ b/.github/workflows/qpext-docker-publish.yml
@@ -20,6 +20,9 @@ on:
       - "!**.md"
       - ".github/workflows/qpext-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: qpext

--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -1,6 +1,8 @@
 name: enforce-required-checks
 on:
   pull_request:
+  merge_group:
+    types: [ checks_requested ]
 jobs:
   enforce-all-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -20,6 +20,9 @@ on:
       - "!**.md"
       - ".github/workflows/router-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: router

--- a/.github/workflows/scheduled-go-security-scan.yml
+++ b/.github/workflows/scheduled-go-security-scan.yml
@@ -2,6 +2,11 @@ name: "Go Security Scan"
 
 on:
   pull_request:
+
+  # Don't do security scan on merge queue. For now, we assume scheduled and PR checks are enough.
+  # merge_group:
+  #   types: [ checks_requested ]
+
   schedule:
     # The scheduled workflow runs every Sunday at 00:00 UTC time.
     - cron: '0 0 * * 0'

--- a/.github/workflows/sklearnserver-docker-publish.yml
+++ b/.github/workflows/sklearnserver-docker-publish.yml
@@ -19,6 +19,9 @@ on:
       - "!**.md"
       - ".github/workflows/sklearnserver-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: sklearnserver

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -19,6 +19,9 @@ on:
       - "!**.md"
       - ".github/workflows/storage-initializer-docker-publisher.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: storage-initializer

--- a/.github/workflows/tf2openapi-docker-publisher.yml
+++ b/.github/workflows/tf2openapi-docker-publisher.yml
@@ -20,6 +20,9 @@ on:
       - "!**.md"
       - ".github/workflows/tf2openapi-docker-publisher.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: tf2openapi

--- a/.github/workflows/transformer-docker-publish.yml
+++ b/.github/workflows/transformer-docker-publish.yml
@@ -15,6 +15,9 @@ on:
       - "!**.md"
       - ".github/workflows/transformer-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: image-transformer

--- a/.github/workflows/xgbserver-docker-publisher.yml
+++ b/.github/workflows/xgbserver-docker-publisher.yml
@@ -19,6 +19,9 @@ on:
       - "!**.md"
       - ".github/workflows/xgbserver-docker-publisher.yml"
       - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
 
 env:
   IMAGE_NAME: xgbserver


### PR DESCRIPTION
**What this PR does / why we need it**:

To support GitHub's merge queue feature, this is adding the needed hook for `merge_group` events to relevant workflows.

Note: Any docker-publish workflows are left out for merge queue with the expectation that it is enough to run those checks on the PR (and skip for the merge queue).


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A


**Feature/Issue validation/testing**:

N/A

**Special notes for your reviewer**:

**Checklist**:

- [N/A] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [N/A] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
