### PR TITLE
ci: add structured E2E test results (JUnit XML + JSON)

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -1,10 +1,16 @@
-name: 'Upload E2E test results'
+name: 'Upload test results'
 description: 'Uploads JUnit XML and JSON structured test result artifacts'
 
 inputs:
   name:
     description: 'Artifact name'
     required: true
+  path:
+    description: 'Glob or path list for result files'
+    required: false
+    default: |
+      /tmp/junit_e2e.xml
+      /tmp/e2e_results.json
 
 runs:
   using: "composite"
@@ -12,7 +18,5 @@ runs:
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.name }}
-        path: |
-          /tmp/junit_e2e.xml
-          /tmp/e2e_results.json
+        path: ${{ inputs.path }}
         if-no-files-found: ignore

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -1,0 +1,18 @@
+name: 'Upload E2E test results'
+description: 'Uploads JUnit XML and JSON structured test result artifacts'
+
+inputs:
+  name:
+    description: 'Artifact name'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: ${{ inputs.name }}
+        path: |
+          /tmp/junit_e2e.xml
+          /tmp/e2e_results.json
+        if-no-files-found: ignore

--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -237,6 +237,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh "llmisvc"
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-llmisvc-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-llmisvc-wva-autoscaling-hpa:
     runs-on: ubuntu-latest
     needs: [detect-changes, llmisvc-image-build]
@@ -329,6 +339,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh "llmisvc"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-llmisvc-autoscaling-hpa-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-llmisvc-wva-autoscaling-keda:
     runs-on: ubuntu-latest
@@ -423,3 +443,13 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh "llmisvc"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-llmisvc-autoscaling-keda-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -239,13 +239,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-llmisvc-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-llmisvc-wva-autoscaling-hpa:
     runs-on: ubuntu-latest
@@ -342,13 +338,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-llmisvc-autoscaling-hpa-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-llmisvc-wva-autoscaling-keda:
     runs-on: ubuntu-latest
@@ -446,10 +438,6 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-llmisvc-autoscaling-keda-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore

--- a/.github/workflows/e2e-test-modelcache.yaml
+++ b/.github/workflows/e2e-test-modelcache.yaml
@@ -396,3 +396,13 @@ jobs:
           cat minikube-tunnel.log
           echo "::endgroup::"
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-modelcache-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-test-modelcache.yaml
+++ b/.github/workflows/e2e-test-modelcache.yaml
@@ -399,10 +399,6 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-modelcache-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -431,6 +431,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-predictor-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-transformer-explainer-mms:
     runs-on: ubuntu-latest
     needs:
@@ -540,6 +550,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-transformer-explainer-mms-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-graph:
     runs-on: ubuntu-latest
     needs:
@@ -637,6 +657,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-graph-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-path-based-routing:
     runs-on: ubuntu-latest
@@ -757,6 +787,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-path-based-routing-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-qpext:
     runs-on: ubuntu-latest
@@ -913,6 +953,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-helm
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-raw:
     runs-on: ubuntu-latest
     strategy:
@@ -1060,6 +1110,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-raw-${{ matrix.network-layer }}-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-autoscaling:
     runs-on: ubuntu-latest
     needs:
@@ -1162,6 +1222,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-autoscaling-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-kourier:
     runs-on: ubuntu-latest
@@ -1272,6 +1342,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh "kourier"
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-kourier-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-llm:
     runs-on: ubuntu-latest
     needs: [detect-changes, kserve-image-build, predictor-runtime-build]
@@ -1349,6 +1429,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-llm-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-huggingface-server-vllm:
     runs-on: ubuntu-latest
     needs: [detect-changes, kserve-image-build, predictor-runtime-build]
@@ -1425,6 +1515,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-vllm-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-modelcache:
     runs-on: ubuntu-latest
@@ -1567,3 +1667,13 @@ jobs:
           cat minikube-tunnel.log
           echo "::endgroup::"
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-modelcache-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -431,6 +431,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-predictor-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-transformer-explainer-mms:
     runs-on: ubuntu-latest
     needs:
@@ -540,6 +550,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-transformer-explainer-mms-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-graph:
     runs-on: ubuntu-latest
     needs:
