### PR TITLE
fix(llmisvc): rename EPP port name to tcp-ext-proc for Istio compatibility

### DIFF
--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -27,6 +27,8 @@ spec:
           - name: main
             ports:
               - containerPort: 9002
+                # "tcp-" prefix prevents Istio from applying HTTP/2 L7 parsing to the ext-proc port.
+                # The port still uses gRPC; this only affects Istio protocol classification.
                 name: tcp-ext-proc
                 protocol: TCP
               - containerPort: 9003

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -27,7 +27,7 @@ spec:
           - name: main
             ports:
               - containerPort: 9002
-                name: grpc
+                name: tcp-ext-proc
                 protocol: TCP
               - containerPort: 9003
                 name: grpc-health

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -476,13 +476,13 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					eppSvc := &corev1.Service{}
 					g.Expect(envTest.Client.Get(ctx, client.ObjectKey{Name: svcName + "-epp-service", Namespace: llmSvc.GetNamespace()}, eppSvc)).To(Succeed())
 
-					// Verify all expected ports are present (grpc, grpc-health, metrics, zmq)
+					// Verify all expected ports are present (tcp-ext-proc, grpc-health, metrics, zmq)
 					portNames := make(map[string]int32)
 					for _, port := range eppSvc.Spec.Ports {
 						portNames[port.Name] = port.Port
 					}
 
-					g.Expect(portNames).To(HaveKeyWithValue("grpc", int32(9002)))
+					g.Expect(portNames).To(HaveKeyWithValue("tcp-ext-proc", int32(9002)))
 					g.Expect(portNames).To(HaveKeyWithValue("grpc-health", int32(9003)))
 					g.Expect(portNames).To(HaveKeyWithValue("metrics", int32(9090)))
 					g.Expect(portNames).To(HaveKeyWithValue("zmq", int32(5557)))

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -239,7 +239,7 @@ func (r *LLMISVCReconciler) expectedSchedulerService(ctx context.Context, llmSvc
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil && llmSvc.Spec.Router.Scheduler.Template != nil {
 		podSpec := llmSvc.Spec.Router.Scheduler.Template.DeepCopy()
 
-		desiredPorts := sets.New("grpc", "grpc-health", "metrics", "zmq")
+		desiredPorts := sets.New("tcp-ext-proc", "grpc-health", "metrics", "zmq")
 
 		actualPorts := make(map[string]*corev1.ContainerPort)
 		for _, container := range podSpec.Containers {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -239,6 +239,8 @@ func (r *LLMISVCReconciler) expectedSchedulerService(ctx context.Context, llmSvc
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil && llmSvc.Spec.Router.Scheduler.Template != nil {
 		podSpec := llmSvc.Spec.Router.Scheduler.Template.DeepCopy()
 
+		// "tcp-" prefix prevents Istio from applying HTTP/2 L7 parsing to the ext-proc port.
+		// The port still uses gRPC; this only affects Istio protocol classification.
 		desiredPorts := sets.New("tcp-ext-proc", "grpc-health", "metrics", "zmq")
 
 		actualPorts := make(map[string]*corev1.ContainerPort)


### PR DESCRIPTION
**What this PR does / why we need it**:

When Istio sidecar injection is enabled in the cluster, the EPP (Endpoint Picker) pod gets an Istio sidecar injected. Istio uses the container port name to determine traffic handling: port names starting with \`grpc\`, \`http\`, or \`http2\` trigger L7 HTTP/2 processing, while names starting with \`tcp\` are treated as raw TCP (L4 passthrough).

With the port named \`grpc\`, the Istio sidecar injected into the EPP pod intercepts incoming traffic and attempts to apply HTTP/2 L7 parsing to the ext-proc stream. The stream does not match the HTTP/2 format Istio expects, so it is rejected with \`http2.invalid.header.field\`, which causes the ext-proc connection to terminate and the gateway to return HTTP 500.

Renaming the port to \`tcp-ext-proc\` tells Istio to handle it as raw TCP, preventing HTTP/2 parsing of the ext-proc stream.

> **Note:** This issue is not specific to Istio Gateway. It occurs whenever Istio sidecar injection is enabled in the EPP pod's namespace, regardless of whether Istio Gateway or Envoy Gateway is used as the gateway component.

**Related upstream issues:**
- istio/istio#14909 — port named \`grpc\` triggers HTTP/2 L7 processing
- istio/istio#59577 — same issue observed with LLMInferenceService + Istio + ext-proc

**Which issue(s) this PR fixes**:

N/A

**Feature/Issue validation/testing**:

Verified on a cluster with Istio 1.28.3 (\`STRICT\` mTLS PeerAuthentication), inference-gateway (Envoy-based) → EPP (port 9002) → vLLM.

- [x] Before fix: HTTP 500 with \`http2.invalid.header.field\` in EPP pod logs
- [x] After fix: HTTP 200 OK, E2E inference working correctly

**Special notes for your reviewer**:

The \`tcp-\` prefix is the standard Istio convention for raw TCP ports. This does not affect gRPC functionality — it only prevents Istio from applying HTTP/2 L7 processing to the ext-proc stream.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
\`\`\`release-note
Fix EPP ext-proc port name from \`grpc\` to \`tcp-ext-proc\` to prevent Istio from applying HTTP/2 L7 processing, which caused \`http2.invalid.header.field\` errors and HTTP 500 responses when Istio sidecar injection is enabled.
\`\`\`