### PR TITLE
feat(multinode): use pod-template-hash for headless service selector

### DIFF
--- a/charts/kserve-resources/files/kserve/resources.yaml
+++ b/charts/kserve-resources/files/kserve/resources.yaml
@@ -137,6 +137,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - httproutes

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -79,6 +79,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - httproutes

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -37825,6 +37825,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - httproutes

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -37411,6 +37411,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - httproutes

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -55,11 +55,11 @@ const (
 
 // InferenceService Constants
 var (
-	InferenceServiceName                  = "inferenceservice"
-	InferenceServiceAPIName               = "inferenceservices"
-	InferenceServicePodLabelKey           = KServeAPIGroupName + "/" + InferenceServiceName
-	InferenceServiceGenerationPodLabelKey = "isvc.generation"
-	InferenceServiceConfigMapName         = "inferenceservice-config"
+	InferenceServiceName          = "inferenceservice"
+	InferenceServiceAPIName       = "inferenceservices"
+	InferenceServicePodLabelKey   = KServeAPIGroupName + "/" + InferenceServiceName
+	PodTemplateHashLabelKey       = "serving.kserve.io/pod-template-hash"
+	InferenceServiceConfigMapName = "inferenceservice-config"
 )
 
 // InferenceGraph Constants
@@ -711,15 +711,15 @@ func GetRawWorkerServiceLabel(service string) string {
 }
 
 // GetHeadServiceName generate head service name
-func GetHeadServiceName(service string, isvcGeneration string) string {
+func GetHeadServiceName(service string, podTemplateHash string) string {
 	isvcName := strings.TrimSuffix(service, "-predictor")
-	return isvcName + "-" + MultiNodeHead + "-" + isvcGeneration
+	return isvcName + "-" + MultiNodeHead + "-" + podTemplateHash
 }
 
 // GetWorkerServiceName generate worker headless service name
-func GetWorkerServiceName(service string, isvcGeneration string) string {
+func GetWorkerServiceName(service string, podTemplateHash string) string {
 	isvcName := strings.TrimSuffix(service, "-predictor")
-	return isvcName + "-" + WorkerNodeSuffixPlural + "-" + isvcGeneration
+	return isvcName + "-" + WorkerNodeSuffixPlural + "-" + podTemplateHash
 }
 
 func (e InferenceServiceComponent) String() string {

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -153,7 +153,7 @@ func handleInferenceGraphRawDeployment(ctx context.Context, cl client.Client, cl
 	objectMeta, componentExtSpec := constructForRawDeployment(graph)
 
 	// create the reconciler
-	reconciler, err := raw.NewRawKubeReconciler(ctx, cl, clientset, scheme, objectMeta, metav1.ObjectMeta{}, &componentExtSpec, desiredSvc, nil, nil, nil, nil, nil, nil)
+	reconciler, err := raw.NewRawKubeReconciler(ctx, cl, clientset, scheme, objectMeta, metav1.ObjectMeta{}, &componentExtSpec, desiredSvc, nil, nil, nil, nil, nil, nil, "")
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "fails to create NewRawKubeReconciler for inference graph")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -187,7 +187,7 @@ func (e *Explainer) reconcileExplainerRawDeployment(ctx context.Context, isvc *v
 	}
 
 	r, err := raw.NewRawKubeReconciler(ctx, e.client, e.clientset, e.scheme, *objectMeta, metav1.ObjectMeta{},
-		&isvc.Spec.Explainer.ComponentExtensionSpec, podSpec, nil, &isvc.Spec.Explainer.StorageUris, storageInitializerConfig, storageSpec, credentialBuilder, storageContainerSpec)
+		&isvc.Spec.Explainer.ComponentExtensionSpec, podSpec, nil, &isvc.Spec.Explainer.StorageUris, storageInitializerConfig, storageSpec, credentialBuilder, storageContainerSpec, "")
 	if err != nil {
 		return errors.Wrapf(err, "fails to create NewRawKubeReconciler for explainer")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -89,13 +89,8 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	var sRuntime v1alpha1.ServingRuntimeSpec
 	var sRuntimeLabels map[string]string
 	var sRuntimeAnnotations map[string]string
-	multiNodeEnabled := false
-	isvcGeneration := strconv.FormatInt(isvc.Generation, 10)
-
+	multiNodeEnabled := isvc.Spec.Predictor.WorkerSpec != nil
 	// Set default value for multi-node
-	if isvc.Spec.Predictor.WorkerSpec != nil {
-		multiNodeEnabled = true
-	}
 
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
@@ -179,14 +174,15 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	objectMeta := p.buildObjectMeta(isvc, predictorName, sRuntimeLabels, predictorLabels, sRuntimeAnnotations, annotations, predictorAnnotations)
 
 	// Autoscaler should be ignored when multiNodeEnabled is true
+	var podTemplateHash string
 	if multiNodeEnabled {
 		var err error
-		workerObjectMeta, workerPodSpec, err = p.reconcileWorker(sRuntime, isvc, &podSpec, annotations, predictorAnnotations, isvcGeneration)
+		workerObjectMeta, workerPodSpec, podTemplateHash, err = p.reconcileWorker(sRuntime, isvc, &podSpec, annotations, predictorAnnotations)
 		if err != nil {
 			isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidGPUAllocation, err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
-		objectMeta.Labels[constants.InferenceServiceGenerationPodLabelKey] = isvcGeneration
+		objectMeta.Labels[constants.PodTemplateHashLabelKey] = podTemplateHash
 	}
 
 	p.Log.Info("Resolved container", "container", predContainer, "podSpec", podSpec)
@@ -200,7 +196,7 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 		rawDeployment = true
 		podLabelKey = constants.RawDeploymentAppLabel
 		// This is main RawKubeReconciler to create objects (deployment, svc, scaler)
-		if err := p.reconcileRawDeployment(ctx, isvc, objectMeta, workerObjectMeta, &podSpec, workerPodSpec); err != nil {
+		if err := p.reconcileRawDeployment(ctx, isvc, objectMeta, workerObjectMeta, &podSpec, workerPodSpec, podTemplateHash); err != nil {
 			isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, "ReconcileFailed", err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
 		}
@@ -470,16 +466,17 @@ func (p *Predictor) buildObjectMeta(isvc *v1beta1.InferenceService, predictorNam
 	}
 }
 
-func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, annotations, predictorAnnotations map[string]string, isvcGeneration string) (metav1.ObjectMeta, *corev1.PodSpec, error) {
+func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, annotations, predictorAnnotations map[string]string) (metav1.ObjectMeta, *corev1.PodSpec, string, error) {
 	var workerObjectMeta metav1.ObjectMeta
 	var workerPodSpec *corev1.PodSpec
+	var podTemplateHash string
 	var err error
 
 	sRuntimeWorkerAnnotations := sRuntime.WorkerSpec.Annotations
 	sRuntimeWorkerLabels := sRuntime.WorkerSpec.Labels
 
-	if workerPodSpec, err = multiNodeProcess(sRuntime, isvc, podSpec, annotations, isvcGeneration); err != nil {
-		return workerObjectMeta, workerPodSpec, err
+	if workerPodSpec, podTemplateHash, err = multiNodeProcess(sRuntime, isvc, podSpec, annotations); err != nil {
+		return workerObjectMeta, workerPodSpec, "", err
 	}
 
 	workerObjectMeta = metav1.ObjectMeta{
@@ -490,9 +487,9 @@ func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *
 			isvc.Labels,
 			isvc.Spec.Predictor.Labels,
 			map[string]string{
-				constants.InferenceServiceGenerationPodLabelKey: isvcGeneration,
-				constants.InferenceServicePodLabelKey:           isvc.Name,
-				constants.KServiceComponentLabel:                string(v1beta1.PredictorComponent),
+				constants.PodTemplateHashLabelKey:     podTemplateHash,
+				constants.InferenceServicePodLabelKey: isvc.Name,
+				constants.KServiceComponentLabel:      string(v1beta1.PredictorComponent),
 			},
 		),
 		Annotations: utils.Union(
@@ -502,13 +499,19 @@ func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *
 		),
 	}
 
-	return workerObjectMeta, workerPodSpec, nil
+	return workerObjectMeta, workerPodSpec, podTemplateHash, nil
 }
 
-func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, annotations map[string]string, isvcGeneration string) (*corev1.PodSpec, error) {
+func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, annotations map[string]string) (*corev1.PodSpec, string, error) {
 	var workerContainer *corev1.Container
 	var mergedWorkerPodSpec *corev1.PodSpec
 	var err error
+
+	if sRuntime.WorkerSpec == nil {
+		errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
+		isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
+		return nil, "", errors.New(errMsg)
+	}
 
 	// Initialize PipelineParallelSize and TensorParallelSize if not set
 	if sRuntime.WorkerSpec.PipelineParallelSize == nil {
@@ -526,12 +529,6 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	if isvc.Spec.Predictor.WorkerSpec.TensorParallelSize != nil {
 		sRuntime.WorkerSpec.TensorParallelSize = isvc.Spec.Predictor.WorkerSpec.TensorParallelSize
 	}
-
-	if sRuntime.WorkerSpec == nil {
-		errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
-		isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
-		return nil, errors.New(errMsg)
-	}
 	// Check if workerSpec in ServingRuntime does not have worker containers information, it should return errors
 	if len(sRuntime.WorkerSpec.Containers) == 0 {
 		errMsg := "No workerSpec container configuration found in selected serving runtime"
@@ -539,7 +536,7 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 			Reason:  v1beta1.InvalidPredictorSpec,
 			Message: errMsg,
 		})
-		return nil, errors.New(errMsg)
+		return nil, "", errors.New(errMsg)
 	}
 
 	targetisvcContainer := corev1.Container{}
@@ -548,7 +545,7 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	}
 	_, workerContainer, mergedWorkerPodSpec, err = isvcutils.MergeServingRuntimeAndInferenceServiceSpecs(sRuntime.WorkerSpec.Containers, targetisvcContainer, isvc, constants.WorkerContainerName, sRuntime.WorkerSpec.ServingRuntimePodSpec, isvc.Spec.Predictor.WorkerSpec.PodSpec)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	mergedWorkerPodSpec.Containers = []corev1.Container{
@@ -569,28 +566,28 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		var err error
 		nodeCount, workerNodeGPUCount, headNodeGPUCount, err = computeRayNodeAndGPUs(mergedWorkerPodSpec, totalRequestGPUCount, podSpec)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	}
 
 	// Add required environment variables: PipelineParallelSize, TensorParallelSize
 	// Deployment node deployement
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.PipelineParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.PipelineParallelSize)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.PipelineParallelSizeEnvName, constants.InferenceServiceContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.PipelineParallelSizeEnvName, constants.InferenceServiceContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.TensorParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.TensorParallelSize)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.InferenceServiceContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.InferenceServiceContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.RayNodeCountEnvName, strconv.Itoa(nodeCount)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.InferenceServiceContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.InferenceServiceContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.RequestGPUCountEnvName, strconv.Itoa(headNodeGPUCount)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RequestGPUCountEnvName, constants.InferenceServiceContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RequestGPUCountEnvName, constants.InferenceServiceContainerName)
 	}
 
 	// Set the environment variable for "isvc name" to the MODEL_NAME when multiNodeEnabled is true.
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, "MODEL_NAME", isvc.Name); err != nil {
-		return nil, errors.Wrapf(err, "failed to add MODEL_NAME environment to the container(%s)", constants.InferenceServiceContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add MODEL_NAME environment to the container(%s)", constants.InferenceServiceContainerName)
 	}
 
 	deploymentAnnotations := annotations[constants.StorageInitializerSourceUriInternalAnnotationKey]
@@ -598,35 +595,46 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	if storageProtocol == "pvc" || storageProtocol == "oci" {
 		// Set the environment variable for "/mnt/models" to the MODEL_DIR when multiNodeEnabled is true.
 		if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, "MODEL_DIR", constants.DefaultModelLocalMountPath); err != nil {
-			return nil, errors.Wrapf(err, "failed to add MODEL_DIR environment to the container(%s)", constants.DefaultModelLocalMountPath)
+			return nil, "", errors.Wrapf(err, "failed to add MODEL_DIR environment to the container(%s)", constants.DefaultModelLocalMountPath)
 		}
 	}
