### PR TITLE
build: add GOTAGS build arg to manager and agent Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM deps AS builder
 
 ARG CMD=manager
+ARG GOTAGS=""
 COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o manager ./cmd/${CMD}
+    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -tags "${GOTAGS}" -a -o manager ./cmd/${CMD}
 
 # ---- License stage (parallel with build on BuildKit) ----
 FROM deps AS license

--- a/agent.Dockerfile
+++ b/agent.Dockerfile
@@ -11,11 +11,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM deps AS builder
 
 ARG CMD=agent
+ARG GOTAGS=""
 COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o agent ./cmd/${CMD}
+    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -tags "${GOTAGS}" -a -o agent ./cmd/${CMD}
 
 # ---- License stage (parallel with build on BuildKit) ----
 FROM deps AS license


### PR DESCRIPTION
**What this PR does / why we need it**:

Downstreams that gate platform-specific code behind Go build tags have no way to pass those tags into the Docker build. Without this hook, `go build` inside Docker always uses the default tag set, so any feature behind `//go:build <tag>` is silently compiled out - the binary behaves differently from what `GOTAGS=<tag> make build` produces.

Adds `ARG GOTAGS=""` to the builder stage of the manager and agent Dockerfiles and threads it through to `go build -tags "${GOTAGS}"`. The default is empty, preserving identical behaviour for all existing upstream builds. Downstreams pass `--build-arg GOTAGS=<tag>` to opt in.

**Feature/Issue validation/testing**:

- [x] Default build (`docker build .`) produces identical binary - `ARG GOTAGS=""` with empty tag is a no-op for `go build`
- [x] `docker build --build-arg GOTAGS=sometag .` compiles with the tag applied

**Special notes for your reviewer**:

This is a minimal, non-breaking addition. No existing builds change behaviour. The motivation comes from downstream usage but the mechanism is generic and useful for anyone working with build-tag-gated features.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

```release-note
NONE
```