### PR TITLE
feat(localmodel): add build hooks for distribution-specific logic

### DIFF
--- a/cmd/localmodelnode/main.go
+++ b/cmd/localmodelnode/main.go
@@ -122,12 +122,14 @@ func main() {
 	localModelNodeEventBroadcaster := record.NewBroadcaster()
 	setupLog.Info("Setting up v1alpha1 LocalModelNode controller")
 	localModelNodeEventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
-	if err = (&localmodelnodecontroller.LocalModelNodeReconciler{
+	reconciler := &localmodelnodecontroller.LocalModelNodeReconciler{
 		Client:    mgr.GetClient(),
 		Clientset: clientSet,
 		Log:       ctrl.Log.WithName("v1alpha1Controllers").WithName("LocalModelNode"),
 		Scheme:    mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}
+
+	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "v1alpha1Controllers", "LocalModelNode")
 		os.Exit(1)
 	}

--- a/localmodel-agent.Dockerfile
+++ b/localmodel-agent.Dockerfile
@@ -21,7 +21,8 @@ RUN go-licenses check ./cmd/${CMD} ./pkg/... --disallowed_types="forbidden,unkno
     go-licenses save --save_path third_party/library ./cmd/${CMD}
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o localmodelnode-agent ./cmd/${CMD}
+ARG GOTAGS=""
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -tags "${GOTAGS}" -a -o localmodelnode-agent ./cmd/${CMD}
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:nonroot

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -67,7 +67,6 @@ type LocalModelNodeReconciler struct {
 }
 
 const (
-	MountPath             = "/mnt/models" // Volume mount path for models, must be the same as the value in the DaemonSet spec
 	DownloadContainerName = "kserve-localmodel-download"
 	PvcSourceMountName    = "kserve-pvc-source"
 )
@@ -204,6 +203,7 @@ func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode
 			},
 		},
 	}
