### PR TITLE
fix(ci): pins github actions in license check

### DIFF
--- a/.github/workflows/go-license-check.yml
+++ b/.github/workflows/go-license-check.yml
@@ -21,9 +21,9 @@ jobs:
   license-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
**What this PR does / why we need it**:

License check workflows didn't have their actions pinned to explicit shas - causing `make precommit` failures.

This commit pins to exact versions by running `make pin-actions` target.


**Release note**:
```release-note
NONE
```
