### PR TITLE
fix(llmisvc): remove unreachable RefsInvalid early-return guards

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -365,13 +365,6 @@ func (r *LLMISVCReconciler) EvaluateGatewayConditions(ctx context.Context, llmSv
 		return nil
 	}
 
-	// Check if there's already a validation failure condition set
-	condition := llmSvc.GetStatus().GetCondition(v1alpha2.GatewaysReady)
-	if condition != nil && condition.IsFalse() && condition.Reason == RefsInvalidReason {
-		logger.Info("Gateway validation failed, skipping readiness evaluation", "reason", condition.Reason, "message", condition.Message)
-		return nil
-	}
-
 	gateways, err := r.CollectReferencedGateways(ctx, llmSvc)
 	if err != nil {
 		llmSvc.MarkGatewaysNotReady("GatewayFetchError", "Failed to fetch referenced Gateways: %v", err.Error())
@@ -461,13 +454,6 @@ func (r *LLMISVCReconciler) EvaluateHTTPRouteConditions(ctx context.Context, llm
 	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil || llmSvc.Spec.Router.Route.HTTP == nil {
 		logger.Info("No HTTPRoute configuration found, clearing HTTPRoutesReady condition")
 		llmSvc.MarkHTTPRoutesReadyUnset()
-		return nil
-	}
-
-	// Check if there's already a validation failure condition set
-	condition := llmSvc.GetStatus().GetCondition(v1alpha2.HTTPRoutesReady)
-	if condition != nil && condition.IsFalse() && condition.Reason == RefsInvalidReason {
-		logger.Info("HTTPRoute validation failed, skipping readiness evaluation", "reason", condition.Reason, "message", condition.Message)
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes dead early-return blocks in `EvaluateGatewayConditions` and `EvaluateHTTPRouteConditions` that checked for a `RefsInvalid` condition and skipped re-evaluation when it was set.

These guards are unreachable through two independent mechanisms:

1. If `validateRouterReferences` fails with `RefsInvalid`, it returns an error and the evaluate functions never run
2. If `validateRouterReferences` succeeds, it clears the conditions via `MarkGatewaysReadyUnset()` / `MarkHTTPRoutesReadyUnset()` before the evaluate functions run - so the `RefsInvalid` check can never match

The guards also masked a real bug - when a referenced Gateway or HTTPRoute was created *after* the `LLMInferenceService`, the initial `RefsInvalid` condition would prevent re-evaluation, leaving stale "does not exist" conditions even after the resources appeared.

**Which issue(s) this PR fixes**:

N/A - dead code cleanup that also prevents a latent staleness bug.

**Feature/Issue validation/testing**:

Integration tests for stale condition clearing already exist (`Stale condition cleanup` context in `controller_int_test.go`) and continue to pass.

- [x] `go build ./pkg/controller/v1alpha2/llmisvc/...`
- [x] `make precommit`

**Special notes for your reviewer**:

Port of opendatahub-io/kserve#1011 (partially - the upstream codebase already had most of the fixes from that PR; only the dead code removal was missing).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```