### PR TITLE
ci: optimize Python Dockerfile builds with cache mounts

### DIFF
--- a/.github/workflows/huggingface-vllm-docker-publish-manual.yml
+++ b/.github/workflows/huggingface-vllm-docker-publish-manual.yml
@@ -19,11 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: 
+        image:
           - version: ${{ inputs.version }}
             path: 'python/huggingface_server_cpu.Dockerfile'
+            cache-scope: hf-cpu
           - version: ${{ inputs.version }}-gpu
             path: 'python/huggingface_server.Dockerfile'
+            cache-scope: hf-gpu
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -67,7 +69,9 @@ jobs:
           context: python
           file: ${{ matrix.image.path }}
           push: true
-          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }} 
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
           # https://github.com/docker/buildx/issues/1533
           provenance: false
           sbom: true
+          cache-from: type=gha,scope=${{ matrix.image.cache-scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.cache-scope }}

--- a/python/.dockerignore
+++ b/python/.dockerignore
@@ -1,14 +1,16 @@
-# Exclude dev artifacts from Python image builds (context: python/)
-**/.venv/
+# Exclude test/doc/build artifacts from all allowed directories
 **/__pycache__/
 **/*.pyc
 **/*.pyo
-**/.pytest_cache/
-**/.ruff_cache/
-**/.mypy_cache/
 **/*.egg-info/
+**/.pytest_cache/
+**/tests/
+**/test/
+**/docs/
+**/.openapi-generator/
+**/.venv/
+**/build/
 **/dist/
-kserve/test/
-kserve/docs/
-**/.idea/
-**/.vscode/
+**/.mypy_cache/
+**/.ruff_cache/
+**/third_party/library/

--- a/python/aiffairness.Dockerfile
+++ b/python/aiffairness.Dockerfile
@@ -5,12 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Required for building packages for arm64 arch
-RUN apt-get update && apt-get install -y --no-install-recommends curl python3-dev build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Set up and activate virtual environment
 ARG VENV_PATH
@@ -18,29 +17,27 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ Install kserve dependencies ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # Copy source code separately (better Docker caching)
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # ------------------ Install aiffairness dependencies ------------------
 COPY aiffairness/pyproject.toml aiffairness/uv.lock aiffairness/
-RUN cd aiffairness && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd aiffairness && uv sync --active
 
 COPY aiffairness aiffairness
-RUN cd aiffairness && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd aiffairness && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 

--- a/python/artexplainer.Dockerfile
+++ b/python/artexplainer.Dockerfile
@@ -5,12 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Required for building packages for arm64 arch
-RUN apt-get update && apt-get install -y --no-install-recommends curl python3-dev build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Setup virtual environment
 ARG VENV_PATH
@@ -18,28 +17,26 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ kserve deps ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # ------------------ artexplainer deps ------------------
 COPY artexplainer/pyproject.toml artexplainer/uv.lock artexplainer/
-RUN cd artexplainer && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd artexplainer && uv sync --active
 
 COPY artexplainer artexplainer
-RUN cd artexplainer && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd artexplainer && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 

--- a/python/custom_model.Dockerfile
+++ b/python/custom_model.Dockerfile
@@ -5,17 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    build-essential \
-    python3-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends build-essential python3-dev
 
 # Install uv and ensure it's in PATH
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Set up Python virtual environment
 ARG VENV_PATH
@@ -23,28 +17,26 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ Install kserve ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # ------------------ Install custom_model ------------------
 COPY custom_model/pyproject.toml custom_model/uv.lock custom_model/
-RUN cd custom_model && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_model && uv sync --active
 
 COPY custom_model custom_model
-RUN cd custom_model && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_model && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ------------------ Final production image ------------------

--- a/python/custom_model_grpc.Dockerfile
+++ b/python/custom_model_grpc.Dockerfile
@@ -5,17 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    build-essential \
-    python3-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends build-essential python3-dev
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Set up and activate virtual environment
 ARG VENV_PATH
@@ -23,28 +17,26 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ kserve deps ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # ------------------ custom_model deps ------------------
 COPY custom_model/pyproject.toml custom_model/uv.lock custom_model/
-RUN cd custom_model && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_model && uv sync --active
 
 COPY custom_model custom_model
-RUN cd custom_model && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_model && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ------------------ Final stage ------------------

--- a/python/custom_tokenizer.Dockerfile
+++ b/python/custom_tokenizer.Dockerfile
@@ -5,17 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    build-essential \
-    python3-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends build-essential python3-dev
 
 # Install uv and ensure it's in PATH
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Create Python virtual environment
 ARG VENV_PATH
@@ -23,28 +17,26 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ Install kserve ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # ------------------ Install custom_tokenizer ------------------
 COPY custom_tokenizer/pyproject.toml custom_tokenizer/uv.lock custom_tokenizer/
