### PR TITLE
fix(ci): make prow slash commands work from PR reviews

### DIFF
--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -4,32 +4,115 @@ name: "Prow github actions"
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [labeled]
 
 # Required for the prow action to manage labels, assignees, milestones, etc.
 permissions:
   issues: write
   pull-requests: write
 
+# Label names used by the prow machinery. Update here if they ever change.
+# Must stay in sync with what jpmcb/prow-github-actions applies for issue comments.
+env:
+  LGTM_LABEL: lgtm
+  HOLD_LABEL: hold
+  APPROVED_LABEL: approved
+
 jobs:
   prow-execute:
+    if: github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
         with:
-          prow-commands: '/assign 
-            /unassign 
-            /approve 
-            /retitle 
-            /area 
-            /kind 
-            /priority 
-            /remove 
-            /lgtm 
-            /close 
-            /reopen 
-            /lock 
-            /milestone 
-            /hold 
-            /cc 
+          prow-commands: '/assign
+            /unassign
+            /approve
+            /retitle
+            /area
+            /kind
+            /remove
+            /lgtm
+            /close
+            /reopen
+            /lock
+            /milestone
+            /hold
+            /cc
             /uncc'
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  # The jpmcb action only handles issue_comment events (reads context.payload.comment.body).
+  # PR reviews fire pull_request_review events with a different payload shape, so we handle
+  # the label-affecting commands here directly via the octokit client, mirroring the action's logic.
+  prow-review:
+    if: github.event_name == 'pull_request_review'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Handle prow commands in PR review body
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const body = context.payload.review.body || '';
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request.number;
+            const reviewer = context.payload.review.user.login;
+
+            // Mirror the auth check from lgtm.ts: org member or repo collaborator only.
+            const isOrgMember = await github.rest.orgs.checkMembershipForUser({ org: owner, username: reviewer })
+              .then(() => true).catch(() => false);
+            const isCollaborator = await github.rest.repos.checkCollaborator({ owner, repo, username: reviewer })
+              .then(() => true).catch(() => false);
+
+            if (!isOrgMember && !isCollaborator) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr,
+                body: `@${reviewer} is not an org member or collaborator — prow labels not applied.`,
+              });
+              return;
+            }
+
+            const commands = [
+              { apply: '/lgtm',     cancel: '/lgtm cancel',     labels: [process.env.LGTM_LABEL] },
+              { apply: '/hold',     cancel: '/hold cancel',     labels: [process.env.HOLD_LABEL] },
+              // Both forms are kept: /approve is the canonical prow command, but contributors
+              // commonly write /approved (confusing the command with the label name it applies).
+              { apply: '/approved', cancel: '/approved cancel', labels: [process.env.APPROVED_LABEL] },
+              { apply: '/approve',  cancel: '/approve cancel',  labels: [process.env.APPROVED_LABEL] },
+            ];
+
+            for (const { apply, cancel, labels } of commands) {
+              if (body.includes(cancel)) {
+                for (const label of labels) {
+                  try {
+                    await github.rest.issues.removeLabel({ owner, repo, issue_number: pr, name: label });
+                    console.log(`Removed label: ${label}`);
+                  } catch {
+                    console.log(`Label not present, skipping: ${label}`);
+                  }
+                }
+              } else if (body.includes(apply)) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: pr, labels });
+                console.log(`Applied labels: ${labels.join(', ')}`);
+              }
+            }
+
+  # Ensures any do-not-merge/* label also sets the hold label so the
+  # jpmcb automerge cron (which only checks for "hold") is always blocked.
+  prow-hold-sync:
+    if: github.event_name == 'pull_request' && startsWith(github.event.label.name, 'do-not-merge')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [process.env.HOLD_LABEL],
+            });
+            console.log(`Applied hold label due to: ${context.payload.label.name}`);


### PR DESCRIPTION
> [!IMPORTANT]
> Due to context execution constraints the job is failing now - see [comment](https://github.com/kserve/kserve/pull/5358/#issuecomment-4205124330) for details.

**What this PR does / why we need it**:

Reviewers naturally use the GitHub review UI to post \`/lgtm\`, \`/hold\`, and \`/approved\` alongside their review feedback. The jpmcb prow action only listens to \`issue_comment\` events, so commands submitted as PR reviews were silently ignored - the \`lgtm\` label was never applied and the automerge never triggered.

Extends [prow-github.yml](https://github.com/bartoszmajsak/kserve/blob/c4675848bb4f26636758af1079cbd42b07625232/.github/workflows/prow-github.yml) to handle \`pull_request_review\` and \`pull_request\` events alongside the existing \`issue_comment\` trigger:

- [**\`prow-review\`**](https://github.com/bartoszmajsak/kserve/blob/c4675848bb4f26636758af1079cbd42b07625232/.github/workflows/prow-github.yml#L51) processes prow commands in review bodies with the same org-member/collaborator auth check that the jpmcb action applies for issue comments. Unauthorized reviewers get a comment explaining why. The separate job is necessary because the jpmcb action reads \`context.payload.comment.body\`, which does not exist for \`pull_request_review\` events.
- [**\`prow-hold-sync\`**](https://github.com/bartoszmajsak/kserve/blob/c4675848bb4f26636758af1079cbd42b07625232/.github/workflows/prow-github.yml#L102) auto-applies the \`hold\` label whenever any \`do-not-merge/*\` label is added to a PR, ensuring the automerge cron is always blocked regardless of which convention was used.
- [\`/approved\`](https://github.com/bartoszmajsak/kserve/blob/c4675848bb4f26636758af1079cbd42b07625232/.github/workflows/prow-github.yml#L81) is recognised alongside \`/approve\` in review bodies since contributors commonly write both forms.
- \`/priority\` removed from [\`prow-execute\`](https://github.com/bartoszmajsak/kserve/blob/c4675848bb4f26636758af1079cbd42b07625232/.github/workflows/prow-github.yml#L25) - no priority labels exist in this repo.

**Feature/Issue validation/testing**:

Full validation requires an actual PR to work with. Event routing verified locally with \`act\` dry-runs for all three trigger scenarios.

**Special notes for your reviewer**:

The \`prow-review\` job cannot reuse the \`jpmcb\` action directly - the action reads \`context.payload.comment.body\` which does not exist for \`pull_request_review\` events. The separate job is intentional and mirrors the action's own logic via the octokit client.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
\`\`\`release-note
NONE
\`\`\`