### PR TITLE
fix(llmisvc): add missing inference.networking RBAC permissions

### DIFF
--- a/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
@@ -1569,10 +1569,25 @@ rules:
   - watch
 - apiGroups:
   - inference.networking.k8s.io
-  - inference.networking.x-k8s.io
   resources:
   - inferencemodels
   - inferenceobjectives
+  - inferencepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.networking.x-k8s.io
+  resources:
+  - inferencemodelrewrites
+  - inferencemodels
+  - inferenceobjectives
+  - inferencepoolimports
   - inferencepools
   verbs:
   - create

--- a/config/rbac/llmisvc/role.yaml
+++ b/config/rbac/llmisvc/role.yaml
@@ -133,10 +133,25 @@ rules:
   - watch
 - apiGroups:
   - inference.networking.k8s.io
-  - inference.networking.x-k8s.io
   resources:
   - inferencemodels
   - inferenceobjectives
+  - inferencepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.networking.x-k8s.io
+  resources:
+  - inferencemodelrewrites
+  - inferencemodels
+  - inferenceobjectives
+  - inferencepoolimports
   - inferencepools
   verbs:
   - create

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -97,7 +97,7 @@ type LLMISVCReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes;gateways;gatewayclasses,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=inference.networking.x-k8s.io,resources=inferencepools;inferenceobjectives;inferencemodels,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=inference.networking.x-k8s.io,resources=inferencepools;inferenceobjectives;inferencemodels;inferencemodelrewrites;inferencepoolimports,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=inference.networking.k8s.io,resources=inferencepools;inferenceobjectives;inferencemodels,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -677,7 +677,8 @@ func (r *LLMISVCReconciler) expectedSchedulerRole(llmSvc *v1alpha2.LLMInferenceS
 		},
 		Rules: []rbacv1.PolicyRule{
 			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list", "watch"}},
-			{APIGroups: []string{"inference.networking.k8s.io", "inference.networking.x-k8s.io"}, Resources: []string{"inferencepools", "inferenceobjectives", "inferencemodels", "inferencemodelrewrites", "inferencepoolimports"}, Verbs: []string{"get", "list", "watch"}},
+			{APIGroups: []string{"inference.networking.k8s.io", "inference.networking.x-k8s.io"}, Resources: []string{"inferencepools", "inferenceobjectives", "inferencemodels"}, Verbs: []string{"get", "list", "watch"}},
+			{APIGroups: []string{"inference.networking.x-k8s.io"}, Resources: []string{"inferencemodelrewrites", "inferencepoolimports"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"discovery.k8s.io"}, Resources: []string{"endpointslices"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"coordination.k8s.io"}, Resources: []string{"leases"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
 		},

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -677,7 +677,7 @@ func (r *LLMISVCReconciler) expectedSchedulerRole(llmSvc *v1alpha2.LLMInferenceS
 		},
 		Rules: []rbacv1.PolicyRule{
 			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list", "watch"}},
-			{APIGroups: []string{"inference.networking.k8s.io", "inference.networking.x-k8s.io"}, Resources: []string{"inferencepools", "inferenceobjectives", "inferencemodels"}, Verbs: []string{"get", "list", "watch"}},
+			{APIGroups: []string{"inference.networking.k8s.io", "inference.networking.x-k8s.io"}, Resources: []string{"inferencepools", "inferenceobjectives", "inferencemodels", "inferencemodelrewrites", "inferencepoolimports"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"discovery.k8s.io"}, Resources: []string{"endpointslices"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"coordination.k8s.io"}, Resources: []string{"leases"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
 		},


### PR DESCRIPTION
The inferencemodelrewrites and inferencepoolimports CRDs were added to the Gateway API Inference Extension in v1.4.0 and v1.2.0 respectively, but the corresponding RBAC permissions were never added.

Without these permissions, EPP service accounts fail at startup with RBAC errors when attempting to register watchers for these CRDs:

```
Error: inferencemodelrewrites.inference.networking.x-k8s.io is forbidden:
User "system:serviceaccount:<ns>:<name>-epp-sa" cannot list resource
"inferencemodelrewrites" in API group "inference.networking.x-k8s.io"
```

Changes:
- Added kubebuilder RBAC annotation for inferencemodelrewrites and inferencepoolimports to inference.networking.x-k8s.io resources
- Regenerated manager ClusterRole from annotations (llmisvc-controller-manager service account gets this role)
- Updated dynamically-created EPP namespace Role in scheduler.go (per-LLMInferenceService <name>-epp-sa service accounts get this role)

**What this PR does / why we need it**:

Adds missing RBAC permissions for `inferencemodelrewrites` and `inferencepoolimports` CRDs that were added in GIE v1.4.0 and v1.2.0. Without these permissions, EPP service accounts cannot watch these resources and fail at startup.

**Which issue(s) this PR fixes**:

None - This is a bug fix discovered during testing.

**Feature/Issue validation/testing**:

- [x] Verified RBAC rules are properly generated via `make manifests`
- [x] Confirmed kubebuilder annotations are correctly formatted
- [x] Checked that both manager ClusterRole and EPP namespace Role include the missing resources

**Special notes for your reviewer**:

This bug was introduced when the GIE CRDs were added but RBAC wasn't updated. The fix adds permissions in two places:
1. kubebuilder annotation in controller.go (generates manager ClusterRole)
2. Dynamic role creation in scheduler.go (creates per-LLMInferenceService EPP roles)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  - N/A - This is an RBAC fix that will be validated by existing E2E tests
- [x] Has code been commented, particularly in hard-to-understand areas?
  - N/A - Only adding resources to existing RBAC rules
- [ ] Have you made corresponding changes to the documentation?
  - N/A - No user-facing documentation change needed

**Release note**:
```release-note
Fixed missing RBAC permissions for inferencemodelrewrites and inferencepoolimports CRDs
```