### PR TITLE
fix: oci support for storageUris (plural)

### DIFF
--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -235,9 +235,48 @@ func CommonStorageInitialization(ctx context.Context, params *StorageInitializer
 		return nil
 	}
 
-	// Don't inject init-containers if a modelcar is used
-	if params.Config.EnableOciImageSource && len(params.StorageURIs) > 0 && strings.HasPrefix(params.StorageURIs[0].Uri, constants.OciURIPrefix) {
-		return nil
+	// Handle OCI URIs via modelcar injection instead of init-containers
+	if params.Config.EnableOciImageSource && len(params.StorageURIs) > 0 {
+		hasOciUri := false
+		for _, storageUri := range params.StorageURIs {
+			if strings.HasPrefix(storageUri.Uri, constants.OciURIPrefix) {
+				hasOciUri = true
+				break
+			}
+		}
+		if hasOciUri {
+			// For the storageUris path (IsLegacyURI == false), inject modelcar directly.
+			// For the legacy path (IsLegacyURI == true), the webhook's InjectModelcar() handles it via annotations.
+			if params.IsLegacyURI {
+				return nil
+			}
+
+			userContainer := utils.GetContainerWithName(params.PodSpec, constants.InferenceServiceContainerName)
+			workerContainer := utils.GetContainerWithName(params.PodSpec, constants.WorkerContainerName)
+			if userContainer == nil && workerContainer == nil {
+				return errors.New("Invalid configuration: cannot find container")
+			}
+
+			for _, storageUri := range params.StorageURIs {
+				if !strings.HasPrefix(storageUri.Uri, constants.OciURIPrefix) {
+					continue
+				}
+				targetContainerName := constants.InferenceServiceContainerName
+				if userContainer == nil {
+					targetContainerName = constants.WorkerContainerName
+				}
+				if err := utils.ConfigureModelcarToContainer(storageUri.Uri, params.PodSpec, targetContainerName, storageUri.MountPath, params.Config); err != nil {
+					return err
+				}
+				// Also configure for transformer if present
+				if utils.GetContainerWithName(params.PodSpec, constants.TransformerContainerName) != nil {
+					if err := utils.ConfigureModelcarToContainer(storageUri.Uri, params.PodSpec, constants.TransformerContainerName, storageUri.MountPath, params.Config); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}
 	}
 
 	// Don't inject if InitContainer already injected

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -5099,3 +5099,155 @@ func createTestPodForModelcarWithWorkerAndTransformer() *corev1.Pod {
 		},
 	}
 }
+
+// TestCommonStorageInitializationWithOciURI tests the fix for issue #5200:
+// storageUris with oci:// should inject modelcar and model volume mounts.
+func TestCommonStorageInitializationWithOciURI(t *testing.T) {
+	t.Run("OCI URI via storageUris injects modelcar", func(t *testing.T) {
+		podSpec := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName},
+			},
+		}
+
+		params := &StorageInitializerParams{
+			Namespace: "default",
+			StorageURIs: []v1beta1.StorageUri{
+				{Uri: "oci://rhuss/kserving-example-sklearn:1.0", MountPath: constants.DefaultModelLocalMountPath},
+			},
+			IsReadOnly:      true,
+			PodSpec:         &podSpec,
+			Config:          &kserveTypes.StorageInitializerConfig{EnableOciImageSource: true},
+			IsvcAnnotations: map[string]string{},
+			IsLegacyURI:     false,
+		}
+
+		err := CommonStorageInitialization(t.Context(), params)
+		require.NoError(t, err)
+
+		// Modelcar sidecar container should be injected
+		modelcarContainer := utils.GetContainerWithName(&podSpec, constants.ModelcarContainerName)
+		assert.NotNil(t, modelcarContainer, "modelcar sidecar container should be injected")
+
+		// Modelcar init container should be injected for pre-fetching
+		assert.Len(t, podSpec.InitContainers, 1, "modelcar init container should be injected")
+		assert.Equal(t, constants.ModelcarInitContainerName, podSpec.InitContainers[0].Name)
+
+		// ShareProcessNamespace should be enabled
+		assert.NotNil(t, podSpec.ShareProcessNamespace)
+		assert.True(t, *podSpec.ShareProcessNamespace, "ShareProcessNamespace should be true")
+
+		// User container should have async model init mode env var
+		userContainer := utils.GetContainerWithName(&podSpec, constants.InferenceServiceContainerName)
+		assert.NotNil(t, userContainer)
+		found := false
+		for _, env := range userContainer.Env {
+			if env.Name == constants.ModelInitModeEnvVarKey && env.Value == "async" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "user container should have MODEL_INIT_MODE=async env var")
+
+		// Volume should exist
+		assert.NotEmpty(t, podSpec.Volumes, "shared volume should be added")
+	})
+
+	t.Run("OCI URI via storageUris with transformer injects modelcar for both", func(t *testing.T) {
+		podSpec := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName},
+				{Name: constants.TransformerContainerName},
+			},
+		}
+
+		params := &StorageInitializerParams{
+			Namespace: "default",
+			StorageURIs: []v1beta1.StorageUri{
+				{Uri: "oci://rhuss/kserving-example-sklearn:1.0", MountPath: constants.DefaultModelLocalMountPath},
+			},
+			IsReadOnly:      true,
+			PodSpec:         &podSpec,
+			Config:          &kserveTypes.StorageInitializerConfig{EnableOciImageSource: true},
+			IsvcAnnotations: map[string]string{},
+			IsLegacyURI:     false,
+		}
+
+		err := CommonStorageInitialization(t.Context(), params)
+		require.NoError(t, err)
+
+		// Both user container and transformer container should have volume mounts
+		userContainer := utils.GetContainerWithName(&podSpec, constants.InferenceServiceContainerName)
+		transformerContainer := utils.GetContainerWithName(&podSpec, constants.TransformerContainerName)
+		assert.NotNil(t, userContainer)
+		assert.NotNil(t, transformerContainer)
+		assert.NotEmpty(t, userContainer.VolumeMounts, "user container should have volume mounts")
+		assert.NotEmpty(t, transformerContainer.VolumeMounts, "transformer container should have volume mounts")
+	})
+
+	t.Run("Legacy OCI URI path still returns nil (handled by webhook)", func(t *testing.T) {
+		podSpec := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName},
+			},
+		}
+
+		params := &StorageInitializerParams{
+			Namespace: "default",
+			StorageURIs: []v1beta1.StorageUri{
+				{Uri: "oci://rhuss/kserving-example-sklearn:1.0", MountPath: constants.DefaultModelLocalMountPath},
+			},
+			IsReadOnly:      true,
+			PodSpec:         &podSpec,
+			Config:          &kserveTypes.StorageInitializerConfig{EnableOciImageSource: true},
+			IsvcAnnotations: map[string]string{},
+			IsLegacyURI:     true,
+		}
+
+		err := CommonStorageInitialization(t.Context(), params)
+		require.NoError(t, err)
+
+		// Should NOT inject modelcar — legacy path is handled by InjectModelcar webhook
+		modelcarContainer := utils.GetContainerWithName(&podSpec, constants.ModelcarContainerName)
+		assert.Nil(t, modelcarContainer, "legacy path should not inject modelcar directly")
+	})
+
+	t.Run("OCI URI via storageUris with worker container only", func(t *testing.T) {
+		podSpec := corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.WorkerContainerName},
+			},
+		}
+
+		params := &StorageInitializerParams{
+			Namespace: "default",
+			StorageURIs: []v1beta1.StorageUri{
+				{Uri: "oci://myrepo/mymodel:latest", MountPath: constants.DefaultModelLocalMountPath},
+			},
+			IsReadOnly:      true,
+			PodSpec:         &podSpec,
+			Config:          &kserveTypes.StorageInitializerConfig{EnableOciImageSource: true},
+			IsvcAnnotations: map[string]string{},
+			IsLegacyURI:     false,
+		}
+
+		err := CommonStorageInitialization(t.Context(), params)
+		require.NoError(t, err)
+
+		// Modelcar sidecar should be injected, targeting the worker container
+		modelcarContainer := utils.GetContainerWithName(&podSpec, constants.ModelcarContainerName)
+		assert.NotNil(t, modelcarContainer, "modelcar sidecar should be injected for worker container")
+
+		// Worker container should have the async env var
+		workerContainer := utils.GetContainerWithName(&podSpec, constants.WorkerContainerName)
+		assert.NotNil(t, workerContainer)
+		found := false
+		for _, env := range workerContainer.Env {
+			if env.Name == constants.ModelInitModeEnvVarKey && env.Value == "async" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "worker container should have MODEL_INIT_MODE=async env var")
+	})
+}


