### PR TITLE
fix(llmisvc): remove cert-hash restart annotation from scheduler

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_loader.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader.go
@@ -41,10 +41,6 @@ const (
 // checked for certificate secret expiration. The first entry is the write key.
 var DefaultExpirationAnnotations = []string{"certificates.kserve.io/expiration"}
 
-// DefaultRestartAnnotation is the default annotation key set on scheduler pod
-// templates with a certificate hash to trigger restarts on renewal.
-const DefaultRestartAnnotation = "certificates.kserve.io/cert-hash"
-
 // SchedulerConfig holds configurable settings for the scheduler component,
 // parsed from the "scheduler" key in the inferenceservice-config ConfigMap.
 //
@@ -52,16 +48,14 @@ const DefaultRestartAnnotation = "certificates.kserve.io/cert-hash"
 //
 //   - ExpirationAnnotations: first entry is the write key (set on new secrets),
 //     all entries are read keys (checked for expiration, first match wins).
-//   - RestartAnnotation: key on scheduler pod template carrying a cert hash
-//     to trigger rollout on renewal. Skipped when the scheduler has --enable-cert-reload.
 //
 // Defaults (upstream - no ConfigMap override needed, can default to values shown below):
 //
-//	{"expirationAnnotations": ["certificates.kserve.io/expiration"], "restartAnnotation": "certificates.kserve.io/cert-hash"}
+//	{"expirationAnnotations": ["certificates.kserve.io/expiration"]}
 //
 // Override example (reads both old and new keys during upgrade):
 //
-//	{"expirationAnnotations": ["certificates.kserve.io/expiration-v2", "certificates.kserve.io/expiration"], "restartAnnotation": "certificates.kserve.io/cert-hash"}
+//	{"expirationAnnotations": ["certificates.kserve.io/expiration-v2", "certificates.kserve.io/expiration"]}
 //
 // During a rolling upgrade, existing secrets carrying the old annotation key are
 // recognized via the read list; no unnecessary cert regeneration or secret updates.
@@ -71,10 +65,6 @@ type SchedulerConfig struct {
 	// determining whether a certificate secret has expired. The first entry is the
 	// write key (set on newly created secrets); all entries are read keys.
 	ExpirationAnnotations []string `json:"expirationAnnotations,omitempty"`
-	// RestartAnnotation is the annotation key set on scheduler pod templates; by default with
-	// a hash of the certificate data. Changing the value triggers a pod rollout so
-	// the new certificate is picked up.
-	RestartAnnotation string `json:"restartAnnotation,omitempty"`
 }
 
 // NewSchedulerConfig parses the "scheduler" key from the inferenceservice-config
@@ -89,9 +79,6 @@ func NewSchedulerConfig(isvcConfigMap *corev1.ConfigMap) (*SchedulerConfig, erro
 
 	if len(cfg.ExpirationAnnotations) == 0 {
 		cfg.ExpirationAnnotations = DefaultExpirationAnnotations
-	}
-	if cfg.RestartAnnotation == "" {
-		cfg.RestartAnnotation = DefaultRestartAnnotation
 	}
 
 	return cfg, nil

--- a/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
@@ -31,13 +31,11 @@ func TestNewSchedulerConfig(t *testing.T) {
 		configMapData             map[string]string
 		wantErr                   bool
 		wantExpirationAnnotations []string
-		wantRestartAnnotation     string
 	}{
 		{
 			name:                      "missing scheduler key uses defaults",
 			configMapData:             map[string]string{},
 			wantExpirationAnnotations: llmisvc.DefaultExpirationAnnotations,
-			wantRestartAnnotation:     llmisvc.DefaultRestartAnnotation,
 		},
 		{
 			name: "empty JSON object uses defaults",
@@ -45,7 +43,6 @@ func TestNewSchedulerConfig(t *testing.T) {
 				"scheduler": `{}`,
 			},
 			wantExpirationAnnotations: llmisvc.DefaultExpirationAnnotations,
-			wantRestartAnnotation:     llmisvc.DefaultRestartAnnotation,
 		},
 		{
 			name: "custom expiration annotations",
@@ -53,23 +50,6 @@ func TestNewSchedulerConfig(t *testing.T) {
 				"scheduler": `{"expirationAnnotations":["custom.io/expiration-v2","custom.io/expiration"]}`,
 			},
 			wantExpirationAnnotations: []string{"custom.io/expiration-v2", "custom.io/expiration"},
-			wantRestartAnnotation:     llmisvc.DefaultRestartAnnotation,
-		},
-		{
-			name: "custom restart annotation",
-			configMapData: map[string]string{
-				"scheduler": `{"restartAnnotation":"custom.io/cert-hash"}`,
-			},
-			wantExpirationAnnotations: llmisvc.DefaultExpirationAnnotations,
-			wantRestartAnnotation:     "custom.io/cert-hash",
-		},
-		{
-			name: "both fields set",
-			configMapData: map[string]string{
-				"scheduler": `{"expirationAnnotations":["a","b"],"restartAnnotation":"c"}`,
-			},
-			wantExpirationAnnotations: []string{"a", "b"},
-			wantRestartAnnotation:     "c",
 		},
 		{
 			name: "invalid JSON returns error",
@@ -105,9 +85,6 @@ func TestNewSchedulerConfig(t *testing.T) {
 				if got.ExpirationAnnotations[i] != tt.wantExpirationAnnotations[i] {
 					t.Errorf("ExpirationAnnotations[%d] = %q, want %q", i, got.ExpirationAnnotations[i], tt.wantExpirationAnnotations[i])
 				}
-			}
-			if got.RestartAnnotation != tt.wantRestartAnnotation {
-				t.Errorf("RestartAnnotation = %q, want %q", got.RestartAnnotation, tt.wantRestartAnnotation)
 			}
 		})
 	}

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -216,7 +216,7 @@ func (r *LLMISVCReconciler) reconcile(ctx context.Context, llmSvc *v1alpha2.LLMI
 		return fmt.Errorf("failed to reconcile workload: %w", err)
 	}
 
-	if err := r.reconcileRouter(ctx, llmSvc, config); err != nil {
+	if err := r.reconcileRouter(ctx, llmSvc); err != nil {
 		return fmt.Errorf("failed to reconcile networking: %w", err)
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
-	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
 )
 
@@ -908,119 +907,6 @@ schedulingProfiles:
 
 			Expect(countLeaderElectionFlags(expectedDeployment)).To(Equal(1),
 				"Expected exactly one --ha-enable-leader-election flag (not duplicated)")
-		})
-	})
-
-	Context("Certificate hash annotation", func() {
-		It("should set cert-hash annotation on the scheduler pod template", func(ctx SpecContext) {
-			// given
-			svcName := "test-llm-scheduler-cert-hash"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
-
-			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
-				WithModelURI("hf://facebook/opt-125m"),
-				WithManagedRoute(),
-				WithManagedGateway(),
-				WithManagedScheduler(),
-			)
-
-			// when
-			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
-			defer func() {
-				testNs.DeleteAndWait(ctx, llmSvc)
-			}()
-
-			// then - verify the scheduler deployment has the cert-hash annotation
-			Eventually(func(g Gomega, ctx context.Context) error {
-				schedulerDeployment := &appsv1.Deployment{}
-				g.Expect(envTest.Get(ctx, types.NamespacedName{
-					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
-					Namespace: testNs.Name,
-				}, schedulerDeployment)).To(Succeed())
-
-				g.Expect(schedulerDeployment.Spec.Template.Annotations).To(
-					HaveKey(llmisvc.DefaultRestartAnnotation),
-					"Scheduler pod template should have cert-hash annotation to trigger restart on cert renewal",
-				)
-				g.Expect(schedulerDeployment.Spec.Template.Annotations[llmisvc.DefaultRestartAnnotation]).To(
-					MatchRegexp("^[0-9a-f]{64}$"), "cert-hash should be a SHA-256 hex string",
-				)
-
-				return nil
-			}).WithContext(ctx).Should(Succeed())
-		})
-
-		It("should skip cert-hash annotation when scheduler supports --enable-cert-reload", func(ctx SpecContext) {
-			// given
-			svcName := "test-llm-cert-reload-skip"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
-
-			modelConfig := LLMInferenceServiceConfig("model-cert-reload",
-				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
-				WithConfigModelName("facebook/opt-125m"),
-				WithConfigModelURI("hf://facebook/opt-125m"),
-			)
-
-			routerConfig := LLMInferenceServiceConfig("router-cert-reload",
-				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
-			)
-			routerConfig.Spec.Router = &v1alpha2.RouterSpec{
-				Gateway: &v1alpha2.GatewaySpec{},
-				Route:   &v1alpha2.GatewayRoutesSpec{},
-				Scheduler: &v1alpha2.SchedulerSpec{
-					Template: &corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.3.0",
-								Args: []string{
-									"--enable-cert-reload",
-									"--poolName",
-									"test-pool",
-								},
-								Ports: []corev1.ContainerPort{
-									{Name: "grpc", ContainerPort: 9002, Protocol: corev1.ProtocolTCP},
-									{Name: "grpc-health", ContainerPort: 9003, Protocol: corev1.ProtocolTCP},
-									{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
-								},
-							},
-						},
-					},
-					Pool: &v1alpha2.InferencePoolSpec{},
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, modelConfig)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, routerConfig)).To(Succeed())
-
-			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
-				WithBaseRefs(
-					corev1.LocalObjectReference{Name: "model-cert-reload"},
-					corev1.LocalObjectReference{Name: "router-cert-reload"},
-				),
-			)
-
-			// when
-			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
-			defer func() {
-				testNs.DeleteAndWait(ctx, llmSvc)
-			}()
-
-			// then - the scheduler deployment must NOT have cert-hash annotation
-			schedulerDeployment := &appsv1.Deployment{}
-			Eventually(func(g Gomega, ctx context.Context) error {
-				return envTest.Get(ctx, types.NamespacedName{
-					Name:      svcName + "-kserve-router-scheduler",
-					Namespace: testNs.Name,
-				}, schedulerDeployment)
-			}).WithContext(ctx).Should(Succeed())
-
-			Expect(schedulerDeployment.Spec.Template.Annotations).NotTo(
-				HaveKey(llmisvc.DefaultRestartAnnotation),
-				"Scheduler with --enable-cert-reload should not have cert-hash annotation",
-			)
 		})
 	})
 

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -59,7 +59,7 @@ var ErrPreconditionNotMet = errors.New("precondition not met")
 
 // reconcileRouter handles the networking and routing components for the LLM service
 // This includes schedulers, HTTP routes, and various validation checks
