### PR TITLE
feat: enable scheduler TLS cert reload

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -1587,6 +1587,7 @@ spec:
           - "9003"
           - --kv-cache-usage-percentage-metric
           - vllm:kv_cache_usage_perc
+          - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
             end }}'

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -72,6 +72,7 @@ spec:
               - "9003"
               - --kv-cache-usage-percentage-metric
               - "vllm:kv_cache_usage_perc"
+              - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
               - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
               - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{- end }}'
               - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4042,6 +4042,7 @@ spec:
           - "9003"
           - --kv-cache-usage-percentage-metric
           - vllm:kv_cache_usage_perc
+          - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
             end }}'

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -3628,6 +3628,7 @@ spec:
           - "9003"
           - --kv-cache-usage-percentage-metric
           - vllm:kv_cache_usage_perc
+          - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
             end }}'

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -450,6 +450,8 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 	// is restarted to pick up the new certificate.
 	// Skip if the main container supports automatic cert reload.
 	if mainIdx >= 0 &&
+		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Command, "--enable-cert-reload") &&
+		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Command, "-enable-cert-reload") &&
 		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Args, "--enable-cert-reload") &&
 		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Args, "-enable-cert-reload") {
 		if h := r.getSelfSignedCertHash(ctx, llmSvc); h != "" {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -449,7 +449,9 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 	// when certificates are renewed the pod template changes and the scheduler
 	// is restarted to pick up the new certificate.
 	// Skip if the main container supports automatic cert reload.
-	if mainIdx >= 0 && !slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Args, "--enable-cert-reload") {
+	if mainIdx >= 0 &&
+		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Args, "--enable-cert-reload") &&
+		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Args, "-enable-cert-reload") {
 		if h := r.getSelfSignedCertHash(ctx, llmSvc); h != "" {
 			if d.Spec.Template.Annotations == nil {
 				d.Spec.Template.Annotations = map[string]string{}


### PR DESCRIPTION
Enable scheduler to automatically reload TLS certs

Related to https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1765