### PR TITLE
chore(ci): remove redundant Go dependency download step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,10 +47,6 @@ jobs:
                go-version-file: go.mod
               id: go
 
-            - name: Get dependencies
-              run: |
-                go get -v -t -d ./...
-
             - name: Test
               id: test
               run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the deprecated `go get -v -t -d ./...` step from the Go test workflow. `go get` for dependency downloading has been deprecated since Go 1.17 in favor of `go mod download`. More importantly, the step is entirely redundant - `actions/setup-go@v5` already [handles module caching automatically](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) when `go-version-file` is set, and `make test` resolves any remaining dependencies on its own.

**Release note**:
```release-note
NONE
```