@@ -637,6 +657,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-graph-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-path-based-routing:
     runs-on: ubuntu-latest
@@ -757,6 +787,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-path-based-routing-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-qpext:
     runs-on: ubuntu-latest
@@ -913,6 +953,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-helm
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-raw:
     runs-on: ubuntu-latest
     strategy:
@@ -1067,6 +1117,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-raw-${{ matrix.network-layer }}-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-autoscaling:
     runs-on: ubuntu-latest
     needs:
@@ -1169,6 +1229,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-autoscaling-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-kourier:
     runs-on: ubuntu-latest
@@ -1279,6 +1349,16 @@ jobs:
         run: |
           ./test/scripts/gh-actions/status-check.sh "kourier"
 
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-kourier-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
+
   test-llm:
     runs-on: ubuntu-latest
     needs: [detect-changes, kserve-image-build, predictor-runtime-build]
@@ -1355,6 +1435,16 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-llm-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore
 
   test-huggingface-server-vllm:
     runs-on: ubuntu-latest
@@ -1433,3 +1523,13 @@ jobs:
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-results-vllm-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e.xml
+            /tmp/e2e_results.json
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -433,13 +433,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-predictor-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-transformer-explainer-mms:
     runs-on: ubuntu-latest
@@ -552,13 +548,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-transformer-explainer-mms-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-graph:
     runs-on: ubuntu-latest
@@ -660,13 +652,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-graph-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-path-based-routing:
     runs-on: ubuntu-latest
@@ -790,13 +778,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-path-based-routing-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-qpext:
     runs-on: ubuntu-latest
@@ -955,13 +939,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-helm
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-raw:
     runs-on: ubuntu-latest
@@ -1119,13 +1099,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-raw-${{ matrix.network-layer }}-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-autoscaling:
     runs-on: ubuntu-latest
@@ -1232,13 +1208,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-autoscaling-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-kourier:
     runs-on: ubuntu-latest
@@ -1351,13 +1323,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-kourier-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-llm:
     runs-on: ubuntu-latest
@@ -1438,13 +1406,9 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-llm-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore
 
   test-huggingface-server-vllm:
     runs-on: ubuntu-latest
@@ -1526,10 +1490,6 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results-vllm-${{ matrix.install-method }}
-          path: |
-            /tmp/junit_e2e.xml
-            /tmp/e2e_results.json
-          if-no-files-found: ignore

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -96,12 +96,12 @@ jobs:
         run: |
           cd python
           source kserve/.venv/bin/activate
-          pytest --cov=kserve ./kserve
+          pytest --cov=kserve --junitxml=/tmp/junit_unit_kserve.xml ./kserve
       - name: Test kserve Storage
         run: |
           cd python
           source kserve/.venv/bin/activate
-          pytest --cov=storage ./storage
+          pytest --cov=storage --junitxml=/tmp/junit_unit_storage.xml ./storage
 
       # ----------------------------------------Kserve Numpy 1.x Unit Tests--------------------------------------------
       - name: Setup kserve numpy 1-x directory
@@ -135,7 +135,7 @@ jobs:
         run: |
           cd python
           source kserve-numpy-1-x/.venv/bin/activate
-          pytest --cov=kserve ./kserve-numpy-1-x
+          pytest --cov=kserve --junitxml=/tmp/junit_unit_kserve-numpy-1-x.xml ./kserve-numpy-1-x
 
       # ----------------------------------------Sklearn Server Unit Tests------------------------------------------------
       # load cached sklearn venv if cache exists
@@ -159,7 +159,7 @@ jobs:
         run: |
           cd python
           source sklearnserver/.venv/bin/activate
-          pytest --cov=sklearnserver ./sklearnserver
+          pytest --cov=sklearnserver --junitxml=/tmp/junit_unit_sklearnserver.xml ./sklearnserver
 
       # ----------------------------------------Xgb Server Unit Tests------------------------------------------------
       # load cached xgb venv if cache exists
@@ -183,7 +183,7 @@ jobs:
         run: |
           cd python
           source xgbserver/.venv/bin/activate
-          pytest --cov=xgbserver ./xgbserver
+          pytest --cov=xgbserver --junitxml=/tmp/junit_unit_xgbserver.xml ./xgbserver
 
       # ----------------------------------------Pmml Server Unit Tests------------------------------------------------
       # load cached pmml venv if cache exists
