### PR TITLE
feat(llmisvc): propagate imagePullSecrets from default SA

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
@@ -283,6 +283,56 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			))
 		})
 
+		It("should propagate imagePullSecrets from default SA to the created multi-node prefill SA", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-mn-ips-prefill"
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+				WithDefaultServiceAccountImagePullSecrets(
+					corev1.LocalObjectReference{Name: "my-registry-secret"},
+				),
+			)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithReplicas(1),
+				WithParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+				)),
+				WithWorker(&corev1.PodSpec{}),
+				WithPrefillParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+				)),
+				WithPrefillWorker(&corev1.PodSpec{}),
+				WithPrefillReplicas(1),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - prefill SA should have the imagePullSecrets from the default SA
+			prefillSA := &corev1.ServiceAccount{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-mn-prefill"),
+					Namespace: testNs.Name,
+				}, prefillSA)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(prefillSA).To(BeOwnedBy(llmSvc))
+			Expect(prefillSA.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "my-registry-secret"},
+			))
+		})
+
 		It("should create multi-node SA with empty imagePullSecrets when default SA has none", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-mn-ips-empty"

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
@@ -234,6 +234,94 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Expect(expectedLWS.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.ServiceAccountName).To(Equal(expectedSA.Name))
 		})
 
+		It("should propagate imagePullSecrets from default SA to the created multi-node SA", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-mn-ips"
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+				WithDefaultServiceAccountImagePullSecrets(
+					corev1.LocalObjectReference{Name: "my-registry-secret"},
+					corev1.LocalObjectReference{Name: "other-pull-secret"},
+				),
+			)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithReplicas(1),
+				WithParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+					WithTensorParallelism(4),
+				)),
+				WithWorker(&corev1.PodSpec{}),
+				WithManagedRoute(),
+				WithManagedScheduler(),
+				WithManagedGateway(),
+				WithPrefill(SimpleWorkerPodSpec()),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - created SA should have the imagePullSecrets from the default SA
+			expectedSA := &corev1.ServiceAccount{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: testNs.Name,
+				}, expectedSA)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedSA).To(BeOwnedBy(llmSvc))
+			Expect(expectedSA.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "my-registry-secret"},
+				corev1.LocalObjectReference{Name: "other-pull-secret"},
+			))
+		})
+
+		It("should create multi-node SA with empty imagePullSecrets when default SA has none", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-mn-ips-empty"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithReplicas(1),
+				WithParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+				)),
+				WithWorker(&corev1.PodSpec{}),
+				WithManagedRoute(),
+				WithManagedScheduler(),
+				WithManagedGateway(),
+				WithPrefill(SimpleWorkerPodSpec()),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then
+			expectedSA := &corev1.ServiceAccount{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: testNs.Name,
+				}, expectedSA)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedSA).To(BeOwnedBy(llmSvc))
+			Expect(expectedSA.ImagePullSecrets).To(BeEmpty())
+		})
+
 		It("should delete multi-node resources when worker spec is removed", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-cleanup"

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -419,6 +419,98 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		})
 	})
 