### PR DESCRIPTION
## What this PR does

Fixes #5200

### Problem
`storageUris` (plural) with `oci://` URIs did not inject the modelcar sidecar or model volume mounts, causing the model container to fail with `FileNotFoundError: /mnt/models`. The same `oci://` URI worked correctly with the singular `storageUri`.

### Root Cause
`CommonStorageInitialization()` early-returned `nil` when OCI URIs were detected, correctly skipping init-container injection (OCI uses a sidecar, not init-containers), but failing to perform the modelcar injection. The singular `storageUri` path worked because it relied on annotations + the `InjectModelcar()` webhook, which the `storageUris` path bypasses.

### Fix
Instead of early-returning, `CommonStorageInitialization()` now calls `ConfigureModelcarToContainer()` for each OCI URI when using the `storageUris` path (`IsLegacyURI == false`). This injects:
- Modelcar sidecar container
- Modelcar init container (for pre-fetching)
- Shared volume + mounts
- `ShareProcessNamespace = true`
- `MODEL_INIT_MODE=async` env var

The legacy path (`IsLegacyURI == true`) behavior is preserved — it continues to rely on annotations + the `InjectModelcar()` webhook.

### Testing
Added `TestCommonStorageInitializationWithOciURI` with 4 sub-tests:
- OCI URI via storageUris injects modelcar (core fix)
- OCI URI with transformer injects modelcar for both containers
- Legacy OCI URI path still returns nil (backward compatibility)
- OCI URI with worker container only (multi-node fallback)

All existing tests pass with no regressions.