### PR TITLE
chore(ci): align action versions across workflows

### DIFF
--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           context: python

--- a/.github/workflows/custom-model-grpc-publish.yml
+++ b/.github/workflows/custom-model-grpc-publish.yml
@@ -51,7 +51,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64
           context: python

--- a/.github/workflows/huggingface-cpu-docker-publish.yml
+++ b/.github/workflows/huggingface-cpu-docker-publish.yml
@@ -54,7 +54,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64
           context: python

--- a/.github/workflows/huggingface-docker-publish.yml
+++ b/.github/workflows/huggingface-docker-publish.yml
@@ -54,7 +54,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64
           context: python

--- a/.github/workflows/lightgbm-docker-publish.yml
+++ b/.github/workflows/lightgbm-docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           context: python

--- a/.github/workflows/paddle-docker-publish.yml
+++ b/.github/workflows/paddle-docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           context: python

--- a/.github/workflows/pmml-docker-publish.yml
+++ b/.github/workflows/pmml-docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           context: python

--- a/.github/workflows/predictiveserver-docker-publish.yml
+++ b/.github/workflows/predictiveserver-docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           context: python

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -111,7 +111,7 @@ jobs:
           uv pip install "numpy<2.0"
       - name: Load cached kserve numpy 1-x venv
         id: cached-kserve-numpy-1-x-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: python/kserve-numpy-1-x/.venv
           key: kserve-numpy-1-x-venv-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/kserve-numpy-1-x/uv.lock') }}

--- a/.github/workflows/sklearnserver-docker-publish.yml
+++ b/.github/workflows/sklearnserver-docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           context: python

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -60,7 +60,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           context: python

--- a/.github/workflows/transformer-docker-publish.yml
+++ b/.github/workflows/transformer-docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64
           context: python
@@ -143,7 +143,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64
           context: python

--- a/.github/workflows/xgbserver-docker-publisher.yml
+++ b/.github/workflows/xgbserver-docker-publisher.yml
@@ -60,7 +60,7 @@ jobs:
           cache-binary: true
 
       - name: Run tests
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64/v8
           context: python


### PR DESCRIPTION
**What this PR does / why we need it**:

Eliminates action version drift across CI workflows. All Python Docker publish workflows were using `docker/build-push-action@v5` in their test jobs while the push jobs already used `@v6`. Similarly, one `actions/cache` step in `python-test.yml` was stuck on `v3` while the other 8 cache steps used `v4`. This mismatch means test and publish builds run on different action versions, which could mask compatibility issues.

**Release note**:
```release-note
NONE
```