### PR TITLE
ci: optimize Go Dockerfiles for faster CI builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Allowlist: exclude everything, then add back only what Go Dockerfiles need.
+# Python images use context: python/ and are unaffected by this file.
+#
+# Needed by the 8 Go image builds (context: .):
+#   go.mod, go.sum  - module deps (6 main-module Dockerfiles + tf2openapi)
+#   cmd/            - service entrypoints
+#   pkg/            - shared Go library code
+#   tools/          - tf2openapi build
+#   qpext/          - queue-proxy extension (has its own go.mod)
+#   LICENSE         - third-party license checks
+
+# Exclude everything by default
+*
+
+# Go module files
+!go.mod
+!go.sum
+
+# Source directories
+!cmd/
+!pkg/
+!tools/
+!qpext/
+
+# License (used by go-licenses in all builds)
+!LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,20 @@ COPY go.sum  go.sum
 
 RUN go mod download
 
-COPY cmd/    cmd/
+# Install license tool (cached independently of source changes)
+RUN go install github.com/google/go-licenses@v1.6.0
+COPY LICENSE LICENSE
+
+ARG CMD=manager
+COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager ./cmd/manager
+# Check and generate third-party licenses (fast, fail-fast on violations)
+RUN go-licenses check ./cmd/${CMD} ./pkg/... --disallowed_types="forbidden,unknown" && \
+    go-licenses save --save_path third_party/library ./cmd/${CMD}
 
-# Generate third-party licenses
-COPY LICENSE LICENSE
-RUN go install github.com/google/go-licenses@latest
-# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
-RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
-RUN go-licenses save --save_path third_party/library ./cmd/manager
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o manager ./cmd/${CMD}
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:nonroot

--- a/agent.Dockerfile
+++ b/agent.Dockerfile
@@ -8,18 +8,20 @@ COPY go.sum  go.sum
 
 RUN go mod download
 
-COPY cmd/    cmd/
+# Install license tool (cached independently of source changes)
+RUN go install github.com/google/go-licenses@v1.6.0
+COPY LICENSE LICENSE
+
+ARG CMD=agent
+COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o agent ./cmd/agent
+# Check and generate third-party licenses (fast, fail-fast on violations)
+RUN go-licenses check ./cmd/${CMD} ./pkg/... --disallowed_types="forbidden,unknown" && \
+    go-licenses save --save_path third_party/library ./cmd/${CMD}
 
-# Generate third-party licenses
-COPY LICENSE LICENSE
-RUN go install github.com/google/go-licenses@latest
-# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
-RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
-RUN go-licenses save --save_path third_party/library ./cmd/agent
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o agent ./cmd/${CMD}
 
 # Copy the inference-agent into a thin image
 FROM gcr.io/distroless/static:nonroot

--- a/llmisvc-controller.Dockerfile
+++ b/llmisvc-controller.Dockerfile
@@ -8,19 +8,21 @@ COPY go.sum  go.sum
 
 RUN go mod download
 
-COPY cmd/    cmd/
+# Install license tool (cached independently of source changes)
+RUN go install github.com/google/go-licenses@v1.6.0
+COPY LICENSE LICENSE
+
+ARG CMD=llmisvc
+COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
+
+# Check and generate third-party licenses (fast, fail-fast on violations)
+RUN go-licenses check ./cmd/${CMD} ./pkg/... --disallowed_types="forbidden,unknown" && \
+    go-licenses save --save_path third_party/library ./cmd/${CMD}
 
 # Build
 ARG GOTAGS=""
-RUN CGO_ENABLED=0 GOOS=linux go build -tags "${GOTAGS}" -a -o manager ./cmd/llmisvc
-
-# Generate third-party licenses
-COPY LICENSE LICENSE
-RUN go install github.com/google/go-licenses@latest
-# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
-RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
-RUN go-licenses save --save_path third_party/library ./cmd/llmisvc
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -tags "${GOTAGS}" -a -o manager ./cmd/${CMD}
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:nonroot

--- a/localmodel-agent.Dockerfile
+++ b/localmodel-agent.Dockerfile
@@ -8,18 +8,20 @@ COPY go.sum  go.sum
 
 RUN go mod download
 