@@ -207,7 +207,7 @@ jobs:
         run: |
           cd python
           source pmmlserver/.venv/bin/activate
-          pytest --cov=pmmlserver ./pmmlserver
+          pytest --cov=pmmlserver --junitxml=/tmp/junit_unit_pmmlserver.xml ./pmmlserver
 
       # ----------------------------------------Lgb Server Unit Tests------------------------------------------------
       # load cached lgb venv if cache exists
@@ -231,7 +231,7 @@ jobs:
         run: |
           cd python
           source lgbserver/.venv/bin/activate
-          pytest --cov=lgbserver ./lgbserver
+          pytest --cov=lgbserver --junitxml=/tmp/junit_unit_lgbserver.xml ./lgbserver
 
       # ----------------------------------------Paddle Server Unit Tests------------------------------------------------
       # load cached paddle venv if cache exists
@@ -256,7 +256,7 @@ jobs:
         run: |
           cd python
           source paddleserver/.venv/bin/activate
-          pytest --cov=paddleserver ./paddleserver
+          pytest --cov=paddleserver --junitxml=/tmp/junit_unit_paddleserver.xml ./paddleserver
 
       # ----------------------------------------Huggingface CPU Server Unit Tests------------------------------------------------
       # load cached huggingface cpu venv if cache exists
@@ -295,7 +295,7 @@ jobs:
           /mnt/python/huggingfaceserver-cpu-venv/bin/python -m pip install pytest pytest-cov
           bash tests/setup_vllm.sh
           source /mnt/python/huggingfaceserver-cpu-venv/bin/activate
-          /mnt/python/huggingfaceserver-cpu-venv/bin/python -m pytest --cov=huggingfaceserver -vv -k 'not test_vllm'
+          /mnt/python/huggingfaceserver-cpu-venv/bin/python -m pytest --cov=huggingfaceserver --junitxml=/tmp/junit_unit_huggingfaceserver.xml -vv -k 'not test_vllm'
           # TODO: The following tests need to be reworked since IPEX support is relatively new for both vLLM and KServe
           # poetry run -- pytest --cov=huggingfaceserver -vv tests/test_vllm_chat_with_reasoning.py
           # poetry run -- pytest --cov=huggingfaceserver -vv tests/test_vllm_chat_with_tools.py
@@ -306,3 +306,10 @@ jobs:
       - name: Free space after cpu tests
         run: |
           df -hT
+
+      - name: Upload unit test results
+        if: always()
+        uses: ./.github/actions/upload-test-results
+        with:
+          name: unit-test-results-py${{ matrix.python-version }}
+          path: /tmp/junit_unit_*.xml

