### PR TITLE
fix: intermittent 403 Forbidden errors during S3 model download

### DIFF
--- a/python/storage/kserve_storage/kserve_storage.py
+++ b/python/storage/kserve_storage/kserve_storage.py
@@ -377,7 +377,8 @@ class Storage(object):
             import boto3
 
             kwargs = Storage._get_s3_client_kwargs()
-            _worker_s3_resource = boto3.resource("s3", **kwargs)
+            session = boto3.Session()
+            _worker_s3_resource = session.resource("s3", **kwargs)
         except Exception as e:
             logger.error(f"Failed to initialize S3 worker: {e}")
             _worker_s3_resource = None

--- a/python/storage/test/test_s3_storage.py
+++ b/python/storage/test/test_s3_storage.py
@@ -53,6 +53,14 @@ class MockPool:
 # Mock multiprocessing.Pool globally for all S3 tests
 mock.patch("kserve_storage.kserve_storage.multiprocessing.Pool", MockPool).start()
 
+class MockSession:
+    def resource(self, *args, **kwargs):
+        import boto3
+        return boto3.resource(*args, **kwargs)
+
+# Mock boto3.Session globally so it returns a session that forwards resource() to the patched boto3.resource
+mock.patch("boto3.Session", return_value=MockSession()).start()
+
 
 def create_mock_obj(path):
     mock_obj = mock.MagicMock()

--- a/python/storage/test/test_s3_storage.py
+++ b/python/storage/test/test_s3_storage.py
@@ -53,10 +53,13 @@ class MockPool:
 # Mock multiprocessing.Pool globally for all S3 tests
 mock.patch("kserve_storage.kserve_storage.multiprocessing.Pool", MockPool).start()
 
+
 class MockSession:
     def resource(self, *args, **kwargs):
         import boto3
+
         return boto3.resource(*args, **kwargs)
+
 
 # Mock boto3.Session globally so it returns a session that forwards resource() to the patched boto3.resource
 mock.patch("boto3.Session", return_value=MockSession()).start()


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes intermittent 403 Forbidden and AccessDenied errors during S3 model downloads.

boto3 relies on botocore, which maintains a connection pool (urllib3) under the hood. When Python's multiprocessing forks a new worker process, the child process inherits the parent's memory space, including the default boto3 session and its open SSL sockets. If multiple worker processes try to read/write concurrently using the same shared SSL socket, the byte streams get interleaved. This corrupts the SSL state and leads to errors like BadStatusLine or SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC.

**Feature/Issue validation/testing**:

Tested via local stress-tester script.