### PR TITLE
feat(ingress): add pathMatchType config flag for GKE Gateway compatibility

### DIFF
--- a/charts/_common/common-patches/configmap-patch.yaml
+++ b/charts/_common/common-patches/configmap-patch.yaml
@@ -87,7 +87,8 @@ data:
         "urlScheme": "{{ .Values.kserve.controller.gateway.urlScheme }}",
         "disableIstioVirtualHost": {{ .Values.kserve.controller.gateway.disableIstioVirtualHost }},
         "disableIngressCreation": {{ .Values.kserve.controller.gateway.disableIngressCreation }},
-        "disableHTTPRouteTimeout": {{ .Values.kserve.controller.gateway.disableHTTPRouteTimeout }}
+        "disableHTTPRouteTimeout": {{ .Values.kserve.controller.gateway.disableHTTPRouteTimeout }},
+        "pathMatchType": "{{ .Values.kserve.controller.gateway.pathMatchType }}"
     }
   logger: |-
     {

--- a/charts/_common/kserve-llmisvc-resources-specific.yaml
+++ b/charts/_common/kserve-llmisvc-resources-specific.yaml
@@ -86,6 +86,7 @@ kserve:
       disableIstioVirtualHost: false
       disableIngressCreation: false
       disableHTTPRouteTimeout: false
+      pathMatchType: ""
       localGateway:
         gateway: knative-serving/knative-local-gateway
         gatewayService: knative-local-gateway.istio-system.svc.cluster.local

--- a/charts/_common/kserve-resources-specific.yaml
+++ b/charts/_common/kserve-resources-specific.yaml
@@ -47,6 +47,7 @@ kserve:
       disableIstioVirtualHost: false
       disableIngressCreation: false
       disableHTTPRouteTimeout: false
+      pathMatchType: ""
       localGateway:
         gateway: knative-serving/knative-local-gateway
         gatewayService: knative-local-gateway.istio-system.svc.cluster.local

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -50,6 +50,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.controller.gateway.localGateway.gateway | string | `"knative-serving/knative-local-gateway"` |  |
 | kserve.controller.gateway.localGateway.gatewayService | string | `"knative-local-gateway.istio-system.svc.cluster.local"` |  |
 | kserve.controller.gateway.localGateway.knativeGatewayService | string | `""` |  |
+| kserve.controller.gateway.pathMatchType | string | `""` |  |
 | kserve.controller.gateway.pathTemplate | string | `""` |  |
 | kserve.controller.gateway.urlScheme | string | `"http"` |  |
 | kserve.createSharedResources | bool | `true` |  |

--- a/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
@@ -87,7 +87,8 @@ data:
         "urlScheme": "{{ .Values.kserve.controller.gateway.urlScheme }}",
         "disableIstioVirtualHost": {{ .Values.kserve.controller.gateway.disableIstioVirtualHost }},
         "disableIngressCreation": {{ .Values.kserve.controller.gateway.disableIngressCreation }},
-        "disableHTTPRouteTimeout": {{ .Values.kserve.controller.gateway.disableHTTPRouteTimeout }}
+        "disableHTTPRouteTimeout": {{ .Values.kserve.controller.gateway.disableHTTPRouteTimeout }},
+        "pathMatchType": "{{ .Values.kserve.controller.gateway.pathMatchType }}"
     }
   logger: |-
     {

--- a/charts/kserve-llmisvc-resources/files/common/configmap.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap.yaml
@@ -301,7 +301,8 @@ data:
            "urlScheme": "http",
            "disableIstioVirtualHost": false,
            "disableIngressCreation": false,
-           "disableHTTPRouteTimeout": false
+           "disableHTTPRouteTimeout": false,
+           "pathMatchType": ""
        }
      ingress: |-
        {
@@ -380,6 +381,11 @@ data:
            # disableHTTPRouteTimeout controls whether to omit the timeout field from HTTPRoute rules.
            # Set to true for Gateway controllers (e.g. GKE Gateway) that do not support the optional timeouts field.
            "disableHTTPRouteTimeout": false,
+
+           # pathMatchType controls the path match type used in HTTPRoute rules.
+           # Set to "PathPrefix" for Gateway controllers (e.g. GKE Gateway) that do not support RegularExpression path matches.
+           # When empty or unset, the default RegularExpression matching is used.
+           "pathMatchType": "",
 
            # pathTemplate specifies the template for generating path based url for each inference service.
            # The following variables can be used in the template for generating url.
@@ -701,7 +707,8 @@ data:
         "urlScheme": "http",
         "disableIstioVirtualHost": false,
         "disableIngressCreation": false,
-        "disableHTTPRouteTimeout": false
+        "disableHTTPRouteTimeout": false,
+        "pathMatchType": ""
     }
   localModel: |-
     {

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -190,6 +190,7 @@ kserve:
       disableIstioVirtualHost: false
       disableIngressCreation: false
       disableHTTPRouteTimeout: false
+      pathMatchType: ""
       localGateway:
         gateway: knative-serving/knative-local-gateway
         gatewayService: knative-local-gateway.istio-system.svc.cluster.local

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -43,6 +43,7 @@ $ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --v
 | kserve.controller.gateway.localGateway.gateway | string | `"knative-serving/knative-local-gateway"` |  |
 | kserve.controller.gateway.localGateway.gatewayService | string | `"knative-local-gateway.istio-system.svc.cluster.local"` |  |
 | kserve.controller.gateway.localGateway.knativeGatewayService | string | `""` |  |
+| kserve.controller.gateway.pathMatchType | string | `""` |  |
 | kserve.controller.gateway.pathTemplate | string | `""` |  |
 | kserve.controller.gateway.urlScheme | string | `"http"` |  |
 | kserve.controller.image | string | `"kserve/kserve-controller"` |  |

--- a/charts/kserve-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-resources/files/common/configmap-patch.yaml
@@ -87,7 +87,8 @@ data:
         "urlScheme": "{{ .Values.kserve.controller.gateway.urlScheme }}",
         "disableIstioVirtualHost": {{ .Values.kserve.controller.gateway.disableIstioVirtualHost }},
         "disableIngressCreation": {{ .Values.kserve.controller.gateway.disableIngressCreation }},
-        "disableHTTPRouteTimeout": {{ .Values.kserve.controller.gateway.disableHTTPRouteTimeout }}
+        "disableHTTPRouteTimeout": {{ .Values.kserve.controller.gateway.disableHTTPRouteTimeout }},
+        "pathMatchType": "{{ .Values.kserve.controller.gateway.pathMatchType }}"
     }
   logger: |-
     {

--- a/charts/kserve-resources/files/common/configmap.yaml
+++ b/charts/kserve-resources/files/common/configmap.yaml
@@ -301,7 +301,8 @@ data:
            "urlScheme": "http",
            "disableIstioVirtualHost": false,
            "disableIngressCreation": false,
-           "disableHTTPRouteTimeout": false
+           "disableHTTPRouteTimeout": false,
+           "pathMatchType": ""
        }
      ingress: |-
        {
@@ -380,6 +381,11 @@ data:
            # disableHTTPRouteTimeout controls whether to omit the timeout field from HTTPRoute rules.
            # Set to true for Gateway controllers (e.g. GKE Gateway) that do not support the optional timeouts field.
            "disableHTTPRouteTimeout": false,
+
+           # pathMatchType controls the path match type used in HTTPRoute rules.
+           # Set to "PathPrefix" for Gateway controllers (e.g. GKE Gateway) that do not support RegularExpression path matches.
+           # When empty or unset, the default RegularExpression matching is used.
+           "pathMatchType": "",
 
            # pathTemplate specifies the template for generating path based url for each inference service.
            # The following variables can be used in the template for generating url.
@@ -701,7 +707,8 @@ data:
         "urlScheme": "http",
         "disableIstioVirtualHost": false,
         "disableIngressCreation": false,
-        "disableHTTPRouteTimeout": false
+        "disableHTTPRouteTimeout": false,
+        "pathMatchType": ""
     }
   localModel: |-
     {

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -153,6 +153,7 @@ kserve:
       disableIstioVirtualHost: false
       disableIngressCreation: false
       disableHTTPRouteTimeout: false
+      pathMatchType: ""
       localGateway:
         gateway: knative-serving/knative-local-gateway
         gatewayService: knative-local-gateway.istio-system.svc.cluster.local

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -305,7 +305,8 @@ data:
            "urlScheme": "http",
            "disableIstioVirtualHost": false,
            "disableIngressCreation": false,
-           "disableHTTPRouteTimeout": false
+           "disableHTTPRouteTimeout": false,
+           "pathMatchType": ""
        }
      ingress: |-
        {
@@ -384,6 +385,11 @@ data:
            # disableHTTPRouteTimeout controls whether to omit the timeout field from HTTPRoute rules.
            # Set to true for Gateway controllers (e.g. GKE Gateway) that do not support the optional timeouts field.
            "disableHTTPRouteTimeout": false,
+
+           # pathMatchType controls the path match type used in HTTPRoute rules.
+           # Set to "PathPrefix" for Gateway controllers (e.g. GKE Gateway) that do not support RegularExpression path matches.
+           # When empty or unset, the default RegularExpression matching is used.
+           "pathMatchType": "",
 
            # pathTemplate specifies the template for generating path based url for each inference service.
            # The following variables can be used in the template for generating url.
@@ -687,7 +693,8 @@ data:
         "urlScheme": "http",
         "disableIstioVirtualHost": false,
         "disableIngressCreation": false,
-        "disableHTTPRouteTimeout": false
+        "disableHTTPRouteTimeout": false,
+        "pathMatchType": ""
     }
 
   logger: |-

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -305,7 +305,8 @@ data:
            "urlScheme": "http",
            "disableIstioVirtualHost": false,
            "disableIngressCreation": false,