-func (r *LLMISVCReconciler) reconcileRouter(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
+func (r *LLMISVCReconciler) reconcileRouter(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
 	logger := log.FromContext(ctx).WithName("reconcileRouter")
 	ctx = log.IntoContext(ctx, logger)
 
@@ -86,7 +86,7 @@ func (r *LLMISVCReconciler) reconcileRouter(ctx context.Context, llmSvc *v1alpha
 	}
 
 	// Reconcile the scheduler component that manages inference pools
-	if err := r.reconcileScheduler(ctx, llmSvc, config.SchedulerConfig); err != nil {
+	if err := r.reconcileScheduler(ctx, llmSvc); err != nil {
 		llmSvc.MarkSchedulerWorkloadNotReady("SchedulerReconcileError", "Failed to reconcile scheduler: %v", err.Error())
 		return fmt.Errorf("failed to reconcile scheduler: %w", err)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -56,13 +56,13 @@ const (
 
 // reconcileScheduler manages the scheduler component and its related resources
 // The scheduler handles load balancing for inference pods
-func (r *LLMISVCReconciler) reconcileScheduler(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, schedulerConfig *SchedulerConfig) error {
+func (r *LLMISVCReconciler) reconcileScheduler(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
 	log.FromContext(ctx).Info("Reconciling Scheduler")
 
 	if err := r.reconcileSchedulerServiceAccount(ctx, llmSvc); err != nil {
 		return err
 	}
-	if err := r.reconcileSchedulerDeployment(ctx, llmSvc, schedulerConfig); err != nil {
+	if err := r.reconcileSchedulerDeployment(ctx, llmSvc); err != nil {
 		return err
 	}
 	if err := r.reconcileSchedulerService(ctx, llmSvc); err != nil {
@@ -156,8 +156,8 @@ func (r *LLMISVCReconciler) reconcileSchedulerServiceAccount(ctx context.Context
 	return r.reconcileSchedulerRoleBinding(ctx, llmSvc, serviceAccount)
 }
 
-func (r *LLMISVCReconciler) reconcileSchedulerDeployment(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, schedulerConfig *SchedulerConfig) error {
-	scheduler, err := r.expectedSchedulerDeployment(ctx, llmSvc, schedulerConfig)
+func (r *LLMISVCReconciler) reconcileSchedulerDeployment(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
+	scheduler, err := r.expectedSchedulerDeployment(ctx, llmSvc)
 	if err != nil {
 		return fmt.Errorf("failed to build expected scheduler deployment: %w", err)
 	}
@@ -333,7 +333,7 @@ func (r *LLMISVCReconciler) expectedSchedulerInferencePoolV1Alpha2(ctx context.C
 	return ip
 }
 
-func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, schedulerConfig *SchedulerConfig) (*appsv1.Deployment, error) {
+func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) (*appsv1.Deployment, error) {
 	labels := SchedulerLabels(llmSvc)
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -365,7 +365,6 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 		},
 	}
 
-	mainIdx := -1
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil && llmSvc.Spec.Router.Scheduler.Template != nil {
 		curr := &appsv1.Deployment{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(d), curr); err != nil && !apierrors.IsNotFound(err) {
@@ -375,7 +374,7 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 		d.Spec.Replicas = llmSvc.Spec.Router.Scheduler.Replicas
 		d.Spec.Template.Spec = *llmSvc.Spec.Router.Scheduler.Template.DeepCopy()
 
-		mainIdx = slices.IndexFunc(d.Spec.Template.Spec.Containers, func(c corev1.Container) bool {
+		mainIdx := slices.IndexFunc(d.Spec.Template.Spec.Containers, func(c corev1.Container) bool {
 			return c.Name == "main"
 		})
 		if mainIdx < 0 {
@@ -444,23 +443,6 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 	}
 
 	r.propagateSchedulerMetadata(llmSvc, d)
-
-	// Set a hash of the current certificate data on the pod template so that
-	// when certificates are renewed the pod template changes and the scheduler
-	// is restarted to pick up the new certificate.
-	// Skip if the main container supports automatic cert reload.
-	if mainIdx >= 0 &&
-		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Command, "--enable-cert-reload") &&
-		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Command, "-enable-cert-reload") &&
-		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Args, "--enable-cert-reload") &&
-		!slices.Contains(d.Spec.Template.Spec.Containers[mainIdx].Args, "-enable-cert-reload") {
-		if h := r.getSelfSignedCertHash(ctx, llmSvc); h != "" {
-			if d.Spec.Template.Annotations == nil {
-				d.Spec.Template.Annotations = map[string]string{}
-			}
-			d.Spec.Template.Annotations[schedulerConfig.RestartAnnotation] = h
-		}
-	}
 
 	log.FromContext(ctx).V(2).Info("Expected router scheduler deployment", "deployment", d)
 

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"maps"
@@ -188,24 +186,6 @@ func (r *LLMISVCReconciler) getExistingSelfSignedCertificate(ctx context.Context
 	return curr
 }
 
-// getSelfSignedCertHash returns the SHA-256 hash of the current self-signed certificate data.
-// It returns an empty string when the secret does not exist yet.
-func (r *LLMISVCReconciler) getSelfSignedCertHash(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) string {
-	secret := r.getExistingSelfSignedCertificate(ctx, llmSvc)
-	if secret == nil {
-		return ""
-	}
-	return certDataHash(secret)
-}
-
-// certDataHash computes a SHA-256 hash over the certificate data in a TLS secret.
-func certDataHash(secret *corev1.Secret) string {
-	h := sha256.New()
-	h.Write(secret.Data["tls.crt"])
-	h.Write(secret.Data["tls.key"])
-	return hex.EncodeToString(h.Sum(nil))
-}
-
 // isCertificateExpired checks all configured expiration annotation keys (first match wins).
 // Returns false when no annotation is found (the x509 NotAfter fallback is handled by
 // ShouldRecreateCertificate).
@@ -301,9 +281,7 @@ func (r *LLMISVCReconciler) collectIPAddresses(ctx context.Context, llmSvc *v1al
 
 	// Exclude scheduler pods from IP collection. Scheduler pods connect via
 	// Service DNS (already covered by collectDNSNames), so their pod IPs are
-	// not needed in the certificate SANs. Not doing it would result in reconciliation
-	// storm: schedulers pod IP added to certs results in cert-hash changes that
-	// will restart scheduler with new pod (and IP), goto 1.
+	// not needed in the certificate SANs.
 	excludeScheduler, errReq := labels.NewRequirement(
 		constants.KubernetesComponentLabelKey,
 		selection.NotIn,


### PR DESCRIPTION
**What this PR does / why we need it**:

The scheduler now handles certificate reloading internally via its --enable-cert-reload flag, eliminating the need for the controller to trigger restarts through a cert-hash pod template annotation.

This also removes a source of unnecessary scheduler churn, as the hash covered the full certificate including workload pod IPs as SANs.

**Release note**:
```release-note
NONE
```
