### PR TITLE
fix(ci): add readiness to seaweedfs deployment

### DIFF
--- a/config/overlays/test/s3-local-backend/seaweedfs-deployment.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-deployment.yaml
@@ -34,6 +34,11 @@ spec:
         image: docker.io/chrislusf/seaweedfs:4.07@sha256:10fa7df90911dd83439f4d3d792a1c5c6c630121cb2094ba209f42d4b0ca975d
         imagePullPolicy: Always
         name: seaweedfs
+        readinessProbe:
+          tcpSocket:
+            port: 8333
+          initialDelaySeconds: 3
+          periodSeconds: 5
         ports:
         - containerPort: 8333
           name: s3

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -70,6 +70,9 @@ if [[ $ENABLE_LLMISVC == "false" ]]; then
 
   kubectl get events -A
 
+  echo "Waiting for seaweedfs to be ready ..."
+  kubectl rollout status deployment/seaweedfs -n kserve --timeout=120s
+
   echo "Add testing models to s3 storage ..."
   kubectl apply -f config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml -n kserve
   kubectl wait --for=condition=complete --timeout=90s job/s3-init -n kserve


### PR DESCRIPTION
The seaweedfs deployment had no readiness probe, so Kubernetes
marked the pod as ready before S3 was actually accepting connections,
causing the s3-init job to fail intermittently.

The s3-init job could start before seaweedfs was ready, causing
a timeout waiting for the job to complete. Add a rollout status
check to ensure seaweedfs is serving before initializing S3 storage.

