### PR TITLE
fix: gate ClusterServingRuntime on CRD availability

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kserve/kserve/pkg/controller/v1alpha1/trainedmodel/reconcilers/modelconfig"
 	v1beta1controller "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
+	kserveutils "github.com/kserve/kserve/pkg/utils"
 	"github.com/kserve/kserve/pkg/webhook/admission/pod"
 	"github.com/kserve/kserve/pkg/webhook/admission/servingruntime"
 )
@@ -225,10 +226,17 @@ func main() {
 		Handler: &pod.Mutator{Client: mgr.GetClient(), Clientset: clientSet, Decoder: admission.NewDecoder(mgr.GetScheme())},
 	})
 
-	setupLog.Info("registering cluster serving runtime validator webhook to the webhook server")
-	hookServer.Register("/validate-serving-kserve-io-v1alpha1-clusterservingruntime", &webhook.Admission{
-		Handler: &servingruntime.ClusterServingRuntimeValidator{Client: mgr.GetClient(), Decoder: admission.NewDecoder(mgr.GetScheme())},
-	})
+	csrAvailable, err := kserveutils.IsCrdAvailable(mgr.GetConfig(), v1alpha1.SchemeGroupVersion.String(), "ClusterServingRuntime")
+	if err != nil {
+		setupLog.Error(err, "failed to check ClusterServingRuntime CRD availability")
+		os.Exit(1)
+	}
+	if csrAvailable {
+		setupLog.Info("registering cluster serving runtime validator webhook to the webhook server")
+		hookServer.Register("/validate-serving-kserve-io-v1alpha1-clusterservingruntime", &webhook.Admission{
+			Handler: &servingruntime.ClusterServingRuntimeValidator{Client: mgr.GetClient(), Decoder: admission.NewDecoder(mgr.GetScheme())},
+		})
+	}
 
 	setupLog.Info("registering serving runtime validator webhook to the webhook server")
 	hookServer.Register("/validate-serving-kserve-io-v1alpha1-servingruntime", &webhook.Admission{

--- a/pkg/apis/serving/v1beta1/predictor_model.go
+++ b/pkg/apis/serving/v1beta1/predictor_model.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -98,7 +99,10 @@ func (m *ModelSpec) GetSupportingRuntimes(ctx context.Context, cl client.Client,
 	// List all cluster-scoped runtimes.
 	clusterRuntimes := &v1alpha1.ClusterServingRuntimeList{}
 	if err := cl.List(ctx, clusterRuntimes); err != nil {
-		return nil, err
+		if !apimeta.IsNoMatchError(err) {
+			return nil, err
+		}
+		// CSR CRD not installed - treat as empty.
 	}
 	// Sort cluster-scoped runtimes by created timestamp desc and name asc.
 	sortClusterServingRuntimeList(clusterRuntimes)

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -709,10 +709,20 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 		ctrlBuilder = ctrlBuilder.Owns(&netv1.Ingress{})
 	}
 
-	return ctrlBuilder.Watches(&v1alpha1.ServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.servingRuntimeFunc), builder.WithPredicates(servingRuntimesPredicate())).
-		Watches(&v1alpha1.ClusterServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.clusterServingRuntimeFunc), builder.WithPredicates(clusterServingRuntimesPredicate())).
-		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.podInitContainersFunc), builder.WithPredicates(podInitContainersPredicate())).
-		Complete(r)
+	ctrlBuilder = ctrlBuilder.Watches(&v1alpha1.ServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.servingRuntimeFunc), builder.WithPredicates(servingRuntimesPredicate())).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.podInitContainersFunc), builder.WithPredicates(podInitContainersPredicate()))
+
+	csrFound, err := utils.IsCrdAvailable(r.ClientConfig, v1alpha1.SchemeGroupVersion.String(), "ClusterServingRuntime")
+	if err != nil {
+		return err
+	}
+	if csrFound {
+		ctrlBuilder = ctrlBuilder.Watches(&v1alpha1.ClusterServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.clusterServingRuntimeFunc), builder.WithPredicates(clusterServingRuntimesPredicate()))
+	} else {
+		r.Log.Info("The InferenceService controller won't watch serving.kserve.io/v1alpha1/ClusterServingRuntime resources because the CRD is not available.")
+	}
+
+	return ctrlBuilder.Complete(r)
 }
 
 func (r *InferenceServiceReconciler) deleteExternalResources(ctx context.Context, isvc *v1beta1.InferenceService) error {

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -30,6 +30,7 @@ import (
 	goerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -336,7 +337,7 @@ func GetServingRuntime(ctx context.Context, cl client.Client, name string, names
 	err = cl.Get(ctx, client.ObjectKey{Name: name}, clusterRuntime)
 	if err == nil {
 		return &clusterRuntime.Spec, clusterRuntime.Annotations, nil, true
-	} else if !apierrors.IsNotFound(err) {
+	} else if !apierrors.IsNotFound(err) && !apimeta.IsNoMatchError(err) {
 		return nil, nil, err, false
 	}
 	return nil, nil, goerrors.New("No ServingRuntimes or ClusterServingRuntimes with the name: " + name), false


### PR DESCRIPTION
**What this PR does / why we need it**:

Applies the existing `IsCrdAvailable` pattern (already used for Knative, KEDA, OTel, and Gateway API) to `ClusterServingRuntime`. In some distributions, the CSR CRD is not installed - making it an optional dependency. Without these guards, the controller panics or errors out in those environments.

Three callsites are covered:

- `cmd/manager/main.go`: skip CSR webhook registration when CRD is absent
- `pkg/controller/v1beta1/inferenceservice/controller.go`: skip CSR watch at startup
- `pkg/apis/serving/v1beta1/predictor_model.go`: treat `NoMatchError` as empty list when listing `ClusterServingRuntime`s
- `pkg/controller/v1beta1/inferenceservice/utils/utils.go`: treat `NoMatchError` as not-found when getting a named `ClusterServingRuntime`

The guards are a no-op in standard kserve deployments where the CSR CRD is always present.

**Which issue(s) this PR fixes**:
Fixes #


**Feature/Issue validation/testing**:

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] No behavior change in standard deployments - CSR CRD is always present there, guards never trigger

**Special notes for your reviewer**:

Uses the same `IsCrdAvailable` pattern already in use for Knative, KEDA, OTel, and Gateway API. Port of opendatahub-io/kserve#1327.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```