### PR TITLE
feat: replace vllm-cpu image with upstream built image

### DIFF
--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
@@ -16,6 +16,8 @@ spec:
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG
+          - name: VLLM_CPU_KVCACHE_SPACE
+            value: "1"
         resources:
           limits:
             cpu: '1'

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
@@ -12,10 +12,7 @@ spec:
   template:
     containers:
       - name: main
-        image: quay.io/pierdipi/vllm-cpu:latest
-        securityContext:
-          # The image is not built in a way that can run as non-root
-          runAsNonRoot: false
+        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml
@@ -14,10 +14,7 @@ spec:
   template:
     containers:
       - name: main
-        image: quay.io/pierdipi/vllm-cpu:latest
-        securityContext:
-          # The image is not built in a way that can run as non-root
-          runAsNonRoot: false
+        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml
@@ -18,6 +18,8 @@ spec:
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG
+          - name: VLLM_CPU_KVCACHE_SPACE
+            value: "1"
         resources:
           limits:
             cpu: '1'

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
@@ -13,10 +13,7 @@ spec:
   template:
     containers:
       - name: main
-        image: quay.io/pierdipi/vllm-cpu:latest
-        securityContext:
-          # The image is not built in a way that can run as non-root
-          runAsNonRoot: false
+        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG
@@ -31,10 +28,7 @@ spec:
     template:
       containers:
         - name: main
-          image: quay.io/pierdipi/vllm-cpu:latest
-          securityContext:
-            # The image is not built in a way that can run as non-root
-            runAsNonRoot: false
+          image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1
           env:
             - name: VLLM_LOGGING_LEVEL
               value: DEBUG

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
@@ -17,6 +17,8 @@ spec:
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG
+          - name: VLLM_CPU_KVCACHE_SPACE
+            value: "1"
         resources:
           limits:
             cpu: '2'

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -38,15 +38,11 @@ LLMINFERENCESERVICE_CONFIGS = {
             "containers": [
                 {
                     "name": "main",
-                    "image": "quay.io/pierdipi/vllm-cpu:latest",
+                    "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                     "env": [{"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"}],
                     "resources": {
                         "limits": {"cpu": "2", "memory": "7Gi"},
                         "requests": {"cpu": "200m", "memory": "2Gi"},
-                    },
-                    "securityContext": {
-                        "runAsNonRoot": False,
-                        "runAsUser": 0,
                     },
                 }
             ]
@@ -57,7 +53,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "containers": [
                 {
                     "name": "main",
-                    "image": "quay.io/pierdipi/vllm-cpu:latest",
+                    "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                     "env": [{"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"}],
                     "resources": {
                         "limits": {"cpu": "2", "memory": "7Gi"},
@@ -77,10 +73,6 @@ LLMINFERENCESERVICE_CONFIGS = {
                         "timeoutSeconds": 5,
                         "failureThreshold": 3,
                     },
-                    "securityContext": {
-                        "runAsNonRoot": False,
-                        "runAsUser": 0,
-                    },
                 }
             ]
         },
@@ -89,7 +81,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                 "containers": [
                     {
                         "name": "main",
-                        "image": "quay.io/pierdipi/vllm-cpu:latest",
+                        "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                         "env": [{"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"}],
                         "resources": {
                             "limits": {"cpu": "2", "memory": "7Gi"},
@@ -316,7 +308,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "containers": [
                 {
                     "name": "main",
-                    "image": "quay.io/pierdipi/vllm-cpu:latest",
+                    "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                     "command": ["vllm", "serve", "/mnt/models"],
                     "args": [
                         "--served-model-name",
@@ -339,7 +331,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "containers": [
                 {
                     "name": "main",
-                    "image": "quay.io/pierdipi/vllm-cpu:latest",
+                    "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                     "command": ["vllm", "serve", "/mnt/models"],
                     "args": [
                         "--served-model-name",

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -39,7 +39,10 @@ LLMINFERENCESERVICE_CONFIGS = {
                 {
                     "name": "main",
                     "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
-                    "env": [{"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"}],
+                    "env": [
+                        {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
+                        {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                    ],
                     "resources": {
                         "limits": {"cpu": "2", "memory": "7Gi"},
                         "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -54,7 +57,10 @@ LLMINFERENCESERVICE_CONFIGS = {
                 {
                     "name": "main",
                     "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
-                    "env": [{"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"}],
+                    "env": [
+                        {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
+                        {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                    ],
                     "resources": {
                         "limits": {"cpu": "2", "memory": "7Gi"},
                         "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -82,7 +88,10 @@ LLMINFERENCESERVICE_CONFIGS = {
                     {
                         "name": "main",
                         "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
-                        "env": [{"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"}],
+                        "env": [
+                            {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
+                            {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                        ],
                         "resources": {
                             "limits": {"cpu": "2", "memory": "7Gi"},
                             "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -316,6 +325,9 @@ LLMINFERENCESERVICE_CONFIGS = {
                         "--port",
                         "8000",
                     ],
+                    "env": [
+                        {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                    ],
                     "resources": {
                         "limits": {"cpu": "2", "memory": "7Gi"},
                         "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -338,6 +350,9 @@ LLMINFERENCESERVICE_CONFIGS = {
                         "{{ .Spec.Model.Name }}",
                         "--port",
                         "8000",
+                    ],
+                    "env": [
+                        {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
                     ],
                     "resources": {
                         "limits": {"cpu": "2", "memory": "7Gi"},

--- a/test/e2e/llmisvc/test_llm_inference_service_conversion.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_conversion.py
@@ -229,7 +229,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "quay.io/pierdipi/vllm-cpu:latest",
+                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
                                 "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -318,7 +318,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "quay.io/pierdipi/vllm-cpu:latest",
+                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
                                 "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -416,7 +416,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "quay.io/pierdipi/vllm-cpu:latest",
+                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
                                 "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -545,7 +545,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "quay.io/pierdipi/vllm-cpu:latest",
+                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
                                 "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -688,7 +688,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "quay.io/pierdipi/vllm-cpu:latest",
+                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
                                 "requests": {"cpu": "200m", "memory": "2Gi"},

--- a/test/e2e/llmisvc/test_pod_watch.py
+++ b/test/e2e/llmisvc/test_pod_watch.py
@@ -365,7 +365,7 @@ async def test_event_storm_prevention_init_container_isolation():
                     "containers": [
                         {
                             "name": "main",
-                            "image": "quay.io/pierdipi/vllm-cpu:latest",
+                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
                                 "requests": {"cpu": "200m", "memory": "2Gi"},
@@ -565,7 +565,7 @@ async def test_quick_reconciliation_on_init_container_failure():
                     "containers": [
                         {
                             "name": "main",
-                            "image": "quay.io/pierdipi/vllm-cpu:latest",
+                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1",
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
                                 "requests": {"cpu": "200m", "memory": "2Gi"},


### PR DESCRIPTION
Currently, we're using my image as it wasn't available the cpu image previously, now it's on ECR and we can use it.

https://gallery.ecr.aws/q9t5s3a7/vllm-cpu-release-repo
