### PR TITLE
fix(llmisvc): migrate tokenProcessorConfig and blockSize

### DIFF
--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-opt-125m-cpu-kv-cache-routing-simulator.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-opt-125m-cpu-kv-cache-routing-simulator.yaml
@@ -27,12 +27,12 @@ spec:
             - type: single-profile-handler
             - type: precise-prefix-cache-scorer
               parameters:
+                tokenProcessorConfig:
+                  blockSize: 16
+                  hashSeed: "42"
                 kvEventsConfig:
                   zmqEndpoint: "tcp://*:5557"
                 indexerConfig:
-                  tokenProcessorConfig:
-                    blockSize: 16
-                    hashSeed: "42"
                   kvBlockIndexConfig:
                     enableMetrics: true
                     metricsLoggingInterval: 60000000000

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
@@ -19,12 +19,12 @@ spec:
             - type: single-profile-handler
             - type: precise-prefix-cache-scorer
               parameters:
+                tokenProcessorConfig:
+                  blockSize: 64       # Must match vLLM --block-size (default is 16)
+                  hashSeed: "42"      # Must match PYTHONHASHSEED in vLLM pods
                 kvEventsConfig:
                   zmqEndpoint: "tcp://*:5557"
                 indexerConfig:
-                  tokenProcessorConfig:
-                    blockSize: 64       # Must match vLLM --block-size (default is 16)
-                    hashSeed: "42"      # Must match PYTHONHASHSEED in vLLM pods
                   kvBlockIndexConfig:
                     enableMetrics: true                   # Enable Prometheus metrics for KV cache index
                     metricsLoggingInterval: 60000000000   # Log metrics every 60 seconds (in nanoseconds)

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1141,6 +1141,9 @@ schedulingProfiles:
 				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
 				g.Expect(configText).To(ContainSubstring("modelName: base"))
 				g.Expect(configText).To(ContainSubstring("socketFile: /tmp/tokenizer/tokenizer-uds.socket"))
+				// Verify tokenProcessorConfig was migrated from indexerConfig to top-level parameters
+				g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
+				g.Expect(configText).To(ContainSubstring("blockSize: 16"))
 				return nil
 			}).WithContext(ctx).Should(Succeed())
 		})
@@ -1206,6 +1209,9 @@ schedulingProfiles:
 				g.Expect(configText).To(ContainSubstring("socketFile: /tmp/tokenizer/tokenizer-uds.socket"))
 				g.Expect(configText).NotTo(ContainSubstring("wrong-model-name"))
 				g.Expect(configText).NotTo(ContainSubstring("/wrong/path"))
+				// Verify tokenProcessorConfig was migrated from indexerConfig to top-level parameters
+				g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
+				g.Expect(configText).To(ContainSubstring("blockSize: 16"))
 				return nil
 			}).WithContext(ctx).Should(Succeed())
 		})
