### PR TITLE
ci: add stale bot to warn 3 times before closing inactive issues and PRs

### DIFF
--- a/.github/workflows/stalebot-reset.yml
+++ b/.github/workflows/stalebot-reset.yml
@@ -1,0 +1,65 @@
+name: Reset Stale Labels
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [labeled, assigned]
+  pull_request:
+    types: [synchronize, review_requested]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  reset-stale-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const staleLabels = ['stale-warning-1', 'stale-warning-2', 'stale-warning-3', 'stale-closed'];
+            let issueNumber, currentLabels;
+
+            if (context.payload.issue) {
+              issueNumber = context.payload.issue.number;
+              currentLabels = context.payload.issue.labels.map(l => l.name);
+            } else if (context.payload.pull_request) {
+              issueNumber = context.payload.pull_request.number;
+              currentLabels = context.payload.pull_request.labels.map(l => l.name);
+            } else {
+              core.info('No issue or pull request found in payload, skipping.');
+              return;
+            }
+
+            // Skip if the comment was made by github-actions bot to avoid
+            // the stale bot's own comments from resetting the labels.
+            if (context.payload.comment && context.payload.comment.user.login === 'github-actions[bot]') {
+              core.info('Comment by github-actions bot, skipping label reset.');
+              return;
+            }
+
+            const labelsToRemove = currentLabels.filter(l => staleLabels.includes(l));
+            if (labelsToRemove.length === 0) {
+              core.info('No stale labels found, nothing to reset.');
+              return;
+            }
+
+            for (const label of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label
+                });
+                core.info(`Removed label: ${label}`);
+              } catch (error) {
+                core.warning(`Failed to remove label ${label}: ${error.message}`);
+              }
+            }

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,0 +1,123 @@
+name: Stale Bot
+
+on:
+  schedule:
+    # Run every day at midnight UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale-warning-1:
+    name: "First stale warning"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          days-before-stale: 30
+          days-before-close: -1
+          stale-issue-label: stale-warning-1
+          stale-pr-label: stale-warning-1
+          exempt-issue-labels: ignore-stale,stale-warning-1,stale-warning-2,stale-warning-3
+          exempt-pr-labels: ignore-stale,stale-warning-1,stale-warning-2,stale-warning-3
+          stale-issue-message: >
+            This issue has been automatically detected as stale because it has
+            not had any activity for 30 days. It will receive two more warnings
+            before being automatically closed. If this issue is still relevant,
+            please comment or remove the stale label. Add the `ignore-stale`
+            label to keep this issue open indefinitely.
+            **Warning 1 of 3.**
+          stale-pr-message: >
+            This pull request has been automatically detected as stale because
+            it has not had any activity for 30 days. It will receive two more
+            warnings before being automatically closed. If this pull request is
+            still relevant, please comment or remove the stale label. Add the
+            `ignore-stale` label to keep this pull request open indefinitely.
+            **Warning 1 of 3.**
+          operations-per-run: 100
+
+  stale-warning-2:
+    name: "Second stale warning"
+    needs: stale-warning-1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          days-before-stale: 1
+          days-before-close: -1
+          only-labels: stale-warning-1
+          stale-issue-label: stale-warning-2
+          stale-pr-label: stale-warning-2
+          remove-stale-when-updated: true
+          exempt-issue-labels: ignore-stale,stale-warning-2,stale-warning-3
+          exempt-pr-labels: ignore-stale,stale-warning-2,stale-warning-3
+          stale-issue-message: >
+            This issue is still stale. It will receive one more warning before
+            being automatically closed. Please comment or remove the stale
+            labels if this issue is still relevant. Add the `ignore-stale` label
+            to keep this issue open indefinitely.
+            **Warning 2 of 3.**
+          stale-pr-message: >
+            This pull request is still stale. It will receive one more warning
+            before being automatically closed. Please comment or remove the
+            stale labels if this pull request is still relevant. Add the
+            `ignore-stale` label to keep this pull request open indefinitely.
+            **Warning 2 of 3.**
+          operations-per-run: 100
+
+  stale-warning-3:
+    name: "Third stale warning"
+    needs: stale-warning-2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          days-before-stale: 1
+          days-before-close: -1
+          only-labels: stale-warning-2
+          stale-issue-label: stale-warning-3
+          stale-pr-label: stale-warning-3
+          remove-stale-when-updated: true
+          exempt-issue-labels: ignore-stale,stale-warning-3
+          exempt-pr-labels: ignore-stale,stale-warning-3
+          stale-issue-message: >
+            This is the **final warning**. This issue will be automatically
+            closed if there is no activity within the next day. Please comment
+            or remove the stale labels if this issue is still relevant. Add the
+            `ignore-stale` label to keep this issue open indefinitely.
+            **Warning 3 of 3.**
+          stale-pr-message: >
+            This is the **final warning**. This pull request will be
+            automatically closed if there is no activity within the next day.
+            Please comment or remove the stale labels if this pull request is
+            still relevant. Add the `ignore-stale` label to keep this pull
+            request open indefinitely.
+            **Warning 3 of 3.**
+          operations-per-run: 100
+
+  close-stale:
+    name: "Close stale issues and PRs"
+    needs: stale-warning-3
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          days-before-stale: 1
+          days-before-close: 0
+          only-labels: stale-warning-3
+          stale-issue-label: stale-closed
+          stale-pr-label: stale-closed
+          exempt-issue-labels: ignore-stale
+          exempt-pr-labels: ignore-stale
+          close-issue-message: >
+            This issue has been automatically closed after 3 warnings with no
+            activity. If you believe this issue is still relevant, feel free to
+            reopen it.
+          close-pr-message: >
+            This pull request has been automatically closed after 3 warnings
+            with no activity. If you believe this pull request is still
+            relevant, feel free to reopen it.
+          operations-per-run: 100


### PR DESCRIPTION
## Summary

- Adds a daily GitHub Actions stale bot (`stalebot.yml`) that detects issues and PRs with no activity for 30+ days
- Issues 3 sequential warnings (one per day after becoming stale) before automatically closing on the 4th day
- Items labeled `ignore-stale` are exempt from all stale processing
- Adds a companion workflow (`stalebot-reset.yml`) that removes all stale warning labels when real activity is detected (comments, PR syncs, reviews), preventing bot comments from resetting the cycle

### Warning timeline for inactive items

| Day | Action |
|-----|--------|
| 30  | Warning 1 of 3 |
| 31  | Warning 2 of 3 |
| 32  | Warning 3 of 3 (final) |
| 33  | Automatically closed |