### PR TITLE
modelcache: run namespace-scoped download jobs in jobNamespace

### DIFF
--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -607,9 +607,10 @@ var _ = Describe("CachedModel controller", func() {
 
 var _ = Describe("LocalModelNamespaceCache controller", func() {
 	const (
-		timeout        = time.Second * 10
-		interval       = time.Millisecond * 250
-		sourceModelUri = "s3://mybucket/mymodel"
+		timeout             = time.Second * 10
+		interval            = time.Millisecond * 250
+		sourceModelUri      = "s3://mybucket/mymodel"
+		modelCacheNamespace = "kserve-localmodel-jobs"
 	)
 	var (
 		localModelNamespaceSpec = v1alpha1.LocalModelNamespaceCacheSpec{
@@ -685,7 +686,7 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 
 			modelLookupKey := types.NamespacedName{Name: modelName, Namespace: testNamespace}
 			pvLookupKey1 := types.NamespacedName{Name: modelName + "-gpu1-" + testNamespace + "-download"}
-			pvcLookupKey1 := types.NamespacedName{Name: modelName + "-gpu1-download", Namespace: testNamespace}
+			pvcLookupKey1 := types.NamespacedName{Name: modelName + "-gpu1-" + testNamespace + "-download", Namespace: modelCacheNamespace}
 
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, modelLookupKey, cachedModel)
@@ -707,7 +708,7 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, pvcLookupKey1, persistentVolumeClaim1)
 				return err == nil && persistentVolumeClaim1 != nil
-			}, timeout, interval).Should(BeTrue(), "Download PVC should be created in the same namespace as the cache")
+			}, timeout, interval).Should(BeTrue(), "Download PVC should be created in jobNamespace")
 
 			nodeName1 := "ns-node-1"
 			node1 := &corev1.Node{
@@ -910,7 +911,7 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 			Expect(k8sClient.Create(ctx, cachedModel)).Should(Succeed())
 
 			modelLookupKey := types.NamespacedName{Name: modelName, Namespace: testNamespace}
-			pvcLookupKey := types.NamespacedName{Name: modelName + "-gpu1-download", Namespace: testNamespace}
+			pvcLookupKey := types.NamespacedName{Name: modelName + "-gpu1-" + testNamespace + "-download", Namespace: modelCacheNamespace}
 
 			// Wait for the model to be created with finalizer
 			Eventually(func() bool {

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
@@ -107,9 +107,7 @@ func (c *LocalModelNamespaceCacheReconciler) Reconcile(ctx context.Context, req 
 		c.Log.Error(err, "failed to reconcile LocalModelNode for namespace cache")
 	}
 
-	// Step 3 - Creates PV & PVC for model download (in the CR's namespace)
-	// Note: The download PVC name includes "-download" suffix to avoid conflict with serving PVCs
-	// since for namespace-scoped caches, both download and serving happen in the same namespace
+	// Step 3 - Creates PV & PVC for model download (in jobNamespace, same as cluster-scoped)
 	for _, nodeGroup := range nodeGroups {
 		pvSpec := nodeGroup.Spec.PersistentVolumeSpec
 		pv := corev1.PersistentVolume{Spec: pvSpec, ObjectMeta: metav1.ObjectMeta{
@@ -121,14 +119,13 @@ func (c *LocalModelNamespaceCacheReconciler) Reconcile(ctx context.Context, req 
 
 		pvc := corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: localModel.Name + "-" + nodeGroup.Name + "-download",
+				Name: localModel.Name + "-" + nodeGroup.Name + "-" + localModel.Namespace + "-download",
 			},
 			Spec: nodeGroup.Spec.PersistentVolumeClaimSpec,
 		}
 		pvc.Spec.VolumeName = pv.Name
 
-		// Download jobs run in the same namespace as the LocalModelNamespaceCache
-		if err := CreatePVC(ctx, c.Clientset, c.Scheme, c.Log, pvc, localModel.Namespace, nil, localModel); err != nil {
+		if err := CreatePVC(ctx, c.Clientset, c.Scheme, c.Log, pvc, localModelConfig.JobNamespace, nil, localModel); err != nil {
 			c.Log.Error(err, "Create PVC err", "name", pvc.Name)
 		}
 	}

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/utils.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/utils.go
@@ -235,14 +235,24 @@ func DeleteModelFromNodes(
 			downloadPVName := params.Name + "-" + nodeGroupName + "-" + params.Namespace + "-download"
 			if err := DeletePV(ctx, clientset, log, downloadPVName); err != nil {
 				log.Error(err, "failed to delete download PV", "name", downloadPVName)
-				// Continue with cleanup, don't return error for PV deletion failures
+			}
+
+			// Delete download PVC from jobNamespace (where download jobs run)
+			downloadPVCName := downloadPVName
+			isvcConfigMap, cfgErr := v1beta1.GetInferenceServiceConfigMap(ctx, clientset)
+			if cfgErr == nil {
+				localModelConfig, cfgErr := v1beta1.NewLocalModelConfig(isvcConfigMap)
+				if cfgErr == nil {
+					if err := DeletePVC(ctx, clientset, log, downloadPVCName, localModelConfig.JobNamespace); err != nil {
+						log.Error(err, "failed to delete download PVC from jobNamespace", "name", downloadPVCName, "namespace", localModelConfig.JobNamespace)
+					}
+				}
 			}
 
 			// Delete serving PV: {modelName}-{nodeGroup}-{namespace}
 			servingPVName := params.Name + "-" + nodeGroupName + "-" + params.Namespace
 			if err := DeletePV(ctx, clientset, log, servingPVName); err != nil {
 				log.Error(err, "failed to delete serving PV", "name", servingPVName)
-				// Continue with cleanup, don't return error for PV deletion failures
 			}
 		}
 	}

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -125,7 +125,7 @@ func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode
 
 	pvcName := modelInfo.ModelName + "-" + nodeGroupName
 	if modelInfo.Namespace != "" {
-		pvcName += "-download"
+		pvcName += "-" + modelInfo.Namespace + "-download"
 	}
 	c.Log.Info("Using PVC name to create download job", "current node", nodeName, "node group", nodeGroupName, "PVC name", pvcName)
 
@@ -163,11 +163,7 @@ func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode
 		},
 	}
 
-	// Determine job namespace: use CR's namespace for LocalModelNamespaceCache, otherwise use configured jobNamespace
 	jobNs := jobNamespace
-	if modelInfo.Namespace != "" {
-		jobNs = modelInfo.Namespace
-	}
 
 	// Only inject if credentials are explicitly configured in LocalModelCache
 	if modelInfo.ServiceAccountName != "" || modelInfo.Storage != nil {
@@ -306,12 +302,7 @@ func (c *LocalModelNodeReconciler) getLatestJob(ctx context.Context, modelInfo v
 		labelSelector["modelNamespace"] = modelInfo.Namespace
 	}
 
-	jobNs := jobNamespace
-	if modelInfo.Namespace != "" {
-		jobNs = modelInfo.Namespace
-	}
-
-	if err := c.List(ctx, jobList, client.InNamespace(jobNs), client.MatchingLabels(labelSelector)); err != nil {
+	if err := c.List(ctx, jobList, client.InNamespace(jobNamespace), client.MatchingLabels(labelSelector)); err != nil {
 		if errors.IsNotFound(err) {
 			c.Log.Info("Job not found", "model", modelInfo.ModelName, "namespace", modelInfo.Namespace)
 			return nil, 0, nil
@@ -485,15 +476,11 @@ func (c *LocalModelNodeReconciler) deleteModels(localModelNode v1alpha1.LocalMod
 func (c *LocalModelNodeReconciler) cleanupJobs(ctx context.Context, localModelNode v1alpha1.LocalModelNode) error {
 	// Build a set of status keys that are in the spec
 	statusKeysInSpec := map[string]struct{}{}
-	namespacesInSpec := map[string]struct{}{jobNamespace: {}} // Always include default job namespace
 	for _, modelInfo := range localModelNode.Spec.LocalModels {
 		statusKeysInSpec[modelInfo.GetStatusKey()] = struct{}{}
-		if modelInfo.Namespace != "" {
-			namespacesInSpec[modelInfo.Namespace] = struct{}{}
-		}
 	}
 
-	for ns := range namespacesInSpec {
+	for _, ns := range []string{jobNamespace} {
 		jobs := &batchv1.JobList{}
 		labelSelector := map[string]string{"node": localModelNode.Name}
 		if err := c.List(ctx, jobs, client.InNamespace(ns), client.MatchingLabels(labelSelector)); err != nil {

--- a/pkg/controller/v1alpha1/localmodelnode/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller_test.go
@@ -814,7 +814,7 @@ var _ = Describe("LocalModelNode controller", func() {
 			}, timeout, interval).Should(BeTrue(), "Download job should be created with storage key")
 		})
 
-		It("Should create download job in model namespace for namespace-scoped LocalModelNamespaceCache", func() {
+		It("Should create download job in jobNamespace for namespace-scoped LocalModelNamespaceCache", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
 			fsMock.clear()
@@ -905,9 +905,9 @@ var _ = Describe("LocalModelNode controller", func() {
 				"modelNamespace": modelNamespace,
 			}
 			Eventually(func() bool {
-				err := k8sClient.List(ctx, jobs, client.InNamespace(modelNamespace), client.MatchingLabels(labelSelector))
+				err := k8sClient.List(ctx, jobs, client.InNamespace(modelCacheNamespace), client.MatchingLabels(labelSelector))
 				return err == nil && len(jobs.Items) == 1
-			}, timeout, interval).Should(BeTrue(), "Download job should be created in the model's namespace")
+			}, timeout, interval).Should(BeTrue(), "Download job should be created in jobNamespace")
 
 			job := &jobs.Items[0]
 			Expect(job.Labels["modelNamespace"]).To(Equal(modelNamespace))
@@ -1007,9 +1007,9 @@ var _ = Describe("LocalModelNode controller", func() {
 				"node":  nodeName,
 			}
 			Eventually(func() bool {
-				err := k8sClient.List(ctx, jobs, client.InNamespace(modelNamespace), client.MatchingLabels(labelSelector))
+				err := k8sClient.List(ctx, jobs, client.InNamespace(modelCacheNamespace), client.MatchingLabels(labelSelector))
 				return err == nil && len(jobs.Items) == 1
-			}, timeout, interval).Should(BeTrue(), "Download job should be created")
+			}, timeout, interval).Should(BeTrue(), "Download job should be created in jobNamespace")
 
 			// Update job status to succeeded
 			job := &jobs.Items[0]
@@ -1282,16 +1282,16 @@ var _ = Describe("LocalModelNode controller", func() {
 				"modelNamespace": nsModelNamespace,
 			}
 			Eventually(func() bool {
-				err := k8sClient.List(ctx, jobs, client.InNamespace(nsModelNamespace), client.MatchingLabels(labelSelector))
+				err := k8sClient.List(ctx, jobs, client.InNamespace(modelCacheNamespace), client.MatchingLabels(labelSelector))
 				return err == nil && len(jobs.Items) == 1
-			}, timeout, interval).Should(BeTrue(), "Download job should be created in the model's namespace")
+			}, timeout, interval).Should(BeTrue(), "Download job should be created in jobNamespace")
 
 			job := &jobs.Items[0]
 			Expect(job.Spec.Template.Spec.Volumes).To(HaveLen(1))
 			pvcVolume := job.Spec.Template.Spec.Volumes[0]
 			Expect(pvcVolume.PersistentVolumeClaim).NotTo(BeNil())
-			Expect(pvcVolume.PersistentVolumeClaim.ClaimName).To(Equal(sklearnModelName+"-"+sklearnNodeGroupName+"-download"),
-				"PVC name for namespace-scoped models must include -download suffix to match the PVC created by the namespace cache reconciler")
+			Expect(pvcVolume.PersistentVolumeClaim.ClaimName).To(Equal(sklearnModelName+"-"+sklearnNodeGroupName+"-"+nsModelNamespace+"-download"),
+				"PVC name for namespace-scoped models must include source namespace and -download suffix")
 		})
 
 		It("Should track both cluster-scoped and namespace-scoped models with separate status entries", func() {
@@ -1408,9 +1408,9 @@ var _ = Describe("LocalModelNode controller", func() {
 				"node":  nodeName,
 			}
 			Eventually(func() bool {
-				err := k8sClient.List(ctx, nsJobs, client.InNamespace(modelNamespace), client.MatchingLabels(nsLabelSelector))
+				err := k8sClient.List(ctx, nsJobs, client.InNamespace(modelCacheNamespace), client.MatchingLabels(nsLabelSelector))
 				return err == nil && len(nsJobs.Items) == 1
-			}, timeout, interval).Should(BeTrue(), "Namespace-scoped job should be in model's namespace")
+			}, timeout, interval).Should(BeTrue(), "Namespace-scoped job should be in jobNamespace")
 
 			// Update both jobs to succeeded
 			clusterJob := &clusterJobs.Items[0]


### PR DESCRIPTION
**What this PR does / why we need it**:

For `LocalModelNamespaceCache`, download jobs were previously created in the CR's namespace. This caused two problems:
1. The node agent's RBAC needed job permissions in every user namespace, expanding the blast radius
2. Job lifecycle management was inconsistent between cluster-scoped (`LocalModelCache`) and namespace-scoped caches

This PR moves namespace-scoped download jobs to the configured `jobNamespace`, matching cluster-scoped behavior. The PVC name now includes the source namespace (`{model}-{nodegroup}-{namespace}-download`) to avoid collisions when multiple namespace caches share the same `jobNamespace`. Cleanup logic in `DeleteModelFromNodes` also deletes the download PVC from `jobNamespace`.

**Which issue(s) this PR fixes**:


**Feature/Issue validation/testing**:

- [x] Existing controller tests updated to assert jobs are created in `jobNamespace` instead of the model's namespace
- [x] PVC name format updated in namespace cache reconciler tests
- [x] All localmodelnode and localmodel controller tests pass

**Special notes for your reviewer**:

Changes are limited to the localmodel controllers — no webhook, API, or manifest changes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fix LocalModelNamespaceCache to run download jobs in the configured jobNamespace instead of the CR's namespace, matching cluster-scoped LocalModelCache behavior.
```