+
+	// Compute pod template hash from head podSpec after all head env vars are set.
+	// Worker env vars (HEAD_SVC, ISVC_NAME, etc.) are set after this point using the hash.
+	// This hash changes when the head pod template changes (e.g., ServingRuntime image update),
+	// ensuring the headless service selector correctly isolates pods during rolling updates.
+	podTemplateHash, err := utils.ComputePodSpecHash(podSpec)
+	if err != nil {
+		return nil, "", err
+	}
+
 	// Worker node deployement
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RayNodeCountEnvName, strconv.Itoa(nodeCount)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.WorkerContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.WorkerContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RequestGPUCountEnvName, strconv.Itoa(workerNodeGPUCount)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RequestGPUCountEnvName, constants.WorkerContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RequestGPUCountEnvName, constants.WorkerContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.PipelineParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.PipelineParallelSize)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.PipelineParallelSizeEnvName, constants.WorkerContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.PipelineParallelSizeEnvName, constants.WorkerContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.TensorParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.TensorParallelSize)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.WorkerContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.WorkerContainerName)
 	}
 	// Set the environment variable for "isvc name" to the ISVC_NAME when multiNodeEnabled is true.
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "ISVC_NAME", isvc.Name); err != nil {
-		return nil, errors.Wrapf(err, "failed to add ISVC_NAME environment to the container(%s)", constants.WorkerContainerName)
+		return nil, "", errors.Wrapf(err, "failed to add ISVC_NAME environment to the container(%s)", constants.WorkerContainerName)
 	}
-	// Set the environment variable for "isvc name" to the HEAD_SVC when multiNodeEnabled is true.
-	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "HEAD_SVC", constants.GetHeadServiceName(isvc.Name, isvcGeneration)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add HEAD_SVC environment to the container(%s)", constants.WorkerContainerName)
+	// Set the HEAD_SVC using pod template hash so workers connect to the correct head service.
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "HEAD_SVC", constants.GetHeadServiceName(isvc.Name, podTemplateHash)); err != nil {
+		return nil, "", errors.Wrapf(err, "failed to add HEAD_SVC environment to the container(%s)", constants.WorkerContainerName)
 	}