-           "disableHTTPRouteTimeout": false
+           "disableHTTPRouteTimeout": false,
+           "pathMatchType": ""
        }
      ingress: |-
        {
@@ -384,6 +385,11 @@ data:
            # disableHTTPRouteTimeout controls whether to omit the timeout field from HTTPRoute rules.
            # Set to true for Gateway controllers (e.g. GKE Gateway) that do not support the optional timeouts field.
            "disableHTTPRouteTimeout": false,
+
+           # pathMatchType controls the path match type used in HTTPRoute rules.
+           # Set to "PathPrefix" for Gateway controllers (e.g. GKE Gateway) that do not support RegularExpression path matches.
+           # When empty or unset, the default RegularExpression matching is used.
+           "pathMatchType": "",
 
            # pathTemplate specifies the template for generating path based url for each inference service.
            # The following variables can be used in the template for generating url.
@@ -687,7 +693,8 @@ data:
         "urlScheme": "http",
         "disableIstioVirtualHost": false,
         "disableIngressCreation": false,
-        "disableHTTPRouteTimeout": false
+        "disableHTTPRouteTimeout": false,
+        "pathMatchType": ""
     }
 
   logger: |-

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -38306,7 +38306,8 @@ data:
            "urlScheme": "http",
            "disableIstioVirtualHost": false,
            "disableIngressCreation": false,
