### PR TITLE
feat(multinode): add groundwork for multinode support without ray

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -343,7 +343,10 @@ var (
 	IstioMeshGateway = "mesh"
 )
 
-const WorkerNodeSuffix = "worker"
+const (
+	WorkerNodeSuffix       = "worker"
+	WorkerNodeSuffixPlural = "workers"
+)
 
 // InferenceService Component enums
 const (
@@ -683,10 +686,18 @@ const (
 	DefaultPipelineParallelSize = 1
 )
 
+// MultiNode executor backend annotation
+// If not set, defaults to ray
+const (
+	MultiNodeExecutorBackendAnnotationKey = "multinode/executor-backend"
+	MultiNodeExecutorBackendMp            = "mp"
+)
+
 // Multi Node Labels
 var (
 	MultiNodeRoleLabelKey = "multinode/role"
 	MultiNodeHead         = "head"
+	MultiNodeWorker       = "worker"
 )
 
 // GetRawServiceLabel generate native service label
@@ -703,6 +714,12 @@ func GetRawWorkerServiceLabel(service string) string {
 func GetHeadServiceName(service string, isvcGeneration string) string {
 	isvcName := strings.TrimSuffix(service, "-predictor")
 	return isvcName + "-" + MultiNodeHead + "-" + isvcGeneration
+}
+
+// GetWorkerServiceName generate worker headless service name
+func GetWorkerServiceName(service string, isvcGeneration string) string {
+	isvcName := strings.TrimSuffix(service, "-predictor")
+	return isvcName + "-" + WorkerNodeSuffixPlural + "-" + isvcGeneration
 }
 
 func (e InferenceServiceComponent) String() string {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -555,15 +555,22 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		*workerContainer,
 	}
 
-	// Calculate the total number of GPUs required for the request based on the tensor parallel size and pipeline parallel size specified in the worker spec.
-	// totalRequestGPUCount is the product of TensorParallelSize and PipelineParallelSize,
-	// which represents the total number of GPUs needed for distributed computation.
+	// Calculate node count and GPU allocation based on executor backend mode.
+	var nodeCount, workerNodeGPUCount, headNodeGPUCount int
+	executorBackend := sRuntime.Annotations[constants.MultiNodeExecutorBackendAnnotationKey]
 
-	totalRequestGPUCount := *sRuntime.WorkerSpec.TensorParallelSize * *sRuntime.WorkerSpec.PipelineParallelSize
-
-	rayNodeCount, workerNodeGPUCount, headNodeGPUCount, err := computeRayNodeAndGPUs(mergedWorkerPodSpec, totalRequestGPUCount, podSpec)
-	if err != nil {
-		return nil, err
+	if executorBackend == constants.MultiNodeExecutorBackendMp {
+		// mp mode: PP determines node count, TP determines GPUs per node
+		nodeCount, workerNodeGPUCount, headNodeGPUCount = computeMpNodeAndGPUs(
+			*sRuntime.WorkerSpec.PipelineParallelSize, *sRuntime.WorkerSpec.TensorParallelSize)
+	} else {
+		// ray mode (default): compute based on total GPU count and worker GPU resources
+		totalRequestGPUCount := *sRuntime.WorkerSpec.TensorParallelSize * *sRuntime.WorkerSpec.PipelineParallelSize
+		var err error
+		nodeCount, workerNodeGPUCount, headNodeGPUCount, err = computeRayNodeAndGPUs(mergedWorkerPodSpec, totalRequestGPUCount, podSpec)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Add required environment variables: PipelineParallelSize, TensorParallelSize
@@ -574,7 +581,7 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.TensorParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.TensorParallelSize)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.InferenceServiceContainerName)
 	}
-	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.RayNodeCountEnvName, strconv.Itoa(rayNodeCount)); err != nil {
+	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.RayNodeCountEnvName, strconv.Itoa(nodeCount)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.InferenceServiceContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.RequestGPUCountEnvName, strconv.Itoa(headNodeGPUCount)); err != nil {
@@ -595,11 +602,17 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		}
 	}
 	// Worker node deployement
