### PR TITLE
feat(llmisvc): surface specific ConfigNotFound condition

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -433,22 +433,38 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 	return out, nil
 }
 
+// configNotFoundError is returned by getConfig when an LLMInferenceServiceConfig
+// cannot be found in either the service namespace or the system namespace.
+// It carries the config name and the ordered list of namespaces that were searched.
+// TODO: extend Error() to list the LLMInferenceServiceConfig resources that do exist
+// in the searched namespaces, so the operator can see available alternatives at a glance.
+type configNotFoundError struct {
+	Name       string
+	Namespaces []string
+}
+
+func (e *configNotFoundError) Error() string {
+	return fmt.Sprintf("LLMInferenceServiceConfig %q not found in namespaces %v", e.Name, e.Namespaces)
+}
+
 // getConfig retrieves kserveapis.LLMInferenceServiceConfig with the given name from either the kserveapis.LLMInferenceService
 // namespace or from the SystemNamespace (e.g. 'kserve'), prioritizing the former.
 // This allows for both global default configs and service-specific overrides.
 func (r *LLMISVCReconciler) getConfig(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, name string) (*v1alpha2.LLMInferenceServiceConfig, error) {
 	cfg := &v1alpha2.LLMInferenceServiceConfig{}
 	if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: llmSvc.Namespace}, cfg); err != nil {
-		if apierrors.IsNotFound(err) {
-			cfg = &v1alpha2.LLMInferenceServiceConfig{}
-			if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: constants.KServeNamespace}, cfg); err != nil {
-				// TODO: add available LLMInferenceServiceConfig in system namespace and llmSvc.Namespace namespace if not found
-
-				return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w", name, llmSvc.Namespace, constants.KServeNamespace, err)
-			}
-			return cfg, nil
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %s/%s: %w", llmSvc.Namespace, name, err)
 		}
-		return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %s/%s: %w", llmSvc.Namespace, name, err)
+		cfg = &v1alpha2.LLMInferenceServiceConfig{}
+		if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: constants.KServeNamespace}, cfg); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, &configNotFoundError{Name: name, Namespaces: []string{llmSvc.Namespace, constants.KServeNamespace}}
+			}
+			return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w",
+				name, llmSvc.Namespace, constants.KServeNamespace, err)
+		}
+		return cfg, nil
 	}
 	return cfg, nil
 }

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -132,6 +133,11 @@ func (r *LLMISVCReconciler) reconcileBaseRefs(ctx context.Context, llmSvc *v1alp
 				Spec: *llmSvc.Spec.DeepCopy(),
 			}
 			return baseCfg, nil
+		}
+		var cfgNotFound *configNotFoundError
+		if errors.As(err, &cfgNotFound) {
+			llmSvc.MarkPresetsCombinedNotReady("ConfigNotFound", cfgNotFound.Error())
+			return nil, nil // watch on LLMInferenceServiceConfig re-triggers when the config is recreated
 		}
 
 		llmSvc.MarkPresetsCombinedNotReady("CombineBaseError", err.Error())
@@ -454,22 +460,38 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 	return out, nil
 }
 
+// configNotFoundError is returned by getConfig when an LLMInferenceServiceConfig
+// cannot be found in either the service namespace or the system namespace.
+// It carries the config name and the ordered list of namespaces that were searched.
+// TODO: extend Error() to list the LLMInferenceServiceConfig resources that do exist
+// in the searched namespaces, so the operator can see available alternatives at a glance.
+type configNotFoundError struct {
+	Name       string
+	Namespaces []string
+}
+
+func (e *configNotFoundError) Error() string {
+	return fmt.Sprintf("LLMInferenceServiceConfig %q not found in namespaces %v", e.Name, e.Namespaces)
+}
+
 // getConfig retrieves kserveapis.LLMInferenceServiceConfig with the given name from either the kserveapis.LLMInferenceService
 // namespace or from the SystemNamespace (e.g. 'kserve'), prioritizing the former.
 // This allows for both global default configs and service-specific overrides.
 func (r *LLMISVCReconciler) getConfig(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, name string) (*v1alpha2.LLMInferenceServiceConfig, error) {
 	cfg := &v1alpha2.LLMInferenceServiceConfig{}
 	if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: llmSvc.Namespace}, cfg); err != nil {
-		if apierrors.IsNotFound(err) {
-			cfg = &v1alpha2.LLMInferenceServiceConfig{}
-			if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: constants.KServeNamespace}, cfg); err != nil {
-				// TODO: add available LLMInferenceServiceConfig in system namespace and llmSvc.Namespace namespace if not found
-
-				return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w", name, llmSvc.Namespace, constants.KServeNamespace, err)
-			}
-			return cfg, nil
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %s/%s: %w", llmSvc.Namespace, name, err)
 		}