-           "disableHTTPRouteTimeout": false
+           "disableHTTPRouteTimeout": false,
+           "pathMatchType": ""
        }
      ingress: |-
        {
@@ -38385,6 +38386,11 @@ data:
            # disableHTTPRouteTimeout controls whether to omit the timeout field from HTTPRoute rules.
            # Set to true for Gateway controllers (e.g. GKE Gateway) that do not support the optional timeouts field.
            "disableHTTPRouteTimeout": false,
+
+           # pathMatchType controls the path match type used in HTTPRoute rules.
+           # Set to "PathPrefix" for Gateway controllers (e.g. GKE Gateway) that do not support RegularExpression path matches.
+           # When empty or unset, the default RegularExpression matching is used.
+           "pathMatchType": "",
 
            # pathTemplate specifies the template for generating path based url for each inference service.
            # The following variables can be used in the template for generating url.
@@ -38706,7 +38712,8 @@ data:
         "urlScheme": "http",
         "disableIstioVirtualHost": false,
         "disableIngressCreation": false,
-        "disableHTTPRouteTimeout": false
+        "disableHTTPRouteTimeout": false,
+        "pathMatchType": ""
     }
   localModel: |-
     {

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -37892,7 +37892,8 @@ data:
            "urlScheme": "http",
            "disableIstioVirtualHost": false,
            "disableIngressCreation": false,
-           "disableHTTPRouteTimeout": false
+           "disableHTTPRouteTimeout": false,
+           "pathMatchType": ""
        }
      ingress: |-
        {
@@ -37971,6 +37972,11 @@ data:
            # disableHTTPRouteTimeout controls whether to omit the timeout field from HTTPRoute rules.
            # Set to true for Gateway controllers (e.g. GKE Gateway) that do not support the optional timeouts field.
            "disableHTTPRouteTimeout": false,
+
+           # pathMatchType controls the path match type used in HTTPRoute rules.
+           # Set to "PathPrefix" for Gateway controllers (e.g. GKE Gateway) that do not support RegularExpression path matches.
+           # When empty or unset, the default RegularExpression matching is used.
+           "pathMatchType": "",
 
            # pathTemplate specifies the template for generating path based url for each inference service.
            # The following variables can be used in the template for generating url.
@@ -38292,7 +38298,8 @@ data:
         "urlScheme": "http",
         "disableIstioVirtualHost": false,
         "disableIngressCreation": false,
-        "disableHTTPRouteTimeout": false
+        "disableHTTPRouteTimeout": false,
+        "pathMatchType": ""
     }
   localModel: |-
     {

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -127,6 +127,7 @@ type IngressConfig struct {
 	PathTemplate                 string    `json:"pathTemplate,omitempty"`
 	DisableIngressCreation       bool      `json:"disableIngressCreation,omitempty"`
 	DisableHTTPRouteTimeout      bool      `json:"disableHTTPRouteTimeout,omitempty"`
+	PathMatchType                string    `json:"pathMatchType,omitempty"`
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -117,6 +117,22 @@ func createHTTPRouteMatch(prefix string) gwapiv1.HTTPRouteMatch {
 	}
 }
 
+// resolvePathMatch returns an HTTPRouteMatch with the appropriate path match type.
+// When pathMatchType is "PathPrefix", it uses PathMatchPathPrefix with the provided
+// prefixEquivalent instead of the regex pattern. This is needed for Gateway
+// implementations (e.g. GKE) that do not support RegularExpression path matches.
+func resolvePathMatch(pathMatchType string, regexPattern string, prefixEquivalent string) gwapiv1.HTTPRouteMatch {
+	if pathMatchType == "PathPrefix" {
+		return gwapiv1.HTTPRouteMatch{
+			Path: &gwapiv1.HTTPPathMatch{
+				Type:  ptr.To(gwapiv1.PathMatchPathPrefix),
+				Value: ptr.To(prefixEquivalent),
+			},
+		}
+	}
+	return createHTTPRouteMatch(regexPattern)
+}
+
 func addIsvcHeaders(name string, namespace string) gwapiv1.HTTPRouteFilter {
 	return gwapiv1.HTTPRouteFilter{
 		Type: gwapiv1.HTTPRouteFilterRequestHeaderModifier,
@@ -191,7 +207,7 @@ func createRawPredictorHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *
 		return nil, fmt.Errorf("failed to generate predictor ingress host: %w", err)
 	}
 	allowedHosts = append(allowedHosts, gwapiv1.Hostname(predictorHost))
-	routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+	routeMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, constants.FallbackPrefix(), "/")}
 	timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Predictor.TimeoutSeconds)
 	httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, predictorName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
 
