### PR TITLE
fix(ci): correct self-referencing path in llmisvc docker workflow

### DIFF
--- a/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
+++ b/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
@@ -18,7 +18,7 @@ on:
       - "!.github/**"
       - "!docs/**"
       - "!**.md"
-      - ".github/workflows/kserve--llmisvccontroller-docker-publish.yml"
+      - ".github/workflows/kserve-llmisvc-controller-docker-publish.yml"
       - ".github/actions/free-up-disk-space/**"
 
 env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo in the llmisvc controller Docker publish workflow's path filter. The self-referencing path had a double dash and missing hyphens (`kserve--llmisvccontroller-docker-publish.yml` instead of `kserve-llmisvc-controller-docker-publish.yml`), which meant the workflow would never trigger on PRs that only modify the workflow file itself.

**Release note**:
```release-note
NONE
```