### PR TITLE
fix: validate HPA metrics when autoscalerClass is unset

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -258,9 +258,9 @@ func validateAutoScalingCompExtension(annotations map[string]string, compExtSpec
 	autoscalerClass := annotations[constants.AutoscalerClass]
 
 	switch deploymentMode {
-	case string(constants.Standard):
+	case string(constants.Standard), string(constants.LegacyRawDeployment):
 		switch autoscalerClass {
-		case string(constants.AutoscalerClassHPA):
+		case string(constants.AutoscalerClassHPA), "":
 			return validateScalingHPACompExtension(compExtSpec)
 		case string(constants.AutoscalerClassKeda):
 			return validateScalingKedaCompExtension(compExtSpec)
@@ -364,8 +364,9 @@ func validateScalingHPACompExtension(compExtSpec *ComponentExtensionSpec) error 
 					return errors.New("metricSpec.Resource is not set for resource metric source type")
 				}
 			default:
-				return fmt.Errorf("invalid HPA metric source type with value [%s],"+
-					"valid metric source types are Resource", metricType)
+				return fmt.Errorf("invalid HPA metric source type with value [%s], "+
+					"valid metric source types are Resource. "+
+					"For External or PodMetric types, set the annotation serving.kserve.io/autoscalerClass to keda", metricType)
 			}
 		}
 	}

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -366,7 +366,7 @@ func validateScalingHPACompExtension(compExtSpec *ComponentExtensionSpec) error 
 			default:
 				return fmt.Errorf("invalid HPA metric source type with value [%s], "+
 					"valid metric source types are Resource. "+
-					"For External or PodMetric types, set the annotation serving.kserve.io/autoscalerClass to keda", metricType)
+					"For External or PodMetric types, set the annotation %s to keda", metricType, constants.AutoscalerClass)
 			}
 		}
 	}

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -253,12 +253,12 @@ func validateMultiNodeVariables(isvc *InferenceService) error {
 
 // Validate scaling options component extensions
 func validateAutoScalingCompExtension(annotations map[string]string, compExtSpec *ComponentExtensionSpec) error {
-	deploymentMode := annotations["serving.kserve.io/deploymentMode"]
+	deploymentMode := constants.ParseDeploymentMode(annotations[constants.DeploymentMode])
 	annotationClass := annotations[autoscaling.ClassAnnotationKey]
 	autoscalerClass := annotations[constants.AutoscalerClass]
 
 	switch deploymentMode {
-	case string(constants.Standard), string(constants.LegacyRawDeployment):
+	case constants.Standard:
 		switch autoscalerClass {
 		case string(constants.AutoscalerClassHPA), "":
 			return validateScalingHPACompExtension(compExtSpec)

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -662,6 +662,9 @@ func TestRejectMultipleModelSpecs(t *testing.T) {
 func TestCustomizeDeploymentStrategyUnsupportedForServerless(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	isvc := makeTestInferenceService()
+	isvc.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.Knative),
+	}
 	isvc.Spec.Predictor.PodSpec = PodSpec{ServiceAccountName: "test"}
 	isvc.Spec.Predictor.DeploymentStrategy = &appsv1.DeploymentStrategy{
 		Type: appsv1.RecreateDeploymentStrategyType,

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -249,7 +249,75 @@ func TestAutoscalerClassHPA(t *testing.T) {
 					},
 				},
 			},
-			errMatcher: gomega.MatchError("invalid HPA metric source type with value [External],valid metric source types are Resource"),
+			errMatcher: gomega.MatchError("invalid HPA metric source type with value [External], " +
+				"valid metric source types are Resource. " +
+				"For External or PodMetric types, set the annotation serving.kserve.io/autoscalerClass to keda"),
+		},
+		"Invalid External metrics without autoscalerClass annotation in Standard mode": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": "Standard",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							AutoScaling: &AutoScalingSpec{
+								Metrics: []MetricsSpec{
+									{
+										Type: ExternalMetricSourceType,
+									},
+								},
+							},
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.MatchError("invalid HPA metric source type with value [External], " +
+				"valid metric source types are Resource. " +
+				"For External or PodMetric types, set the annotation serving.kserve.io/autoscalerClass to keda"),
+		},
+		"Invalid External metrics without autoscalerClass annotation in RawDeployment mode": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": "RawDeployment",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							AutoScaling: &AutoScalingSpec{
+								Metrics: []MetricsSpec{
+									{
+										Type: ExternalMetricSourceType,
+									},
+								},
+							},
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.MatchError("invalid HPA metric source type with value [External], " +
+				"valid metric source types are Resource. " +
+				"For External or PodMetric types, set the annotation serving.kserve.io/autoscalerClass to keda"),
 		},
 		"Valid HPA CPU metrics with target utilization": {
 			isvc: &InferenceService{


### PR DESCRIPTION
## What this PR does

  Fixes the controller panic (nil pointer dereference) reported in #4548 when an `InferenceService` configures `External` autoscaling metrics without
  setting the `serving.kserve.io/autoscalerClass: keda` annotation.

  ## Root Cause

  The validation webhook in `validateAutoScalingCompExtension` had two gaps:

  1. **Missing default case for `autoscalerClass`**: When `deploymentMode` is `Standard` and `autoscalerClass` is not set, the reconciler defaults to HPA
  (`DefaultAutoscalerClass = AutoscalerClassHPA`), but the validation switch did not match the empty string case — it silently returned `nil`, skipping all
  HPA metric validation. This allowed `External` metric types to pass through unchecked, and the HPA reconciler then panicked on `metric.Resource.Name`
  because `Resource` is `nil` for External metrics.

  2. **Legacy `RawDeployment` mode not handled**: The legacy `RawDeployment` deployment mode (deprecated alias for `Standard`) was not included in the
  `Standard` case of the switch, causing it to fall into the `default` branch and run KPA validation instead of HPA validation.

  ## Changes

  ### `pkg/apis/serving/v1beta1/inference_service_validation.go`
  - Added `""` (empty string) to the `autoscalerClass` switch so that when no autoscaler class annotation is set, HPA validation runs by default — matching
  the reconciler's default behavior.
  - Added `LegacyRawDeployment` (`"RawDeployment"`) to the `deploymentMode` switch alongside `Standard`.
  - Improved the error message to be more actionable: it now suggests setting `serving.kserve.io/autoscalerClass` to `keda` when `External` or `PodMetric`
  metric types are used.

  ### `pkg/apis/serving/v1beta1/inference_service_validation_test.go`
  - Updated the existing `"Invalid HPA CPU metrics with wrong metric source"` test to match the new error message.
  - Added `"Invalid External metrics without autoscalerClass annotation in Standard mode"` test — verifies that External metrics are rejected with a clear
  error when `autoscalerClass` is not set in Standard mode.
  - Added `"Invalid External metrics without autoscalerClass annotation in RawDeployment mode"` test — verifies the same validation applies to the legacy
  `RawDeployment` mode.

  ## How to reproduce the original panic

  Apply the YAML from #4548 (an `InferenceService` with `serving.kserve.io/deploymentMode: RawDeployment`, External autoscaling metrics, and **no**
  `serving.kserve.io/autoscalerClass` annotation). Before this fix, the controller crashes with:

  panic: runtime error: invalid memory address or nil pointer dereference
    github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa.getHPAMetrics

  After this fix, the webhook rejects the request with:

  invalid HPA metric source type with value [External], valid metric source types are Resource.
  For External or PodMetric types, set the annotation serving.kserve.io/autoscalerClass to keda

  ## Test plan
  - [x] `go test ./pkg/apis/serving/v1beta1/ -run TestAutoscalerClassHPA` — all 12 subtests pass
  - [x] `go test ./pkg/apis/serving/v1beta1/` — full package tests pass

  Fixes #4548