+
 	// Set the environment variable for worker headless service name to the WORKER_SVC when multiNodeEnabled is true.
-	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "WORKER_SVC", constants.GetWorkerServiceName(constants.PredictorServiceName(isvc.Name), isvcGeneration)); err != nil {
-		return nil, errors.Wrapf(err, "failed to add WORKER_SVC environment to the container(%s)", constants.WorkerContainerName)
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "WORKER_SVC", constants.GetWorkerServiceName(constants.PredictorServiceName(isvc.Name), podTemplateHash)); err != nil {
+		return nil, "", errors.Wrapf(err, "failed to add WORKER_SVC environment to the container(%s)", constants.WorkerContainerName)
 	}
-	return mergedWorkerPodSpec, nil
+	return mergedWorkerPodSpec, podTemplateHash, nil
 }
 
 // The `rayNodeCount` is determined based on the requested GPU count.
@@ -716,7 +724,7 @@ func computeMpNodeAndGPUs(pipelineParallelSize, tensorParallelSize int) (int, in
 	return nodeCount, gpuPerNode, gpuPerNode
 }
 
-func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.InferenceService, objectMeta, workerObjectMeta metav1.ObjectMeta, podSpec, workerPodSpec *corev1.PodSpec) error {
+func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.InferenceService, objectMeta, workerObjectMeta metav1.ObjectMeta, podSpec, workerPodSpec *corev1.PodSpec, podTemplateHash string) error {
 	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, p.clientset)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get InferenceService ConfigMap")
@@ -744,7 +752,7 @@ func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.In
 	}
 
 	r, err := raw.NewRawKubeReconciler(ctx, p.client, p.clientset, p.scheme, objectMeta, workerObjectMeta, &isvc.Spec.Predictor.ComponentExtensionSpec,
-		podSpec, workerPodSpec, &isvc.Spec.Predictor.StorageUris, storageInitializerConfig, storageSpec, credentialBuilder, storageContainerSpec)
+		podSpec, workerPodSpec, &isvc.Spec.Predictor.StorageUris, storageInitializerConfig, storageSpec, credentialBuilder, storageContainerSpec, podTemplateHash)
 	if err != nil {
 		return errors.Wrapf(err, "fails to create NewRawKubeReconciler for predictor")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -472,6 +472,12 @@ func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *
 	var podTemplateHash string
 	var err error
 
+	if sRuntime.WorkerSpec == nil {
+		errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
+		isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
+		return workerObjectMeta, nil, "", errors.New(errMsg)
+	}
+
 	sRuntimeWorkerAnnotations := sRuntime.WorkerSpec.Annotations
 	sRuntimeWorkerLabels := sRuntime.WorkerSpec.Labels
 
@@ -506,12 +512,6 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	var workerContainer *corev1.Container
 	var mergedWorkerPodSpec *corev1.PodSpec
 	var err error
-
-	if sRuntime.WorkerSpec == nil {
-		errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
-		isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
-		return nil, "", errors.New(errMsg)
-	}
 
 	// Initialize PipelineParallelSize and TensorParallelSize if not set
 	if sRuntime.WorkerSpec.PipelineParallelSize == nil {
@@ -599,20 +599,14 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		}
 	}
 
-	// Compute pod template hash from head podSpec after all head env vars are set.
-	// Worker env vars (HEAD_SVC, ISVC_NAME, etc.) are set after this point using the hash.
-	// Hash covers both the head PodSpec (ServingRuntime info) and the ISVC Predictor spec
-	// (storage URI, WorkerSpec, etc.) so that any effective pod template change — including
-	// storage URI updates that only affect the storage-initializer init container — produces
-	// a new hash and triggers correct service isolation during rolling updates.
-	// Only Predictor spec is used (not Transformer/Explainer) to avoid unnecessary hash
-	// changes when unrelated components are modified.
+	// Hash head podSpec + Predictor spec so any effective change (SR image, storage URI, etc.)
+	// produces a new value for correct headless service isolation during rolling updates.
 	podTemplateHash, err := utils.ComputeHash(podSpec, isvc.Spec.Predictor)
 	if err != nil {
 		return nil, "", err
 	}
 
-	// Worker node deployement
+	// Worker node deployment
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RayNodeCountEnvName, strconv.Itoa(nodeCount)); err != nil {
 		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.WorkerContainerName)
 	}
@@ -625,7 +619,6 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.TensorParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.TensorParallelSize)); err != nil {
 		return nil, "", errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.WorkerContainerName)
 	}
-	// Set the environment variable for "isvc name" to the ISVC_NAME when multiNodeEnabled is true.
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "ISVC_NAME", isvc.Name); err != nil {
 		return nil, "", errors.Wrapf(err, "failed to add ISVC_NAME environment to the container(%s)", constants.WorkerContainerName)
 	}
@@ -633,7 +626,6 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "HEAD_SVC", constants.GetHeadServiceName(isvc.Name, podTemplateHash)); err != nil {
 		return nil, "", errors.Wrapf(err, "failed to add HEAD_SVC environment to the container(%s)", constants.WorkerContainerName)
 	}
-
 	// Set the environment variable for worker headless service name to the WORKER_SVC when multiNodeEnabled is true.
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "WORKER_SVC", constants.GetWorkerServiceName(constants.PredictorServiceName(isvc.Name), podTemplateHash)); err != nil {
 		return nil, "", errors.Wrapf(err, "failed to add WORKER_SVC environment to the container(%s)", constants.WorkerContainerName)

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -601,9 +601,13 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 
 	// Compute pod template hash from head podSpec after all head env vars are set.
 	// Worker env vars (HEAD_SVC, ISVC_NAME, etc.) are set after this point using the hash.
-	// This hash changes when the head pod template changes (e.g., ServingRuntime image update),
-	// ensuring the headless service selector correctly isolates pods during rolling updates.
-	podTemplateHash, err := utils.ComputePodSpecHash(podSpec)
+	// Hash covers both the head PodSpec (ServingRuntime info) and the ISVC Predictor spec
+	// (storage URI, WorkerSpec, etc.) so that any effective pod template change — including
+	// storage URI updates that only affect the storage-initializer init container — produces
+	// a new hash and triggers correct service isolation during rolling updates.
+	// Only Predictor spec is used (not Transformer/Explainer) to avoid unnecessary hash
+	// changes when unrelated components are modified.
+	podTemplateHash, err := utils.ComputeHash(podSpec, isvc.Spec.Predictor)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -223,7 +223,7 @@ func (p *Transformer) reconcileTransformerRawDeployment(ctx context.Context, isv
 	}
 
 	r, err := raw.NewRawKubeReconciler(ctx, p.client, p.clientset, p.scheme, *objectMeta, metav1.ObjectMeta{},
-		&isvc.Spec.Transformer.ComponentExtensionSpec, podSpec, nil, &isvc.Spec.Transformer.StorageUris, storageInitializerConfig, storageSpec, credentialBuilder, storageContainerSpec)
+		&isvc.Spec.Transformer.ComponentExtensionSpec, podSpec, nil, &isvc.Spec.Transformer.StorageUris, storageInitializerConfig, storageSpec, credentialBuilder, storageContainerSpec, "")
 	if err != nil {
 		return errors.Wrapf(err, "fails to create NewRawKubeReconciler for transformer")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -88,6 +88,7 @@ import (
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -8909,16 +8909,25 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 			// Check Services
 			actualService := &corev1.Service{}
-			headServiceName := constants.GetHeadServiceName(isvcName+"-predictor", "1")
 			defaultServiceName := isvcName + "-predictor"
-			expectedHeadServiceName := types.NamespacedName{Name: headServiceName, Namespace: isvcNamespace}
 			expectedDefaultServiceName := types.NamespacedName{Name: defaultServiceName, Namespace: isvcNamespace}
 
-			// Verify if head service is created
+			// Verify if head service is created by listing with multinode head label
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, expectedHeadServiceName, actualService); err != nil {
+				svcList := &corev1.ServiceList{}
+				if err := k8sClient.List(ctx, svcList,
+					client.InNamespace(isvcNamespace),
+					client.MatchingLabels{
+						constants.MultiNodeRoleLabelKey:       constants.MultiNodeHead,
+						constants.InferenceServicePodLabelKey: isvcName,
+					},
+				); err != nil {
 					return false
 				}
+				if len(svcList.Items) != 1 {
+					return false
+				}
+				*actualService = svcList.Items[0]
 				return true
 			}, timeout, interval).Should(BeTrue())
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/factory.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/factory.go
@@ -53,6 +53,7 @@ type ServiceReconcilerParams struct {
 	PodSpec          *corev1.PodSpec
 	MultiNodeEnabled bool
 	ServiceConfig    *v1beta1.ServiceConfig
+	PodTemplateHash  string
 }
 
 // IngressReconcilerParams contains parameters for ingress reconciler creation