-COPY cmd/    cmd/
+# Install license tool (cached independently of source changes)
+RUN go install github.com/google/go-licenses@v1.6.0
+COPY LICENSE LICENSE
+
+ARG CMD=localmodelnode
+COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o localmodelnode-agent ./cmd/localmodelnode
+# Check and generate third-party licenses (fast, fail-fast on violations)
+RUN go-licenses check ./cmd/${CMD} ./pkg/... --disallowed_types="forbidden,unknown" && \
+    go-licenses save --save_path third_party/library ./cmd/${CMD}
 
-# Generate third-party licenses
-COPY LICENSE LICENSE
-RUN go install github.com/google/go-licenses@latest
-# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
-RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
-RUN go-licenses save --save_path third_party/library ./cmd/localmodelnode
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o localmodelnode-agent ./cmd/${CMD}
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:nonroot

--- a/localmodel.Dockerfile
+++ b/localmodel.Dockerfile
@@ -8,18 +8,20 @@ COPY go.sum  go.sum
 
 RUN go mod download
 
-COPY cmd/    cmd/
+# Install license tool (cached independently of source changes)
+RUN go install github.com/google/go-licenses@v1.6.0
+COPY LICENSE LICENSE
+
+ARG CMD=localmodel
+COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o localmodel-manager ./cmd/localmodel
+# Check and generate third-party licenses (fast, fail-fast on violations)
+RUN go-licenses check ./cmd/${CMD} ./pkg/... --disallowed_types="forbidden,unknown" && \
+    go-licenses save --save_path third_party/library ./cmd/${CMD}
 
-# Generate third-party licenses
-COPY LICENSE LICENSE
-RUN go install github.com/google/go-licenses@latest
-# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
-RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
-RUN go-licenses save --save_path third_party/library ./cmd/localmodel
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o localmodel-manager ./cmd/${CMD}
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:nonroot

--- a/router.Dockerfile
+++ b/router.Dockerfile
@@ -8,18 +8,20 @@ COPY go.sum  go.sum
 
 RUN go mod download
 
-COPY cmd/    cmd/
+# Install license tool (cached independently of source changes)
+RUN go install github.com/google/go-licenses@v1.6.0
+COPY LICENSE LICENSE
+
+ARG CMD=router
+COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 
-# Build
-RUN CGO_ENABLED=0  go build -a -o router ./cmd/router
+# Check and generate third-party licenses (fast, fail-fast on violations)
+RUN go-licenses check ./cmd/${CMD} ./pkg/... --disallowed_types="forbidden,unknown" && \
+    go-licenses save --save_path third_party/library ./cmd/${CMD}
 
-# Generate third-party licenses
-COPY LICENSE LICENSE
-RUN go install github.com/google/go-licenses@latest
-# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
-RUN go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
-RUN go-licenses save --save_path third_party/library ./cmd/router
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o router ./cmd/${CMD}
 
 # Copy the inference-router into a thin image
 FROM gcr.io/distroless/static:nonroot


### PR DESCRIPTION
**What this PR does / why we need it**:

Every Go Dockerfile was copying the entire `cmd/` tree and running license checks across all commands, causing unnecessary cache invalidation when unrelated services changed.

This PR scopes each Dockerfile to only its own `cmd/` subdirectory, pins `go-licenses` to v1.6.0 for reproducible builds, and adds an allowlist-based `.dockerignore`.

Reorders layers so that tool installation and license checks run before compilation - giving faster feedback on violations and caching the `go-licenses` install independently of source changes.

Builds use `-mod=readonly` to guarantee reproducibility against `go.sum`.

The allowlist `.dockerignore` cuts Go build context from ~1.57 GB to ~12 MB (99.2% reduction, consistent across legacy Docker, BuildKit, and Podman). See [measurements](https://gist.github.com/bartoszmajsak/acef582989d99f1f79f86984a63c3fc5).

**Feature/Issue validation/testing**:

- [x] All six Go images built successfully with `make docker-build-kserve-controller`, `make docker-build-agent`, `make docker-build-router`, `make docker-build-llmisvc-controller`, `make docker-build-localmodel-controller`, `make docker-build-localmodel-agent`
- [x] Context size measured across legacy Docker (1.572 GB -> 11.85 MB), BuildKit (1.5 GB -> 11.9 MB), and Podman (1.5 GB -> 11.9 MB)

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```