@@ -251,7 +267,7 @@ func createRawTransformerHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig
 		return nil, fmt.Errorf("failed to generate transformer ingress host: %w", err)
 	}
 	allowedHosts = append(allowedHosts, gwapiv1.Hostname(transformerHost))
-	routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+	routeMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, constants.FallbackPrefix(), "/")}
 	timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Transformer.TimeoutSeconds)
 	httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, transformerName, isvc.Namespace,
 		constants.CommonDefaultHttpPort, timeout))
@@ -314,7 +330,7 @@ func createRawExplainerHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *
 	allowedHosts = append(allowedHosts, gwapiv1.Hostname(explainerHost))
 
 	// Add explainer host rules
-	routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+	routeMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, constants.FallbackPrefix(), "/")}
 	timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Explainer.TimeoutSeconds)
 	httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, explainerName, isvc.Namespace,
 		constants.CommonDefaultHttpPort, timeout))
@@ -405,7 +421,7 @@ func createRawTopLevelHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v
 		timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Explainer.TimeoutSeconds)
 		// Add toplevel host :explain route
 		// :explain routes to the explainer when there is only explainer
-		explainRouteMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.ExplainPrefix())}
+		explainRouteMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, constants.ExplainPrefix(), "/v1/models/")}
 		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(explainRouteMatch, filters,
 			explainerName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
 	}
@@ -421,13 +437,13 @@ func createRawTopLevelHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v
 		}
 		timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Transformer.TimeoutSeconds)
 		// :predict routes to the transformer when there are both predictor and transformer