-RUN cd custom_tokenizer && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_tokenizer && uv sync --active
 
 COPY custom_tokenizer custom_tokenizer
-RUN cd custom_tokenizer && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_tokenizer && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 

--- a/python/custom_transformer.Dockerfile
+++ b/python/custom_transformer.Dockerfile
@@ -5,17 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    build-essential \
-    python3-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends build-essential python3-dev
 
 # Install uv and ensure it's in PATH
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Create virtual environment
 ARG VENV_PATH
@@ -23,28 +17,26 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install kserve dependencies
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # Install custom_transformer dependencies
 COPY custom_transformer/pyproject.toml custom_transformer/uv.lock custom_transformer/
-RUN cd custom_transformer && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_transformer && uv sync --active
 
 COPY custom_transformer custom_transformer
-RUN cd custom_transformer && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_transformer && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ---------- Production image ----------

--- a/python/custom_transformer_grpc.Dockerfile
+++ b/python/custom_transformer_grpc.Dockerfile
@@ -5,17 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    build-essential \
-    python3-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends build-essential python3-dev
 
 # Install uv and ensure it's in PATH
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Create Python virtual environment
 ARG VENV_PATH
@@ -23,28 +17,26 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ------------------ Install kserve ------------------
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # ------------------ Install custom_transformer ------------------
 COPY custom_transformer/pyproject.toml custom_transformer/uv.lock custom_transformer/
-RUN cd custom_transformer && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_transformer && uv sync --active
 
 COPY custom_transformer custom_transformer
-RUN cd custom_transformer && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd custom_transformer && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ------------------ Final Production Image ------------------

--- a/python/error_404_isvc.Dockerfile
+++ b/python/error_404_isvc.Dockerfile
@@ -4,12 +4,11 @@ ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
 
-RUN apt-get update && apt-get install -y gcc python3-dev curl && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y gcc python3-dev
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Activate virtual env
 ARG VENV_PATH
@@ -17,27 +16,23 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
-RUN echo $(pwd)
-RUN echo $(ls)
 COPY test_resources/graph/error_404_isvc/pyproject.toml test_resources/graph/error_404_isvc/uv.lock test_resources/graph/error_404_isvc/
-RUN cd test_resources/graph/error_404_isvc && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd test_resources/graph/error_404_isvc && uv sync --active
 COPY test_resources/graph/error_404_isvc test_resources/graph/error_404_isvc
-RUN cd test_resources/graph/error_404_isvc && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd test_resources/graph/error_404_isvc && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 FROM ${BASE_IMAGE} AS prod

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -124,7 +124,7 @@ WORKDIR ${WORKSPACE_DIR}
 RUN apt-get update -y \
     && apt-get upgrade -y \
     && apt-get install -y software-properties-common curl \
-    && apt-get install -y ffmpeg libsm6 libxext6 libgl1 gcc libibverbs1 \
+    && apt-get install -y ffmpeg libsm6 libxext6 libgl1 gcc libibverbs-dev \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update -y \
     && apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -116,7 +116,7 @@ COPY huggingfaceserver huggingfaceserver
 # --no-deps: deps are already correct from the sync above; this just makes the
 # package importable from source without reinstalling (and re-CPU-ifying) torch.
 RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && \
-    uv pip install --active --no-deps -e .
+    uv pip install --no-deps -e .
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -100,14 +100,23 @@ RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
 
 COPY huggingfaceserver/pyproject.toml huggingfaceserver/uv.lock huggingfaceserver/health_check.py huggingfaceserver/
 RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
-COPY huggingfaceserver huggingfaceserver
-RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
 
-# Restore GPU torch via pip - uv sync resolves torch to CPU wheels from the lockfile
-# (evaluated on CPU CI runners). Unlike uv, pip's wheel resolver selects CUDA-compiled
-# torch when running inside a CUDA container, overriding whatever uv installed.
+# Restore GPU torch - uv sync resolves torch to CPU wheels from the lockfile since it's
+# evaluated on CPU CI runners. pip's wheel resolver picks CUDA-compiled wheels inside a
+# CUDA container. Placed after metadata-only sync so this layer stays cached on hfserver
+# source changes (only lockfile/pyproject changes bust this layer).
+# Only torch is reinstalled - much lighter than reinstalling vllm.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir vllm[runai,tensorizer,fastsafetensors]==${VLLM_VERSION}
+    TORCH_VER=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
+    CUDA_SHORT=$(echo ${CUDA_VERSION} | cut -d. -f1,2 | tr -d '.') && \
+    pip install --no-cache-dir "torch==${TORCH_VER}" \
+        --index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
+
+COPY huggingfaceserver huggingfaceserver
+# --no-deps: deps are already correct from the sync above; this just makes the
+# package importable from source without reinstalling (and re-CPU-ifying) torch.
+RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && \
+    uv pip install --active --no-deps -e .
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -103,6 +103,12 @@ RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --
 COPY huggingfaceserver huggingfaceserver
 RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
 
