### PR TITLE
fix(test): assert worker count via exec instead of log PIDs

### DIFF
--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -15,12 +15,14 @@
 import asyncio
 import json
 import os
+import time
 from concurrent import futures
 from typing import Union, List, Dict
 from urllib.parse import urlparse
 
 import portforward
 from kubernetes import client as k8s_client
+from kubernetes.stream import stream as k8s_stream
 from orjson import orjson
 
 from httpx import HTTPStatusError
@@ -521,11 +523,49 @@ def is_model_ready(
     return rest_client.is_model_ready(base_url, model_name, headers=headers)
 
 
-def extract_process_ids_from_logs(logs: str) -> set[int]:
-    process_ids = set()
-    for line in logs.splitlines():
-        tokens = line.strip().split()
-        if len(tokens) >= 5 and tokens[3] == "kserve.trace":
-            process_ids.add(int(tokens[2]))
-    logger.info("Extracted process ids: %s", process_ids)
-    return process_ids
+_WORKER_COUNT_SCRIPT = (
+    "import glob\n"
+    "print(sum(1 for f in glob.glob('/proc/[0-9]*/cmdline')"
+    " if b'spawn_main' in open(f,'rb').read()))"
+)
+
+
+def get_container_worker_count(
+    core_api: k8s_client.CoreV1Api,
+    pod_name: str,
+    namespace: str,
+    container: str = INFERENCESERVICE_CONTAINER,
+    timeout: int = 30,
+    interval: int = 2,
+) -> int:
+    """Count multiprocessing REST worker processes inside a running container.
+
+    Scans ``/proc/*/cmdline`` for ``spawn_main`` via a Python one-liner
+    (the runtime images are slim Debian and may lack ``pgrep``).
+    Retries until *timeout* to allow workers to finish starting.
+    """
+    cmd = ["python", "-c", _WORKER_COUNT_SCRIPT]
+    deadline = time.monotonic() + timeout
+    last_count = 0
+    while True:
+        resp = k8s_stream(
+            core_api.connect_get_namespaced_pod_exec,
+            pod_name,
+            namespace,
+            container=container,
+            command=cmd,
+            stderr=True,
+            stdout=True,
+            stdin=False,
+            tty=False,
+        )
+        try:
+            last_count = int(resp.strip())
+        except ValueError:
+            logger.warning("Unexpected worker-count output: %r", resp)
+            last_count = 0
+        if last_count > 0 or time.monotonic() >= deadline:
+            break
+        time.sleep(interval)
+    logger.info("Worker process count in %s/%s: %d", namespace, pod_name, last_count)
+    return last_count

--- a/test/e2e/predictor/test_sklearn.py
+++ b/test/e2e/predictor/test_sklearn.py
@@ -36,7 +36,7 @@ from ..common.utils import (
     KSERVE_TEST_NAMESPACE,
     predict_isvc,
     predict_grpc,
-    extract_process_ids_from_logs,
+    get_container_worker_count,
 )
 
 
@@ -157,6 +157,20 @@ async def test_sklearn_runtime_kserve(rest_v1_client):
 
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+    pods = kserve_client.core_api.list_namespaced_pod(
+        KSERVE_TEST_NAMESPACE,
+        label_selector="serving.kserve.io/inferenceservice={}".format(service_name),
+    )
+    worker_count = get_container_worker_count(
+        kserve_client.core_api,
+        pods.items[0].metadata.name,
+        KSERVE_TEST_NAMESPACE,
+    )
+    assert worker_count == 2, (
+        f"Expected 2 multiprocessing workers but found {worker_count}"
+    )
+
     tasks = [
         predict_isvc(rest_v1_client, service_name, "./data/news_grouping_input_v1.json")
         for _ in range(25)
@@ -165,19 +179,6 @@ async def test_sklearn_runtime_kserve(rest_v1_client):
     for res in responses:
         assert res["predictions"] == [19]
 
-    pods = kserve_client.core_api.list_namespaced_pod(
-        KSERVE_TEST_NAMESPACE,
-        label_selector="serving.kserve.io/inferenceservice={}".format(service_name),
-    )
-    # Wait for logs to be available
-    await asyncio.sleep(5)
-    logs = kserve_client.core_api.read_namespaced_pod_log(
-        name=pods.items[0].metadata.name,
-        namespace=pods.items[0].metadata.namespace,
-        container="kserve-container",
-    )
-    process_ids = extract_process_ids_from_logs(logs)
-    assert len(process_ids) == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 


### PR DESCRIPTION
## Summary

- `test_sklearn_runtime_kserve` verified `--workers=2` by extracting PIDs from `kserve.trace` log lines after 25 concurrent requests. After #5071 removed blanket sleeps, httpx connection pooling can route all requests through a single TCP connection, so only one worker handles traffic and `assert len(process_ids) == 2` flakes -- particularly on Istio/OpenShift where Envoy manages upstream connections.
- Replace the traffic-dependent log assertion with a deterministic in-container process check via `kubectl exec`. A Python one-liner scans `/proc/*/cmdline` for multiprocessing `spawn_main` children. This is network-layer agnostic and works on slim Debian images that lack `pgrep`.
- Remove the now-unused `extract_process_ids_from_logs` utility and the post-predict `asyncio.sleep(5)` + log fetch.

## Test plan

- [ ] Verify `test_sklearn_runtime_kserve` passes in `test-predictor` (istio) CI job
- [ ] Verify `test_sklearn_runtime_kserve` passes in `test-kourier` CI job
- [ ] Confirm no regressions in other predictor E2E tests

Made with [Cursor](https://cursor.com)