### PR TITLE
build: optimize Python Dockerfile caching and build context

### DIFF
--- a/python/.dockerignore
+++ b/python/.dockerignore
@@ -1,0 +1,14 @@
+# Exclude dev artifacts from Python image builds (context: python/)
+**/.venv/
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/.pytest_cache/
+**/.ruff_cache/
+**/.mypy_cache/
+**/*.egg-info/
+**/dist/
+kserve/test/
+kserve/docs/
+**/.idea/
+**/.vscode/

--- a/python/aiffairness.Dockerfile
+++ b/python/aiffairness.Dockerfile
@@ -18,8 +18,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ Install kserve dependencies ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/

--- a/python/artexplainer.Dockerfile
+++ b/python/artexplainer.Dockerfile
@@ -18,8 +18,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ kserve deps ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -50,8 +50,6 @@ FROM ${BASE_IMAGE} AS prod
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-COPY third_party third_party
 
 RUN useradd kserve -m -u 1000 -d /home/kserve
 

--- a/python/custom_model.Dockerfile
+++ b/python/custom_model.Dockerfile
@@ -23,8 +23,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ Install kserve ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -54,9 +54,6 @@ FROM ${BASE_IMAGE} AS prod
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-# Copy third-party dependencies
-COPY third_party third_party
 
 # Create non-root user
 RUN useradd kserve -m -u 1000 -d /home/kserve

--- a/python/custom_model_grpc.Dockerfile
+++ b/python/custom_model_grpc.Dockerfile
@@ -23,8 +23,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ kserve deps ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -54,9 +54,6 @@ FROM ${BASE_IMAGE} AS prod
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-# Copy third-party non-Python dependencies
-COPY third_party third_party
 
 # Create and switch to a non-root user
 RUN useradd kserve -m -u 1000 -d /home/kserve

--- a/python/custom_tokenizer.Dockerfile
+++ b/python/custom_tokenizer.Dockerfile
@@ -23,8 +23,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ Install kserve ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -55,8 +55,6 @@ FROM ${BASE_IMAGE} AS prod
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-COPY third_party third_party
 
 # Create non-root user
 RUN useradd kserve -m -u 1000 -d /home/kserve

--- a/python/custom_transformer.Dockerfile
+++ b/python/custom_transformer.Dockerfile
@@ -23,8 +23,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install kserve dependencies
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -54,9 +54,6 @@ FROM ${BASE_IMAGE} AS prod
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
-# Copy any external shared resources
-COPY third_party third_party
 
 # Create non-root user
 RUN useradd kserve -m -u 1000 -d /home/kserve

--- a/python/custom_transformer_grpc.Dockerfile
+++ b/python/custom_transformer_grpc.Dockerfile
@@ -23,8 +23,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ Install kserve ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -54,8 +54,6 @@ FROM ${BASE_IMAGE} AS prod
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-COPY third_party third_party
 
 # Create non-root user
 RUN useradd kserve -m -u 1000 -d /home/kserve

--- a/python/error_404_isvc.Dockerfile
+++ b/python/error_404_isvc.Dockerfile
@@ -17,8 +17,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
 RUN cd kserve && uv sync --active --no-cache

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -66,16 +66,15 @@ ENV PATH="${WORKSPACE_DIR}/${VENV_PATH}/bin:$PATH"
 
 # From this point, all Python packages will be installed in the virtual environment and copied to the final image
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
 RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active --no-cache
 COPY kserve kserve  
 RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active --no-cache
 
-COPY storage/pyproject.toml storage/uv.lock storage/
-RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv sync --active --no-cache
+# Install kserve-storage
 COPY storage storage
 RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install . --no-cache
 

--- a/python/huggingface_server_cpu.Dockerfile
+++ b/python/huggingface_server_cpu.Dockerfile
@@ -54,9 +54,15 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ARG TORCH_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
 ARG TORCH_VERSION=2.10.0
 
-# Install kserve using UV
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
+
+# Install kserve dependencies (metadata-first for cache)
+COPY kserve/pyproject.toml kserve/uv.lock kserve/
+RUN cd kserve && \
+    uv sync --active --no-cache && \
+    uv cache clean && \
+    rm -rf ~/.cache/uv
 
 COPY kserve kserve
 RUN cd kserve && \
@@ -64,20 +70,23 @@ RUN cd kserve && \
     uv cache clean && \
     rm -rf ~/.cache/uv
 
- # Copy and install dependencies for kserve-storage using uv
-COPY storage/pyproject.toml storage/uv.lock storage/
-RUN cd storage && uv sync --active --no-cache
-
+# Install kserve-storage
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache  
+RUN cd storage && uv pip install . --no-cache
 
-# Install huggingfaceserver using UV
-COPY huggingfaceserver huggingfaceserver
+# Install huggingfaceserver dependencies (metadata-first for cache)
+COPY huggingfaceserver/pyproject.toml huggingfaceserver/uv.lock huggingfaceserver/health_check.py huggingfaceserver/
 RUN cd huggingfaceserver && \
     uv pip install --no-cache-dir --index-url ${TORCH_EXTRA_INDEX_URL} \
         torch==${TORCH_VERSION} \
         torchvision \
         torchaudio && \
+    uv sync --active --no-cache && \
+    uv cache clean && \
+    rm -rf ~/.cache/uv
+
+COPY huggingfaceserver huggingfaceserver
+RUN cd huggingfaceserver && \
     uv sync --active --no-cache && \
     uv cache clean && \
     rm -rf ~/.cache/uv