@@ -108,7 +109,7 @@ func (f *ReconcilerFactory) CreateServiceReconciler(
 	case constants.Standard, constants.LegacyRawDeployment:
 		return service.NewServiceReconciler(
 			params.Client, params.Scheme, params.ComponentMeta, params.ComponentExt,
-			params.PodSpec, params.MultiNodeEnabled, params.ServiceConfig,
+			params.PodSpec, params.MultiNodeEnabled, params.ServiceConfig, params.PodTemplateHash,
 		), nil
 
 	default:

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -69,6 +69,7 @@ func NewRawKubeReconciler(ctx context.Context,
 	storageSpec *v1beta1.StorageSpec,
 	credentialBuilder *credentials.CredentialBuilder,
 	storageContainerSpec *v1alpha1.StorageContainerSpec,
+	podTemplateHash string,
 ) (*RawKubeReconciler, error) {
 	var otelCollector *otel.OtelReconciler
 	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, clientset)
@@ -207,6 +208,7 @@ func NewRawKubeReconciler(ctx context.Context,
 			PodSpec:          podSpec,
 			MultiNodeEnabled: multiNodeEnabled,
 			ServiceConfig:    serviceConfig,
+			PodTemplateHash:  podTemplateHash,
 		},
 	)
 	if err != nil {
@@ -243,14 +245,15 @@ func (r *RawKubeReconciler) Reconcile(ctx context.Context) ([]*appsv1.Deployment
 			return nil, err
 		}
 	}