@@ -1262,6 +1268,134 @@ schedulingProfiles:
 				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
 				g.Expect(configText).NotTo(ContainSubstring("tokenizersPoolConfig"))
 				g.Expect(configText).NotTo(ContainSubstring("modelName: base"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("tokenProcessorConfig migration from indexerConfig to top-level parameters", func() {
+		It("should migrate tokenProcessorConfig from indexerConfig to top-level plugin parameters", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-tpc-migrate"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			oldFormatConfig := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: precise-prefix-cache-scorer
+  parameters:
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      kvBlockIndexConfig:
+        enableMetrics: true
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: precise-prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(oldFormatConfig),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - verify tokenProcessorConfig was migrated to top-level parameters
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-router-scheduler",
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+				// tokenProcessorConfig should be at top-level parameters (sibling of indexerConfig)
+				g.Expect(configText).To(ContainSubstring("blockSize: 64"))
+				g.Expect(configText).To(ContainSubstring("hashSeed: \"42\""))
+				// indexerConfig should still have kvBlockIndexConfig but not tokenProcessorConfig
+				g.Expect(configText).To(ContainSubstring("kvBlockIndexConfig"))
+				g.Expect(configText).To(ContainSubstring("enableMetrics: true"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should not overwrite top-level tokenProcessorConfig if already present", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-tpc-no-overwrite"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			newFormatConfig := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: precise-prefix-cache-scorer
+  parameters:
+    tokenProcessorConfig:
+      blockSize: 128
+      hashSeed: "99"
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: precise-prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(newFormatConfig),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - verify top-level tokenProcessorConfig is preserved, not overwritten
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-router-scheduler",
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+				// Top-level values should be preserved
+				g.Expect(configText).To(ContainSubstring("blockSize: 128"))
+				g.Expect(configText).To(ContainSubstring("hashSeed: \"99\""))
 				return nil
 			}).WithContext(ctx).Should(Succeed())
 		})

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -51,6 +51,7 @@ const (
 	tokenizerContainerName = "tokenizer"
 
 	precisePrefixCacheScorerPlugin = "precise-prefix-cache-scorer"
+	prefixCacheScorerPlugin        = "prefix-cache-scorer"
 	udsTokenizerBaseModelName      = "base"
 	udsTokenizerSocketFile         = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
 )
@@ -438,10 +439,11 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 				return d, fmt.Errorf("failed to attach model artifacts to scheduler deployment: %w", err)
 			}
 
-			// Migrate tokenProcessorConfig from indexerConfig to top-level parameters
-			// for the precise-prefix-cache-scorer plugin (schema change in v0.6.0).
-			if err := mutateSchedulerConfig(d, WithUdsTokenizerConfig, WithMigrateTokenProcessorConfig); err != nil {
-				return d, fmt.Errorf("failed to mutate scheduler config for tokenizer: %w", err)
+			// Mutate scheduler config: inject UDS tokenizer settings, migrate
+			// tokenProcessorConfig from indexerConfig to top-level parameters, and
+			// rename deprecated blockSize to blockSizeTokens (schema changes in v0.6.0).
+			if err := mutateSchedulerConfig(d, WithUdsTokenizerConfig, WithMigrateTokenProcessorConfig, WithMigrateBlockSizeToBlockSizeTokens); err != nil {
+				return d, fmt.Errorf("failed to mutate scheduler config: %w", err)
 			}
 		}
 	}
@@ -857,6 +859,48 @@ func WithMigrateTokenProcessorConfig(u *unstructured.Unstructured) error {
 
 		// Move to top-level parameters
 		if err := unstructured.SetNestedField(pluginMap, tpc, "parameters", "tokenProcessorConfig"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WithMigrateBlockSizeToBlockSizeTokens migrates the deprecated blockSize
+// field to blockSizeTokens in the prefix-cache-scorer plugin parameters.
+// In llm-d-inference-scheduler v0.6.0 the prefix-cache-scorer plugin renamed
+// blockSize (characters) to blockSizeTokens (tokens). If only blockSize is
+// set the plugin refuses to start. This migration copies blockSize to
+// blockSizeTokens when blockSizeTokens is not already present.
+func WithMigrateBlockSizeToBlockSizeTokens(u *unstructured.Unstructured) error {
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	if err != nil || !found {
+		return err
+	}
+	plugins, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, plugin := range plugins {
+		pluginMap, ok := plugin.(map[string]interface{})
+		if !ok || pluginMap["type"] != prefixCacheScorerPlugin {
+			continue
+		}
+
+		// Skip if blockSizeTokens already exists
+		if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "blockSizeTokens"); exists {
+			continue
+		}
+
+		// Check if deprecated blockSize exists
+		bs, found, err := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "blockSize")
+		if err != nil || !found {
+			continue
+		}
+
+		// Copy blockSize value to blockSizeTokens
+		if err := unstructured.SetNestedField(pluginMap, bs, "parameters", "blockSizeTokens"); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -50,8 +50,9 @@ import (
 const (
 	tokenizerContainerName = "tokenizer"
 
-	udsTokenizerBaseModelName = "base"
-	udsTokenizerSocketFile    = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
+	precisePrefixCacheScorerPlugin = "precise-prefix-cache-scorer"
+	udsTokenizerBaseModelName      = "base"
+	udsTokenizerSocketFile         = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
 )
 
 // reconcileScheduler manages the scheduler component and its related resources
@@ -437,7 +438,9 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 				return d, fmt.Errorf("failed to attach model artifacts to scheduler deployment: %w", err)
 			}
 
-			if err := mutateSchedulerConfig(d, WithUdsTokenizerConfig); err != nil {
+			// Migrate tokenProcessorConfig from indexerConfig to top-level parameters
+			// for the precise-prefix-cache-scorer plugin (schema change in v0.6.0).
+			if err := mutateSchedulerConfig(d, WithUdsTokenizerConfig, WithMigrateTokenProcessorConfig); err != nil {
 				return d, fmt.Errorf("failed to mutate scheduler config for tokenizer: %w", err)
 			}
 		}
@@ -790,9 +793,8 @@ func mutateSchedulerConfig(d *appsv1.Deployment, opts ...mutateSchedulerConfigFu
 
 func WithUdsTokenizerConfig(u *unstructured.Unstructured) error {
 	var (
-		precisePrefixCacheScorerPlugin = "precise-prefix-cache-scorer"
-		modelNameField                 = []string{"parameters", "indexerConfig", "tokenizersPoolConfig", "modelName"}
-		udsSocketFileField             = []string{"parameters", "indexerConfig", "tokenizersPoolConfig", "uds", "socketFile"}
+		modelNameField     = []string{"parameters", "indexerConfig", "tokenizersPoolConfig", "modelName"}
+		udsSocketFileField = []string{"parameters", "indexerConfig", "tokenizersPoolConfig", "uds", "socketFile"}
 	)
 
 	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
@@ -814,6 +816,47 @@ func WithUdsTokenizerConfig(u *unstructured.Unstructured) error {
 			return err
 		}
 		if err := unstructured.SetNestedField(pluginMap, udsTokenizerSocketFile, udsSocketFileField...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WithMigrateTokenProcessorConfig migrates tokenProcessorConfig from inside
+// indexerConfig to the top level of the plugin parameters for the
+// precise-prefix-cache-scorer plugin. This handles the schema change in
+// llm-d-inference-scheduler v0.6.0 where tokenProcessorConfig was promoted
+// from indexerConfig to a top-level plugin parameter.
+func WithMigrateTokenProcessorConfig(u *unstructured.Unstructured) error {
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	if err != nil || !found {
+		return err
+	}
+	plugins, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, plugin := range plugins {
+		pluginMap, ok := plugin.(map[string]interface{})
+		if !ok || pluginMap["type"] != precisePrefixCacheScorerPlugin {
+			continue
+		}
+
+		// Skip if tokenProcessorConfig already exists at the top level
+		if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "tokenProcessorConfig"); exists {
+			continue
+		}
+
+		// Check if tokenProcessorConfig exists inside indexerConfig (old location)
+		tpc, found, err := unstructured.NestedFieldCopy(pluginMap, "parameters", "indexerConfig", "tokenProcessorConfig")
+		if err != nil || !found {
+			continue
+		}
+
+		// Move to top-level parameters
+		if err := unstructured.SetNestedField(pluginMap, tpc, "parameters", "tokenProcessorConfig"); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -442,7 +442,7 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 			// Mutate scheduler config: inject UDS tokenizer settings, migrate
 			// tokenProcessorConfig from indexerConfig to top-level parameters, and
 			// rename deprecated blockSize to blockSizeTokens (schema changes in v0.6.0).
-			if err := mutateSchedulerConfig(d, WithUdsTokenizerConfig, WithMigrateTokenProcessorConfig, WithMigrateBlockSizeToBlockSizeTokens); err != nil {
+			if err := mutateSchedulerConfig(ctx, d, WithUdsTokenizerConfig, WithMigrateTokenProcessorConfig, WithMigrateBlockSizeToBlockSizeTokens); err != nil {
 				return d, fmt.Errorf("failed to mutate scheduler config: %w", err)
 			}
 		}
@@ -762,9 +762,9 @@ func (r *LLMISVCReconciler) propagateSchedulerDeploymentStatus(ctx context.Conte
 	return nil
 }
 
-type mutateSchedulerConfigFunc func(u *unstructured.Unstructured) error
+type mutateSchedulerConfigFunc func(ctx context.Context, u *unstructured.Unstructured) error
 
-func mutateSchedulerConfig(d *appsv1.Deployment, opts ...mutateSchedulerConfigFunc) error {
+func mutateSchedulerConfig(ctx context.Context, d *appsv1.Deployment, opts ...mutateSchedulerConfigFunc) error {
 	schedulerContainer := utils.GetContainerWithName(&d.Spec.Template.Spec, "main")
 	if schedulerContainer == nil {
 		return nil
@@ -779,7 +779,7 @@ func mutateSchedulerConfig(d *appsv1.Deployment, opts ...mutateSchedulerConfigFu
 				return nil //nolint:nilerr // unmarshal error is intentionally discarded for non-YAML config values
 			}
 			for _, opt := range opts {
-				if err := opt(&u); err != nil {
+				if err := opt(ctx, &u); err != nil {
 					return fmt.Errorf("failed to mutate config for scheduler deployment %s/%s: %w", d.GetNamespace(), d.GetName(), err)
 				}
 			}
@@ -793,7 +793,7 @@ func mutateSchedulerConfig(d *appsv1.Deployment, opts ...mutateSchedulerConfigFu
 	return nil
 }
 
-func WithUdsTokenizerConfig(u *unstructured.Unstructured) error {
+func WithUdsTokenizerConfig(_ context.Context, u *unstructured.Unstructured) error {
 	var (
 		modelNameField     = []string{"parameters", "indexerConfig", "tokenizersPoolConfig", "modelName"}
 		udsSocketFileField = []string{"parameters", "indexerConfig", "tokenizersPoolConfig", "uds", "socketFile"}
@@ -830,7 +830,7 @@ func WithUdsTokenizerConfig(u *unstructured.Unstructured) error {
 // precise-prefix-cache-scorer plugin. This handles the schema change in
 // llm-d-inference-scheduler v0.6.0 where tokenProcessorConfig was promoted
 // from indexerConfig to a top-level plugin parameter.
-func WithMigrateTokenProcessorConfig(u *unstructured.Unstructured) error {
+func WithMigrateTokenProcessorConfig(ctx context.Context, u *unstructured.Unstructured) error {
 	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 	if err != nil || !found {
 		return err
@@ -848,15 +848,21 @@ func WithMigrateTokenProcessorConfig(u *unstructured.Unstructured) error {
 
 		// Skip if tokenProcessorConfig already exists at the top level
 		if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "tokenProcessorConfig"); exists {
+			log.FromContext(ctx).V(2).Info("tokenProcessorConfig already at top-level parameters, skipping migration")
 			continue
 		}
 
 		// Check if tokenProcessorConfig exists inside indexerConfig (old location)
 		tpc, found, err := unstructured.NestedFieldCopy(pluginMap, "parameters", "indexerConfig", "tokenProcessorConfig")
-		if err != nil || !found {
+		if err != nil {
+			log.FromContext(ctx).Error(err, "Failed to read tokenProcessorConfig from indexerConfig")
+			continue
+		}
+		if !found {
 			continue
 		}
 
+		log.FromContext(ctx).Info("Migrating tokenProcessorConfig from indexerConfig to top-level plugin parameters")
 		// Move to top-level parameters
 		if err := unstructured.SetNestedField(pluginMap, tpc, "parameters", "tokenProcessorConfig"); err != nil {
 			return err
@@ -872,7 +878,7 @@ func WithMigrateTokenProcessorConfig(u *unstructured.Unstructured) error {
 // blockSize (characters) to blockSizeTokens (tokens). If only blockSize is
 // set the plugin refuses to start. This migration copies blockSize to
 // blockSizeTokens when blockSizeTokens is not already present.
-func WithMigrateBlockSizeToBlockSizeTokens(u *unstructured.Unstructured) error {
+func WithMigrateBlockSizeToBlockSizeTokens(ctx context.Context, u *unstructured.Unstructured) error {
 	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 	if err != nil || !found {
 		return err
@@ -890,15 +896,21 @@ func WithMigrateBlockSizeToBlockSizeTokens(u *unstructured.Unstructured) error {
 
 		// Skip if blockSizeTokens already exists
 		if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "blockSizeTokens"); exists {
+			log.FromContext(ctx).V(2).Info("blockSizeTokens already set, skipping migration from deprecated blockSize")
 			continue
 		}
 
 		// Check if deprecated blockSize exists
 		bs, found, err := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "blockSize")
-		if err != nil || !found {
+		if err != nil {
+			log.FromContext(ctx).Error(err, "Failed to read blockSize from plugin parameters")
+			continue
+		}
+		if !found {
 			continue
 		}
 
+		log.FromContext(ctx).Info("Migrating deprecated blockSize to blockSizeTokens for prefix-cache-scorer plugin", "blockSize", bs)
 		// Copy blockSize value to blockSizeTokens
 		if err := unstructured.SetNestedField(pluginMap, bs, "parameters", "blockSizeTokens"); err != nil {
 			return err

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -675,14 +675,14 @@ LLMINFERENCESERVICE_CONFIGS = {
                             {
                                 "type": "precise-prefix-cache-scorer",
                                 "parameters": {
+                                    "tokenProcessorConfig": {
+                                        "blockSize": 16,
+                                        "hashSeed": "42",
+                                    },
                                     "kvEventsConfig": {
                                         "zmqEndpoint": "tcp://*:5557",
                                     },
                                     "indexerConfig": {
-                                        "tokenProcessorConfig": {
-                                            "blockSize": 16,
-                                            "hashSeed": "42",
-                                        },
                                         "kvBlockIndexConfig": {
                                             "enableMetrics": True,
                                             "metricsLoggingInterval": 60000000000,


### PR DESCRIPTION
In llm-d-inference-scheduler v0.6.0, the precise-prefix-cache-scorer plugin changed its config schema: tokenProcessorConfig moved from being nested inside indexerConfig to a top-level field under the plugin parameters. Without migration, the scorer silently falls back to defaults (blockSize: 16) and produces zero scores, breaking prefix cache routing entirely.

Add WithMigrateTokenProcessorConfig mutation that detects tokenProcessorConfig nested inside indexerConfig and moves it to the top level of the plugin parameters. The migration skips if a top-level tokenProcessorConfig already exists to avoid overwriting explicit user configuration. Update sample docs and e2e fixtures to use the new schema.

the prefix-cache-scorer plugin renamed the blockSize field (characters) to blockSizeTokens (tokens).
If only the deprecated blockSize is present the plugin refuses to start. Add WithMigrateBlockSizeToBlockSizeTokens mutation that copies blockSize to blockSizeTokens when the new field is not already set.