### PR TITLE
fix: merge automation

### DIFF
--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -5,6 +5,11 @@ on:
   issue_comment:
     types: [created]
 
+# Required for the prow action to manage labels, assignees, milestones, etc.
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   prow-execute:
     runs-on: ubuntu-latest

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -4,7 +4,7 @@
 name: "Prow merge on lgtm label"
 on:
   schedule:
-  - cron: "0 * * * *" # every hour
+  - cron: "*/10 * * * *" # every 10 minutes
 
 jobs:
   auto-merge:

--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -3,8 +3,14 @@ on:
   pull_request:
   merge_group:
     types: [ checks_requested ]
+  issue_comment:
+    types: [created]
 jobs:
   enforce-all-checks:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/rerun'))
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -13,7 +19,7 @@ jobs:
         uses: poseidon/wait-for-status-checks@v0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          interval: 10s
-          # seconds to wait before first poll. 
-          delay: 120s
-          timeout: 10800s # 3 hour (based on the highest avg runtime of a job https://github.com/kserve/kserve/actions/metrics/performance?tab=jobs) 
+          interval: 60s
+          # seconds to wait before first poll.
+          delay: 300s
+          timeout: 10800s # 3 hour (based on the highest avg runtime of a job https://github.com/kserve/kserve/actions/metrics/performance?tab=jobs)


### PR DESCRIPTION
* Add issues and pull-requests write permissions at the workflow level
so the prow action can manage labels, assignees, and milestones.

* Reduce the schedule interval from hourly to every 10 minutes for
faster PR automerge on lgtm label.

* Add issue_comment trigger so users can re-run the enforce-all-checks
job by commenting /rerun on a PR. Also increase polling interval and
initial delay to reduce API usage.
