### PR TITLE
fix(charts): remove workloadType from ClusterStorageContainer resources

### DIFF
--- a/charts/kserve-llmisvc-resources/files/common/storagecontainer.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/storagecontainer.yaml
@@ -23,4 +23,3 @@ spec:
   - regex: https://(.+?).blob.core.windows.net/(.+)
   - regex: https://(.+?).file.core.windows.net/(.+)
   - regex: https?://(.+)/(.+)
-  workloadType: initContainer

--- a/charts/kserve-resources/files/common/storagecontainer.yaml
+++ b/charts/kserve-resources/files/common/storagecontainer.yaml
@@ -23,4 +23,3 @@ spec:
   - regex: https://(.+?).blob.core.windows.net/(.+)
   - regex: https://(.+?).file.core.windows.net/(.+)
   - regex: https?://(.+)/(.+)
-  workloadType: initContainer


### PR DESCRIPTION
**What this PR does / why we need it**:

The CRD ClusterStorageContainer doesn't contain any workloadType attribue, and in environments where CI checks if resources matches their spec it may end up in validation failures.

Remove workloadType from ClusterStorageContainer definitions.

**Feature/Issue validation/testing**:

Deployed the chart in my kubernetes environment and made sure CI passed tests.

**Release note**:
```release-note
NONE
```