-	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RayNodeCountEnvName, strconv.Itoa(rayNodeCount)); err != nil {
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RayNodeCountEnvName, strconv.Itoa(nodeCount)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.WorkerContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RequestGPUCountEnvName, strconv.Itoa(workerNodeGPUCount)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RequestGPUCountEnvName, constants.WorkerContainerName)
+	}
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.PipelineParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.PipelineParallelSize)); err != nil {
+		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.PipelineParallelSizeEnvName, constants.WorkerContainerName)
+	}
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.TensorParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.TensorParallelSize)); err != nil {
+		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.WorkerContainerName)
 	}
 	// Set the environment variable for "isvc name" to the ISVC_NAME when multiNodeEnabled is true.
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "ISVC_NAME", isvc.Name); err != nil {
@@ -608,6 +621,10 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	// Set the environment variable for "isvc name" to the HEAD_SVC when multiNodeEnabled is true.
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "HEAD_SVC", constants.GetHeadServiceName(isvc.Name, isvcGeneration)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add HEAD_SVC environment to the container(%s)", constants.WorkerContainerName)
+	}
+	// Set the environment variable for worker headless service name to the WORKER_SVC when multiNodeEnabled is true.
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "WORKER_SVC", constants.GetWorkerServiceName(constants.PredictorServiceName(isvc.Name), isvcGeneration)); err != nil {
+		return nil, errors.Wrapf(err, "failed to add WORKER_SVC environment to the container(%s)", constants.WorkerContainerName)
 	}
 	return mergedWorkerPodSpec, nil
 }
