### PR TITLE
fix: include default to prevent manifest drift

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -1573,7 +1573,8 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
-            - kind: Service
+            - group: ""
+              kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000
               weight: 1

--- a/config/llmisvcconfig/config-llm-router-route.yaml
+++ b/config/llmisvcconfig/config-llm-router-route.yaml
@@ -79,7 +79,8 @@ spec:
                 backendRequest: 0s
                 request: 0s
             - backendRefs:
-                - kind: Service
+                - group: ""
+                  kind: Service
                   name: |-
                     {{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}
                   port: 8000

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4029,7 +4029,8 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
-            - kind: Service
+            - group: ""
+              kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000
               weight: 1

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -3615,7 +3615,8 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
-            - kind: Service
+            - group: ""
+              kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000
               weight: 1

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -3948,7 +3948,8 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
-            - kind: Service
+            - group: ""
+              kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000
               weight: 1


### PR DESCRIPTION
When deploying the chart via ArgoCD, there is a constant drift between the live cluster manifest and the one generated by Helm. This is due to the empty group field missing from the Helm template.

**What this PR does / why we need it**:

It is a quality improvement for the Helm chart. It might only affect a fraction of users. But it makes sense for this project to play nice with ArgoCD (and possibly other GitOps tools).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5353 


**Feature/Issue validation/testing**:

- I manually tested this by applying this fix on top of the latest release and deploying that instead of your published helm chart. As expected, ArgoCD stops showing a constant manifest drift.

**Release note**:

```release-note
Fixed / no user action required: Include the default group to the `Service` backendRefs of the `LLMInferenceServiceConfig` kserve-config-llm-router-route to prevent manifest drift when deploying the Helm chart via GitOps tools like ArgoCD.

```
