### PR TITLE
fix(helm): hardcoded namespaces in llmisvcconfigs

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-decode-template
-  namespace: kserve
+  namespace: {{ .Release.Namespace | default kserve }}
 spec:
   template:
     containers:
@@ -278,7 +278,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-decode-worker-data-parallel
-  namespace: kserve
+  namespace: {{ .Release.Namespace | default kserve }}
 spec:
   template:
     containers:
@@ -812,7 +812,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-prefill-template
-  namespace: kserve
+  namespace: {{ .Release.Namespace | default kserve }}
 spec:
   prefill:
     template:
@@ -1030,7 +1030,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-prefill-worker-data-parallel
-  namespace: kserve
+  namespace: {{ .Release.Namespace | default kserve }}
 spec:
   prefill:
     template:
@@ -1503,7 +1503,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-router-route
-  namespace: kserve
+  namespace: {{ .Release.Namespace | default kserve }}
 spec:
   router:
     route:
@@ -1595,7 +1595,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-scheduler
-  namespace: kserve
+  namespace: {{ .Release.Namespace | default kserve }}
 spec:
   router:
     scheduler:
@@ -1766,7 +1766,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-template
-  namespace: kserve
+  namespace: {{ .Release.Namespace | default kserve }}
 spec:
   template:
     containers:
@@ -1983,7 +1983,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-worker-data-parallel
-  namespace: kserve
+  namespace: {{ .Release.Namespace | default kserve }}
 spec:
   template:
     containers:


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:
Fixes hardcoded kserve namespace usage in `charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml`. Helm chart webhook configuration by templating it with `.Release.Namespace` and defaulting to `kserve`

**Which issue(s) this PR fixes**:
Fixes #5372


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
