### PR TITLE
fix(llmisvc): shorten webhook name to comply with 63-char label limit

### DIFF
--- a/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
@@ -1913,7 +1913,7 @@ webhooks:
       path: /validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig
   failurePolicy: Fail
   matchPolicy: Exact
-  name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator
+  name: llmisvcconfig.kserve-webhook-server.v1alpha2.validator
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -1936,7 +1936,7 @@ webhooks:
       path: /validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig
   failurePolicy: Fail
   matchPolicy: Exact
-  name: llminferenceserviceconfig.kserve-webhook-server.v1alpha1.validator
+  name: llmisvcconfig.kserve-webhook-server.v1alpha1.validator
   rules:
   - apiGroups:
     - serving.kserve.io

--- a/config/llmisvc/llmisvcconfig_validatingwebhook_cainjection_patch.yaml
+++ b/config/llmisvc/llmisvcconfig_validatingwebhook_cainjection_patch.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(kserveNamespace)/llmisvc-serving-cert
 webhooks:
-  - name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator
+  - name: llmisvcconfig.kserve-webhook-server.v1alpha2.validator

--- a/config/webhook/llmisvc/manifests.yaml
+++ b/config/webhook/llmisvc/manifests.yaml
@@ -58,7 +58,7 @@ webhooks:
         path: /validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig
     failurePolicy: Fail
     matchPolicy: Exact
-    name: llminferenceserviceconfig.kserve-webhook-server.v1alpha1.validator
+    name: llmisvcconfig.kserve-webhook-server.v1alpha1.validator
     sideEffects: None
     admissionReviewVersions: [ "v1", "v1beta1" ]
     rules:
@@ -79,7 +79,7 @@ webhooks:
         path: /validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig
     failurePolicy: Fail
     matchPolicy: Exact
-    name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator
+    name: llmisvcconfig.kserve-webhook-server.v1alpha2.validator
     sideEffects: None
     admissionReviewVersions: [ "v1", "v1beta1" ]
     rules:

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_config_validation.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_config_validation.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kserve/kserve/pkg/utils"
 )
 
-// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha1,name=llminferenceserviceconfig.kserve-webhook-server.v1alpha1.validator,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha1,name=llmisvcconfig.kserve-webhook-server.v1alpha1.validator,admissionReviewVersions=v1
 
 // LLMInferenceServiceConfigValidator is responsible for validating the LLMInferenceServiceConfig resource
 // when it is created, updated, or deleted.

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kserve/kserve/pkg/utils"
 )
 
-// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha2,name=llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha2,name=llmisvcconfig.kserve-webhook-server.v1alpha2.validator,admissionReviewVersions=v1
 
 // LLMInferenceServiceConfigValidator is responsible for validating the LLMInferenceServiceConfig resource
 // when it is created, updated, or deleted.

--- a/test/webhooks/manifests.yaml
+++ b/test/webhooks/manifests.yaml
@@ -40,7 +40,7 @@ webhooks:
         path: /validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig
     failurePolicy: Fail
     sideEffects: None
-    name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator
+    name: llmisvcconfig.kserve-webhook-server.v1alpha2.validator
     rules:
       - apiGroups:
           - serving.kserve.io


### PR DESCRIPTION
The LLMInferenceServiceConfig validating webhook name `llminferenceserviceconfig.kserve-webhook-server.v1alpha{1,2}.validator` was 66 characters, exceeding the Kubernetes 63-character label value limit. This caused OLM CSV installation to fail as it uses the webhook name as a generateName label value.

Shortened to `llmisvcconfig.kserve-webhook-server.v1alpha{1,2}.validator` (54 chars).

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**

- [ ] Test A
- [ ] Test B

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note

```