+	Context("ImagePullSecrets propagation", func() {
+		It("should propagate imagePullSecrets from default SA to the created single-node SA", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-ips-singlenode"
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+				WithDefaultServiceAccountImagePullSecrets(
+					corev1.LocalObjectReference{Name: "my-registry-secret"},
+					corev1.LocalObjectReference{Name: "other-pull-secret"},
+				),
+			)
+
+			// Use a template with the routing sidecar so the controller creates a ServiceAccount
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithTemplate(&corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "test-vllm:latest"},
+					},
+					InitContainers: []corev1.Container{
+						{Name: "llm-d-routing-sidecar", Image: "test-sidecar:latest"},
+					},
+				}),
+				WithPrefill(SimpleWorkerPodSpec()),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - created SA should have the imagePullSecrets from the default SA
+			expectedSA := &corev1.ServiceAccount{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: testNs.Name,
+				}, expectedSA)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedSA).To(BeOwnedBy(llmSvc))
+			Expect(expectedSA.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "my-registry-secret"},
+				corev1.LocalObjectReference{Name: "other-pull-secret"},
+			))
+		})
+
+		It("should create single-node SA with empty imagePullSecrets when default SA has none", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-ips-sn-empty"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithTemplate(&corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Image: "test-vllm:latest"},
+					},
+					InitContainers: []corev1.Container{
+						{Name: "llm-d-routing-sidecar", Image: "test-sidecar:latest"},
+					},
+				}),
+				WithPrefill(SimpleWorkerPodSpec()),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then
+			expectedSA := &corev1.ServiceAccount{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: testNs.Name,
+				}, expectedSA)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedSA).To(BeOwnedBy(llmSvc))
+			Expect(expectedSA.ImagePullSecrets).To(BeEmpty())
+		})
+	})
+
 	Context("Routing reconciliation ", func() {
 		When("HTTP route is managed", func() {
 			It("should create routes pointing to the default gateway when both are managed", func(ctx SpecContext) {

--- a/pkg/controller/v1alpha2/llmisvc/fixture/test_namespace.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/test_namespace.go
@@ -77,6 +77,18 @@ func WithDefaultServiceAccount() TestNamespaceOption {
 	}
 }
 
+// WithDefaultServiceAccountImagePullSecrets creates the default ServiceAccount
+// with the given ImagePullSecrets. This is used to test propagation of
+// ImagePullSecrets from the default SA to controller-created ServiceAccounts.
+func WithDefaultServiceAccountImagePullSecrets(secrets ...corev1.LocalObjectReference) TestNamespaceOption {
+	return func(ctx context.Context, tn *TestNamespace) {
+		sa := &corev1.ServiceAccount{}
+		gomega.Expect(tn.client.Get(ctx, client.ObjectKey{Name: "default", Namespace: tn.Name}, sa)).To(gomega.Succeed())
+		sa.ImagePullSecrets = secrets
+		gomega.Expect(tn.client.Update(ctx, sa)).To(gomega.Succeed())
+	}
+}
+
 // WithServiceAccount creates a custom ServiceAccount in the namespace.
 func WithServiceAccount(name string) TestNamespaceOption {
 	return func(ctx context.Context, tn *TestNamespace) {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -637,6 +637,9 @@ func (r *LLMISVCReconciler) expectedSchedulerServiceAccount(ctx context.Context,
 			sa.Secrets = mainSA.Secrets
 			sa.ImagePullSecrets = mainSA.ImagePullSecrets
 		}
+	} else {
+		// No explicit main workload SA — fall back to the default SA for registry credentials.
+		r.injectSecretsFromDefaultServiceAccount(ctx, sa)
 	}
 
 	return sa, useExistingServiceAccount, nil

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -40,6 +40,8 @@ const (
 	// routingSidecarContainerName is the name of the routing sidecar container
 	// that handles prefill disaggregation routing.
 	routingSidecarContainerName = "llm-d-routing-sidecar"
+
+	defaultServiceAccountName = "default"
 )
 
 // sidecarSSRFProtectionRules defines RBAC rules for the routing sidecar

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -25,6 +25,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
@@ -173,6 +174,21 @@ func GetWorkloadLabelSelector(meta metav1.ObjectMeta, _ *v1alpha2.LLMInferenceSe
 	// TODO https://github.com/llm-d/llm-d-inference-scheduler/issues/220 and DP template
 
 	return s
+}
+
+// injectSecretsFromDefaultServiceAccount copies ImagePullSecrets and Secrets from the
+// namespace's default ServiceAccount onto the target ServiceAccount. This ensures that
+// controller-created ServiceAccounts inherit private registry credentials configured on
+// the default SA. If the default SA cannot be retrieved, a warning is logged and the
+// target SA is left unchanged.
+func (r *LLMISVCReconciler) injectSecretsFromDefaultServiceAccount(ctx context.Context, target *corev1.ServiceAccount) {
+	defaultSa := &corev1.ServiceAccount{}
+	if err := r.Get(ctx, types.NamespacedName{Name: defaultServiceAccountName, Namespace: target.Namespace}, defaultSa); err != nil {
+		log.FromContext(ctx).Error(err, "Warning: failed to retrieve 'default' service account, continuing ...")
+		return
+	}
+	target.ImagePullSecrets = defaultSa.ImagePullSecrets
+	target.Secrets = defaultSa.Secrets
 }
 
 func hasRoutingSidecar(pod corev1.PodSpec) bool {

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -482,6 +482,11 @@ func (r *LLMISVCReconciler) expectedMultiNodeMainServiceAccount(ctx context.Cont
 		return existingServiceAccount, useExistingServiceAccount, nil
 	}
 
+	defaultSa := &corev1.ServiceAccount{}
+	if err := r.Get(ctx, types.NamespacedName{Name: defaultServiceAccountName, Namespace: llmSvc.Namespace}, defaultSa); err != nil {
+		log.FromContext(ctx).Error(err, "Warning: failed to retrieve 'default' service account, continuing ...")
+	}
+
 	expectedServiceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      expectedServiceAccountName,
@@ -490,6 +495,8 @@ func (r *LLMISVCReconciler) expectedMultiNodeMainServiceAccount(ctx context.Cont
 				*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
 			},
 		},
+		ImagePullSecrets: defaultSa.ImagePullSecrets,
+		Secrets:          defaultSa.Secrets,
 	}
 
 	// Add required labels to the created service account

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -482,11 +482,6 @@ func (r *LLMISVCReconciler) expectedMultiNodeMainServiceAccount(ctx context.Cont
 		return existingServiceAccount, useExistingServiceAccount, nil
 	}
 
-	defaultSa := &corev1.ServiceAccount{}
-	if err := r.Get(ctx, types.NamespacedName{Name: defaultServiceAccountName, Namespace: llmSvc.Namespace}, defaultSa); err != nil {
-		log.FromContext(ctx).Error(err, "Warning: failed to retrieve 'default' service account, continuing ...")
-	}
-
 	expectedServiceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      expectedServiceAccountName,
@@ -495,9 +490,9 @@ func (r *LLMISVCReconciler) expectedMultiNodeMainServiceAccount(ctx context.Cont
 				*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
 			},
 		},
-		ImagePullSecrets: defaultSa.ImagePullSecrets,
-		Secrets:          defaultSa.Secrets,
 	}
+
+	r.injectSecretsFromDefaultServiceAccount(ctx, expectedServiceAccount)
 
 	// Add required labels to the created service account
 	if expectedServiceAccount.Labels == nil {
@@ -541,6 +536,8 @@ func (r *LLMISVCReconciler) expectedMultiNodePrefillServiceAccount(ctx context.C
 			},
 		},
 	}
+
+	r.injectSecretsFromDefaultServiceAccount(ctx, expectedServiceAccount)
 
 	// Add required labels to the created service account
 	if expectedServiceAccount.Labels == nil {

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -405,6 +405,11 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainServiceAccount(ctx context.Con
 		return existingServiceAccount, useExistingServiceAccount, nil
 	}
 
+	defaultSa := &corev1.ServiceAccount{}
+	if err := r.Get(ctx, types.NamespacedName{Name: defaultServiceAccountName, Namespace: llmSvc.Namespace}, defaultSa); err != nil {
+		log.FromContext(ctx).Error(err, "Warning: failed to retrieve 'default' service account, continuing ...")
+	}
+
 	expectedServiceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      expectedServiceAccountName,
@@ -413,6 +418,8 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainServiceAccount(ctx context.Con
 				*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
 			},
 		},
+		ImagePullSecrets: defaultSa.ImagePullSecrets,
+		Secrets:          defaultSa.Secrets,
 	}
 
 	if expectedServiceAccount.Labels == nil {

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -405,11 +405,6 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainServiceAccount(ctx context.Con
 		return existingServiceAccount, useExistingServiceAccount, nil
 	}
 
-	defaultSa := &corev1.ServiceAccount{}
-	if err := r.Get(ctx, types.NamespacedName{Name: defaultServiceAccountName, Namespace: llmSvc.Namespace}, defaultSa); err != nil {
-		log.FromContext(ctx).Error(err, "Warning: failed to retrieve 'default' service account, continuing ...")
-	}
-
 	expectedServiceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      expectedServiceAccountName,
@@ -418,9 +413,9 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainServiceAccount(ctx context.Con
 				*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
 			},
 		},
-		ImagePullSecrets: defaultSa.ImagePullSecrets,
-		Secrets:          defaultSa.Secrets,
 	}
