### PR TITLE
chore: remove coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # KServe
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/kserve/kserve)
-[![Coverage Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/andyi2it/5174bd748ac63a6e4803afea902e9810/raw/coverage.json)](https://github.com/kserve/kserve/actions/workflows/go.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kserve/kserve)](https://goreportcard.com/report/github.com/kserve/kserve)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6643/badge)](https://bestpractices.coreinfrastructure.org/projects/6643)
 [![Releases](https://img.shields.io/github/release-pre/kserve/kserve.svg?sort=semver)](https://github.com/kserve/kserve/releases)


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the coverage badge from `README.md`

The data is not up to date. The [source Gist](https://gist.githubusercontent.com/andyi2it/5174bd748ac63a6e4803afea902e9810) hasn't been updated in about 9 months.

**Release note**:
```release-note
NONE
```