+	enhanceDownloadJob(job, storageKey)
 	if err := controllerutil.SetControllerReference(&localModelNode, job, c.Scheme); err != nil {
 		c.Log.Error(err, "Failed to set controller reference", "name", modelInfo.ModelName)
 		return nil, err
@@ -526,10 +526,8 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// fsHelper is a global variable to allow mocking in tests
 	if fsHelper == nil {
 		fsHelper = NewFileSystemHelper(modelsRootFolder)
-		// TODO we need a way to ensure that the local path on persistent volume is the same as the local path of the node agent DaemonSet.
-		err := fsHelper.ensureModelRootFolderExists()
-		if err != nil {
-			panic("Failed to ensure model root folder exists: " + err.Error())
+		if err := fsHelper.ensureModelRootFolderExists(); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to ensure model root folder: %w", err)
 		}
 	}
 
@@ -575,6 +573,11 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if c.CredentialBuilder == nil {
 		c.CredentialBuilder = credentials.NewCredentialBuilder(c.Client, c.Clientset, isvcConfigMap)
+	}
+
+	result, cont, err := ensureVolumePermissions(ctx, c, localModelConfig)
+	if !cont || err != nil {
+		return result, err
 	}
 
 	if err := c.downloadModels(ctx, &localModelNode); err != nil {

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -64,6 +64,7 @@ type LocalModelNodeReconciler struct {
 	Log               logr.Logger
 	Scheme            *runtime.Scheme
 	CredentialBuilder *credentials.CredentialBuilder
+	IsvcConfigMap     *corev1.ConfigMap
 }
 
 const (
@@ -523,34 +524,13 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	c.Log.Info("Agent reconciling LocalModelNode", "name", req.Name, "node", nodeName)
 
-	// fsHelper is a global variable to allow mocking in tests
-	if fsHelper == nil {
-		fsHelper = NewFileSystemHelper(modelsRootFolder)
-		if err := fsHelper.ensureModelRootFolderExists(); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to ensure model root folder: %w", err)
-		}
-	}
-
-	// Create Jobs to download models if the model is not present locally.
-	// 1. Check if LocalModelNode CR is for current node
-	localModelNode := v1alpha1.LocalModelNode{}
-	if err := c.Get(ctx, req.NamespacedName, &localModelNode); err != nil {
-		c.Log.Error(err, "Error getting LocalModelNode", "name", req.Name)
-		return reconcile.Result{}, client.IgnoreNotFound(err)
-	}
-
-	// 2. Cleanup jobs for models that are not in the spec
-	if err := c.cleanupJobs(ctx, localModelNode); err != nil {
-		c.Log.Error(err, "Job cleanup err")
-		return reconcile.Result{}, err
-	}
-
-	// 3. Kick off download jobs for all models in spec
+	// 1. Load config
 	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, c.Clientset)
 	if err != nil {
 		c.Log.Error(err, "unable to get configmap", "name", constants.InferenceServiceConfigMapName, "namespace", constants.KServeNamespace)
 		return reconcile.Result{}, err
 	}
+	c.IsvcConfigMap = isvcConfigMap
 	localModelConfig, err := v1beta1.NewLocalModelConfig(isvcConfigMap)
 	if err != nil {
 		c.Log.Error(err, "Failed to get local model config")
@@ -568,29 +548,47 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	storageInitializerConfig, err = v1beta1.GetStorageInitializerConfigs(isvcConfigMap)
 	if err != nil {
 		c.Log.Error(err, "Failed to get storage initializer config, using defaults")
-		// Don't fail, just use defaults
 	}
 
 	if c.CredentialBuilder == nil {
 		c.CredentialBuilder = credentials.NewCredentialBuilder(c.Client, c.Clientset, isvcConfigMap)
 	}
 
-	result, cont, err := ensureVolumePermissions(ctx, c, localModelConfig)
+	// 2. Init fsHelper and ensure model root folder exists and is writable
+	if fsHelper == nil {
+		fsHelper = NewFileSystemHelper(modelsRootFolder)
+	}
+
+	result, cont, err := ensureModelRootFolderExistsAndIsWritable(ctx, c, localModelConfig)
 	if !cont || err != nil {
 		return result, err
 	}
 
+	// 3. Get LocalModelNode CR
+	localModelNode := v1alpha1.LocalModelNode{}
+	if err := c.Get(ctx, req.NamespacedName, &localModelNode); err != nil {
+		c.Log.Error(err, "Error getting LocalModelNode", "name", req.Name)
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// 4. Cleanup jobs for models that are not in the spec
+	if err := c.cleanupJobs(ctx, localModelNode); err != nil {
+		c.Log.Error(err, "Job cleanup err")
+		return reconcile.Result{}, err
+	}
+
+	// 5. Download models
 	if err := c.downloadModels(ctx, &localModelNode); err != nil {
 		c.Log.Error(err, "Model download err")
 		return reconcile.Result{}, err
 	}
 
-	// 4. Delete models that are not in the spec. This function does not modify the resource.
+	// 6. Delete models that are not in the spec
 	if err := c.deleteModels(localModelNode); err != nil {
 		c.Log.Error(err, "Model deletion err")
 		return reconcile.Result{}, err
 	}
-	// Requeue to check local folders periodically
+
 	return reconcile.Result{RequeueAfter: reconcilationFreqency}, nil
 }
 

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -58,6 +58,11 @@ import (
 	pkgtypes "github.com/kserve/kserve/pkg/types"
 )
 
+type ensureModelRootFolderResult struct {
+	Result   ctrl.Result
+	Continue bool
+}
+
 type LocalModelNodeReconciler struct {
 	client.Client
 	Clientset         *kubernetes.Clientset
@@ -204,7 +209,10 @@ func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode
 			},
 		},
 	}
-	enhanceDownloadJob(job, storageKey)
+	if err := enhanceDownloadJob(job, storageKey); err != nil {
+		c.Log.Error(err, "Failed to enhance download job", "name", modelInfo.ModelName)
+		return nil, err
+	}
 	if err := controllerutil.SetControllerReference(&localModelNode, job, c.Scheme); err != nil {
 		c.Log.Error(err, "Failed to set controller reference", "name", modelInfo.ModelName)
 		return nil, err
@@ -548,6 +556,7 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	storageInitializerConfig, err = v1beta1.GetStorageInitializerConfigs(isvcConfigMap)
 	if err != nil {
 		c.Log.Error(err, "Failed to get storage initializer config, using defaults")
+		// Don't fail, just use defaults
 	}
 
 	if c.CredentialBuilder == nil {
@@ -559,9 +568,12 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		fsHelper = NewFileSystemHelper(modelsRootFolder)
 	}
 
-	result, cont, err := ensureModelRootFolderExistsAndIsWritable(ctx, c, localModelConfig)
-	if !cont || err != nil {
-		return result, err
+	folderResult, err := ensureModelRootFolderExistsAndIsWritable(ctx, c, localModelConfig)
+	if err != nil || !folderResult.Continue {
+		if folderResult != nil {
+			return folderResult.Result, err
+		}
+		return ctrl.Result{}, err
 	}
 
 	// 3. Get LocalModelNode CR
@@ -577,7 +589,7 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return reconcile.Result{}, err
 	}
 
-	// 5. Download models
+	// 5. Download models not present locally
 	if err := c.downloadModels(ctx, &localModelNode); err != nil {
 		c.Log.Error(err, "Model download err")
 		return reconcile.Result{}, err
@@ -589,6 +601,7 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return reconcile.Result{}, err
 	}
 
+	// Requeue to check local folders periodically
 	return reconcile.Result{RequeueAfter: reconcilationFreqency}, nil
 }
 