-		return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %s/%s: %w", llmSvc.Namespace, name, err)
+		cfg = &v1alpha2.LLMInferenceServiceConfig{}
+		if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: constants.KServeNamespace}, cfg); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, &configNotFoundError{Name: name, Namespaces: []string{llmSvc.Namespace, constants.KServeNamespace}}
+			}
+			return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w",
+				name, llmSvc.Namespace, constants.KServeNamespace, err)
+		}
+		return cfg, nil
 	}
 	return cfg, nil
 }

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -18,6 +18,7 @@ package llmisvc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"k8s.io/client-go/kubernetes"
@@ -202,6 +203,11 @@ func (r *LLMISVCReconciler) reconcile(ctx context.Context, llmSvc *v1alpha2.LLMI
 	// This includes default configs based on deployment pattern (single node, multi-node, etc.)
 	baseCfg, err := r.combineBaseRefsConfig(ctx, llmSvc, config)
 	if err != nil {
+		var cfgNotFound *configNotFoundError
+		if errors.As(err, &cfgNotFound) {
+			llmSvc.MarkPresetsCombinedNotReady("ConfigNotFound", cfgNotFound.Error())
+			return nil // watch on LLMInferenceServiceConfig re-triggers when the config is recreated
+		}
 		llmSvc.MarkPresetsCombinedNotReady("CombineBaseError", err.Error())
 		return fmt.Errorf("failed to combine base-configurations: %w", err)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -200,8 +200,9 @@ func (r *LLMISVCReconciler) reconcile(ctx context.Context, llmSvc *v1alpha2.LLMI
 		return fmt.Errorf("failed to load ingress config: %w", configErr)
 	}
 
+	// nil baseCfg means config resolution set a condition (e.g. ConfigNotFound) and there's nothing more to do.
 	baseCfg, err := r.reconcileBaseRefs(ctx, llmSvc, config)
-	if err != nil {
+	if err != nil || baseCfg == nil {
 		return err
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_config_not_found_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_config_not_found_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+	. "github.com/kserve/kserve/pkg/testing"
+)
+
+var _ = Describe("LLMInferenceService Config resolution", func() {
+	Context("when a referenced config does not exist", func() {
+		It("should set PresetsCombined=False with reason ConfigNotFound for a missing BaseRef", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-cfg-not-found"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithBaseRefs(corev1.LocalObjectReference{Name: "does-not-exist"}),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - PresetsCombined must be False with ConfigNotFound reason
+			Eventually(func(g Gomega, ctx context.Context) error {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "False"))
+				cond := current.Status.GetCondition(v1alpha2.PresetsCombined)
+				g.Expect(cond.Reason).To(Equal("ConfigNotFound"))
+				g.Expect(cond.Message).To(ContainSubstring("does-not-exist"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+
+			// and no Deployment should have been created
+			Consistently(func(g Gomega, ctx context.Context) {
+				deployment := &appsv1.Deployment{}
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: testNs.Name,
+				}, deployment)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).
+				Within(2 * time.Second).
+				WithPolling(300 * time.Millisecond).
+				Should(Succeed())
+		})
+
+		It("should recover PresetsCombined to True when the missing BaseRef config is created", func(ctx SpecContext) {
+			// given - a service pointing to a config that does not exist yet
+			svcName := "test-llm-cfg-not-found-recover"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			configName := "recoverable-config"
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithBaseRefs(corev1.LocalObjectReference{Name: configName}),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - condition starts as False / ConfigNotFound
+			Eventually(func(g Gomega, ctx context.Context) error {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "False"))
+				cond := current.Status.GetCondition(v1alpha2.PresetsCombined)
+				g.Expect(cond.Reason).To(Equal("ConfigNotFound"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - the missing config is created in the service namespace
+			cfg := LLMInferenceServiceConfig(configName,
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
+			)
+			Expect(envTest.Create(ctx, cfg)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, cfg)
+			}()
+
+			// then - watch fires, reconcile runs, condition recovers to True
+			Eventually(func(g Gomega, ctx context.Context) error {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "True"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+})

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
@@ -1276,7 +1276,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 				presetsCombinedCondition := llmSvc.Status.GetCondition(v1alpha2.PresetsCombined)
 				g.Expect(presetsCombinedCondition).ToNot(BeNil())
 				g.Expect(presetsCombinedCondition.Status).To(Equal(corev1.ConditionFalse))
-				g.Expect(presetsCombinedCondition.Reason).To(Equal("CombineBaseError"))
+				g.Expect(presetsCombinedCondition.Reason).To(Equal("ConfigNotFound"))
 				return nil
 			}).WithContext(ctx).Should(Succeed(), "PresetsCombined should report config error when config is missing and service is not stopped")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When versioned config resolution pins a config name in `Status.Annotations` and that config is later deleted or renamed, the reconciler previously surfaced a generic `CombineBaseError` condition that gave operators no actionable signal - requiring log inspection to understand what failed.

Introduces a dedicated `PresetsCombined=False/ConfigNotFound` condition that names the missing `LLMInferenceServiceConfig` and the namespaces searched, making the failure diagnosable from `kubectl get llmisvc` without logs.

Applies to both well-known pinned configs and user-specified `BaseRefs`.

On `ConfigNotFound` the reconciler returns `nil` instead of propagating the error, avoiding unnecessary exponential-backoff requeues. The existing watch on `LLMInferenceServiceConfig` events re-triggers reconciliation as soon as the config is recreated, providing automatic recovery.

**Feature/Issue validation/testing**:

- [x] Integration test: `PresetsCombined=False/ConfigNotFound` when a `BaseRef` points to a non-existent config, no `Deployment` created
- [x] Integration test: condition recovers to `True` when the missing config is created (watch-driven auto-heal)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Surfaces a dedicated PresetsCombined=False/ConfigNotFound condition when a referenced LLMInferenceServiceConfig cannot be found, replacing a generic error that required log inspection to diagnose.
```