-	// reconcile Workload (Deployment)
-	deploymentList, err := r.Workload.Reconcile(ctx)
-	if err != nil {
+	// reconcile Service before Workload so that headless services exist
+	// before new pods start — prevents DNS NXDOMAIN when worker pods boot
+	// and resolve the head service DNS name on first connection.
+	if _, err := r.Service.Reconcile(ctx); err != nil {
 		return nil, err
 	}
 
-	// reconcile Service
-	_, err = r.Service.Reconcile(ctx)
+	// reconcile Workload (Deployment)
+	deploymentList, err := r.Workload.Reconcile(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,11 +54,12 @@ func NewServiceReconciler(client client.Client,
 	componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, multiNodeEnabled bool,
 	serviceConfig *v1beta1.ServiceConfig,
+	podTemplateHash string,
 ) *ServiceReconciler {
 	return &ServiceReconciler{
 		client:       client,
 		scheme:       scheme,
-		ServiceList:  createService(componentMeta, componentExt, podSpec, multiNodeEnabled, serviceConfig),
+		ServiceList:  createService(componentMeta, componentExt, podSpec, multiNodeEnabled, serviceConfig, podTemplateHash),
 		componentExt: componentExt,
 	}
 }
@@ -79,6 +81,7 @@ func getAppProtocol(port corev1.ContainerPort) *string {
 
 func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, multiNodeEnabled bool, serviceConfig *v1beta1.ServiceConfig,
+	podTemplateHash string,
 ) []*corev1.Service {
 	var svcList []*corev1.Service
 
@@ -91,10 +94,10 @@ func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compon
 		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
 
-		headSvc := createHeadlessSvc(componentMeta)
+		headSvc := createHeadlessSvc(componentMeta, podTemplateHash)
 		svcList = append(svcList, headSvc)
 
-		workerSvc := createWorkerHeadlessSvc(componentMeta)
+		workerSvc := createWorkerHeadlessSvc(componentMeta, podTemplateHash)
 		svcList = append(svcList, workerSvc)
 	}
 
@@ -188,19 +191,18 @@ func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Com
 	return service
 }
 
-func createWorkerHeadlessSvc(componentMeta metav1.ObjectMeta) *corev1.Service {
+func createWorkerHeadlessSvc(componentMeta metav1.ObjectMeta, podTemplateHash string) *corev1.Service {
 	workerComponentMeta := componentMeta.DeepCopy()
 	predictorSvcName := workerComponentMeta.Name
-	isvcGeneration := componentMeta.GetLabels()[constants.InferenceServiceGenerationPodLabelKey]
-	workerComponentMeta.Name = constants.GetWorkerServiceName(predictorSvcName, isvcGeneration)
+	workerComponentMeta.Name = constants.GetWorkerServiceName(predictorSvcName, podTemplateHash)
 	workerComponentMeta.Labels[constants.MultiNodeRoleLabelKey] = constants.MultiNodeWorker
 
 	service := &corev1.Service{
 		ObjectMeta: *workerComponentMeta,
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app": constants.GetRawWorkerServiceLabel(predictorSvcName),
-				constants.InferenceServiceGenerationPodLabelKey: isvcGeneration,
+				"app":                             constants.GetRawWorkerServiceLabel(predictorSvcName),
+				constants.PodTemplateHashLabelKey: podTemplateHash,
 			},
 			ClusterIP:                "None",
 			PublishNotReadyAddresses: true,
@@ -209,19 +211,18 @@ func createWorkerHeadlessSvc(componentMeta metav1.ObjectMeta) *corev1.Service {
 	return service
 }
 
-func createHeadlessSvc(componentMeta metav1.ObjectMeta) *corev1.Service {
+func createHeadlessSvc(componentMeta metav1.ObjectMeta, podTemplateHash string) *corev1.Service {
 	workerComponentMeta := componentMeta.DeepCopy()
 	predictorSvcName := workerComponentMeta.Name
-	isvcGeneration := componentMeta.GetLabels()[constants.InferenceServiceGenerationPodLabelKey]
-	workerComponentMeta.Name = constants.GetHeadServiceName(predictorSvcName, isvcGeneration)
+	workerComponentMeta.Name = constants.GetHeadServiceName(predictorSvcName, podTemplateHash)
 	workerComponentMeta.Labels[constants.MultiNodeRoleLabelKey] = constants.MultiNodeHead
 
 	service := &corev1.Service{
 		ObjectMeta: *workerComponentMeta,
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app": constants.GetRawServiceLabel(predictorSvcName),
-				constants.InferenceServiceGenerationPodLabelKey: isvcGeneration,
+				"app":                             constants.GetRawServiceLabel(predictorSvcName),
+				constants.PodTemplateHashLabelKey: podTemplateHash,
 			},
 			ClusterIP:                "None", // Without this, it requires a Port but this Service does not need it.
 			PublishNotReadyAddresses: true,
@@ -298,7 +299,86 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context) ([]*corev1.Service, e
 			return nil, opErr
 		}
 	}
+
+	// Clean up old headless services from previous pod template hashes
+	if err := r.cleanupOldHeadlessServices(ctx); err != nil {
+		return nil, err
+	}
+
 	return r.ServiceList, nil
+}
+
+// cleanupOldHeadlessServices removes headless services that belong to the same
+// InferenceService but have a stale pod-template-hash (from a previous rollout).
+func (r *ServiceReconciler) cleanupOldHeadlessServices(ctx context.Context) error {
+	// Collect current head and worker service names
+	currentSvcNames := map[string]bool{}
+	var namespace, isvcName string
+	for _, svc := range r.ServiceList {
+		if svc.Labels != nil {
+			role := svc.Labels[constants.MultiNodeRoleLabelKey]
+			if role == constants.MultiNodeHead || role == constants.MultiNodeWorker {
+				currentSvcNames[svc.Name] = true
+				namespace = svc.Namespace
+				if isvcName == "" {
+					isvcName = svc.Labels[constants.InferenceServicePodLabelKey]
+				}
+			}
+		}
+	}
+	if len(currentSvcNames) == 0 || isvcName == "" {
+		return nil
+	}
+
+	// List all head and worker headless services for this ISVC and delete stale ones
+	for _, role := range []string{constants.MultiNodeHead, constants.MultiNodeWorker} {
+		svcList := &corev1.ServiceList{}
+		if err := r.client.List(ctx, svcList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{
+				constants.MultiNodeRoleLabelKey:       role,
+				constants.InferenceServicePodLabelKey: isvcName,
+			},
+		); err != nil {
+			return err
+		}
+
+		for i := range svcList.Items {
+			if currentSvcNames[svcList.Items[i].Name] {
+				continue
+			}
+			// Skip deletion while pods still use this service as their master address.
+			// PublishNotReadyAddresses is set, so all pods appear in the slice regardless
+			// of readiness; any entry means at least one pod still needs this service.
+			epSliceList := &discoveryv1.EndpointSliceList{}
+			if err := r.client.List(ctx, epSliceList,
+				client.InNamespace(namespace),
+				client.MatchingLabels{discoveryv1.LabelServiceName: svcList.Items[i].Name},
+			); err != nil {
+				log.Error(err, "Failed to list EndpointSlices for stale service, skipping deletion",
+					"name", svcList.Items[i].Name)
+				continue
+			}
+			hasEndpoints := false
+			for _, eps := range epSliceList.Items {
+				if len(eps.Endpoints) > 0 {
+					hasEndpoints = true
+					break
+				}
+			}
+			if hasEndpoints {
+				log.Info("Skipping cleanup of old headless service — endpoints still active",
+					"name", svcList.Items[i].Name)
+				continue
+			}
+			log.Info("Cleaning up old headless service", "name", svcList.Items[i].Name)
+			if err := r.client.Delete(ctx, &svcList.Items[i]); err != nil && !apierr.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // GetServiceList returns all managed services

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -148,8 +148,9 @@ func TestCreateDefaultDeployment(t *testing.T) {
 		"multiNode-service": nil, // populated dynamically below
 	}
 
-	// Compute hash for multiNode test case using the same inputs as production:
-	// ComputeHash(podSpec, isvc.Spec) — podSpec captures SR info, isvc.Spec captures storage URI etc.
+	// Compute hash using the same inputs as production code (podSpec + PredictorSpec).
+	// isvcPredictor is zero-value here — this test verifies hash propagation to
+	// service names/selectors, not hash computation accuracy.
 	multiNodeHash, err := utils.ComputeHash(testInput["multiNode-service"].podSpec, testInput["multiNode-service"].isvcPredictor)
 	require.NoError(t, err)
 	// Set the hash in input componentMeta labels
@@ -365,14 +366,33 @@ func TestServiceSetControllerReferences(t *testing.T) {
 	assert.Equal(t, owner.Name, service2.GetOwnerReferences()[0].Name)
 }
 
-func newHeadSvc(name, namespace, isvcName, hash string) *corev1.Service {
+func newHeadSvc(name, hash string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: "default",
 			Labels: map[string]string{
 				constants.MultiNodeRoleLabelKey:       constants.MultiNodeHead,
-				constants.InferenceServicePodLabelKey: isvcName,
+				constants.InferenceServicePodLabelKey: "my-isvc",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				constants.PodTemplateHashLabelKey: hash,
+			},
+			ClusterIP: "None",
+		},
+	}
+}
+
+func newWorkerSvc(name, hash string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.MultiNodeRoleLabelKey:       constants.MultiNodeWorker,
+				constants.InferenceServicePodLabelKey: "my-isvc",
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -435,8 +455,8 @@ func TestCleanupOldHeadlessServices(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			staleSvc := newHeadSvc(oldSvcName, ns, isvcName, oldHash)
-			currentSvc := newHeadSvc(newSvcName, ns, isvcName, newHash)
+			staleSvc := newHeadSvc(oldSvcName, oldHash)
+			currentSvc := newHeadSvc(newSvcName, newHash)
 			staleEPS := newEndpointSlice(oldSvcName, ns, tc.staleHasEPs)
 
 			cl := fake.NewClientBuilder().
@@ -465,6 +485,84 @@ func TestCleanupOldHeadlessServices(t *testing.T) {
 			assert.True(t, names[newSvcName], "current service must always be kept")
 			assert.Equal(t, tc.expectStaleKept, names[oldSvcName],
 				"stale service presence mismatch")
+		})
+	}
+}
+
+func TestCleanupOldWorkerHeadlessServices(t *testing.T) {
+	const (
+		ns       = "default"
+		isvcName = "my-isvc"
+		oldHash  = "aabbccdd"
+		newHash  = "11223344"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, discoveryv1.AddToScheme(scheme))
+
+	predictorSvcName := constants.PredictorServiceName(isvcName)
+	oldWorkerSvcName := constants.GetWorkerServiceName(predictorSvcName, oldHash)
+	newWorkerSvcName := constants.GetWorkerServiceName(predictorSvcName, newHash)
+	oldHeadSvcName := constants.GetHeadServiceName(predictorSvcName, oldHash)
+	newHeadSvcName := constants.GetHeadServiceName(predictorSvcName, newHash)
+
+	tests := []struct {
+		name                  string
+		staleWorkerHasEPs     bool
+		expectStaleWorkerKept bool
+	}{
+		{
+			name:                  "stale worker service with active endpoints is preserved",
+			staleWorkerHasEPs:     true,
+			expectStaleWorkerKept: true,
+		},
+		{
+			name:                  "stale worker service without endpoints is deleted",
+			staleWorkerHasEPs:     false,
+			expectStaleWorkerKept: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			staleWorkerSvc := newWorkerSvc(oldWorkerSvcName, oldHash)
+			currentWorkerSvc := newWorkerSvc(newWorkerSvcName, newHash)
+			currentHeadSvc := newHeadSvc(newHeadSvcName, newHash)
+			// stale head service with no endpoints — should always be deleted
+			staleHeadSvc := newHeadSvc(oldHeadSvcName, oldHash)
+			staleWorkerEPS := newEndpointSlice(oldWorkerSvcName, ns, tc.staleWorkerHasEPs)
+			staleHeadEPS := newEndpointSlice(oldHeadSvcName, ns, false)
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(staleWorkerSvc, currentWorkerSvc, currentHeadSvc, staleHeadSvc, staleWorkerEPS, staleHeadEPS).
+				Build()
+
+			r := &ServiceReconciler{
+				client: cl,
+				ServiceList: []*corev1.Service{
+					currentHeadSvc,
+					currentWorkerSvc,
+				},
+			}
+
+			err := r.cleanupOldHeadlessServices(context.Background())
+			require.NoError(t, err)
+
+			remaining := &corev1.ServiceList{}
+			require.NoError(t, cl.List(context.Background(), remaining))
+
+			names := make(map[string]bool)
+			for _, s := range remaining.Items {
+				names[s.Name] = true
+			}
+
+			assert.True(t, names[newHeadSvcName], "current head service must always be kept")
+			assert.True(t, names[newWorkerSvcName], "current worker service must always be kept")
+			assert.False(t, names[oldHeadSvcName], "stale head service with no endpoints must be deleted")
+			assert.Equal(t, tc.expectStaleWorkerKept, names[oldWorkerSvcName],
+				"stale worker service presence mismatch")
 		})
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -43,6 +43,7 @@ func TestCreateDefaultDeployment(t *testing.T) {
 		podSpec          *corev1.PodSpec
 		multiNodeEnabled bool
 		podTemplateHash  string
+		isvcPredictor    v1beta1.PredictorSpec
 	}
 
 	testInput := map[string]args{
@@ -147,8 +148,9 @@ func TestCreateDefaultDeployment(t *testing.T) {
 		"multiNode-service": nil, // populated dynamically below
 	}
 
-	// Compute hash for multiNode test case
-	multiNodeHash, err := utils.ComputePodSpecHash(testInput["multiNode-service"].podSpec)
+	// Compute hash for multiNode test case using the same inputs as production:
+	// ComputeHash(podSpec, isvc.Spec) — podSpec captures SR info, isvc.Spec captures storage URI etc.
+	multiNodeHash, err := utils.ComputeHash(testInput["multiNode-service"].podSpec, testInput["multiNode-service"].isvcPredictor)
 	require.NoError(t, err)
 	// Set the hash in input componentMeta labels
 	multiNodeInput := testInput["multiNode-service"]

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -16,18 +16,22 @@ limitations under the License.
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 var emptyServiceConfig = &v1beta1.ServiceConfig{}
@@ -38,6 +42,7 @@ func TestCreateDefaultDeployment(t *testing.T) {
 		componentExt     *v1beta1.ComponentExtensionSpec
 		podSpec          *corev1.PodSpec
 		multiNodeEnabled bool
+		podTemplateHash  string
 	}
 
 	testInput := map[string]args{
@@ -81,10 +86,10 @@ func TestCreateDefaultDeployment(t *testing.T) {
 					"annotation": "annotation-value",
 				},
 				Labels: map[string]string{
-					constants.RawDeploymentAppLabel:                 "isvc.default-predictor",
-					constants.InferenceServicePodLabelKey:           "default-predictor",
-					constants.KServiceComponentLabel:                string(v1beta1.PredictorComponent),
-					constants.InferenceServiceGenerationPodLabelKey: "1",
+					constants.RawDeploymentAppLabel:       "isvc.default-predictor",
+					constants.InferenceServicePodLabelKey: "default-predictor",
+					constants.KServiceComponentLabel:      string(v1beta1.PredictorComponent),
+					constants.PodTemplateHashLabelKey:     "", // will be set below
 				},
 			},
 
@@ -139,82 +144,93 @@ func TestCreateDefaultDeployment(t *testing.T) {
 			},
 			nil,
 		},
-		"multiNode-service": {
-			&corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default-predictor",
-					Namespace: "default-predictor-namespace",
-					Labels: map[string]string{
-						constants.RawDeploymentAppLabel:                 "isvc.default-predictor",
-						constants.KServiceComponentLabel:                "predictor",
-						constants.InferenceServicePodLabelKey:           "default-predictor",
-						constants.InferenceServiceGenerationPodLabelKey: "1",
-					},
-					Annotations: map[string]string{
-						"annotation": "annotation-value",
-					},
+		"multiNode-service": nil, // populated dynamically below
+	}
+
+	// Compute hash for multiNode test case
+	multiNodeHash, err := utils.ComputePodSpecHash(testInput["multiNode-service"].podSpec)
+	require.NoError(t, err)
+	// Set the hash in input componentMeta labels
+	multiNodeInput := testInput["multiNode-service"]
+	multiNodeInput.componentMeta.Labels[constants.PodTemplateHashLabelKey] = multiNodeHash
+	multiNodeInput.podTemplateHash = multiNodeHash
+	testInput["multiNode-service"] = multiNodeInput
+
+	expectedServices["multiNode-service"] = []*corev1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-predictor",
+				Namespace: "default-predictor-namespace",
+				Labels: map[string]string{
+					constants.RawDeploymentAppLabel:       "isvc.default-predictor",
+					constants.KServiceComponentLabel:      "predictor",
+					constants.InferenceServicePodLabelKey: "default-predictor",
+					constants.PodTemplateHashLabelKey:     multiNodeHash,
 				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{
-						{
-							Name:       "default-predictor",
-							Protocol:   corev1.ProtocolTCP,
-							Port:       80,
-							TargetPort: intstr.IntOrString{IntVal: 8080},
-						},
-					},
-					Selector: map[string]string{
-						"app": "isvc.default-predictor",
-					},
+				Annotations: map[string]string{
+					"annotation": "annotation-value",
 				},
 			},
-			&corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default-head-1",
-					Namespace: "default-predictor-namespace",
-					Labels: map[string]string{
-						constants.RawDeploymentAppLabel:                 "isvc.default-predictor",
-						constants.KServiceComponentLabel:                "predictor",
-						constants.InferenceServicePodLabelKey:           "default-predictor",
-						constants.InferenceServiceGenerationPodLabelKey: "1",
-						constants.MultiNodeRoleLabelKey:                 constants.MultiNodeHead,
-					},
-					Annotations: map[string]string{
-						"annotation": "annotation-value",
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "default-predictor",
+						Protocol:   corev1.ProtocolTCP,
+						Port:       80,
+						TargetPort: intstr.IntOrString{IntVal: 8080},
 					},
 				},
-				Spec: corev1.ServiceSpec{
-					Selector: map[string]string{
-						constants.RawDeploymentAppLabel:                 "isvc.default-predictor",
-						constants.InferenceServiceGenerationPodLabelKey: "1",
-					},
-					ClusterIP:                "None",
-					PublishNotReadyAddresses: true,
+				Selector: map[string]string{
+					"app": "isvc.default-predictor",
 				},
 			},
-			&corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "default-workers-1",
-					Namespace: "default-predictor-namespace",
-					Labels: map[string]string{
-						constants.RawDeploymentAppLabel:                 "isvc.default-predictor",
-						constants.KServiceComponentLabel:                "predictor",
-						constants.InferenceServicePodLabelKey:           "default-predictor",
-						constants.InferenceServiceGenerationPodLabelKey: "1",
-						constants.MultiNodeRoleLabelKey:                 constants.MultiNodeWorker,
-					},
-					Annotations: map[string]string{
-						"annotation": "annotation-value",
-					},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.GetHeadServiceName("default-predictor", multiNodeHash),
+				Namespace: "default-predictor-namespace",
+				Labels: map[string]string{
+					constants.RawDeploymentAppLabel:       "isvc.default-predictor",
+					constants.KServiceComponentLabel:      "predictor",
+					constants.InferenceServicePodLabelKey: "default-predictor",
+					constants.PodTemplateHashLabelKey:     multiNodeHash,
+					constants.MultiNodeRoleLabelKey:       constants.MultiNodeHead,
 				},
-				Spec: corev1.ServiceSpec{
-					Selector: map[string]string{
-						"app": "isvc.default-predictor-worker",
-						constants.InferenceServiceGenerationPodLabelKey: "1",
-					},
-					ClusterIP:                "None",
-					PublishNotReadyAddresses: true,
+				Annotations: map[string]string{
+					"annotation": "annotation-value",
 				},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"app":                             "isvc.default-predictor",
+					constants.PodTemplateHashLabelKey: multiNodeHash,
+				},
+				ClusterIP:                "None",
+				PublishNotReadyAddresses: true,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-workers-" + multiNodeHash,
+				Namespace: "default-predictor-namespace",
+				Labels: map[string]string{
+					constants.RawDeploymentAppLabel:       "isvc.default-predictor",
+					constants.KServiceComponentLabel:      "predictor",
+					constants.InferenceServicePodLabelKey: "default-predictor",
+					constants.PodTemplateHashLabelKey:     multiNodeHash,
+					constants.MultiNodeRoleLabelKey:       constants.MultiNodeWorker,
+				},
+				Annotations: map[string]string{
+					"annotation": "annotation-value",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"app":                             "isvc.default-predictor-worker",
+					constants.PodTemplateHashLabelKey: multiNodeHash,
+				},
+				ClusterIP:                "None",
+				PublishNotReadyAddresses: true,
 			},
 		},
 	}