--- a/python/aiffairness/uv.lock
+++ b/python/aiffairness/uv.lock
@@ -1189,6 +1189,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/artexplainer/uv.lock
+++ b/python/artexplainer/uv.lock
@@ -926,6 +926,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/custom_model/uv.lock
+++ b/python/custom_model/uv.lock
@@ -907,6 +907,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/custom_tokenizer/uv.lock
+++ b/python/custom_tokenizer/uv.lock
@@ -784,6 +784,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/custom_transformer/uv.lock
+++ b/python/custom_transformer/uv.lock
@@ -828,6 +828,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/huggingfaceserver/uv.lock
+++ b/python/huggingfaceserver/uv.lock
@@ -2182,6 +2182,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -80,6 +80,7 @@ test = [
     "pytest<8.0.0,>=7.4.4",
     "pytest-cov<6.0.0,>=5.0.0",
     "pytest-xdist<4.0.0,>=3.0.2",
+    "pytest-json-report<2.0.0,>=1.5.0",
     "pytest-asyncio<1.0.0,>=0.23.4",
     "pytest-httpx<1.0.0,>=0.30.0",
     "mypy<1.0,>=0.991",

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -83,6 +83,7 @@ test = [
     "pytest<8.0.0,>=7.4.4",
     "pytest-cov<6.0.0,>=5.0.0",
     "pytest-xdist<4.0.0,>=3.0.2",
+    "pytest-json-report<2.0.0,>=1.5.0",
     "pytest-asyncio<1.0.0,>=0.23.4",
     "pytest-httpx<1.0.0,>=0.30.0",
     "mypy<1.0,>=0.991",

--- a/python/kserve/uv.lock
+++ b/python/kserve/uv.lock
@@ -1939,6 +1939,7 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
+    { name = "pytest-json-report" },
     { name = "pytest-xdist" },
     { name = "tomlkit" },
 ]
@@ -1995,6 +1996,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]
@@ -3757,6 +3759,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/84/82/28ae814b16ac7c756d4a53797fbec98965b7d84dad3e50c3b4d56d3c0c77/pytest-httpx-0.30.0.tar.gz", hash = "sha256:755b8edca87c974dd4f3605c374fda11db84631de3d163b99c0df5807023a19a", size = 36959, upload-time = "2024-02-21T17:59:56.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/60/ba9895a260e16c1115e40f8ae6f615c7e8ccdfa5d55418078391dd30b476/pytest_httpx-0.30.0-py3-none-any.whl", hash = "sha256:6d47849691faf11d2532565d0c8e0e02b9f4ee730da31687feae315581d7520c", size = 15373, upload-time = "2024-02-21T17:59:54.488Z" },
+]
+
+[[package]]
+name = "pytest-json-report"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "pytest-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/d3/765dae9712fcd68d820338908c1337e077d5fdadccd5cacf95b9b0bea278/pytest-json-report-1.5.0.tar.gz", hash = "sha256:2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de", size = 21241, upload-time = "2022-03-15T21:03:10.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/35/d07400c715bf8a88aa0c1ee9c9eb6050ca7fe5b39981f0eea773feeb0681/pytest_json_report-1.5.0-py3-none-any.whl", hash = "sha256:9897b68c910b12a2e48dd849f9a284b2c79a732a8a9cb398452ddd23d3c8c325", size = 13222, upload-time = "2022-03-15T21:03:08.65Z" },
+]
+
+[[package]]
+name = "pytest-metadata"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952, upload-time = "2024-02-12T19:38:44.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428, upload-time = "2024-02-12T19:38:42.531Z" },
 ]
 
 [[package]]

--- a/python/lgbserver/uv.lock
+++ b/python/lgbserver/uv.lock
@@ -1124,6 +1124,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/paddleserver/uv.lock
+++ b/python/paddleserver/uv.lock
@@ -1140,6 +1140,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/pmmlserver/uv.lock
+++ b/python/pmmlserver/uv.lock
@@ -1153,6 +1153,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/predictiveserver/uv.lock
+++ b/python/predictiveserver/uv.lock
@@ -1115,6 +1115,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/sklearnserver/uv.lock
+++ b/python/sklearnserver/uv.lock
@@ -1115,6 +1115,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/test_resources/graph/error_404_isvc/uv.lock
+++ b/python/test_resources/graph/error_404_isvc/uv.lock
@@ -770,6 +770,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/test_resources/graph/success_200_isvc/uv.lock
+++ b/python/test_resources/graph/success_200_isvc/uv.lock
@@ -751,6 +751,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/python/xgbserver/uv.lock
+++ b/python/xgbserver/uv.lock
@@ -1124,6 +1124,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0,<1.0.0" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.2,<4.0.0" },
     { name = "tomlkit", specifier = ">=0.12.0,<1.0.0" },
 ]

--- a/test/README.md
+++ b/test/README.md
@@ -1,2 +1,2 @@
 # Testing