+# Restore GPU torch - uv sync resolves torch to CPU wheels on CPU CI runners since the
+# lockfile is platform-evaluated at build time. Reinstalling vllm pins GPU torch back.
+# This layer is fast: wheels are already in the uv cache from the install above.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install vllm[runai,tensorizer,fastsafetensors]==${VLLM_VERSION}
+
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -101,20 +101,16 @@ RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
 COPY huggingfaceserver/pyproject.toml huggingfaceserver/uv.lock huggingfaceserver/health_check.py huggingfaceserver/
 RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
 
-# Restore GPU torch - uv sync resolves torch to CPU wheels from the lockfile since it's
-# evaluated on CPU CI runners. pip's wheel resolver picks CUDA-compiled wheels inside a
-# CUDA container. Placed after metadata-only sync so this layer stays cached on hfserver
-# source changes (only lockfile/pyproject changes bust this layer).
-# Only torch is reinstalled - much lighter than reinstalling vllm.
+# Restore GPU torch via pip - uv sync resolves torch to CPU wheels from the lockfile
+# (evaluated on CPU CI runners). pip's CUDA-aware wheel resolver overrides this.
+# Positioned after metadata-only sync so this layer stays cached on hfserver source
+# changes - only lockfile/pyproject changes bust it.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    TORCH_VER=$(python -c "import torch; print(torch.__version__.split('+')[0])") && \
-    CUDA_SHORT=$(echo ${CUDA_VERSION} | cut -d. -f1,2 | tr -d '.') && \
-    pip install --no-cache-dir "torch==${TORCH_VER}" \
-        --index-url "https://download.pytorch.org/whl/cu${CUDA_SHORT}"
+    pip install --no-cache-dir vllm[runai,tensorizer,fastsafetensors]==${VLLM_VERSION}
 
 COPY huggingfaceserver huggingfaceserver
-# --no-deps: deps are already correct from the sync above; this just makes the
-# package importable from source without reinstalling (and re-CPU-ifying) torch.
+# --no-deps: vllm and GPU torch are already pinned above; this just makes hfserver
+# importable from source without touching deps (avoids re-CPU-ifying torch).
 RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && \
     uv pip install --no-deps -e .
 

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -25,8 +25,7 @@ RUN apt-get update -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install uv and ensure it's in PATH
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Workaround for https://github.com/openai/triton/issues/2507 and
 # https://github.com/pytorch/pytorch/issues/107960 -- hopefully
@@ -66,42 +65,43 @@ ENV PATH="${WORKSPACE_DIR}/${VENV_PATH}/bin:$PATH"
 
 # From this point, all Python packages will be installed in the virtual environment and copied to the final image
 
-# Copy storage metadata for editable dependency resolution
-COPY storage/pyproject.toml storage/uv.lock storage/
-
-COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active --no-cache
-COPY kserve kserve  
-RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active --no-cache
-
-# Install kserve-storage
-COPY storage storage
-RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install . --no-cache
-
-COPY huggingfaceserver/pyproject.toml huggingfaceserver/uv.lock huggingfaceserver/health_check.py huggingfaceserver/
-RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --no-cache
-COPY huggingfaceserver huggingfaceserver
-RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --no-cache
+# ---- ML dependencies FIRST (change rarely, expensive to download) ----
 
 # Install vllm
 # https://docs.vllm.ai/en/latest/models/extensions/runai_model_streamer.html, https://docs.vllm.ai/en/latest/models/extensions/tensorizer.html
 # https://docs.vllm.ai/en/latest/models/extensions/fastsafetensor.html
-RUN --mount=type=cache,target=/root/.cache/pip pip install vllm[runai,tensorizer,fastsafetensors]==${VLLM_VERSION}
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install vllm[runai,tensorizer,fastsafetensors]==${VLLM_VERSION}
 
 # Install lmcache
-RUN --mount=type=cache,target=/root/.cache/pip pip install lmcache==${LMCACHE_VERSION}
-
-# Use Bash with `-o pipefail` so we can leverage Bash-specific features (like `[[ … ]]` for glob tests)
-# and ensure that failures in any part of a piped command cause the build to fail immediately.
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install lmcache==${LMCACHE_VERSION}
 
 # Install flashinfer
 # https://docs.flashinfer.ai/installation.html
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install flashinfer-cubin==${FLASHINFER_VERSION} && \
-    pip install flashinfer-jit-cache==${FLASHINFER_VERSION} \
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install flashinfer-cubin==${FLASHINFER_VERSION} && \
+    uv pip install flashinfer-jit-cache==${FLASHINFER_VERSION} \
         --extra-index-url https://flashinfer.ai/whl/cu$(echo ${CUDA_VERSION} | cut -d. -f1,2 | tr -d '.') && \
     flashinfer show-config