@@ -241,13 +257,14 @@ func TestCreateDefaultDeployment(t *testing.T) {
 				componentExt:     testInput["multiNode-service"].componentExt,
 				podSpec:          testInput["multiNode-service"].podSpec,
 				multiNodeEnabled: testInput["multiNode-service"].multiNodeEnabled,
+				podTemplateHash:  testInput["multiNode-service"].podTemplateHash,
 			},
 			expected: expectedServices["multiNode-service"],
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := createService(tt.args.componentMeta, tt.args.componentExt, tt.args.podSpec, tt.args.multiNodeEnabled, emptyServiceConfig)
+			got := createService(tt.args.componentMeta, tt.args.componentExt, tt.args.podSpec, tt.args.multiNodeEnabled, emptyServiceConfig, tt.args.podTemplateHash)
 			for i, service := range got {
 				if diff := cmp.Diff(tt.expected[i], service); diff != "" {
 					t.Errorf("Test %q unexpected service (-want +got): %v", tt.name, diff)
@@ -299,7 +316,7 @@ func runTestServiceCreate(serviceConfig *v1beta1.ServiceConfig, expectedClusterI
 	componentExt := &v1beta1.ComponentExtensionSpec{}
 	podSpec := &corev1.PodSpec{}
 
-	service := createService(componentMeta, componentExt, podSpec, false, serviceConfig)
+	service := createService(componentMeta, componentExt, podSpec, false, serviceConfig, "")
 	assert.Equal(t, componentMeta, service[0].ObjectMeta, "Expected ObjectMeta to be equal")
 	assert.Equal(t, map[string]string{"app": "isvc.test-service"}, service[0].Spec.Selector, "Expected Selector to be equal")
 	assert.Equal(t, expectedClusterIP, service[0].Spec.ClusterIP, "Expected ClusterIP to be equal")
@@ -344,4 +361,108 @@ func TestServiceSetControllerReferences(t *testing.T) {
 	assert.Equal(t, owner.Name, service1.GetOwnerReferences()[0].Name)
 	assert.Len(t, service2.GetOwnerReferences(), 1)
 	assert.Equal(t, owner.Name, service2.GetOwnerReferences()[0].Name)
+}
+
+func newHeadSvc(name, namespace, isvcName, hash string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.MultiNodeRoleLabelKey:       constants.MultiNodeHead,
+				constants.InferenceServicePodLabelKey: isvcName,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				constants.PodTemplateHashLabelKey: hash,
+			},
+			ClusterIP: "None",
+		},
+	}
+}
+
+func newEndpointSlice(svcName, namespace string, hasEndpoints bool) *discoveryv1.EndpointSlice {
+	eps := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName + "-eps",
+			Namespace: namespace,
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: svcName,
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+	}
+	if hasEndpoints {
+		eps.Endpoints = []discoveryv1.Endpoint{{Addresses: []string{"10.0.0.1"}}}
+	}
+	return eps
+}
+
+func TestCleanupOldHeadlessServices(t *testing.T) {
+	const (
+		ns       = "default"
+		isvcName = "my-isvc"
+		oldHash  = "aabbccdd"
+		newHash  = "11223344"
+	)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, discoveryv1.AddToScheme(scheme))
+
+	oldSvcName := constants.GetHeadServiceName(isvcName+"-predictor", oldHash)
+	newSvcName := constants.GetHeadServiceName(isvcName+"-predictor", newHash)
+
+	tests := []struct {
+		name            string
+		staleHasEPs     bool // whether the stale service has active endpoints
+		expectStaleKept bool // whether the stale service should be preserved
+	}{
+		{
+			name:            "stale service with active endpoints is preserved",
+			staleHasEPs:     true,
+			expectStaleKept: true,
+		},
+		{
+			name:            "stale service without endpoints is deleted",
+			staleHasEPs:     false,
+			expectStaleKept: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			staleSvc := newHeadSvc(oldSvcName, ns, isvcName, oldHash)
+			currentSvc := newHeadSvc(newSvcName, ns, isvcName, newHash)
+			staleEPS := newEndpointSlice(oldSvcName, ns, tc.staleHasEPs)
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(staleSvc, currentSvc, staleEPS).
+				Build()
+
+			r := &ServiceReconciler{
+				client: cl,
+				ServiceList: []*corev1.Service{
+					currentSvc,
+				},
+			}
+
+			err := r.cleanupOldHeadlessServices(context.Background())
+			require.NoError(t, err)
+
+			remaining := &corev1.ServiceList{}
+			require.NoError(t, cl.List(context.Background(), remaining))
+
+			names := make(map[string]bool)
+			for _, s := range remaining.Items {
+				names[s.Name] = true
+			}
+
+			assert.True(t, names[newSvcName], "current service must always be kept")
+			assert.Equal(t, tc.expectStaleKept, names[oldSvcName],
+				"stale service presence mismatch")
+		})
+	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"path/filepath"
@@ -489,18 +490,24 @@ func GetParentDirectory(path string) string {
 	return parentDir
 }
 