-		routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+		routeMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, constants.FallbackPrefix(), "/")}
 		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, transformerName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
 	} else {
 		// Scenario: When predictor without transformer and with/without explainer present
 		timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Predictor.TimeoutSeconds)
 		// Add toplevel host rules for predictor which routes all traffic to predictor
-		routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+		routeMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, constants.FallbackPrefix(), "/")}
 		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, predictorName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
 	}
 
@@ -445,7 +461,7 @@ func createRawTopLevelHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v
 		if isvc.Spec.Explainer != nil {
 			timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Explainer.TimeoutSeconds)
 			// Add path based routing rule for :explain endpoint
-			explainerPathRouteMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(path + constants.PathBasedExplainPrefix())}
+			explainerPathRouteMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, path+constants.PathBasedExplainPrefix(), path+"/v1/models/")}
 			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(explainerPathRouteMatch, filters, explainerName, isvc.Namespace,
 				constants.CommonDefaultHttpPort, timeout))
 		}
@@ -453,13 +469,13 @@ func createRawTopLevelHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v
 		if isvc.Spec.Transformer != nil {
 			timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Transformer.TimeoutSeconds)
 			// :predict routes to the transformer when there are both predictor and transformer
-			pathRouteMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(path + "/")}
+			pathRouteMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, path+"/", path+"/")}
 			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(pathRouteMatch, filters, transformerName, isvc.Namespace,
 				constants.CommonDefaultHttpPort, timeout))
 		} else {
 			timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Predictor.TimeoutSeconds)
 			// :predict routes to the predictor when there is only predictor
-			pathRouteMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(path + "/")}
+			pathRouteMatch := []gwapiv1.HTTPRouteMatch{resolvePathMatch(ingressConfig.PathMatchType, path+"/", path+"/")}
 			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(pathRouteMatch, filters, predictorName, isvc.Namespace,
 				constants.CommonDefaultHttpPort, timeout))
 		}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -3420,3 +3420,106 @@ func TestCreateRawPredictorHTTPRouteDisableTimeout(t *testing.T) {
 		}
 	})
 }
