### PR TITLE
fix(ci): restrict workflow re-run to repo collaborators

### DIFF
--- a/.github/workflows/re-run-actions.yml
+++ b/.github/workflows/re-run-actions.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   rerun_pr_tests:
     name: rerun_pr_tests
-    if: ${{ github.event.issue.pull_request }}
+    if: github.event.issue.pull_request != '' && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR' || github.event.comment.author_association == 'MEMBER')
     runs-on: ubuntu-latest
     steps:
     - uses: estroz/rerun-actions@main


### PR DESCRIPTION
**What this PR does / why we need it**:

Restricts the `/rerun-all` comment command to repository collaborators (`OWNER`, `COLLABORATOR`, `CONTRIBUTOR, MEMBER`). Previously, any GitHub user could comment on a PR to retrigger all failed CI workflows - potentially burning CI minutes without authorization. This matches the access control pattern already used by `comment-cherry-pick.yml`.

**Release note**:
```release-note
NONE
```