-// ComputePodSpecHash computes a FNV-32a hash of the given PodSpec.
+// ComputeHash computes a FNV-32a hash over one or more objects by JSON-marshaling
+// each in order and feeding the bytes into the same hasher.
 // Used for multinode headless service selectors so that rolling updates
 // correctly isolate old and new pods when the pod template changes
-// (e.g., ServingRuntime image updates that don't bump ISVC generation).
-func ComputePodSpecHash(podSpec *corev1.PodSpec) (string, error) {
-	data, err := json.Marshal(podSpec)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal PodSpec: %w", err)
+// (e.g., ServingRuntime image updates or ISVC spec changes like storage URI).
+func ComputeHash(objects ...interface{}) (string, error) {
+	if len(objects) == 0 {
+		return "", errors.New("ComputeHash: at least one object required")
 	}
 	hasher := fnv.New32a()
-	if _, err = hasher.Write(data); err != nil {
-		return "", fmt.Errorf("failed to hash PodSpec: %w", err)
+	for _, obj := range objects {
+		data, err := json.Marshal(obj)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal object: %w", err)
+		}
+		if _, err = hasher.Write(data); err != nil {
+			return "", fmt.Errorf("failed to hash object: %w", err)
+		}
 	}
 	return fmt.Sprintf("%08x", hasher.Sum32()), nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"path/filepath"
 	"strings"
 
@@ -486,4 +487,20 @@ func GetParentDirectory(path string) string {
 	}
 
 	return parentDir
+}
+
+// ComputePodSpecHash computes a FNV-32a hash of the given PodSpec.
+// Used for multinode headless service selectors so that rolling updates
+// correctly isolate old and new pods when the pod template changes
+// (e.g., ServingRuntime image updates that don't bump ISVC generation).
+func ComputePodSpecHash(podSpec *corev1.PodSpec) (string, error) {
+	data, err := json.Marshal(podSpec)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal PodSpec: %w", err)
+	}
+	hasher := fnv.New32a()
+	if _, err = hasher.Write(data); err != nil {
+		return "", fmt.Errorf("failed to hash PodSpec: %w", err)
+	}
+	return fmt.Sprintf("%08x", hasher.Sum32()), nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1162,7 +1162,7 @@ func TestGetGPUResourceQtyByType(t *testing.T) {
 	}
 }
 
