### PR TITLE
revert(llmisvc): restore original webhook names, reverts #5381

### DIFF
--- a/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
@@ -1928,7 +1928,7 @@ webhooks:
       path: /validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig
   failurePolicy: Fail
   matchPolicy: Exact
-  name: llmisvcconfig.kserve-webhook-server.v1alpha2.validator
+  name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator
   rules:
   - apiGroups:
     - serving.kserve.io
@@ -1951,7 +1951,7 @@ webhooks:
       path: /validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig
   failurePolicy: Fail
   matchPolicy: Exact
-  name: llmisvcconfig.kserve-webhook-server.v1alpha1.validator
+  name: llminferenceserviceconfig.kserve-webhook-server.v1alpha1.validator
   rules:
   - apiGroups:
     - serving.kserve.io

--- a/config/llmisvc/llmisvcconfig_validatingwebhook_cainjection_patch.yaml
+++ b/config/llmisvc/llmisvcconfig_validatingwebhook_cainjection_patch.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(kserveNamespace)/llmisvc-serving-cert
 webhooks:
-  - name: llmisvcconfig.kserve-webhook-server.v1alpha2.validator
+  - name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator

--- a/config/webhook/llmisvc/manifests.yaml
+++ b/config/webhook/llmisvc/manifests.yaml
@@ -58,7 +58,7 @@ webhooks:
         path: /validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig
     failurePolicy: Fail
     matchPolicy: Exact
-    name: llmisvcconfig.kserve-webhook-server.v1alpha1.validator
+    name: llminferenceserviceconfig.kserve-webhook-server.v1alpha1.validator
     sideEffects: None
     admissionReviewVersions: [ "v1", "v1beta1" ]
     rules:
@@ -79,7 +79,7 @@ webhooks:
         path: /validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig
     failurePolicy: Fail
     matchPolicy: Exact
-    name: llmisvcconfig.kserve-webhook-server.v1alpha2.validator
+    name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator
     sideEffects: None
     admissionReviewVersions: [ "v1", "v1beta1" ]
     rules:

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_config_validation.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_config_validation.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kserve/kserve/pkg/utils"
 )
 
-// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha1,name=llmisvcconfig.kserve-webhook-server.v1alpha1.validator,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha1,name=llminferenceserviceconfig.kserve-webhook-server.v1alpha1.validator,admissionReviewVersions=v1
 
 // LLMInferenceServiceConfigValidator is responsible for validating the LLMInferenceServiceConfig resource
 // when it is created, updated, or deleted.

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kserve/kserve/pkg/utils"
 )
 
-// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha2,name=llmisvcconfig.kserve-webhook-server.v1alpha2.validator,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha2,name=llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator,admissionReviewVersions=v1
 
 // LLMInferenceServiceConfigValidator is responsible for validating the LLMInferenceServiceConfig resource
 // when it is created, updated, or deleted.

--- a/test/webhooks/manifests.yaml
+++ b/test/webhooks/manifests.yaml
@@ -40,7 +40,7 @@ webhooks:
         path: /validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig
     failurePolicy: Fail
     sideEffects: None
-    name: llmisvcconfig.kserve-webhook-server.v1alpha2.validator
+    name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator
     rules:
       - apiGroups:
           - serving.kserve.io


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts #5381, which shortened the `ValidatingWebhookConfiguration` webhook names for `LLMInferenceServiceConfig` from `llminferenceserviceconfig.kserve-webhook-server.{v1alpha1,v1alpha2}.validator` to `llmisvcconfig.*`.

Renaming a webhook entry is a breaking change for any cluster with LLMInferenceService already deployed. When the webhook name changes, the old entry is not automatically removed during an upgrade. With OLM-managed operators in particular, the old `ValidatingWebhookConfiguration` entry can persist alongside the new one, causing every admission request for `LLMInferenceServiceConfig` to be evaluated twice - once by each webhook.

The 63-char label value limit that motivated #5381 is an OLM-side concern: OLM should sanitize (e.g. via hashing) the label values it derives from webhook names, not require upstream to rename the webhook itself. Fixing it by shortening the name just moves the problem while introducing a silent breaking upgrade.

**Feature/Issue validation/testing**:

- [ ] Verified webhook names are restored to their original values across all manifests and Go kubebuilder markers

**Special notes for your reviewer**:

The 63-char label limit is and the fix belongs on the OLM side (label sanitization/hashing), not here.

**Release note**:
```release-note
NONE
```