--- a/python/lgb.Dockerfile
+++ b/python/lgb.Dockerfile
@@ -18,8 +18,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -28,10 +28,7 @@ RUN cd kserve && uv sync --active --no-cache
 COPY kserve kserve
 RUN cd kserve && uv sync --active --no-cache
 
-# Copy and install dependencies for kserve-storage using uv
-COPY storage/pyproject.toml storage/uv.lock storage/
-RUN cd storage && uv sync --active --no-cache
-
+# Install kserve-storage
 COPY storage storage
 RUN cd storage && uv pip install . --no-cache
 
@@ -56,8 +53,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-COPY third_party third_party
 
 # Activate virtual env
 ARG VENV_PATH

--- a/python/paddle.Dockerfile
+++ b/python/paddle.Dockerfile
@@ -20,8 +20,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install kserve dependencies using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -30,10 +30,7 @@ RUN cd kserve && uv sync --active --no-cache
 COPY kserve kserve
 RUN cd kserve && uv sync --active --no-cache
 
-# Copy and install dependencies for kserve-storage using uv
-COPY storage/pyproject.toml storage/uv.lock storage/
-RUN cd storage && uv sync --active --no-cache
-
+# Install kserve-storage
 COPY storage storage
 RUN cd storage && uv pip install . --no-cache
 

--- a/python/pmml.Dockerfile
+++ b/python/pmml.Dockerfile
@@ -28,8 +28,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -38,10 +38,7 @@ RUN cd kserve && uv sync --active --no-cache
 COPY kserve kserve
 RUN cd kserve && uv sync --active --no-cache
 
-# Copy and install dependencies for kserve-storage using uv
-COPY storage/pyproject.toml storage/uv.lock storage/
-RUN cd storage && uv sync --active --no-cache
-
+# Install kserve-storage
 COPY storage storage
 RUN cd storage && uv pip install . --no-cache
 

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -18,8 +18,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ========== Install kserve dependencies ==========
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -29,9 +29,6 @@ COPY kserve kserve
 RUN cd kserve && uv sync --active --no-cache
 
 # ========== Install kserve storage dependencies ==========
-COPY storage/pyproject.toml storage/uv.lock storage/
-RUN cd storage && uv sync --active --no-cache
-
 COPY storage storage
 RUN cd storage && uv pip install . --no-cache
 
@@ -52,8 +49,6 @@ RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # =================== Final stage ===================
 FROM ${BASE_IMAGE} AS prod
-
-COPY third_party third_party
 
 # Activate virtual env
 ARG VENV_PATH

--- a/python/success_200_isvc.Dockerfile
+++ b/python/success_200_isvc.Dockerfile
@@ -17,8 +17,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
 RUN cd kserve && uv sync --active --no-cache

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -18,8 +18,8 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN python3 -m venv ${VIRTUAL_ENV}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage directory for editable install
-COPY storage storage
+# Copy storage metadata for editable dependency resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Copy and install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
@@ -27,11 +27,8 @@ RUN cd kserve && uv sync --active --no-cache
 COPY kserve kserve
 RUN cd kserve && uv sync --active --no-cache
 
-# Copy and install dependencies for kserve-storage using uv
-COPY storage/pyproject.toml storage/uv.lock storage/
-RUN cd storage && uv sync --active --no-cache
-
-COPY storage storage 
+# Install kserve-storage
+COPY storage storage
 RUN cd storage && uv pip install . --no-cache
 
 # Copy and install dependencies for xgbserver using uv


### PR DESCRIPTION
**What this PR does / why we need it**:

Every Python Dockerfile copied the full `storage/` directory as its first COPY instruction, invalidating all downstream layers whenever any storage file changed - even for images that only need storage metadata for editable dependency resolution.

This PR switches 16 Dockerfiles to a metadata-first pattern that copies only `storage/pyproject.toml` and `storage/uv.lock` early, deferring the full source copy until actually needed. For images that install storage as a package (sklearn, lgb, xgb, paddle, pmml, huggingface), the redundant two-phase storage install is collapsed into a single step.

Removes duplicate `COPY third_party` in prod stages where it was followed by a `COPY --from=builder` that merged over it (Docker COPY merges directory contents rather than replacing them, so the build-time `pip-licenses.py` script was leaking into runtime images).

The `huggingface_server_cpu` Dockerfile gets the largest restructure, applying metadata-first to both kserve and huggingfaceserver dependencies - preventing a ~2GB torch re-download on source-only changes.

Adds `python/.dockerignore` to exclude dev artifacts (`.venv/`, `__pycache__/`, `.egg-info/`, test/docs directories). In a clean checkout the context is already small (~18 MB), but in dev environments with virtualenvs and caches this prevents unnecessary bloat from reaching the daemon.

**Feature/Issue validation/testing**:

- [x] Built sklearn image: `KO_DOCKER_REPO=kserve make docker-build-sklearn`
- [x] Built custom_model image: `KO_DOCKER_REPO=kserve make docker-build-custom-model`
- [x] Built aiffairness image: `KO_DOCKER_REPO=kserve make docker-build-aif`
- [x] Built artexplainer image: `KO_DOCKER_REPO=kserve make docker-build-art`
- [x] Built success_200_isvc image: `KO_DOCKER_REPO=kserve make docker-build-success-200-isvc`
- [x] Context size measured: 18.3 MB without `.dockerignore`, 16.7 MB with (clean checkout - dev environments with `.venv/` would see a larger delta)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```