### PR TITLE
fix(agent): mirror user-defined httpGet path onto agent readiness probe

### DIFF
--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -348,6 +348,7 @@ func (ag *AgentInjector) InjectAgent(pod *corev1.Pod) error {
 	}
 	args = append(args, constants.AgentComponentPortArgName, componentPort)
 
+	agentReadinessProbePath := "/"
 	if !queueProxyAvailable {
 		readinessProbe := pod.Spec.Containers[0].ReadinessProbe
 		// If the transformer container is present, use its readiness probe
@@ -370,6 +371,13 @@ func (ag *AgentInjector) InjectAgent(pod *corev1.Pod) error {
 
 				// Append the marshaled readiness probe as an environment variable for the agent container
 				agentEnvs = append(agentEnvs, corev1.EnvVar{Name: "SERVING_READINESS_PROBE", Value: string(readinessProbeJson)})
+
+				// Mirror the user-defined httpGet path onto the agent's Kubernetes readiness probe.
+				// The agent serves on this path via SERVING_READINESS_PROBE; leaving the probe
+				// hardcoded to "/" causes 404s when a custom path is set.
+				if readinessProbe.HTTPGet != nil && readinessProbe.HTTPGet.Path != "" {
+					agentReadinessProbePath = readinessProbe.HTTPGet.Path
+				}
 			} else if readinessProbe.Exec != nil {
 				// Log the skipping of ExecAction readiness probes
 				klog.Infof("Exec readiness probe skipped for pod %s/%s", pod.Namespace, pod.Name)
@@ -422,7 +430,7 @@ func (ag *AgentInjector) InjectAgent(pod *corev1.Pod) error {
 						},
 					},
 					Port:   intstr.FromInt(constants.InferenceServiceDefaultAgentPort),
-					Path:   "/",
+					Path:   agentReadinessProbePath,
 					Scheme: "HTTP",
 				},
 			},

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -1700,6 +1700,138 @@ func TestAgentInjector(t *testing.T) {
 				},
 			},
 		},
+		"AddAgentWithHTTPGetReadinessProbe": {
+			original: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.AgentShouldInjectAnnotationKey:          "true",
+						constants.AgentModelConfigVolumeNameAnnotationKey: "modelconfig-deployment-0",
+						constants.AgentModelDirAnnotationKey:              "/mnt/models",
+						constants.AgentModelConfigMountPathAnnotationKey:  "/mnt/configs",
+					},
+					Labels: map[string]string{
+						"serving.kserve.io/inferenceservice": "sklearn",
+						constants.KServiceModelLabel:         "sklearn",
+						constants.KServiceEndpointLabel:      "default",
+						constants.KServiceComponentLabel:     "predictor",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "sa",
+					Containers: []corev1.Container{
+						{
+							Name: "sklearn",
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/v1/health/ready",
+										Port:   intstr.FromInt(8080),
+										Scheme: "HTTP",
+									},
+								},
+								TimeoutSeconds:   1,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
+							},
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+					Annotations: map[string]string{
+						constants.AgentShouldInjectAnnotationKey: "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "sa",
+					Containers: []corev1.Container{
+						{
+							Name: "sklearn",
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/v1/health/ready",
+										Port:   intstr.FromInt(8080),
+										Scheme: "HTTP",
+									},
+								},
+								TimeoutSeconds:   1,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
+							},
+						},
+						{
+							Name:      constants.AgentContainerName,
+							Image:     agentConfig.Image,
+							Resources: agentResourceRequirement,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      constants.ModelDirVolumeName,
+									ReadOnly:  false,
+									MountPath: constants.ModelDir,
+								},
+								{
+									Name:      constants.ModelConfigVolumeName,
+									ReadOnly:  false,
+									MountPath: constants.ModelConfigDir,
+								},
+							},
+							Args: []string{
+								"--enable-puller", "--config-dir", "/mnt/configs", "--model-dir", "/mnt/models", constants.AgentComponentPortArgName,
+								constants.InferenceServiceDefaultHttpPort,
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "agent-port",
+									ContainerPort: constants.InferenceServiceDefaultAgentPort,
+									Protocol:      "TCP",
+								},
+							},
+							Env: []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"httpGet\":{\"path\":\"/v1/health/ready\",\"port\":8080,\"scheme\":\"HTTP\"},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										HTTPHeaders: []corev1.HTTPHeader{
+											{
+												Name:  "K-Network-Probe",
+												Value: "queue",
+											},
+										},
+										Port:   intstr.FromInt(9081),
+										Path:   "/v1/health/ready",
+										Scheme: "HTTP",
+									},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "model-dir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "model-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "modelconfig-deployment-0",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	clientset := fakeclientset.NewSimpleClientset()
 	credentialBuilder := credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{


### PR DESCRIPTION
**What this PR does / why we need it**:

When a user defines a custom `httpGet` readinessProbe on their model container (e.g. `path: /v1/health/ready`), the injected agent sidecar is permanently stuck not ready:

```
NAME                                    READY   STATUS    RESTARTS   AGE
m-nhwsljyc-predictor-6b64759cd7-cnnd8   1/2     Running   0          13m
```

Root cause: `agent_injector.go` correctly passes the user-defined probe to the agent via `SERVING_READINESS_PROBE` (line 372), so the agent configures itself to serve on that path. However, the agent container's Kubernetes readiness probe spec was hardcoded to `Path: "/"`. When the agent only serves `/v1/health/ready`, kubelet gets 404 on `GET /` and the container never becomes Ready.

**Which issue(s) this PR fixes**:
Fixes #5341

**Feature/Issue validation/testing**:

- [x] Added unit test `AddAgentWithHTTPGetReadinessProbe` in `agent_injector_test.go` that injects an agent into a pod with a custom `httpGet` readinessProbe path and asserts the agent container probe uses the same path
- [x] Existing unit tests pass (`go test ./pkg/webhook/admission/pod/...`)

**Notes**:

`agentReadinessProbePath` defaults to `"/"` — if no custom path is set (or the probe is TCPSocket/Exec), behavior is unchanged.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix agent container readiness probe ignoring user-defined httpGet path, causing pods to be stuck at 1/2 Ready when a custom readiness probe path is set on the model container.
```