### PR TITLE
feat: add /v1/responses HTTPRoute for OpenAI Responses API support

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -1530,6 +1530,25 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/config/llmisvcconfig/config-llm-router-route.yaml
+++ b/config/llmisvcconfig/config-llm-router-route.yaml
@@ -58,6 +58,27 @@ spec:
                 backendRequest: 0s
                 request: 0s
             - backendRefs:
+                - group: inference.networking.k8s.io
+                  kind: InferencePool
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
+                      /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /v1/responses
+              timeouts:
+                backendRequest: 0s
+                request: 0s
+            - backendRefs:
                 - kind: Service
                   name: |-
                     {{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -3985,6 +3985,25 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -3571,6 +3571,25 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
@@ -39,7 +39,6 @@ from .types import (
 
 COMPLETIONS_ENDPOINT = "/v1/completions"
 CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
-RESPONSES_ENDPOINT = "/v1/responses"
 
 
 def error_handler(f):
@@ -144,9 +143,6 @@ class OpenAIProxyModel(OpenAIGenerativeModel):
         )
         self._chat_completions_endpoint = (
             f"{self.predictor_url.rstrip('/')}{CHAT_COMPLETIONS_ENDPOINT}"
-        )
-        self._responses_endpoint = (
-            f"{self.predictor_url.rstrip('/')}{RESPONSES_ENDPOINT}"
         )
         if health_endpoint:
             self._health_endpoint = f"{self.predictor_url.rstrip('/')}{health_endpoint}"

--- a/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
+++ b/python/kserve/kserve/protocol/rest/openai/openai_proxy_model.py
@@ -39,6 +39,7 @@ from .types import (
 
 COMPLETIONS_ENDPOINT = "/v1/completions"
 CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
+RESPONSES_ENDPOINT = "/v1/responses"
 
 
 def error_handler(f):
@@ -143,6 +144,9 @@ class OpenAIProxyModel(OpenAIGenerativeModel):
         )
         self._chat_completions_endpoint = (
             f"{self.predictor_url.rstrip('/')}{CHAT_COMPLETIONS_ENDPOINT}"
+        )
+        self._responses_endpoint = (
+            f"{self.predictor_url.rstrip('/')}{RESPONSES_ENDPOINT}"
         )
         if health_endpoint:
             self._health_endpoint = f"{self.predictor_url.rstrip('/')}{health_endpoint}"


### PR DESCRIPTION
Route /v1/responses traffic through InferencePool in LLMInferenceService configs, enabling backends (vLLM, SGLang) that already implement the Responses API to receive requests. Added route rules to both kustomize and Helm chart configs, added RESPONSES_ENDPOINT constant to the Python proxy model, and regenerated quick-install scripts.