--- a/pkg/controller/v1alpha1/localmodelnode/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller_test.go
@@ -51,8 +51,9 @@ func (m *MockFileInfo) Info() (fs.FileInfo, error) { return nil, nil }
 
 type mockFileSystem struct {
 	FileSystemInterface
-	// represents the dirs under /mnt/models/models
-	subDirs []os.DirEntry
+	// represents the dirs under models root
+	subDirs  []os.DirEntry
+	writable bool
 }
 
 func (f *mockFileSystem) removeModel(model string) error {
@@ -92,13 +93,18 @@ func (f *mockFileSystem) ensureModelRootFolderExists() error {
 	return nil
 }
 
+func (f *mockFileSystem) isWritable() bool {
+	return f.writable
+}
+
 func (f *mockFileSystem) clear() {
 	f.subDirs = []os.DirEntry{}
 }
 
 func newMockFileSystem() *mockFileSystem {
 	return &mockFileSystem{
-		subDirs: []os.DirEntry{},
+		subDirs:  []os.DirEntry{},
+		writable: true,
 	}
 }
 

--- a/pkg/controller/v1alpha1/localmodelnode/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller_test.go
@@ -52,8 +52,7 @@ func (m *MockFileInfo) Info() (fs.FileInfo, error) { return nil, nil }
 type mockFileSystem struct {
 	FileSystemInterface
 	// represents the dirs under models root
-	subDirs  []os.DirEntry
-	writable bool
+	subDirs []os.DirEntry
 }
 
 func (f *mockFileSystem) removeModel(model string) error {
@@ -93,18 +92,13 @@ func (f *mockFileSystem) ensureModelRootFolderExists() error {
 	return nil
 }
 
-func (f *mockFileSystem) isWritable() bool {
-	return f.writable
-}
-
 func (f *mockFileSystem) clear() {
 	f.subDirs = []os.DirEntry{}
 }
 
 func newMockFileSystem() *mockFileSystem {
 	return &mockFileSystem{
-		subDirs:  []os.DirEntry{},
-		writable: true,
+		subDirs: []os.DirEntry{},
 	}
 }
 

--- a/pkg/controller/v1alpha1/localmodelnode/file_utils.go
+++ b/pkg/controller/v1alpha1/localmodelnode/file_utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package localmodelnode
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -26,6 +28,7 @@ type FileSystemInterface interface {
 	hasModelFolder(modelName string) (bool, error)
 	getModelFolders() ([]os.DirEntry, error)
 	ensureModelRootFolderExists() error
+	isWritable() bool
 }
 
 type FileSystemHelper struct {
@@ -49,7 +52,14 @@ func (f *FileSystemHelper) removeModel(modelName string) error {
 }
 
 func (f *FileSystemHelper) getModelFolders() ([]os.DirEntry, error) {
-	return os.ReadDir(f.modelsRootFolder)
+	entries, err := os.ReadDir(f.modelsRootFolder)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return entries, nil
 }
 
 func (f *FileSystemHelper) hasModelFolder(modelName string) (bool, error) {
@@ -70,4 +80,15 @@ func (f *FileSystemHelper) ensureModelRootFolderExists() error {
 		return err
 	}
 	return nil
+}
+
+func (f *FileSystemHelper) isWritable() bool {
+	file, err := os.CreateTemp(f.modelsRootFolder, ".write-test-*")
+	if err != nil {
+		return false
+	}
+	name := file.Name()
+	_ = file.Close()
+	_ = os.Remove(name)
+	return true
 }

--- a/pkg/controller/v1alpha1/localmodelnode/file_utils.go
+++ b/pkg/controller/v1alpha1/localmodelnode/file_utils.go
@@ -28,7 +28,6 @@ type FileSystemInterface interface {
 	hasModelFolder(modelName string) (bool, error)
 	getModelFolders() ([]os.DirEntry, error)
 	ensureModelRootFolderExists() error
-	isWritable() bool
 }
 
 type FileSystemHelper struct {
@@ -80,14 +79,4 @@ func (f *FileSystemHelper) ensureModelRootFolderExists() error {
 		return err
 	}
 	return nil
-}
-
-func (f *FileSystemHelper) isWritable() bool {
-	file, err := os.CreateTemp(f.modelsRootFolder, ".write-test-*")
-	if err != nil {
-		return false
-	}
-	defer os.Remove(file.Name())
-	defer file.Close()
-	return true
 }

--- a/pkg/controller/v1alpha1/localmodelnode/file_utils.go
+++ b/pkg/controller/v1alpha1/localmodelnode/file_utils.go
@@ -87,8 +87,7 @@ func (f *FileSystemHelper) isWritable() bool {
 	if err != nil {
 		return false
 	}
-	name := file.Name()
-	_ = file.Close()
-	_ = os.Remove(name)
+	defer os.Remove(file.Name())
+	defer file.Close()
 	return true
 }

--- a/pkg/controller/v1alpha1/localmodelnode/file_utils_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/file_utils_test.go
@@ -149,3 +149,23 @@ func TestFileSystemHelper_ensureModelRootFolderExists(t *testing.T) {
 		t.Errorf("expected error due to permission denied, got nil")
 	}
 }
+
+func TestFileSystemHelper_isWritable(t *testing.T) {
+	// Case 1: Writable directory returns true
+	tempDir := t.TempDir()
+	helper := NewFileSystemHelper(tempDir)
+	if !helper.isWritable() {
+		t.Errorf("expected writable temp dir to return true")
+	}
+
+	// Case 2: Read-only directory returns false
+	readOnlyDir := t.TempDir()
+	if err := os.Chmod(readOnlyDir, 0o555); err != nil { //nolint:gosec // intentionally restrictive permissions for test
+		t.Fatalf("failed to chmod: %v", err)
+	}
+	defer os.Chmod(readOnlyDir, 0o755) //nolint
+	helper2 := NewFileSystemHelper(readOnlyDir)
+	if helper2.isWritable() {
+		t.Errorf("expected read-only dir to return false")
+	}
+}

--- a/pkg/controller/v1alpha1/localmodelnode/file_utils_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/file_utils_test.go
@@ -149,23 +149,3 @@ func TestFileSystemHelper_ensureModelRootFolderExists(t *testing.T) {
 		t.Errorf("expected error due to permission denied, got nil")
 	}
 }
-
-func TestFileSystemHelper_isWritable(t *testing.T) {
-	// Case 1: Writable directory returns true
-	tempDir := t.TempDir()
-	helper := NewFileSystemHelper(tempDir)
-	if !helper.isWritable() {
-		t.Errorf("expected writable temp dir to return true")
-	}
-
-	// Case 2: Read-only directory returns false
-	readOnlyDir := t.TempDir()
-	if err := os.Chmod(readOnlyDir, 0o555); err != nil { //nolint:gosec // intentionally restrictive permissions for test
-		t.Fatalf("failed to chmod: %v", err)
-	}
-	defer os.Chmod(readOnlyDir, 0o755) //nolint
-	helper2 := NewFileSystemHelper(readOnlyDir)
-	if helper2.isWritable() {
-		t.Errorf("expected read-only dir to return false")
-	}
-}

--- a/pkg/controller/v1alpha1/localmodelnode/platform_default.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_default.go
@@ -23,21 +23,20 @@ import (
 	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 )
 
 const MountPath = "/mnt/models"
 
-func enhanceDownloadJob(_ *batchv1.Job, _ string) {}
+func enhanceDownloadJob(_ *batchv1.Job, _ string) error { return nil }
 
-//nolint:unparam // signature must match distro variant which returns non-zero Result
+// TODO we need a way to ensure that the local path on persistent volume is the same as the local path of the node agent DaemonSet.
 func ensureModelRootFolderExistsAndIsWritable(_ context.Context, _ *LocalModelNodeReconciler,
 	_ *v1beta1.LocalModelConfig,
-) (ctrl.Result, bool, error) {
+) (*ensureModelRootFolderResult, error) {
 	if err := fsHelper.ensureModelRootFolderExists(); err != nil {
-		return ctrl.Result{}, false, fmt.Errorf("failed to ensure model root folder: %w", err)
+		return nil, fmt.Errorf("failed to ensure model root folder: %w", err)
 	}
-	return ctrl.Result{}, true, nil
+	return &ensureModelRootFolderResult{Continue: true}, nil
 }

--- a/pkg/controller/v1alpha1/localmodelnode/platform_default.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_default.go
@@ -1,0 +1,42 @@
+//go:build !distro
+
+/*
+Copyright 2024 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localmodelnode
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+)
+
+const MountPath = "/mnt/models"
+
+func enhanceDownloadJob(_ *batchv1.Job, _ string) {}
+
+func ensureVolumePermissions(_ context.Context, _ *LocalModelNodeReconciler,
+	_ *v1beta1.LocalModelConfig,
+) (ctrl.Result, bool, error) {
+	return ctrl.Result{}, true, nil
+}
+
+func (c *LocalModelNodeReconciler) EnsurePermissions(_ context.Context) error {
+	return nil
+}

--- a/pkg/controller/v1alpha1/localmodelnode/platform_default.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_default.go
@@ -20,6 +20,7 @@ package localmodelnode
 
 import (
 	"context"
+	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,12 +32,12 @@ const MountPath = "/mnt/models"
 
 func enhanceDownloadJob(_ *batchv1.Job, _ string) {}
 
-func ensureVolumePermissions(_ context.Context, _ *LocalModelNodeReconciler,
+//nolint:unparam // signature must match distro variant which returns non-zero Result
+func ensureModelRootFolderExistsAndIsWritable(_ context.Context, _ *LocalModelNodeReconciler,
 	_ *v1beta1.LocalModelConfig,
 ) (ctrl.Result, bool, error) {
+	if err := fsHelper.ensureModelRootFolderExists(); err != nil {
+		return ctrl.Result{}, false, fmt.Errorf("failed to ensure model root folder: %w", err)
+	}
 	return ctrl.Result{}, true, nil
-}
-
-func (c *LocalModelNodeReconciler) EnsurePermissions(_ context.Context) error {
-	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds compile-time hook points to the LocalModelNode agent controller using Go build tags (`distro`/`!distro`), following the pattern established in #5217 for LLMInferenceService.

Upstream gets zero-cost no-op stubs. Distributions can provide real implementations behind the `distro` tag without forking core reconciliation files — reducing merge conflicts and making upstream rebases clean.

Hook points:
- **`enhanceDownloadJob`** — platform-specific modifications to download jobs before creation (e.g., clearing SubPath, setting SELinux context, ServiceAccount)
- **`ensureVolumePermissions`** — guards model download by checking volume writability and launching permission fix jobs if needed
- **`EnsurePermissions`** — startup-time permission check before the controller manager starts

Also adds:
- `GOTAGS` variable to `localmodel-agent.Dockerfile` so distributions can activate build tags through the build pipeline
- `isWritable()` method on `FileSystemInterface` for volume permission detection
- Improved `getModelFolders()` to return `nil` instead of error on missing directory
- Replaced `panic()` with error return in `fsHelper` initialization

**Which issue(s) this PR fixes**:

Depends on #5262

**Feature/Issue validation/testing**:

- [x] Upstream builds compile and run tests without the `distro` tag (no-op stubs)
- [x] Distribution builds compile with `-tags distro`
- [x] Verified no behavioral change for upstream — all stubs return nil
- [x] `TestFileSystemHelper_isWritable` — verifies writable and read-only directory detection

**Special notes for your reviewer**:


This follows the same pattern established in #5217 for `llmisvc`. The `platform_default.go` file uses `//go:build !distro` to provide upstream no-op stubs. A corresponding platform_go files can be created downstream for platform specific implementation 

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Add compile-time hook points to LocalModelNode agent controller for distribution-specific logic using Go build tags. Distributions can now inject platform-specific behavior (download job customization, volume permissions) without forking core controller files.
```