-Please refer to [unit and e2e tests guide](https://github.com/kserve/website/blob/main/docs/developer/developer.md#running-unitintegration-tests)
+Please refer to [unit and e2e tests guide](https://github.com/kserve/website/blob/main/docs/developer-guide/index.md#running-unitintegration-tests)

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -46,7 +46,10 @@ echo "Parallelism requested for pytest is ${PARALLELISM}"
 
 source python/kserve/.venv/bin/activate
 
-PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" -vv --tb=long -s)
+REPORT_DIR="${ARTIFACT_DIR:-/tmp}"
+mkdir -p "$REPORT_DIR"
+
+PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" -vv --tb=long -s --junitxml="$REPORT_DIR/junit_e2e.xml" --json-report --json-report-file="$REPORT_DIR/e2e_results.json")
 
 MARKER_ARGS=()
 if [[ -n "$MARKER" ]]; then

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -16,6 +16,15 @@
 
 # The script is used to deploy knative and kserve, and run e2e tests.
 # Usage: run-e2e-tests.sh $MARKER $PARALLELISM $NETWORK_LAYER
+#
+# Extra pytest flags can be passed via the PYTEST_ARGS env var, e.g.:
+#   PYTEST_ARGS="-k test_sklearn_v2" ./test/scripts/gh-actions/run-e2e-tests.sh predictor
+#
+# Quoted selectors are supported (parsed via xargs):
+#   PYTEST_ARGS='-k "test_a or test_b"' ./test/scripts/gh-actions/run-e2e-tests.sh predictor
+#
+# To run a specific test by path, pass an empty marker:
+#   PYTEST_ARGS="predictor/test_sklearn.py::test_sklearn_v2" ./test/scripts/gh-actions/run-e2e-tests.sh
 
 set -o errexit
 set -o nounset
@@ -29,18 +38,31 @@ source "${PROJECT_ROOT}/kserve-images.sh"
 export GITHUB_SHA="${TAG:-latest}"
 
 echo "Starting E2E functional tests ..."
-MARKER="${1}"
+MARKER="${1:-}"
 PARALLELISM="${2:-1}"
 NETWORK_LAYER="${3:-'istio'}"
 
 echo "Parallelism requested for pytest is ${PARALLELISM}"
 
 source python/kserve/.venv/bin/activate
+
+PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" -vv --tb=long -s)
+
+MARKER_ARGS=()
+if [[ -n "$MARKER" ]]; then
+  MARKER_ARGS=(-m "$MARKER")
+fi
+
+PYTEST_EXTRA_ARGS=()
+if [[ -n "${PYTEST_ARGS:-}" ]]; then
+  readarray -t PYTEST_EXTRA_ARGS < <(xargs printf '%s\n' <<< "$PYTEST_ARGS")
+fi
+
 pushd test/e2e >/dev/null
-  if [[ $MARKER == "raw" && $NETWORK_LAYER == "istio-ingress" ]]; then
+  if [[ "$MARKER" == "raw" && "$NETWORK_LAYER" == "istio-ingress" ]]; then
     echo "Skipping explainer tests for raw deployment with ingress"
-    pytest -m "$MARKER" --ignore=qpext --log-cli-level=INFO -n $PARALLELISM --dist worksteal --network-layer $NETWORK_LAYER --ignore=explainer/ -vv --tb=long -s    
+    pytest "${MARKER_ARGS[@]}" "${PYTEST_COMMON_ARGS[@]}" --ignore=explainer/ "${PYTEST_EXTRA_ARGS[@]}"
   else
-    pytest -m "$MARKER" --ignore=qpext --log-cli-level=INFO -n $PARALLELISM --dist worksteal --network-layer $NETWORK_LAYER -vv --tb=long -s
+    pytest "${MARKER_ARGS[@]}" "${PYTEST_COMMON_ARGS[@]}" "${PYTEST_EXTRA_ARGS[@]}"
   fi
 popd

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -16,6 +16,15 @@
 
 # The script is used to deploy knative and kserve, and run e2e tests.
 # Usage: run-e2e-tests.sh $MARKER $PARALLELISM $NETWORK_LAYER
+#
+# Extra pytest flags can be passed via the PYTEST_ARGS env var, e.g.:
+#   PYTEST_ARGS="-k test_sklearn_v2" ./test/scripts/gh-actions/run-e2e-tests.sh predictor
+#
+# Quoted selectors are supported (parsed via xargs):
+#   PYTEST_ARGS='-k "test_a or test_b"' ./test/scripts/gh-actions/run-e2e-tests.sh predictor
+#
+# To run a specific test by path, pass an empty marker:
+#   PYTEST_ARGS="predictor/test_sklearn.py::test_sklearn_v2" ./test/scripts/gh-actions/run-e2e-tests.sh
 
 set -o errexit
 set -o nounset
@@ -29,7 +38,7 @@ source "${PROJECT_ROOT}/kserve-images.sh"
 export GITHUB_SHA="${TAG:-latest}"
 
 echo "Starting E2E functional tests ..."
-MARKER="${1}"
+MARKER="${1:-}"
 PARALLELISM="${2:-1}"
 NETWORK_LAYER="${3:-istio}"
 
@@ -41,11 +50,24 @@ echo "Parallelism requested for pytest is ${PARALLELISM}"
 MAXFAIL="${PYTEST_MAXFAIL:-5}"
 
 source python/kserve/.venv/bin/activate
+
+PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" --maxfail="$MAXFAIL" -vv --tb=long -s)
+
+MARKER_ARGS=()
+if [[ -n "$MARKER" ]]; then
+  MARKER_ARGS=(-m "$MARKER")
+fi
+
+PYTEST_EXTRA_ARGS=()
+if [[ -n "${PYTEST_ARGS:-}" ]]; then
+  readarray -t PYTEST_EXTRA_ARGS < <(xargs printf '%s\n' <<< "$PYTEST_ARGS")
+fi
+
 pushd test/e2e >/dev/null
-  if [[ $MARKER == "raw" && $NETWORK_LAYER == "istio-ingress" ]]; then
+  if [[ "$MARKER" == "raw" && "$NETWORK_LAYER" == "istio-ingress" ]]; then
     echo "Skipping explainer tests for raw deployment with ingress"
-    pytest -m "$MARKER" --ignore=qpext --log-cli-level=INFO -n $PARALLELISM --dist worksteal --network-layer $NETWORK_LAYER --ignore=explainer/ --maxfail="$MAXFAIL" -vv --tb=long -s
+    pytest "${MARKER_ARGS[@]}" "${PYTEST_COMMON_ARGS[@]}" --ignore=explainer/ "${PYTEST_EXTRA_ARGS[@]}"
   else
-    pytest -m "$MARKER" --ignore=qpext --log-cli-level=INFO -n $PARALLELISM --dist worksteal --network-layer $NETWORK_LAYER --maxfail="$MAXFAIL" -vv --tb=long -s
+    pytest "${MARKER_ARGS[@]}" "${PYTEST_COMMON_ARGS[@]}" "${PYTEST_EXTRA_ARGS[@]}"
   fi
 popd

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -51,7 +51,10 @@ MAXFAIL="${PYTEST_MAXFAIL:-5}"
 
 source python/kserve/.venv/bin/activate
 
-PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" --maxfail="$MAXFAIL" -vv --tb=long -s)
+REPORT_DIR="${ARTIFACT_DIR:-/tmp}"
+mkdir -p "$REPORT_DIR"
+
+PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" --maxfail="$MAXFAIL" -vv --tb=long -s --junitxml="$REPORT_DIR/junit_e2e.xml" --json-report --json-report-file="$REPORT_DIR/e2e_results.json" --json-report-omit=log)
 
 MARKER_ARGS=()
 if [[ -n "$MARKER" ]]; then


### PR DESCRIPTION
## Summary

- Parametrize PYTEST_ARGS in `run-e2e-tests.sh` 
- Add `--junitxml` and `--json-report` flags to the E2E pytest invocation so every CI run produces structured per-test results
- Add `pytest-json-report` to the test dependency group
- Add `upload-artifact` steps to all E2E jobs in GitHub Actions

## Motivation

The E2E test runner currently produces only console output with no structured test results. This means:
- No way to distinguish infrastructure failures from test failures at the per-test level
- No way to identify flaky tests or track trends over time

## What this produces

Two output files per E2E run, written to `$ARTIFACT_DIR` (or `/tmp` if unset):

| File | Format | Consumer |
|------|--------|----------|
| `junit_e2e.xml` | JUnit XML (built-in pytest) | Prow Spyglass JUnit lens, Sippy, TestGrid |
| `e2e_results.json` | JSON (pytest-json-report) | Custom analysis tooling (richer: per-test timings, setup/call/teardown stages, tracebacks) |

Both files are written even when tests fail, enabling partial failure analysis.


## Test plan

- [x] GitHub Actions: Verify `junit_e2e.xml` and `e2e_results.json` appear as uploaded artifacts

Made with [Cursor](https://cursor.com)