### PR TITLE
feat: block PYTHONPATH env var in ISVC and ServingRuntime webhooks

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -28,6 +28,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -36,6 +37,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/utils"
+	"github.com/kserve/kserve/pkg/validation"
 )
 
 // regular expressions for validation of isvc name
@@ -120,6 +122,10 @@ func validateInferenceService(isvc *InferenceService) (admission.Warnings, error
 		return allWarnings, err
 	}
 
+	if err := validateBlockedEnvVars(isvc); err != nil {
+		return allWarnings, err
+	}
+
 	if err := validateMultiNodeVariables(isvc); err != nil {
 		return allWarnings, err
 	}
@@ -189,6 +195,73 @@ func validatePredictor(isvc *InferenceService) error {
 		return errors.New("the 'name' field is not allowed in standard predictor")
 	}
 	return nil
+}
+
+func validateBlockedEnvVars(isvc *InferenceService) error {
+	if err := validation.ValidateBlockedEnvVars(isvc.Spec.Predictor.Containers, validation.DefaultBlockedEnvVars); err != nil {
+		return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+	}
+
+	if c := predictorFrameworkContainer(&isvc.Spec.Predictor); c != nil {
+		if err := validation.ValidateBlockedEnvVars([]corev1.Container{*c}, validation.DefaultBlockedEnvVars); err != nil {
+			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+		}
+	}
+
+	if isvc.Spec.Predictor.WorkerSpec != nil {
+		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Predictor.WorkerSpec.Containers, validation.DefaultBlockedEnvVars); err != nil {
+			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+		}
+	}
+
+	if isvc.Spec.Transformer != nil {
+		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Transformer.Containers, validation.DefaultBlockedEnvVars); err != nil {
+			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+		}
+	}
+
+	if isvc.Spec.Explainer != nil {
+		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Explainer.Containers, validation.DefaultBlockedEnvVars); err != nil {
+			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+		}
+
+		if isvc.Spec.Explainer.ART != nil {
+			if err := validation.ValidateBlockedEnvVars([]corev1.Container{isvc.Spec.Explainer.ART.Container}, validation.DefaultBlockedEnvVars); err != nil {
+				return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func predictorFrameworkContainer(p *PredictorSpec) *corev1.Container {
+	switch {
+	case p.Model != nil:
+		return &p.Model.Container
+	case p.SKLearn != nil:
+		return &p.SKLearn.Container
+	case p.XGBoost != nil:
+		return &p.XGBoost.Container
+	case p.Tensorflow != nil:
+		return &p.Tensorflow.Container
+	case p.PyTorch != nil:
+		return &p.PyTorch.Container
+	case p.Triton != nil:
+		return &p.Triton.Container
+	case p.ONNX != nil:
+		return &p.ONNX.Container
+	case p.HuggingFace != nil:
+		return &p.HuggingFace.Container
+	case p.PMML != nil:
+		return &p.PMML.Container
+	case p.LightGBM != nil:
+		return &p.LightGBM.Container
+	case p.Paddle != nil:
+		return &p.Paddle.Container
+	default:
+		return nil
+	}
 }
 
 // validateMultiNodeVariables validates when there is workerSpec set in isvc

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -202,6 +202,10 @@ func validateBlockedEnvVars(isvc *InferenceService) error {
 		return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
 	}
 
+	if err := validation.ValidateBlockedEnvVars(isvc.Spec.Predictor.InitContainers, validation.DefaultBlockedEnvVars); err != nil {
+		return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+	}
+
 	if c := predictorFrameworkContainer(&isvc.Spec.Predictor); c != nil {
 		if err := validation.ValidateBlockedEnvVars([]corev1.Container{*c}, validation.DefaultBlockedEnvVars); err != nil {
 			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
@@ -212,16 +216,28 @@ func validateBlockedEnvVars(isvc *InferenceService) error {
 		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Predictor.WorkerSpec.Containers, validation.DefaultBlockedEnvVars); err != nil {
 			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
 		}
+
+		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Predictor.WorkerSpec.InitContainers, validation.DefaultBlockedEnvVars); err != nil {
+			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+		}
 	}
 
 	if isvc.Spec.Transformer != nil {
 		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Transformer.Containers, validation.DefaultBlockedEnvVars); err != nil {
 			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
 		}
+
+		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Transformer.InitContainers, validation.DefaultBlockedEnvVars); err != nil {
+			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+		}
 	}
 
 	if isvc.Spec.Explainer != nil {
 		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Explainer.Containers, validation.DefaultBlockedEnvVars); err != nil {
+			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+		}
+
+		if err := validation.ValidateBlockedEnvVars(isvc.Spec.Explainer.InitContainers, validation.DefaultBlockedEnvVars); err != nil {
 			return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
 		}
 

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1810,3 +1810,171 @@ func TestValidateStorageUri(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBlockedEnvVars(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	scenarios := map[string]struct {
+		isvc      *InferenceService
+		expectErr bool
+	}{
+		"PYTHONPATH in predictor model env should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								Container: corev1.Container{
+									Env: []corev1.EnvVar{
+										{Name: "PYTHONPATH", Value: "/custom"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"PYTHONPATH in predictor custom container should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						PodSpec: PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "kserve-container",
+									Env: []corev1.EnvVar{
+										{Name: "PYTHONPATH", Value: "/injected"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"PYTHONPATH in workerSpec container should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "huggingface"},
+						},
+						WorkerSpec: &WorkerSpec{
+							PodSpec: PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "worker",
+										Env: []corev1.EnvVar{
+											{Name: "PYTHONPATH", Value: "/bad"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"PYTHONPATH in transformer container should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+						},
+					},
+					Transformer: &TransformerSpec{
+						PodSpec: PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "transformer",
+									Env: []corev1.EnvVar{
+										{Name: "PYTHONPATH", Value: "/evil"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"allowed env vars should pass": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								Container: corev1.Container{
+									Env: []corev1.EnvVar{
+										{Name: "MODEL_NAME", Value: "my-model"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"PYTHONPATH in explainer ART container should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+						},
+					},
+					Explainer: &ExplainerSpec{
+						ART: &ARTExplainerSpec{
+							ExplainerExtensionSpec: ExplainerExtensionSpec{
+								Container: corev1.Container{
+									Env: []corev1.EnvVar{
+										{Name: "PYTHONPATH", Value: "/injected"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"no env vars should pass": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for name, tc := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			err := validateBlockedEnvVars(tc.isvc)
+			if tc.expectErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(err.Error()).To(gomega.ContainSubstring("PYTHONPATH"))
+			} else {
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+		})
+	}
+}

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1951,6 +1951,104 @@ func TestValidateBlockedEnvVars(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		"PYTHONPATH in predictor initContainer should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+						},
+						PodSpec: PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name: "init-setup",
+									Env: []corev1.EnvVar{
+										{Name: "PYTHONPATH", Value: "/injected"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"PYTHONPATH in workerSpec initContainer should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "huggingface"},
+						},
+						WorkerSpec: &WorkerSpec{
+							PodSpec: PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name: "init-worker",
+										Env: []corev1.EnvVar{
+											{Name: "PYTHONPATH", Value: "/injected"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"PYTHONPATH in explainer initContainer should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+						},
+					},
+					Explainer: &ExplainerSpec{
+						PodSpec: PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name: "init-explainer",
+									Env: []corev1.EnvVar{
+										{Name: "PYTHONPATH", Value: "/evil"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"PYTHONPATH in transformer initContainer should be rejected": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+						},
+					},
+					Transformer: &TransformerSpec{
+						PodSpec: PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name: "init-transform",
+									Env: []corev1.EnvVar{
+										{Name: "PYTHONPATH", Value: "/evil"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
 		"no env vars should pass": {
 			isvc: &InferenceService{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-isvc"},

--- a/pkg/validation/env_policy.go
+++ b/pkg/validation/env_policy.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var DefaultBlockedEnvVars = []string{
+	"PYTHONPATH",
+}
+
+func ValidateBlockedEnvVars(containers []corev1.Container, blockedVars []string) error {
+	blocked := make(map[string]bool, len(blockedVars))
+	for _, v := range blockedVars {
+		blocked[v] = true
+	}
+
+	for _, container := range containers {
+		for _, env := range container.Env {
+			if blocked[env.Name] {
+				return fmt.Errorf("setting %s in container %q is not allowed for security reasons", env.Name, container.Name)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/validation/env_policy_test.go
+++ b/pkg/validation/env_policy_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestValidateBlockedEnvVars(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tests := map[string]struct {
+		containers  []corev1.Container
+		blockedVars []string
+		expectErr   bool
+		errContains string
+	}{
+		"no containers": {
+			containers:  []corev1.Container{},
+			blockedVars: DefaultBlockedEnvVars,
+			expectErr:   false,
+		},
+		"no blocked vars": {
+			containers: []corev1.Container{
+				{
+					Name: "kserve-container",
+					Env: []corev1.EnvVar{
+						{Name: "PYTHONPATH", Value: "/custom"},
+					},
+				},
+			},
+			blockedVars: []string{},
+			expectErr:   false,
+		},
+		"allowed env vars pass": {
+			containers: []corev1.Container{
+				{
+					Name: "kserve-container",
+					Env: []corev1.EnvVar{
+						{Name: "MODEL_NAME", Value: "my-model"},
+						{Name: "HTTP_PORT", Value: "8080"},
+					},
+				},
+			},
+			blockedVars: DefaultBlockedEnvVars,
+			expectErr:   false,
+		},
+		"PYTHONPATH blocked in single container": {
+			containers: []corev1.Container{
+				{
+					Name: "kserve-container",
+					Env: []corev1.EnvVar{
+						{Name: "PYTHONPATH", Value: "/malicious/path"},
+					},
+				},
+			},
+			blockedVars: DefaultBlockedEnvVars,
+			expectErr:   true,
+			errContains: "PYTHONPATH",
+		},
+		"PYTHONPATH blocked in second container": {
+			containers: []corev1.Container{
+				{
+					Name: "init-container",
+					Env: []corev1.EnvVar{
+						{Name: "MODEL_NAME", Value: "ok"},
+					},
+				},
+				{
+					Name: "sidecar",
+					Env: []corev1.EnvVar{
+						{Name: "PYTHONPATH", Value: "/injected"},
+					},
+				},
+			},
+			blockedVars: DefaultBlockedEnvVars,
+			expectErr:   true,
+			errContains: "sidecar",
+		},
+		"multiple blocked vars": {
+			containers: []corev1.Container{
+				{
+					Name: "kserve-container",
+					Env: []corev1.EnvVar{
+						{Name: "LD_PRELOAD", Value: "/lib/inject.so"},
+					},
+				},
+			},
+			blockedVars: []string{"PYTHONPATH", "LD_PRELOAD"},
+			expectErr:   true,
+			errContains: "LD_PRELOAD",
+		},
+		"container with no env vars passes": {
+			containers: []corev1.Container{
+				{Name: "kserve-container"},
+			},
+			blockedVars: DefaultBlockedEnvVars,
+			expectErr:   false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateBlockedEnvVars(tc.containers, tc.blockedVars)
+			if tc.expectErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(err.Error()).To(gomega.ContainSubstring(tc.errContains))
+			} else {
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+		})
+	}
+}

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
@@ -104,7 +104,7 @@ func (sr *ServingRuntimeValidator) Handle(ctx context.Context, req admission.Req
 	}
 
 	if err := validateBlockedEnvVars(&servingRuntime.Spec); err != nil {
-		return admission.Denied(err.Error())
+		return admission.Denied(fmt.Sprintf("the %s %q is invalid: %s", servingRuntime.Kind, servingRuntime.Name, err.Error()))
 	}
 
 	return admission.Allowed("")
@@ -146,7 +146,7 @@ func (csr *ClusterServingRuntimeValidator) Handle(ctx context.Context, req admis
 	}
 
 	if err := validateBlockedEnvVars(&clusterServingRuntime.Spec); err != nil {
-		return admission.Denied(err.Error())
+		return admission.Denied(fmt.Sprintf("the %s %q is invalid: %s", clusterServingRuntime.Kind, clusterServingRuntime.Name, err.Error()))
 	}
 	return admission.Allowed("")
 }

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/utils"
+	"github.com/kserve/kserve/pkg/validation"
 )
 
 var log = logf.Log.WithName(constants.ServingRuntimeValidatorWebhookName)
@@ -102,6 +103,10 @@ func (sr *ServingRuntimeValidator) Handle(ctx context.Context, req admission.Req
 		return admission.Denied(fmt.Sprintf(InvalidMultiNodeSpecError, servingRuntime.Kind, servingRuntime.Name, err.Error()))
 	}
 
+	if err := validateBlockedEnvVars(&servingRuntime.Spec); err != nil {
+		return admission.Denied(err.Error())
+	}
+
 	return admission.Allowed("")
 }
 
@@ -138,6 +143,10 @@ func (csr *ClusterServingRuntimeValidator) Handle(ctx context.Context, req admis
 
 	if err := validateMultiNodeSpec(&clusterServingRuntime.Spec, &existingRuntimeSpec); err != nil {
 		return admission.Denied(fmt.Sprintf(InvalidMultiNodeSpecError, clusterServingRuntime.Kind, clusterServingRuntime.Name, err.Error()))
+	}
+
+	if err := validateBlockedEnvVars(&clusterServingRuntime.Spec); err != nil {
+		return admission.Denied(err.Error())
 	}
 	return admission.Allowed("")
 }
@@ -255,5 +264,19 @@ func validateMultiNodeSpec(newSpec *v1alpha1.ServingRuntimeSpec, existingSpec *v
 			return fmt.Errorf(InvalidWorkerSpecTensorParallelSizeValueError, strconv.Itoa(tensorParallelSize))
 		}
 	}
+	return nil
+}
+
+func validateBlockedEnvVars(spec *v1alpha1.ServingRuntimeSpec) error {
+	if err := validation.ValidateBlockedEnvVars(spec.Containers, validation.DefaultBlockedEnvVars); err != nil {
+		return err
+	}
+
+	if spec.WorkerSpec != nil {
+		if err := validation.ValidateBlockedEnvVars(spec.WorkerSpec.Containers, validation.DefaultBlockedEnvVars); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook_test.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook_test.go
@@ -1931,6 +1931,97 @@ func (f *fakeDecoder) Decode(_ admission.Request, into runtime.Object) error {
 	return nil
 }
 
+func TestValidateBlockedEnvVars(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	scenarios := map[string]struct {
+		spec      *v1alpha1.ServingRuntimeSpec
+		expectErr bool
+	}{
+		"PYTHONPATH in main container should be rejected": {
+			spec: &v1alpha1.ServingRuntimeSpec{
+				ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "kserve/sklearnserver:latest",
+							Env: []corev1.EnvVar{
+								{Name: "PYTHONPATH", Value: "/custom"},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"PYTHONPATH in workerSpec container should be rejected": {
+			spec: &v1alpha1.ServingRuntimeSpec{
+				ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "kserve/sklearnserver:latest",
+						},
+					},
+				},
+				WorkerSpec: &v1alpha1.WorkerSpec{
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "worker-container",
+								Env: []corev1.EnvVar{
+									{Name: "PYTHONPATH", Value: "/bad"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"allowed env vars should pass": {
+			spec: &v1alpha1.ServingRuntimeSpec{
+				ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "kserve/sklearnserver:latest",
+							Env: []corev1.EnvVar{
+								{Name: "MODEL_NAME", Value: "test"},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		"no env vars should pass": {
+			spec: &v1alpha1.ServingRuntimeSpec{
+				ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "kserve/sklearnserver:latest",
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for name, tc := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			err := validateBlockedEnvVars(tc.spec)
+			if tc.expectErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(err.Error()).To(gomega.ContainSubstring("PYTHONPATH"))
+			} else {
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+		})
+	}
+}
+
 func intPtr(i int) *int {
 	return &i
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add shared `pkg/validation/` package to block security-sensitive env vars (PYTHONPATH) in admission webhooks
- Validate all container types: predictor (PodSpec + framework spec), workerSpec, transformer, explainer (PodSpec + ART)
- Apply to both InferenceService and ServingRuntime/ClusterServingRuntime validators
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note

```
