### PR TITLE
fix: vllm ServingEmbedding doesn't have the create_embedding method

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
@@ -31,6 +31,7 @@ from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.cli_args import validate_parsed_serve_args
 from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse as engineError
+from vllm.exceptions import VLLMValidationError
 from vllm.reasoning import ReasoningParserManager
 
 from kserve.protocol.rest.openai.errors import create_error_response
@@ -298,9 +299,13 @@ class VLLMModel(OpenAIEncoderModel, OpenAIGenerativeModel):  # pylint:disable=c-
                 message="The model does not support Embeddings API",
                 status_code=HTTPStatus.BAD_REQUEST,
             )
-        response = await self.openai_serving_embedding.create_embedding(
-            request, raw_request
-        )
+        try:
+            response = await self.openai_serving_embedding(request, raw_request)
+        except VLLMValidationError as e:
+            return create_error_response(
+                message=str(e),
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
 
         if isinstance(response, engineError):
             return create_error_response(

--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
@@ -31,6 +31,7 @@ from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.cli_args import validate_parsed_serve_args
 from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse as engineError
+from vllm.exceptions import VLLMValidationError
 from vllm.reasoning import ReasoningParserManager
 
 from kserve.protocol.rest.openai.errors import create_error_response
@@ -298,7 +299,13 @@ class VLLMModel(OpenAIEncoderModel, OpenAIGenerativeModel):  # pylint:disable=c-
                 message="The model does not support Embeddings API",
                 status_code=HTTPStatus.BAD_REQUEST,
             )
-        response = await self.openai_serving_embedding(request, raw_request)
+        try:
+            response = await self.openai_serving_embedding(request, raw_request)
+        except VLLMValidationError as e:
+            return create_error_response(
+                message=str(e),
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
 
         if isinstance(response, engineError):
             return create_error_response(

--- a/python/huggingfaceserver/tests/test_vllm_embeddings.py
+++ b/python/huggingfaceserver/tests/test_vllm_embeddings.py
@@ -1,0 +1,115 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import requests
+
+from kserve.protocol.rest.openai.types import Embedding
+from server import RemoteOpenAIServer
+
+
+MODEL = "intfloat/e5-small"
+MODEL_NAME = "test-model"
+
+
+@pytest.fixture(scope="module")
+def server():  # noqa: F811
+    args = [
+        # use half precision for speed and memory savings in CI environment
+        "--dtype",
+        "bfloat16",
+        "--enforce-eager",
+    ]
+
+    with RemoteOpenAIServer(MODEL, MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
+async def test_embed_texts(server: RemoteOpenAIServer, model_name: str):
+    inputs = [
+        "Hello, how are you?",
+        "The quick brown fox jumps over the lazy dog",
+    ]
+
+    embed_response = requests.post(
+        server.url_for("openai/v1", "embeddings"),
+        json={
+            "model": model_name,
+            "input": inputs,
+            "encoding_format": "float",
+        },
+    )
+    embed_response.raise_for_status()
+    embedding = Embedding.model_validate(embed_response.json())
+
+    assert embedding.object == "list"
+    assert embedding.model is not None
+    assert len(embedding.data) == 2
+    for i, item in enumerate(embedding.data):
+        assert item.index == i
+        assert item.object == "embedding"
+        assert isinstance(item.embedding, list)
+        assert len(item.embedding) > 0
+        assert all(isinstance(v, float) for v in item.embedding)
+    assert embedding.usage.prompt_tokens > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
+async def test_embed_single_text(server: RemoteOpenAIServer, model_name: str):
+    embed_response = requests.post(
+        server.url_for("openai/v1", "embeddings"),
+        json={
+            "model": model_name,
+            "input": "Hello, how are you?",
+            "encoding_format": "float",
+        },
+    )
+    embed_response.raise_for_status()
+    embedding = Embedding.model_validate(embed_response.json())
+
+    assert embedding.object == "list"
+    assert len(embedding.data) == 1
+    assert embedding.data[0].object == "embedding"
+    assert isinstance(embedding.data[0].embedding, list)
+    assert len(embedding.data[0].embedding) > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
+async def test_embed_max_model_len(server: RemoteOpenAIServer, model_name: str):
+    # Sending a very long input should return a 400 error
+    long_input = "Hello, how are you? " * 1000
+
+    embed_response = requests.post(
+        server.url_for("openai/v1", "embeddings"),
+        json={
+            "model": model_name,
+            "input": long_input,
+            "encoding_format": "float",
+        },
+    )
+    assert embed_response.status_code == 400


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the vLLM embeddings endpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5399


**Feature/Issue validation/testing**:

Same steps mentioned in #5399 + added tests:

```bash
uv sync --all-groups
uv run pytest tests/test_vllm_embeddings.py
```

**Special notes for your reviewer**:

**Checklist**:

- [X] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
NONE
```