+
+# ---- kserve packages (change often, fast to reinstall) ----
+
+# Copy only storage metadata for kserve's editable path dep resolution
+COPY storage/pyproject.toml storage/uv.lock storage/
+
+COPY kserve/pyproject.toml kserve/uv.lock kserve/
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active --inexact
+COPY kserve kserve
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active --inexact
+
+COPY storage storage
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
+
+COPY huggingfaceserver/pyproject.toml huggingfaceserver/uv.lock huggingfaceserver/health_check.py huggingfaceserver/
+RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
+COPY huggingfaceserver huggingfaceserver
+RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
@@ -124,7 +124,7 @@ WORKDIR ${WORKSPACE_DIR}
 RUN apt-get update -y \
     && apt-get upgrade -y \
     && apt-get install -y software-properties-common curl \
-    && apt-get install -y ffmpeg libsm6 libxext6 libgl1 gcc libibverbs-dev \
+    && apt-get install -y ffmpeg libsm6 libxext6 libgl1 gcc libibverbs1 \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update -y \
     && apt-get install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \

--- a/python/huggingface_server.Dockerfile
+++ b/python/huggingface_server.Dockerfile
@@ -103,11 +103,11 @@ RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --
 COPY huggingfaceserver huggingfaceserver
 RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
 
-# Restore GPU torch - uv sync resolves torch to CPU wheels on CPU CI runners since the
-# lockfile is platform-evaluated at build time. Reinstalling vllm pins GPU torch back.
-# This layer is fast: wheels are already in the uv cache from the install above.
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install vllm[runai,tensorizer,fastsafetensors]==${VLLM_VERSION}
+# Restore GPU torch via pip - uv sync resolves torch to CPU wheels from the lockfile
+# (evaluated on CPU CI runners). Unlike uv, pip's wheel resolver selects CUDA-compiled
+# torch when running inside a CUDA container, overriding whatever uv installed.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-cache-dir vllm[runai,tensorizer,fastsafetensors]==${VLLM_VERSION}
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml

--- a/python/huggingface_server_cpu.Dockerfile
+++ b/python/huggingface_server_cpu.Dockerfile
@@ -9,6 +9,7 @@ ARG PYTHON=python3
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends --fix-missing -y \
+        google-perftools \
         libgl1 \
         libglib2.0-0 \
         libjemalloc2 \
@@ -134,10 +135,9 @@ COPY --from=builder --chown=kserve:kserve storage storage
 ENV HF_HOME="/tmp/huggingface"
 ENV HF_HUB_DISABLE_TELEMETRY="1"
 
-# Use jemalloc for better memory management (matches the GPU image).
-# The original Dockerfile loaded both tcmalloc and jemalloc, but LD_PRELOAD
-# resolves left-to-right so only the first allocator is used - the second is dead weight.
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+# Use TCMalloc for CPU inference performance - it significantly reduces memory allocation
+# overhead for vllm's CPU-bound workloads. Jemalloc is retained as secondary allocator.
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4:/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 USER 1000
 ENV PYTHONPATH=/huggingfaceserver

--- a/python/huggingface_server_cpu.Dockerfile
+++ b/python/huggingface_server_cpu.Dockerfile
@@ -1,16 +1,14 @@
 ARG BASE_IMAGE=ubuntu:22.04
 ARG VENV_PATH=/prod_venv
 
-FROM ${BASE_IMAGE} AS base
+# ---- Runtime base: only what the production image needs ----
+FROM ${BASE_IMAGE} AS base-runtime
 
 ARG PYTHON=python3
 
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends --fix-missing -y \
-        g++-12 \
-        gcc-12 \
-        google-perftools \
         libgl1 \
         libglib2.0-0 \
         libjemalloc2 \
@@ -18,35 +16,32 @@ RUN apt-get update && \
         numactl \
         python3.10-dev \
         python3.10-venv \
-        python3-pip \
-        curl && \
+        python3-pip && \
     apt-get clean && \
-    apt-get autoclean && \
-    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
-
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10 --slave /usr/bin/g++ g++ /usr/bin/g++-12
-ENV CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12
 
 RUN ln -sf "$(which ${PYTHON})" /usr/bin/python
 
-FROM base AS builder
+# ---- Build base: adds compilers and build tools ----
+FROM base-runtime AS base-build
 
-# Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
-
-# Install build dependencies
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
     apt-get update && \
     apt-get install --no-install-recommends --fix-missing -y \
         build-essential \