+
+func TestResolvePathMatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	t.Run("default (empty) uses RegularExpression", func(t *testing.T) {
+		match := resolvePathMatch("", constants.FallbackPrefix(), "/")
+		g.Expect(*match.Path.Type).To(Equal(gwapiv1.PathMatchRegularExpression))
+		g.Expect(*match.Path.Value).To(Equal(constants.FallbackPrefix()))
+	})
+
+	t.Run("PathPrefix uses PathPrefix type with equivalent path", func(t *testing.T) {
+		match := resolvePathMatch("PathPrefix", constants.FallbackPrefix(), "/")
+		g.Expect(*match.Path.Type).To(Equal(gwapiv1.PathMatchPathPrefix))
+		g.Expect(*match.Path.Value).To(Equal("/"))
+	})
+
+	t.Run("PathPrefix with ExplainPrefix", func(t *testing.T) {
+		match := resolvePathMatch("PathPrefix", constants.ExplainPrefix(), "/v1/models/")
+		g.Expect(*match.Path.Type).To(Equal(gwapiv1.PathMatchPathPrefix))
+		g.Expect(*match.Path.Value).To(Equal("/v1/models/"))
+	})
+
+	t.Run("PathPrefix with path-based routing", func(t *testing.T) {
+		match := resolvePathMatch("PathPrefix", "/serving/default/test-isvc/", "/serving/default/test-isvc/")
+		g.Expect(*match.Path.Type).To(Equal(gwapiv1.PathMatchPathPrefix))
+		g.Expect(*match.Path.Value).To(Equal("/serving/default/test-isvc/"))
+	})
+
+	t.Run("RegularExpression explicitly set", func(t *testing.T) {
+		match := resolvePathMatch("RegularExpression", constants.FallbackPrefix(), "/")
+		g.Expect(*match.Path.Type).To(Equal(gwapiv1.PathMatchRegularExpression))
+		g.Expect(*match.Path.Value).To(Equal(constants.FallbackPrefix()))
+	})
+}
+
+func TestCreateRawPredictorHTTPRoutePathMatchType(t *testing.T) {
+	g := NewGomegaWithT(t)
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-isvc",
+			Namespace: "default",
+		},
+		Spec: v1beta1.InferenceServiceSpec{
+			Predictor: v1beta1.PredictorSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{},
+			},
+		},
+		Status: v1beta1.InferenceServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					{
+						Type:   v1beta1.PredictorReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	isvcConfig := &v1beta1.InferenceServicesConfig{
+		ServiceAnnotationDisallowedList: []string{},
+		ServiceLabelDisallowedList:      []string{},
+	}
+
+	t.Run("PathPrefix produces PathPrefix match type", func(t *testing.T) {
+		ingressConfig := &v1beta1.IngressConfig{
+			IngressDomain:        "example.com",
+			UrlScheme:            "http",
+			DomainTemplate:       "{{.Name}}-{{.Namespace}}.{{.IngressDomain}}",
+			KserveIngressGateway: "kserve/kserve-gateway",
+			EnableGatewayAPI:     true,
+			PathMatchType:        "PathPrefix",
+		}
+		httpRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(httpRoute).ToNot(BeNil())
+		for _, rule := range httpRoute.Spec.Rules {
+			for _, match := range rule.Matches {
+				g.Expect(*match.Path.Type).To(Equal(gwapiv1.PathMatchPathPrefix),
+					"expected PathPrefix match type when pathMatchType is PathPrefix")
+			}
+		}
+	})
+
+	t.Run("default produces RegularExpression match type", func(t *testing.T) {
+		ingressConfig := &v1beta1.IngressConfig{
+			IngressDomain:        "example.com",
+			UrlScheme:            "http",
+			DomainTemplate:       "{{.Name}}-{{.Namespace}}.{{.IngressDomain}}",
+			KserveIngressGateway: "kserve/kserve-gateway",
+			EnableGatewayAPI:     true,
+		}
+		httpRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(httpRoute).ToNot(BeNil())
+		for _, rule := range httpRoute.Spec.Rules {
+			for _, match := range rule.Matches {
+				g.Expect(*match.Path.Type).To(Equal(gwapiv1.PathMatchRegularExpression),
+					"expected RegularExpression match type when pathMatchType is not set")
+			}
+		}
+	})
+}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6824,6 +6824,12 @@ func schema_pkg_apis_serving_v1beta1_IngressConfig(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"pathMatchType": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -3749,6 +3749,9 @@
         "localGatewayService": {
           "type": "string"
         },
+        "pathMatchType": {
+          "type": "string"
+        },
         "pathTemplate": {
           "type": "string"
         },

--- a/python/kserve/docs/V1beta1IngressConfig.md
+++ b/python/kserve/docs/V1beta1IngressConfig.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **kserve_ingress_gateway** | **str** |  | [optional] 
 **local_gateway** | **str** |  | [optional] 
 **local_gateway_service** | **str** |  | [optional] 
+**path_match_type** | **str** |  | [optional] 
 **path_template** | **str** |  | [optional] 
 **url_scheme** | **str** |  | [optional] 
 

--- a/python/kserve/kserve/models/v1beta1_ingress_config.py
+++ b/python/kserve/kserve/models/v1beta1_ingress_config.py
@@ -61,6 +61,7 @@ class V1beta1IngressConfig(object):
         'kserve_ingress_gateway': 'str',
         'local_gateway': 'str',
         'local_gateway_service': 'str',
+        'path_match_type': 'str',
         'path_template': 'str',
         'url_scheme': 'str'
     }
@@ -80,11 +81,12 @@ class V1beta1IngressConfig(object):
         'kserve_ingress_gateway': 'kserveIngressGateway',
         'local_gateway': 'localGateway',
         'local_gateway_service': 'localGatewayService',
+        'path_match_type': 'pathMatchType',
         'path_template': 'pathTemplate',
         'url_scheme': 'urlScheme'
     }
 