-func TestComputePodSpecHash(t *testing.T) {
+func TestComputeHash(t *testing.T) {
 	spec1 := &corev1.PodSpec{
 		Containers: []corev1.Container{
 			{Name: "kserve-container", Image: "image:v1"},
@@ -1174,17 +1174,17 @@ func TestComputePodSpecHash(t *testing.T) {
 		},
 	}
 
-	hash1, err1 := ComputePodSpecHash(spec1)
+	hash1, err1 := ComputeHash(spec1)
 	if err1 != nil {
 		t.Fatalf("unexpected error: %v", err1)
 	}
-	hash2, err2 := ComputePodSpecHash(spec2)
+	hash2, err2 := ComputeHash(spec2)
 	if err2 != nil {
 		t.Fatalf("unexpected error: %v", err2)
 	}
 
 	// Same input produces same hash
-	hash1Again, err := ComputePodSpecHash(spec1)
+	hash1Again, err := ComputeHash(spec1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1198,5 +1198,14 @@ func TestComputePodSpecHash(t *testing.T) {
 	// Hash is 8 hex chars
 	if len(hash1) != 8 {
 		t.Errorf("expected 8 char hash, got %d chars: %s", len(hash1), hash1)
+	}
+
+	// Multiple objects: combining different inputs should differ from single input
+	hashCombined, err := ComputeHash(spec1, spec2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hashCombined == hash1 || hashCombined == hash2 {
+		t.Errorf("combined hash should differ from individual hashes")
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1161,3 +1161,42 @@ func TestGetGPUResourceQtyByType(t *testing.T) {
 		})
 	}
 }
+
+func TestComputePodSpecHash(t *testing.T) {
+	spec1 := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "kserve-container", Image: "image:v1"},
+		},
+	}
+	spec2 := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: "kserve-container", Image: "image:v2"},
+		},
+	}
+
+	hash1, err1 := ComputePodSpecHash(spec1)
+	if err1 != nil {
+		t.Fatalf("unexpected error: %v", err1)
+	}
+	hash2, err2 := ComputePodSpecHash(spec2)
+	if err2 != nil {
+		t.Fatalf("unexpected error: %v", err2)
+	}
+
+	// Same input produces same hash
+	hash1Again, err := ComputePodSpecHash(spec1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash1Again != hash1 {
+		t.Errorf("expected deterministic hash, got different values")
+	}
+	// Different input produces different hash
+	if hash1 == hash2 {
+		t.Errorf("expected different hashes for different specs, both got %s", hash1)
+	}
+	// Hash is 8 hex chars
+	if len(hash1) != 8 {
+		t.Errorf("expected 8 char hash, got %d chars: %s", len(hash1), hash1)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Multinode headless services (`head`, `workers`) used `isvc.generation` as both the selector label and service name suffix. This caused two issues:                                                                    
                                                                                                                                     
  1. **Stale selector on ServingRuntime-only updates** — when only the `ServingRuntime`                                              
     changes (e.g. new image), the ISVC generation doesn't increment. Old and new pods                                               
     share the same `isvc.generation` label, so a single headless service selects pods                                               
     from both rollouts, breaking NCCL/mp rendezvous.                                                                                
                                                                                                                                     
  2. **DNS NXDOMAIN at worker boot** — `Service.Reconcile` ran after `Workload.Reconcile`,                                           
     so new pods could start before their head service existed, causing DNS failures on                                              
     the first connection attempt.                                         

## Changes      
                                                                                                                                     
  **Hash-based service isolation**
  - Replace `isvc.generation` with a FNV-32a hash of the head `PodSpec`
    (`serving.kserve.io/pod-template-hash`).  
  - Hash is recomputed after all head env vars are set, so it changes whenever the
    effective pod template changes — even on ServingRuntime-only updates.
  - Head and worker services are named `<isvc>-head-<hash>` / `<isvc>-workers-<hash>`,                                               
    and their selectors use the same hash label.                                                                                     
  - Worker pods receive `HEAD_SVC=<isvc>-head-<hash>` so they always connect to the                                                  
    matching head.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

added unit tests

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
 **Breaking change** (multinode RawDeployment only): existing multinode  InferenceServices will undergo a one-time rolling restart when upgrading  to this version. No action is required — the restart is automatic.              
```