+        ccache \
+        g++-12 \
+        gcc-12 \
         git \
-        libnuma-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+        libnuma-dev
 
-# Activate virtual env
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10 --slave /usr/bin/g++ g++ /usr/bin/g++-12
+
+# ---- Builder stage ----
+FROM base-build AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
+
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
@@ -55,44 +50,14 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ARG TORCH_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
 ARG TORCH_VERSION=2.10.0
 
-# Copy storage metadata for editable dependency resolution
-COPY storage/pyproject.toml storage/uv.lock storage/
-
-# Install kserve dependencies (metadata-first for cache)
-COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && \
-    uv sync --active --no-cache && \
-    uv cache clean && \
-    rm -rf ~/.cache/uv
-
-COPY kserve kserve
-RUN cd kserve && \
-    uv sync --active --no-cache && \
-    uv cache clean && \
-    rm -rf ~/.cache/uv
-
-# Install kserve-storage
-COPY storage storage
-RUN cd storage && uv pip install . --no-cache
-
-# Install huggingfaceserver dependencies (metadata-first for cache)
-COPY huggingfaceserver/pyproject.toml huggingfaceserver/uv.lock huggingfaceserver/health_check.py huggingfaceserver/
-RUN cd huggingfaceserver && \
-    uv pip install --no-cache-dir --index-url ${TORCH_EXTRA_INDEX_URL} \
+# ---- Install torch (needed by both vllm build and huggingfaceserver) ----
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --index-url ${TORCH_EXTRA_INDEX_URL} \
         torch==${TORCH_VERSION} \
         torchvision \
-        torchaudio && \
-    uv sync --active --no-cache && \
-    uv cache clean && \
-    rm -rf ~/.cache/uv
+        torchaudio
 
-COPY huggingfaceserver huggingfaceserver
-RUN cd huggingfaceserver && \
-    uv sync --active --no-cache && \
-    uv cache clean && \
-    rm -rf ~/.cache/uv
-
-# install vllm
+# ---- Build vllm FIRST (changes rarely, most expensive step) ----
 ARG VLLM_VERSION=0.17.1
 ARG VLLM_CPU_DISABLE_AVX512=true
 ENV VLLM_CPU_DISABLE_AVX512=${VLLM_CPU_DISABLE_AVX512}
@@ -100,52 +65,60 @@ ARG VLLM_CPU_AVX512BF16=1
 ENV VLLM_CPU_AVX512BF16=${VLLM_CPU_AVX512BF16}
 ARG VLLM_TARGET_DEVICE=cpu
 ENV VLLM_TARGET_DEVICE=${VLLM_TARGET_DEVICE}
-# Clone vLLM repo
+
 RUN git clone --single-branch --branch v${VLLM_VERSION} https://github.com/vllm-project/vllm.git
 
-# Install vLLM build requirements
-RUN cd vllm && \
-    uv pip install --no-cache -v --index-strategy unsafe-best-match --extra-index-url ${TORCH_EXTRA_INDEX_URL} -r requirements/cpu-build.txt && \
-    uv cache clean
+RUN --mount=type=cache,target=/root/.cache/uv cd vllm && \
+    uv pip install -v --index-strategy unsafe-best-match --extra-index-url ${TORCH_EXTRA_INDEX_URL} -r requirements/cpu-build.txt
 
-# Install vLLM cpu requirements
-RUN cd vllm && \
-    uv pip install --no-cache -v --index-strategy unsafe-best-match --extra-index-url ${TORCH_EXTRA_INDEX_URL} -r requirements/cpu.txt && \
-    uv cache clean
+RUN --mount=type=cache,target=/root/.cache/uv cd vllm && \
+    uv pip install -v --index-strategy unsafe-best-match --extra-index-url ${TORCH_EXTRA_INDEX_URL} -r requirements/cpu.txt
 
-# Build vLLM wheel
-RUN cd vllm && \
-    python setup.py bdist_wheel
+ENV PATH="/usr/lib/ccache:$PATH"
+RUN --mount=type=cache,target=/root/.ccache \
+    cd vllm && CCACHE_DIR=/root/.ccache python setup.py bdist_wheel
 
-# Install built vLLM wheel
-RUN uv pip install --no-cache vllm/dist/vllm-${VLLM_VERSION}*.whl
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install vllm/dist/vllm-${VLLM_VERSION}*.whl
 