-    def __init__(self, additional_ingress_domains=None, disable_http_route_timeout=None, disable_ingress_creation=None, disable_istio_virtual_host=None, domain_template=None, enable_gateway_api=None, enable_llm_inference_service_tls=None, ingress_class_name=None, ingress_domain=None, ingress_gateway=None, knative_local_gateway_service=None, kserve_ingress_gateway=None, local_gateway=None, local_gateway_service=None, path_template=None, url_scheme=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, additional_ingress_domains=None, disable_http_route_timeout=None, disable_ingress_creation=None, disable_istio_virtual_host=None, domain_template=None, enable_gateway_api=None, enable_llm_inference_service_tls=None, ingress_class_name=None, ingress_domain=None, ingress_gateway=None, knative_local_gateway_service=None, kserve_ingress_gateway=None, local_gateway=None, local_gateway_service=None, path_match_type=None, path_template=None, url_scheme=None, local_vars_configuration=None):  # noqa: E501
         """V1beta1IngressConfig - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -104,6 +106,7 @@ class V1beta1IngressConfig(object):
         self._kserve_ingress_gateway = None
         self._local_gateway = None
         self._local_gateway_service = None
+        self._path_match_type = None
         self._path_template = None
         self._url_scheme = None
         self.discriminator = None
@@ -136,6 +139,8 @@ class V1beta1IngressConfig(object):
             self.local_gateway = local_gateway
         if local_gateway_service is not None:
             self.local_gateway_service = local_gateway_service
+        if path_match_type is not None:
+            self.path_match_type = path_match_type
         if path_template is not None:
             self.path_template = path_template
         if url_scheme is not None:
@@ -434,6 +439,27 @@ class V1beta1IngressConfig(object):
         """
 
         self._local_gateway_service = local_gateway_service
+
+    @property
+    def path_match_type(self):
+        """Gets the path_match_type of this V1beta1IngressConfig.  # noqa: E501
+
+
+        :return: The path_match_type of this V1beta1IngressConfig.  # noqa: E501
+        :rtype: str
+        """
+        return self._path_match_type
+
+    @path_match_type.setter
+    def path_match_type(self, path_match_type):
+        """Sets the path_match_type of this V1beta1IngressConfig.
+
+
+        :param path_match_type: The path_match_type of this V1beta1IngressConfig.  # noqa: E501
+        :type: str
+        """
+
+        self._path_match_type = path_match_type
 
     @property
     def path_template(self):


### PR DESCRIPTION
## Summary

GKE's Gateway controller does not support `RegularExpression` path matches on HTTPRoutes (Extended conformance). KServe hardcodes `PathMatchRegularExpression` with patterns like `^/.*$` in `httproute_reconciler.go`, causing GKE Gateway to reject the route with `GWCER104: Paths must start with '/' character`. There is currently no config flag to change the path match type.

This PR adds a `pathMatchType` field to the `inferenceservice-config` ConfigMap (ingress section). When set to `"PathPrefix"`, the controller uses `PathMatchPathPrefix` with equivalent prefix paths instead of regex patterns. Default behavior is **unchanged** — existing users who rely on regex path matching are unaffected.

Follows the same pattern as `disableHTTPRouteTimeout` (#5313).

Fixes: #5319
Docs: kserve/website#646

## Changes

**Core Go code (3 files):**
- `pkg/apis/serving/v1beta1/configmap.go` — Added `PathMatchType string` to `IngressConfig`
- `pkg/controller/.../httproute_reconciler.go` — Added `resolvePathMatch()` helper that returns a `PathPrefix` match when the flag is set; updated all 9 path match call sites across `createRawPredictorHTTPRoute`, `createRawTransformerHTTPRoute`, `createRawExplainerHTTPRoute`, and `createRawTopLevelHTTPRoute`
- `pkg/controller/.../httproute_reconciler_test.go` — Added 7 test cases (5 unit + 2 integration)

**Helm charts, ConfigMaps, quick-install scripts, OpenAPI, Python SDK** — updated following the same pattern as #5313 (20 additional files via manual edits + `make generate`).

## Usage

```json
// inferenceservice-config ConfigMap, ingress section:
{
    "enableGatewayApi": true,
    "kserveIngressGateway": "kserve/kserve-ingress-gateway",
    "disableHTTPRouteTimeout": true,
    "pathMatchType": "PathPrefix"
}
```

When `pathMatchType` is empty or unset, the default `RegularExpression` matching is used.

## Test plan

- [x] Unit tests: all new and existing tests pass
- [x] **Manual cluster test on GKE**: Built a custom controller image from this branch, deployed to a GKE cluster (Gateway class `gke-l7-global-external-managed`), and verified:
  - HTTPRoutes use `PathPrefix: /` instead of `RegularExpression: ^/.*$`
  - GKE Gateway accepts the HTTPRoutes (`Accepted: True`, `ResolvedRefs: True`, `Reconciled: True`)
  - InferenceService reaches `Ready: True`
  - End-to-end inference works through the external load balancer: `curl -> GKE Gateway -> InferenceService -> {"predictions":[1,0]}`
  - Without the fix (stock v0.17.0), the same HTTPRoute is rejected by GKE Gateway with `GWCER104`