+
+	r.injectSecretsFromDefaultServiceAccount(ctx, expectedServiceAccount)
 
 	if expectedServiceAccount.Labels == nil {
 		expectedServiceAccount.Labels = make(map[string]string)

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -175,7 +175,7 @@ func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAc
 		// If service account is nil, fetch the default service account
 		if serviceAccount == nil {
 			serviceAccount = &corev1.ServiceAccount{}
-			err := r.Get(ctx, types.NamespacedName{Name: "default", Namespace: llmSvc.Namespace}, serviceAccount)
+			err := r.Get(ctx, types.NamespacedName{Name: defaultServiceAccountName, Namespace: llmSvc.Namespace}, serviceAccount)
 			if err != nil {
 				log.FromContext(ctx).Error(err, "Failed to find default service account", "namespace", llmSvc.Namespace)
 				injectCaBundle(llmSvc.Namespace, podSpec, initContainer, storageConfig)
@@ -226,7 +226,7 @@ func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, serviceAc
 		// If service account is nil, fetch the default service account
 		if serviceAccount == nil {
 			serviceAccount = &corev1.ServiceAccount{}
-			err := r.Get(ctx, types.NamespacedName{Name: "default", Namespace: llmSvc.Namespace}, serviceAccount)
+			err := r.Get(ctx, types.NamespacedName{Name: defaultServiceAccountName, Namespace: llmSvc.Namespace}, serviceAccount)
 			if err != nil {
 				log.FromContext(ctx).Error(err, "Failed to find default service account", "namespace", llmSvc.Namespace)
 				return nil


### PR DESCRIPTION
When the controller creates a ServiceAccount for single-node or multi-node workloads, copy ImagePullSecrets and Secrets from the namespace's default ServiceAccount. This ensures workload pods can pull images from private registries configured via the default SA.

Also extract the "default" SA name into a constant and use it in workload_storage.go for consistency.