-# Ensure CPU-only torch, torchvision, and torchaudio are installed.
-# Previous uv sync / pip install steps may have pulled CUDA wheels from PyPI;
-# this final reinstall from the CPU index guarantees CPU-only builds.
-RUN uv pip install --no-cache-dir --index-url ${TORCH_EXTRA_INDEX_URL} --reinstall \
-    torch==${TORCH_VERSION} \
-    torchvision \
-    torchaudio
+RUN rm -rf vllm /tmp/*
 
-# Cleanup vllm source code and caches
-RUN rm -rf /vllm /root/.cache/uv /root/.cache/pip /tmp/*
+# ---- Install kserve (changes often, fast to reinstall) ----
+COPY storage/pyproject.toml storage/uv.lock storage/
+COPY kserve/pyproject.toml kserve/uv.lock kserve/
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active --inexact
 
-RUN df -hT
+COPY kserve kserve
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active --inexact
+
+# ---- Install storage ----
+COPY storage storage
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
+
+# ---- Install huggingfaceserver ----
+COPY huggingfaceserver/pyproject.toml huggingfaceserver/uv.lock huggingfaceserver/
+RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
+
+COPY huggingfaceserver huggingfaceserver
+RUN --mount=type=cache,target=/root/.cache/uv cd huggingfaceserver && uv sync --active --inexact
+
+# Restore CPU-optimized torch - uv sync resolves torch to the generic PyPI version
+# (pinned in huggingfaceserver's lockfile), replacing the CPU-index wheels installed earlier.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --index-url ${TORCH_EXTRA_INDEX_URL} \
+        torch==${TORCH_VERSION} \
+        torchvision \
+        torchaudio
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
 # TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
+RUN --mount=type=cache,target=/root/.cache/pip pip install tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
-# Build the final image
-FROM base AS prod
+# ---- Production image ----
+FROM base-runtime AS prod
 
-RUN echo 'ulimit -c 0' >> ~/.bashrc
-
-# Activate virtual env
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -158,15 +131,13 @@ COPY --from=builder --chown=kserve:kserve huggingfaceserver huggingfaceserver
 COPY --from=builder --chown=kserve:kserve kserve kserve
 COPY --from=builder --chown=kserve:kserve storage storage
 
-RUN df -hT
-
-# Set a writable Hugging Face home folder to avoid permission issue. See https://github.com/kserve/kserve/issues/3562
 ENV HF_HOME="/tmp/huggingface"
-# https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfhubdisabletelemetry
 ENV HF_HUB_DISABLE_TELEMETRY="1"
 
-# Use TCMalloc and jemalloc for better memory management
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4:/usr/lib/x86_64-linux-gnu/libjemalloc.so.2:${LD_PRELOAD}
+# Use jemalloc for better memory management (matches the GPU image).
+# The original Dockerfile loaded both tcmalloc and jemalloc, but LD_PRELOAD
+# resolves left-to-right so only the first allocator is used - the second is dead weight.
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 USER 1000
 ENV PYTHONPATH=/huggingfaceserver

--- a/python/lgb.Dockerfile
+++ b/python/lgb.Dockerfile
@@ -5,12 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
 # Install uv and ensure it's in PATH
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Activate virtual env
 ARG VENV_PATH
@@ -23,27 +22,28 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
-# Install kserve-storage
+# Copy and install dependencies for kserve-storage using uv
+COPY storage/pyproject.toml storage/uv.lock storage/
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv sync --active
+
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
 
 # Install dependencies for lgbserver using uv
 COPY lgbserver/pyproject.toml lgbserver/uv.lock lgbserver/
-RUN cd lgbserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd lgbserver && uv sync --active
 
 COPY lgbserver lgbserver
-RUN cd lgbserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd lgbserver && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ---------- Production image ----------

--- a/python/paddle.Dockerfile
+++ b/python/paddle.Dockerfile
@@ -7,12 +7,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
 # Install uv and ensure it's in PATH
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Activate virtual env
 ARG VENV_PATH
@@ -25,27 +24,28 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install kserve dependencies using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
-# Install kserve-storage
+# Copy and install dependencies for kserve-storage using uv
+COPY storage/pyproject.toml storage/uv.lock storage/
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv sync --active
+
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
 
 # Install paddleserver dependencies using uv
 COPY paddleserver/pyproject.toml paddleserver/uv.lock paddleserver/
-RUN cd paddleserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd paddleserver && uv sync --active
 
 COPY paddleserver paddleserver
-RUN cd paddleserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd paddleserver && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ---------- Production image ----------

--- a/python/pmml.Dockerfile
+++ b/python/pmml.Dockerfile
@@ -7,20 +7,17 @@ FROM ${BASE_IMAGE} AS builder
 
 ARG PYTHON_VERSION
 # Install python
-RUN apt-get update && \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     "python${PYTHON_VERSION}" \
     "python${PYTHON_VERSION}-dev" \
     "python${PYTHON_VERSION}-venv" \
     python3-pip \
-    curl \
-    gcc build-essential && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    gcc build-essential
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Setup virtual environment
 ARG VENV_PATH
@@ -33,27 +30,28 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
-# Install kserve-storage
+# Copy and install dependencies for kserve-storage using uv
+COPY storage/pyproject.toml storage/uv.lock storage/
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv sync --active
+
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
 
 # Install dependencies for pmmlserver using uv
 COPY pmmlserver/pyproject.toml pmmlserver/uv.lock pmmlserver/
-RUN cd pmmlserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd pmmlserver && uv sync --active
 
 COPY pmmlserver pmmlserver
-RUN cd pmmlserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd pmmlserver && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN uv pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ---------- Production image ----------

--- a/python/predictiveserver.Dockerfile
+++ b/python/predictiveserver.Dockerfile
@@ -12,8 +12,7 @@ RUN dnf install -y python3.11-devel gcc gcc-c++ make && \
     dnf clean all
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Create virtual environment with Python 3.11
 ARG VENV_PATH
@@ -31,13 +30,11 @@ COPY predictiveserver predictiveserver
 
 # ========== Install everything through predictiveserver ==========
 # predictiveserver depends on all other packages, so installing it will install everything
-RUN cd predictiveserver && uv pip install --no-cache .
+RUN --mount=type=cache,target=/root/.cache/uv cd predictiveserver && uv pip install .
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party third_party
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 third_party/pip-licenses.py
 
 

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -5,12 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Create virtual environment
 ARG VENV_PATH
@@ -23,27 +22,28 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # ========== Install kserve dependencies ==========
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 # ========== Install kserve storage dependencies ==========
+COPY storage/pyproject.toml storage/uv.lock storage/
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv sync --active
+
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
 
 # ========== Install sklearnserver dependencies ==========
 COPY sklearnserver/pyproject.toml sklearnserver/uv.lock sklearnserver/
-RUN cd sklearnserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd sklearnserver && uv sync --active
 
 COPY sklearnserver sklearnserver
-RUN cd sklearnserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd sklearnserver && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 

--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -5,11 +5,10 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install all system dependencies first
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Activate virtual env
 ARG VENV_PATH
@@ -19,21 +18,21 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install Python dependencies
 COPY storage/pyproject.toml storage/uv.lock storage/
-RUN cd storage && uv sync --active --no-cache 
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv sync --active
 
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache 
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y \
     gcc \
     libkrb5-dev \
-    krb5-config \
-    && rm -rf /var/lib/apt/lists/*
+    krb5-config
 
 # Install Kerberos-related packages
-RUN uv pip install --no-cache \
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install \
     krbcontext==0.10 \
     hdfs~=2.6.0 \
     requests-kerberos==0.14.0
@@ -41,8 +40,6 @@ RUN uv pip install --no-cache \
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 FROM ${BASE_IMAGE} AS prod

--- a/python/success_200_isvc.Dockerfile
+++ b/python/success_200_isvc.Dockerfile
@@ -4,12 +4,11 @@ ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
 
-RUN apt-get update && apt-get install -y gcc python3-dev curl && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y gcc python3-dev
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Activate virtual env
 ARG VENV_PATH
@@ -17,27 +16,23 @@ ENV VIRTUAL_ENV=${VENV_PATH}
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Copy storage metadata for editable dependency resolution
+# Copy only storage metadata for kserve's editable path dep resolution
 COPY storage/pyproject.toml storage/uv.lock storage/
 
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
-RUN echo $(pwd)
-RUN echo $(ls)
 COPY test_resources/graph/success_200_isvc/pyproject.toml test_resources/graph/success_200_isvc/uv.lock test_resources/graph/success_200_isvc/
-RUN cd test_resources/graph/success_200_isvc && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd test_resources/graph/success_200_isvc && uv sync --active
 COPY test_resources/graph/success_200_isvc test_resources/graph/success_200_isvc
-RUN cd test_resources/graph/success_200_isvc && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd test_resources/graph/success_200_isvc && uv sync --active
 
-# Generate third-party licenses 
+# Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 FROM ${BASE_IMAGE} AS prod

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -5,12 +5,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install necessary dependencies for building Python packages
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt --mount=type=cache,sharing=locked,target=/var/lib/apt/lists \
+    apt-get update && apt-get install -y --no-install-recommends python3-dev build-essential
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /usr/local/bin/uv
 
 # Activate virtual env
 ARG VENV_PATH
@@ -23,25 +22,26 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Copy and install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd kserve && uv sync --active
 
-# Install kserve-storage
+# Copy and install dependencies for kserve-storage using uv
+COPY storage/pyproject.toml storage/uv.lock storage/
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv sync --active
+
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd storage && uv pip install .
 
 # Copy and install dependencies for xgbserver using uv
 COPY xgbserver/pyproject.toml xgbserver/uv.lock xgbserver/
-RUN cd xgbserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd xgbserver && uv sync --active
 COPY xgbserver xgbserver
-RUN cd xgbserver && uv sync --active --no-cache
+RUN --mount=type=cache,target=/root/.cache/uv cd xgbserver && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
-# TODO: Remove this when upgrading to python 3.11+
-RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ---------- Production Image ----------

--- a/test/scripts/gh-actions/build-server-runtimes.sh
+++ b/test/scripts/gh-actions/build-server-runtimes.sh
@@ -89,6 +89,8 @@ pushd python >/dev/null
         df -hT
     echo "Building Huggingface CPU image"
     docker buildx build -t "${HUGGINGFACE_CPU_IMG_TAG}" -f huggingface_server_cpu.Dockerfile \
+      --cache-from type=gha,scope=hf-cpu \
+      --cache-to type=gha,mode=max,scope=hf-cpu \
       -o type=docker,dest="${DOCKER_IMAGES_PATH}/${HUGGINGFACE_IMG}-${TAG}",compression-level=0 .
     echo "Disk usage after Building Huggingface CPU image:"
         df -hT


### PR DESCRIPTION
**What this PR does / why we need it**:

Optimizes all 18 Python Dockerfiles for faster incremental builds. The main bottleneck today is that any kserve source change triggers full dependency reinstalls - including expensive ML packages like vllm, flashinfer, and lmcache on the HuggingFace images.

Three key changes drive the improvement:

- **BuildKit cache mounts** for uv/pip/apt/ccache across all Dockerfiles. The lightweight images used \`--no-cache\` to avoid polluting layers (correct without mounts), while the GPU HF Dockerfile already had cache mounts but still passed \`--no-cache\` to uv - making the mounts useless. This PR adds cache mounts everywhere and drops \`--no-cache\` so they actually work.
- **Layer reordering on HF images** - ML dependencies (vllm, lmcache, flashinfer) are installed before kserve source code, so source changes don't cascade into 300+ second reinstalls. Uses \`uv sync --inexact\` to prevent uv from removing ML packages that aren't in the project's lockfile but were installed in earlier layers.
- **Storage metadata-first pattern** - only \`pyproject.toml\` and \`uv.lock\` are copied for dependency resolution instead of the full storage directory, preventing storage source changes from busting the kserve dependency layer.

Also cleans up stale patterns: deterministic uv install via \`COPY --from\` instead of \`curl | sh\`, removal of dead code, \`sharing=locked\` on apt cache mounts, and a \`.dockerignore\` to shrink build contexts.

CPU HF Dockerfile gets a deeper restructure: base split into runtime/build stages so compilers don't leak into the production image, and ccache for incremental vllm C++ builds.

**Note on two reverted changes:** The original version of this PR also dropped \`google-perftools\` (tcmalloc) from the CPU runtime image and switched \`libibverbs-dev\` to \`libibverbs1\` in the GPU image. Both turned out to be regressions caught by CI:

- The LD_PRELOAD analysis was correct (ld.so resolves left-to-right, so tcmalloc was the effective allocator and jemalloc was shadowed) — but the conclusion was wrong. Jemalloc is not a performance-equivalent replacement for tcmalloc on vllm CPU workloads. Model loading timed out in E2E tests without it. \`google-perftools\` and the original \`LD_PRELOAD\` are restored.
- \`libibverbs1\` (runtime-only) caused vllm engine core init to crash. \`libibverbs-dev\` is restored.

Benchmark results ([full details with script](https://gist.github.com/bartoszmajsak/76f29289e95a1a8d3f01f02d75a87847)):

| Image | Scenario | Master | This PR | Speedup |
|---|---|---|---|---|
| custom_model | kserve source change | 99s | 66s | 33% faster |
| custom_model | storage source change | 92s | 1s | 92x faster |
| HF GPU | kserve source change | 561s | 220s | 61% faster |
| HF GPU | hfserver source change | 334s | 100s | 70% faster |

Cold builds are roughly the same (cache mounts start empty, reorder doesn't help first build). All gains are on incremental rebuilds - the common case during development and CI.

Functional equivalence verified by comparing installed packages between master and feature images. GPU image differs only in numpy patch version (2.2.0 vs 2.2.4). CPU image is identical.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] All 18 Dockerfiles build successfully
- [x] GPU image package parity verified (213 packages, only numpy patch diff)
- [x] CPU image package parity verified (zero diff)
- [x] Incremental build benchmarks measured on cold-pruned docker cache

**Special notes for your reviewer**:

The HF Dockerfiles use \`uv sync --active --inexact\` after the ML dependency block. The \`--inexact\` flag prevents \`uv sync\` from removing packages (vllm, flashinfer, etc.) that aren't in the project's lockfile but were installed in earlier layers. Without it, the reorder silently strips ML dependencies from the final image.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

\`\`\`release-note
NONE
\`\`\`