### PR TITLE
fix(ci): add missing disk space cleanup to docker push jobs

### DIFF
--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
         with:

--- a/.github/workflows/custom-model-grpc-publish.yml
+++ b/.github/workflows/custom-model-grpc-publish.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the missing free-up disk space step to the push jobs in the artexplainer and custom-model-grpc Docker publish workflows. Every other Python Docker publish workflow already includes this step in both test and push jobs. Without it, multi-arch builds on these two workflows risk running out of disk on the runner.

**Release note**:
```release-note
NONE
```