### PR TITLE
feat(llmisvc): propagate spec.labels and annotations to service

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
@@ -389,8 +389,8 @@ func TestPropagateWorkloadServiceMetadata(t *testing.T) {
 		constants.KubernetesComponentLabelKey: constants.LLMComponentWorkload,
 		constants.KubernetesAppNameLabelKey:   "test-llm",
 		constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
-		"model":    "llama-3.1-8b",
-		"endpoint": "my-endpoint",
+		"model":                               "llama-3.1-8b",
+		"endpoint":                            "my-endpoint",
 	}
 	assert.Equal(t, expectedLabels, svc.Labels)
 	assert.Equal(t, map[string]string{"prometheus.io/scrape": "true"}, svc.Annotations)

--- a/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
@@ -21,9 +21,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 func TestPropagateDeploymentMetadata(t *testing.T) {
@@ -349,4 +352,46 @@ func TestPropagateSchedulerMetadata(t *testing.T) {
 			assert.Empty(t, deployment.Annotations, "Scheduler annotations should not be set on the Deployment itself")
 		})
 	}
+}
+
+func TestPropagateWorkloadServiceMetadata(t *testing.T) {
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-llm",
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			WorkloadSpec: v1alpha2.WorkloadSpec{
+				Labels: map[string]string{
+					"model":    "llama-3.1-8b",
+					"endpoint": "my-endpoint",
+				},
+				Annotations: map[string]string{
+					"prometheus.io/scrape": "true",
+				},
+			},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.KubernetesComponentLabelKey: constants.LLMComponentWorkload,
+				constants.KubernetesAppNameLabelKey:   llmSvc.GetName(),
+				constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
+			},
+		},
+	}
+
+	utils.PropagateMap(llmSvc.Spec.Labels, &svc.Labels)
+	utils.PropagateMap(llmSvc.Spec.Annotations, &svc.Annotations)
+
+	expectedLabels := map[string]string{
+		constants.KubernetesComponentLabelKey: constants.LLMComponentWorkload,
+		constants.KubernetesAppNameLabelKey:   "test-llm",
+		constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
+		"model":    "llama-3.1-8b",
+		"endpoint": "my-endpoint",
+	}
+	assert.Equal(t, expectedLabels, svc.Labels)
+	assert.Equal(t, map[string]string{"prometheus.io/scrape": "true"}, svc.Annotations)
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -157,6 +157,9 @@ func (r *LLMISVCReconciler) reconcileWorkloadService(ctx context.Context, llmSvc
 		},
 	}
 
+	utils.PropagateMap(llmSvc.Spec.Labels, &expected.Labels)
+	utils.PropagateMap(llmSvc.Spec.Annotations, &expected.Annotations)
+
 	if utils.GetForceStopRuntime(llmSvc) {
 		return Delete(ctx, r, llmSvc, expected)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`LLMInferenceService.spec.labels` and `spec.annotations` are propagated to Pods (via LWS/Deployment templates) but not to the workload `Service` (`<name>-kserve-workload-svc`). This means external systems that discover or route to endpoints by querying Service labels (e.g., Prometheus ServiceMonitor, network policies, custom operators) cannot find these services.

This PR adds two `utils.PropagateMap` calls to `reconcileWorkloadService` in `workload.go` to propagate `spec.labels` and `spec.annotations` to the workload Service, consistent with how they are already propagated to LWS, Deployments, and Pod templates.

**Which issue(s) this PR fixes**:
Fixes #5364 

**Feature/Issue validation/testing**:

- [x] Unit test added: `TestPropagateWorkloadServiceMetadata` in `label_propagation_test.go`
- [x] E2E validated on LLMISVC
  - Before fix: workload Service had only 3 base `app.kubernetes.io/*` labels
  - After fix: workload Service has all 8 labels (3 base + 5 from `spec.labels`)

**Notes for reviewer**:

- The change follows the exact same pattern used for Pod template label propagation.
- `semanticServiceIsEqual` in `scheduler.go` already compares both `Labels` and `Annotations`, so Service updates are correctly triggered when labels/annotations change.
- No changes to CRDs, RBAC, or API schemas.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fix spec.labels and spec.annotations not being propagated to the LLMInferenceService workload Service.
```