### PR TITLE
fix: replace MD5 with SHA-256 in e2e fixtures

### DIFF
--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -922,7 +922,7 @@ def generate_k8s_safe_suffix(
 
     full_name = full_name.lower().replace("_", "-")
 
-    name_hash = hashlib.md5(full_name.encode()).hexdigest()[:8]
+    name_hash = hashlib.sha256(full_name.encode()).hexdigest()[:8]
 
     # TODO: we can't use the real maximum (63), LWS and STS add additional suffixes (ie `-0`) and don't handle that case.
     max_total = 40


### PR DESCRIPTION
## Summary

Replace `hashlib.md5` with `hashlib.sha256` in `test/e2e/llmisvc/fixtures.py` for FIPS 140-3 compliance. MD5 is prohibited under FIPS 140-3 section 4.8.1 and causes failures in FIPS-enabled environments.

The hash is only used to generate short k8s resource name suffixes — no functional change.

## Test plan

- [x] `grep -r "hashlib.md5" test/ --include="*.py"` returns no results
- [ ] CI passes

Assisted-by: Claude Code (claude.ai/code)