### PR TITLE
fix: recover multi download flag in default CSC

### DIFF
--- a/charts/kserve-llmisvc-resources/files/common/storagecontainer.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/storagecontainer.yaml
@@ -23,4 +23,5 @@ spec:
   - regex: https://(.+?).blob.core.windows.net/(.+)
   - regex: https://(.+?).file.core.windows.net/(.+)
   - regex: https?://(.+)/(.+)
+  supportsMultiModelDownload: true
   workloadType: initContainer

--- a/charts/kserve-resources/files/common/storagecontainer.yaml
+++ b/charts/kserve-resources/files/common/storagecontainer.yaml
@@ -23,4 +23,5 @@ spec:
   - regex: https://(.+?).blob.core.windows.net/(.+)
   - regex: https://(.+?).file.core.windows.net/(.+)
   - regex: https?://(.+)/(.+)
+  supportsMultiModelDownload: true
   workloadType: initContainer

--- a/config/storagecontainers/default.yaml
+++ b/config/storagecontainers/default.yaml
@@ -24,3 +24,4 @@ spec:
     - regex: "https://(.+?).file.core.windows.net/(.+)"
     - regex: "https?://(.+)/(.+)"
   workloadType: initContainer
+  supportsMultiModelDownload: true

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -39008,6 +39008,7 @@ spec:
   - regex: https://(.+?).blob.core.windows.net/(.+)
   - regex: https://(.+?).file.core.windows.net/(.+)
   - regex: https?://(.+)/(.+)
+  supportsMultiModelDownload: true
   workloadType: initContainer
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -38594,6 +38594,7 @@ spec:
   - regex: https://(.+?).blob.core.windows.net/(.+)
   - regex: https://(.+?).file.core.windows.net/(.+)
   - regex: https?://(.+)/(.+)
+  supportsMultiModelDownload: true
   workloadType: initContainer
 ---
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**:

In #4702, a `supportsMultiModelDownload: true` flag was introduced and Helm charts where updated, although an update to Kustomize manifests is missing.

Later, in a manifest refactor, such default of `true` was lost. This recovers the right default for the provided storage-initializer.


**Feature/Issue validation/testing**:

- Run `kubectl apply -k config/overlays/standalone/kserve` as mentioned in [v0.17 install docs](https://kserve.github.io/website/docs/install/kserve-install#method-1-kustomize) and check that the right configuration of the ClusterStorageContainer resource is installed in the cluster.
- Create an ISVC with multiple storageURIs, and check that it deploys correctly (no message in logs about the storage-init not supporting multi downloads).

**Checklist**:

- [N/A] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [N/A] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