@@ -688,6 +705,15 @@ func computeRayNodeAndGPUs(mergedWorkerPodSpec *corev1.PodSpec, totalRequestGPUC
 
 	// Case 4: No GPUs found → Default values
 	return totalRequestGPUCount, 1, 1, nil
+}
+
+// computeMpNodeAndGPUs computes node count and GPU allocation for mp (multiprocessing) executor backend.
+// In mp mode, PipelineParallelSize directly determines the number of nodes,
+// and TensorParallelSize determines the number of GPUs per node.
+func computeMpNodeAndGPUs(pipelineParallelSize, tensorParallelSize int) (int, int, int) {
+	nodeCount := pipelineParallelSize
+	gpuPerNode := tensorParallelSize
+	return nodeCount, gpuPerNode, gpuPerNode
 }
 
 func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.InferenceService, objectMeta, workerObjectMeta metav1.ObjectMeta, podSpec, workerPodSpec *corev1.PodSpec) error {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package components
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeMpNodeAndGPUs(t *testing.T) {
+	tests := []struct {
+		name                 string
+		pipelineParallelSize int
+		tensorParallelSize   int
+		expectedNodeCount    int
+		expectedWorkerGPU    int
+		expectedHeadGPU      int
+	}{
+		{
+			name:                 "PP=2, TP=2: 2 nodes, 2 GPUs per node",
+			pipelineParallelSize: 2,
+			tensorParallelSize:   2,
+			expectedNodeCount:    2,
+			expectedWorkerGPU:    2,
+			expectedHeadGPU:      2,
+		},
+		{
+			name:                 "PP=4, TP=8: 4 nodes, 8 GPUs per node",
+			pipelineParallelSize: 4,
+			tensorParallelSize:   8,
+			expectedNodeCount:    4,
+			expectedWorkerGPU:    8,
+			expectedHeadGPU:      8,
+		},
+		{
+			name:                 "PP=1, TP=4: 1 node, 4 GPUs",
+			pipelineParallelSize: 1,
+			tensorParallelSize:   4,
+			expectedNodeCount:    1,
+			expectedWorkerGPU:    4,
+			expectedHeadGPU:      4,
+		},
+		{
+			name:                 "PP=2, TP=1: 2 nodes, 1 GPU per node",
+			pipelineParallelSize: 2,
+			tensorParallelSize:   1,
+			expectedNodeCount:    2,
+			expectedWorkerGPU:    1,
+			expectedHeadGPU:      1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeCount, workerGPU, headGPU := computeMpNodeAndGPUs(tt.pipelineParallelSize, tt.tensorParallelSize)
+			assert.Equal(t, tt.expectedNodeCount, nodeCount)
+			assert.Equal(t, tt.expectedWorkerGPU, workerGPU)
+			assert.Equal(t, tt.expectedHeadGPU, headGPU)
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -81,27 +81,21 @@ func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compon
 	podSpec *corev1.PodSpec, multiNodeEnabled bool, serviceConfig *v1beta1.ServiceConfig,
 ) []*corev1.Service {
 	var svcList []*corev1.Service
-	var isWorkerContainer bool
-
-	if multiNodeEnabled {
-		for _, container := range podSpec.Containers {
-			if container.Name == constants.WorkerContainerName {
-				isWorkerContainer = true
-			}
-		}
-	}
 
 	if !multiNodeEnabled {
 		// If multiNodeEnabled is false, only defaultSvc will be created.
 		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
-	} else if multiNodeEnabled && !isWorkerContainer {
-		// If multiNodeEnabled is true, both defaultSvc and headSvc will be created.
+	} else {
+		// If multiNodeEnabled is true, create defaultSvc, headSvc and workerSvc.
 		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
 
 		headSvc := createHeadlessSvc(componentMeta)
 		svcList = append(svcList, headSvc)
+
+		workerSvc := createWorkerHeadlessSvc(componentMeta)
+		svcList = append(svcList, workerSvc)
 	}
 
 	return svcList
@@ -191,6 +185,27 @@ func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Com
 		service.Spec.ClusterIP = corev1.ClusterIPNone
 	}
 
+	return service
+}
+
+func createWorkerHeadlessSvc(componentMeta metav1.ObjectMeta) *corev1.Service {
+	workerComponentMeta := componentMeta.DeepCopy()
+	predictorSvcName := workerComponentMeta.Name
+	isvcGeneration := componentMeta.GetLabels()[constants.InferenceServiceGenerationPodLabelKey]
+	workerComponentMeta.Name = constants.GetWorkerServiceName(predictorSvcName, isvcGeneration)
+	workerComponentMeta.Labels[constants.MultiNodeRoleLabelKey] = constants.MultiNodeWorker
+
+	service := &corev1.Service{
+		ObjectMeta: *workerComponentMeta,
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": constants.GetRawWorkerServiceLabel(predictorSvcName),
+				constants.InferenceServiceGenerationPodLabelKey: isvcGeneration,
+			},
+			ClusterIP:                "None",
+			PublishNotReadyAddresses: true,
+		},
+	}
 	return service
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -192,6 +192,30 @@ func TestCreateDefaultDeployment(t *testing.T) {
 					PublishNotReadyAddresses: true,
 				},
 			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-workers-1",
+					Namespace: "default-predictor-namespace",
+					Labels: map[string]string{
+						constants.RawDeploymentAppLabel:                 "isvc.default-predictor",
+						constants.KServiceComponentLabel:                "predictor",
+						constants.InferenceServicePodLabelKey:           "default-predictor",
+						constants.InferenceServiceGenerationPodLabelKey: "1",
+						constants.MultiNodeRoleLabelKey:                 constants.MultiNodeWorker,
+					},
+					Annotations: map[string]string{
+						"annotation": "annotation-value",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "isvc.default-predictor-worker",
+						constants.InferenceServiceGenerationPodLabelKey: "1",
+					},
+					ClusterIP:                "None",
+					PublishNotReadyAddresses: true,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add worker headless service (ClusterIP=None, PublishNotReadyAddresses=true) for multi-node deployments, enabling worker pod DNS discovery
- Add `multinode/executor-backend` annotation on ServingRuntime spec to switch between ray (default) and mp mode
- mp mode: PP determines node count, TP determines GPUs per node. Existing ray logic unchanged
- Inject PIPELINE_PARALLEL_SIZE, TENSOR_PARALLEL_SIZE, WORKER_SVC env vars into worker container
- Worker service name includes generation for rollout support (e.g. `foo-workers-1`)
- Add sample ClusterServingRuntime for vllm multi-node with `--distributed-executor-backend=mp`

Currently, the huggingfaceserver runtime supports multi-node deployments, but it relies on Ray as a required component for distributed execution. With recent vLLM updates, multi-node execution is now also possible without Ray by leveraging the mp (multiprocessing) distributed executor backend.

However, this approach requires passing specific vLLM CLI parameters (e.g., --master-addr, --master, --nnode) which are not supported by the existing huggingfaceserver runtime. For this reason, a dedicated ServingRuntime based directly on the vLLM image is required to fully enable this functionality.

Additionally, the node calculation logic differs between Ray and mp modes:

In Ray mode, node allocation is managed externally by Ray.
In mp mode, the number of nodes is derived from pipeline parallelism (PP), and GPUs per node are determined by tensor parallelism (TP).

To support this distinction, an annotation (multinode/executor-backend) has been introduced so that the controller can apply different logic depending on the execution backend.

A vLLM-based ServingRuntime is not included in this PR. However:

It has been tested locally and verified to work as expected.
The current huggingfaceserver runtime was also tested and confirmed not to work correctly with this approach.

A dedicated PR introducing the vLLM ServingRuntime will follow.

### Known Limitations
- Worker headless service name uses `isvcGeneration` as selector. If only the ServingRuntime 
  image changes (without ISVC spec change), generation won't increment and old/new worker pods 
  may share the same headless service during rolling updates. A follow-up PR will switch to 
  `pod-template-hash` based selector.

## Test plan

- [ ] Unit tests for `computeMpNodeAndGPUs` (PP/TP combinations)
- [ ] Unit tests for worker headless service creation in `createService`
- [ ] Existing ray-mode tests pass without changes
- [ ] E2E: deploy multi-node InferenceService with mp-mode ServingRuntime, verify worker service created and pods communicate