### PR TITLE
fix(llmisvc): allow stop when LLMInferenceServiceConfig is missing

### DIFF
--- a/pkg/apis/serving/v1alpha2/llm_inference_service_defaults.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_defaults.go
@@ -50,4 +50,8 @@ func (in *LLMInferenceServiceSpec) SetDefaults(_ context.Context) {
 	if in.Prefill != nil && in.Prefill.Worker != nil && in.Prefill.Worker.Containers == nil {
 		in.Prefill.Worker.Containers = []corev1.Container{}
 	}
+
+	if in.Router != nil && in.Router.Scheduler != nil && in.Router.Scheduler.Template != nil && in.Router.Scheduler.Template.Containers == nil {
+		in.Router.Scheduler.Template.Containers = []corev1.Container{}
+	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -120,6 +120,28 @@ func WithSkipClearSchedulerConfigRef() CombineOption {
 	}
 }
 
+func (r *LLMISVCReconciler) reconcileBaseRefs(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) (*v1alpha2.LLMInferenceServiceConfig, error) {
+	// Combine base configurations with service-specific overrides
+	// This includes default configs based on deployment pattern (single node, multi-node, etc.)
+	baseCfg, err := r.combineBaseRefsConfig(ctx, llmSvc, config)
+	if err != nil {
+		if utils.GetForceStopRuntime(llmSvc) {
+			llmSvc.MarkPresetsCombinedNotReady("Stopped", "Service is stopped with warning: %v", err.Error())
+
+			baseCfg = &v1alpha2.LLMInferenceServiceConfig{
+				Spec: *llmSvc.Spec.DeepCopy(),
+			}
+			return baseCfg, nil
+		}
+
+		llmSvc.MarkPresetsCombinedNotReady("CombineBaseError", err.Error())
+		return nil, fmt.Errorf("failed to combine base-configurations: %w", err)
+	}
+
+	llmSvc.MarkPresetsCombinedReady()
+	return baseCfg, nil
+}
+
 // combineBaseRefsConfig applies well-known config overlays to inject default values for various components, when some components are
 // enabled. These LLMInferenceServiceConfig resources must exist in either resource namespace (prioritized) or
 // SystemNamespace (e.g. `kserve`).

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -198,14 +198,10 @@ func (r *LLMISVCReconciler) reconcile(ctx context.Context, llmSvc *v1alpha2.LLMI
 		return fmt.Errorf("failed to load ingress config: %w", configErr)
 	}
 
-	// Combine base configurations with service-specific overrides
-	// This includes default configs based on deployment pattern (single node, multi-node, etc.)
-	baseCfg, err := r.combineBaseRefsConfig(ctx, llmSvc, config)
+	baseCfg, err := r.reconcileBaseRefs(ctx, llmSvc, config)
 	if err != nil {
-		llmSvc.MarkPresetsCombinedNotReady("CombineBaseError", err.Error())
-		return fmt.Errorf("failed to combine base-configurations: %w", err)
+		return err
 	}
-	llmSvc.MarkPresetsCombinedReady()
 
 	logger.V(2).Info("Reconciling with combined base configurations", "combined.spec", baseCfg.Spec, "original.spec", llmSvc.Spec)
 	// Replace the spec with the merged configuration for reconciliation

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
@@ -1080,8 +1080,8 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 				}, &appsv1.Deployment{})
 				return err != nil && errors.IsNotFound(err)
 			}).WithContext(ctx).
-				WithTimeout(2 * time.Second).
-				WithPolling(300 * time.Millisecond).
+				WithTimeout(2*time.Second).
+				WithPolling(300*time.Millisecond).
 				Should(BeTrue(), "no deployment should be created when service is stopped")
 		})
 

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
@@ -591,4 +591,608 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}).WithContext(ctx).Should(BeTrue(), "LeaderWorkerSet should be deleted when service is stopped")
 		})
 	})
+
+	Context("When service is stopped with missing LLMInferenceServiceConfig (baseRef not found)", func() {
+		It("should delete single-node workload resources when baseRef config is deleted before stop", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-missing-cfg"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(ctx, namespace)
+			}()
+
+			// Create the LLMInferenceServiceConfig that will later be deleted
+			modelConfig := LLMInferenceServiceConfig("custom-model-config",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				WithConfigModelURI("hf://facebook/opt-125m"),
+			)
+			Expect(envTest.Client.Create(ctx, modelConfig)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithBaseRefs(
+					corev1.LocalObjectReference{Name: "custom-model-config"},
+				),
+			)
+
+			// when - Create LLMInferenceService with baseRef
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify deployment is created
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Delete the LLMInferenceServiceConfig before stopping
+			Expect(envTest.Client.Delete(ctx, modelConfig)).To(Succeed())
+
+			// when - Set stop annotation (config is now missing)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify the service is marked as stopped despite missing config
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				mainWorkloadCondition := llmSvc.Status.GetCondition(v1alpha2.MainWorkloadReady)
+				g.Expect(mainWorkloadCondition).ToNot(BeNil())
+				g.Expect(mainWorkloadCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(mainWorkloadCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "service should be marked as stopped even when config is missing")
+
+			// verify PresetsCombined condition reflects the warning about missing config
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				presetsCombinedCondition := llmSvc.Status.GetCondition(v1alpha2.PresetsCombined)
+				g.Expect(presetsCombinedCondition).ToNot(BeNil())
+				g.Expect(presetsCombinedCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(presetsCombinedCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "PresetsCombined should indicate stopped with warning")
+
+			// verify deployment is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "deployment should be deleted when service is stopped with missing config")
+		})
+
+		It("should delete router resources when baseRef config is deleted before stop", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-cfg-router"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(ctx, namespace)
+			}()
+
+			// Create the LLMInferenceServiceConfig with router config
+			routerConfig := LLMInferenceServiceConfig("custom-router-config",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				WithConfigModelURI("hf://facebook/opt-125m"),
+				WithConfigManagedRouter(),
+			)
+			Expect(envTest.Client.Create(ctx, routerConfig)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithBaseRefs(
+					corev1.LocalObjectReference{Name: "custom-router-config"},
+				),
+			)
+
+			// when - Create LLMInferenceService with baseRef
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify deployment and HTTPRoute are created
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			Eventually(func(g Gomega, ctx context.Context) error {
+				routes, errList := managedRoutes(ctx, llmSvc)
+				g.Expect(errList).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Delete the LLMInferenceServiceConfig before stopping
+			Expect(envTest.Client.Delete(ctx, routerConfig)).To(Succeed())
+
+			// when - Set stop annotation (config is now missing)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify the service is marked as stopped
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				mainWorkloadCondition := llmSvc.Status.GetCondition(v1alpha2.MainWorkloadReady)
+				g.Expect(mainWorkloadCondition).ToNot(BeNil())
+				g.Expect(mainWorkloadCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(mainWorkloadCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "service should be marked as stopped")
+
+			// verify deployment is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "deployment should be deleted when stopped with missing config")
+
+			// verify HTTPRoute is deleted
+			Eventually(func(g Gomega, ctx context.Context) error {
+				routes, errList := managedRoutes(ctx, llmSvc)
+				g.Expect(errList).ToNot(HaveOccurred())
+				g.Expect(routes).To(BeEmpty())
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "HTTPRoute should be deleted when stopped with missing config")
+		})
+
+		It("should delete multi-node LeaderWorkerSet resources when baseRef config is deleted before stop", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-cfg-mn"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(ctx, namespace)
+			}()
+
+			// Create the LLMInferenceServiceConfig for multi-node
+			multiNodeConfig := LLMInferenceServiceConfig("custom-mn-config",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				WithConfigModelURI("hf://facebook/opt-125m"),
+			)
+			Expect(envTest.Client.Create(ctx, multiNodeConfig)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithBaseRefs(
+					corev1.LocalObjectReference{Name: "custom-mn-config"},
+				),
+				WithReplicas(1),
+				WithParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+					WithTensorParallelism(1),
+				)),
+				WithWorker(SimpleWorkerPodSpec()),
+			)
+
+			// when - Create LLMInferenceService with worker (multi-node) and baseRef
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify LeaderWorkerSet is created
+			expectedLWS := &leaderworkerset.LeaderWorkerSet{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, expectedLWS)
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Delete the LLMInferenceServiceConfig before stopping
+			Expect(envTest.Client.Delete(ctx, multiNodeConfig)).To(Succeed())
+
+			// when - Set stop annotation (config is now missing)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify the service is marked as stopped
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				mainWorkloadCondition := llmSvc.Status.GetCondition(v1alpha2.MainWorkloadReady)
+				g.Expect(mainWorkloadCondition).ToNot(BeNil())
+				g.Expect(mainWorkloadCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(mainWorkloadCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "service should be marked as stopped with missing config")
+
+			// verify LeaderWorkerSet is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, expectedLWS)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "LeaderWorkerSet should be deleted when stopped with missing config")
+		})
+
+		It("should delete scheduler resources when baseRef config is deleted before stop", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-cfg-sched"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(ctx, namespace)
+			}()
+
+			// Create the LLMInferenceServiceConfig with scheduler config
+			schedulerConfig := LLMInferenceServiceConfig("custom-sched-config",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				WithConfigModelURI("hf://facebook/opt-125m"),
+				WithConfigManagedRouter(),
+				WithConfigManagedScheduler(),
+			)
+			Expect(envTest.Client.Create(ctx, schedulerConfig)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithBaseRefs(
+					corev1.LocalObjectReference{Name: "custom-sched-config"},
+				),
+			)
+
+			// when - Create LLMInferenceService with baseRef
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// Ensure router and scheduler resources are ready (required for envTest)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
+
+			// then - verify scheduler deployment is created
+			schedulerDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-router-scheduler",
+					Namespace: nsName,
+				}, schedulerDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// verify InferencePool is created
+			inferencePool := &igwapi.InferencePool{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-inference-pool",
+					Namespace: nsName,
+				}, inferencePool)
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Delete the LLMInferenceServiceConfig before stopping
+			Expect(envTest.Client.Delete(ctx, schedulerConfig)).To(Succeed())
+
+			// when - Set stop annotation (config is now missing)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify the service is marked as stopped
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				mainWorkloadCondition := llmSvc.Status.GetCondition(v1alpha2.MainWorkloadReady)
+				g.Expect(mainWorkloadCondition).ToNot(BeNil())
+				g.Expect(mainWorkloadCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(mainWorkloadCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "service should be marked as stopped")
+
+			// verify scheduler deployment is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-epp",
+					Namespace: nsName,
+				}, schedulerDeployment)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "scheduler deployment should be deleted when stopped with missing config")
+
+			// verify InferencePool is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-inference-pool",
+					Namespace: nsName,
+				}, inferencePool)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "InferencePool should be deleted when stopped with missing config")
+
+			// verify HTTPRoute is deleted
+			Eventually(func(g Gomega, ctx context.Context) error {
+				routes, errList := managedRoutes(ctx, llmSvc)
+				g.Expect(errList).ToNot(HaveOccurred())
+				g.Expect(routes).To(BeEmpty())
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "HTTPRoute should be deleted when stopped with missing config")
+		})
+
+		It("should not block reconciliation when baseRef config never existed and stop is set", func(ctx SpecContext) {
+			// This simulates a user creating a service with a typo in the config name,
+			// then trying to stop it.
+			// given
+			svcName := "test-llm-stop-no-cfg"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(ctx, namespace)
+			}()
+
+			// Create the service with stop annotation AND a non-existent baseRef from the start
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithBaseRefs(
+					corev1.LocalObjectReference{Name: "nonexistent-config"},
+				),
+				WithAnnotations(map[string]string{
+					constants.StopAnnotationKey: "true",
+				}),
+			)
+
+			// when - Create LLMInferenceService with stop annotation and missing baseRef
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify the service is marked as stopped (not stuck in error loop)
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				mainWorkloadCondition := llmSvc.Status.GetCondition(v1alpha2.MainWorkloadReady)
+				g.Expect(mainWorkloadCondition).ToNot(BeNil())
+				g.Expect(mainWorkloadCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(mainWorkloadCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "service should be marked as stopped even with non-existent config")
+
+			// verify PresetsCombined condition reflects the warning
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				presetsCombinedCondition := llmSvc.Status.GetCondition(v1alpha2.PresetsCombined)
+				g.Expect(presetsCombinedCondition).ToNot(BeNil())
+				g.Expect(presetsCombinedCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(presetsCombinedCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "PresetsCombined should indicate stopped with warning about missing config")
+
+			// verify no deployment was created
+			Consistently(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, &appsv1.Deployment{})
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).
+				WithTimeout(2 * time.Second).
+				WithPolling(300 * time.Millisecond).
+				Should(BeTrue(), "no deployment should be created when service is stopped")
+		})
+
+		It("should toggle stop on and off with missing baseRef config", func(ctx SpecContext) {
+			// This tests the full lifecycle: running -> config deleted -> stop -> unstop (should fail gracefully)
+			// given
+			svcName := "test-llm-stop-cfg-toggle"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(ctx, namespace)
+			}()
+
+			// Create the LLMInferenceServiceConfig
+			modelConfig := LLMInferenceServiceConfig("toggle-config",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				WithConfigModelURI("hf://facebook/opt-125m"),
+			)
+			Expect(envTest.Client.Create(ctx, modelConfig)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithBaseRefs(
+					corev1.LocalObjectReference{Name: "toggle-config"},
+				),
+			)
+
+			// Create and verify initial deployment
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// Delete the config
+			Expect(envTest.Client.Delete(ctx, modelConfig)).To(Succeed())
+
+			// Stop the service
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Verify deployment is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "deployment should be deleted when stopped with missing config")
+
+			// Remove stop annotation (config is still missing — service should report config error)
+			errRetry = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					delete(llmSvc.Annotations, constants.StopAnnotationKey)
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Verify that PresetsCombined shows the config error (not stuck or panicking)
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				presetsCombinedCondition := llmSvc.Status.GetCondition(v1alpha2.PresetsCombined)
+				g.Expect(presetsCombinedCondition).ToNot(BeNil())
+				g.Expect(presetsCombinedCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(presetsCombinedCondition.Reason).To(Equal("CombineBaseError"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "PresetsCombined should report config error when config is missing and service is not stopped")
+
+			// Recreate the config and verify deployment comes back
+			modelConfig = LLMInferenceServiceConfig("toggle-config",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				WithConfigModelURI("hf://facebook/opt-125m"),
+			)
+			Expect(envTest.Client.Create(ctx, modelConfig)).To(Succeed())
+
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed(), "deployment should be recreated after config is restored")
+		})
+	})
 })

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
@@ -694,6 +694,106 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}).WithContext(ctx).Should(BeTrue(), "deployment should be deleted when service is stopped with missing config")
 		})
 
+		It("should delete single-node workload with Template when baseRef config providing model URI is deleted before stop", func(ctx SpecContext) {
+			// This covers the case where Template is set directly on the service
+			// but the model URI comes from a baseRef config. Without the early stop
+			// check, expectedSingleNodeMainDeployment would fail on attachModelArtifacts
+			// because the fallback spec has Template (enters the attachModelArtifacts path)
+			// but no model URI.
+			// given
+			svcName := "test-llm-stop-cfg-tmpl"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(ctx, namespace)
+			}()
+
+			// Create the LLMInferenceServiceConfig that provides the model URI
+			modelConfig := LLMInferenceServiceConfig("model-uri-config",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](nsName),
+				WithConfigModelURI("hf://facebook/opt-125m"),
+			)
+			Expect(envTest.Client.Create(ctx, modelConfig)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](nsName),
+				WithBaseRefs(
+					corev1.LocalObjectReference{Name: "model-uri-config"},
+				),
+				// Template is set directly on the service, not via the config
+				WithTemplate(&corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "main",
+							Image: "quay.io/test/vllm:latest",
+						},
+					},
+				}),
+			)
+
+			// when - Create LLMInferenceService with baseRef and Template
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify deployment is created
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Delete the LLMInferenceServiceConfig before stopping
+			Expect(envTest.Client.Delete(ctx, modelConfig)).To(Succeed())
+
+			// when - Set stop annotation (config is now missing, but Template is still on the service)
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify the service is marked as stopped
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				mainWorkloadCondition := llmSvc.Status.GetCondition(v1alpha2.MainWorkloadReady)
+				g.Expect(mainWorkloadCondition).ToNot(BeNil())
+				g.Expect(mainWorkloadCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(mainWorkloadCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "service should be marked as stopped")
+
+			// verify deployment is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "deployment should be deleted when stopped with missing config and Template set")
+		})
+
 		It("should delete router resources when baseRef config is deleted before stop", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-stop-cfg-router"

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -187,7 +187,7 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 		return nil, fmt.Errorf("failed to get current leader worker set %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
 	}
 
-	if llmSvc.Spec.Template != nil {
+	if llmSvc.Spec.Template != nil && !utils.GetForceStopRuntime(llmSvc) {
 		expected.Spec.LeaderWorkerTemplate.LeaderTemplate = &corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: leaderLabels,
@@ -222,7 +222,7 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 			}
 		}
 	}
-	if llmSvc.Spec.Worker != nil {
+	if llmSvc.Spec.Worker != nil && !utils.GetForceStopRuntime(llmSvc) {
 		expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec = *llmSvc.Spec.Worker.DeepCopy()
 
 		serviceAccount, _, err := r.expectedMultiNodeMainServiceAccount(ctx, llmSvc)
@@ -299,7 +299,7 @@ func (r *LLMISVCReconciler) expectedPrefillMultiNodeLWS(ctx context.Context, llm
 		},
 	}
 
-	if llmSvc.Spec.Prefill != nil {
+	if llmSvc.Spec.Prefill != nil && !utils.GetForceStopRuntime(llmSvc) {
 		expected.Spec.Replicas = llmSvc.Spec.Prefill.Replicas
 		expected.Spec.LeaderWorkerTemplate.Size = llmSvc.Spec.Prefill.Parallelism.GetSize()
 

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -390,7 +390,7 @@ func (r *LLMISVCReconciler) reconcileMultiNodeMainServiceAccount(ctx context.Con
 		return fmt.Errorf("failed to create expected multi node service account: %w", err)
 	}
 	if !useExistingServiceAccount {
-		if llmSvc.Spec.Worker == nil {
+		if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Worker == nil {
 			return Delete(ctx, r, llmSvc, serviceAccount)
 		}
 
@@ -411,7 +411,7 @@ func (r *LLMISVCReconciler) reconcileMultiNodePrefillServiceAccount(ctx context.
 		return fmt.Errorf("failed to create expected multi node service account: %w", err)
 	}
 	if !useExistingServiceAccount {
-		if llmSvc.Spec.Prefill == nil || llmSvc.Spec.Prefill.Worker == nil {
+		if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Prefill == nil || llmSvc.Spec.Prefill.Worker == nil {
 			return Delete(ctx, r, llmSvc, serviceAccount)
 		}
 

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -57,21 +57,23 @@ func (r *LLMISVCReconciler) reconcileMultiNodeWorkload(ctx context.Context, llmS
 }
 
 func (r *LLMISVCReconciler) reconcileMultiNodeMainWorkload(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
-	expected, err := r.expectedMainMultiNodeLWS(ctx, llmSvc, config)
-	if err != nil {
-		return fmt.Errorf("failed to build the expected main LWS: %w", err)
-	}
-
 	if isStopped := utils.GetForceStopRuntime(llmSvc); isStopped || llmSvc.Spec.Worker == nil {
 		if isStopped {
 			llmSvc.MarkWorkerWorkloadNotReady("Stopped", "Service is stopped")
 		} else {
 			llmSvc.MarkWorkerWorkloadUnset()
 		}
-		if err := Delete(ctx, r, llmSvc, expected); err != nil {
-			return err
-		}
-		return nil
+		return Delete(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mainLWSName(llmSvc),
+				Namespace: llmSvc.GetNamespace(),
+			},
+		})
+	}
+
+	expected, err := r.expectedMainMultiNodeLWS(ctx, llmSvc, config)
+	if err != nil {
+		return fmt.Errorf("failed to build the expected main LWS: %w", err)
 	}
 	if err := Reconcile(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{}, expected, semanticLWSIsEqual, PreserveLWSReplicas()); err != nil {
 		return err
@@ -80,21 +82,23 @@ func (r *LLMISVCReconciler) reconcileMultiNodeMainWorkload(ctx context.Context, 
 }
 
 func (r *LLMISVCReconciler) reconcileMultiNodePrefillWorkload(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
-	expected, err := r.expectedPrefillMultiNodeLWS(ctx, llmSvc, config)
-	if err != nil {
-		return fmt.Errorf("failed to build the expected prefill LWS: %w", err)
-	}
 	if isStopped := utils.GetForceStopRuntime(llmSvc); isStopped || llmSvc.Spec.Prefill == nil || llmSvc.Spec.Prefill.Worker == nil {
 		if isStopped {
 			llmSvc.MarkPrefillWorkerWorkloadNotReady("Stopped", "Service is stopped")
 		} else {
 			llmSvc.MarkPrefillWorkerWorkloadUnset()
 		}
+		return Delete(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prefillLWSName(llmSvc),
+				Namespace: llmSvc.GetNamespace(),
+			},
+		})
+	}
 
-		if err := Delete(ctx, r, llmSvc, expected); err != nil {
-			return err
-		}
-		return nil
+	expected, err := r.expectedPrefillMultiNodeLWS(ctx, llmSvc, config)
+	if err != nil {
+		return fmt.Errorf("failed to build the expected prefill LWS: %w", err)
 	}
 	if err := Reconcile(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{}, expected, semanticLWSIsEqual, PreserveLWSReplicas()); err != nil {
 		return err

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -57,17 +57,23 @@ func (r *LLMISVCReconciler) reconcileSingleNodeWorkload(ctx context.Context, llm
 }
 
 func (r *LLMISVCReconciler) reconcileSingleNodeMainWorkload(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
-	expected, err := r.expectedSingleNodeMainDeployment(ctx, llmSvc, config)
-	if err != nil {
-		return fmt.Errorf("failed to get expected main deployment: %w", err)
-	}
 	if isStopped := utils.GetForceStopRuntime(llmSvc); isStopped || llmSvc.Spec.Worker != nil {
 		if isStopped {
 			llmSvc.MarkMainWorkloadNotReady("Stopped", "Service is stopped")
 		} else {
 			llmSvc.MarkMainWorkloadUnset()
 		}
-		return Delete(ctx, r, llmSvc, expected)
+		return Delete(ctx, r, llmSvc, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mainDeploymentName(llmSvc),
+				Namespace: llmSvc.GetNamespace(),
+			},
+		})
+	}
+
+	expected, err := r.expectedSingleNodeMainDeployment(ctx, llmSvc, config)
+	if err != nil {
+		return fmt.Errorf("failed to get expected main deployment: %w", err)
 	}
 	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, expected, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
 		return err
@@ -168,21 +174,23 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 }
 
 func (r *LLMISVCReconciler) reconcileSingleNodePrefill(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
-	prefill, err := r.expectedPrefillMainDeployment(ctx, llmSvc, config)
-	if err != nil {
-		return fmt.Errorf("failed to get expected prefill deployment: %w", err)
-	}
 	if isStopped := utils.GetForceStopRuntime(llmSvc); isStopped || llmSvc.Spec.Prefill == nil || llmSvc.Spec.Prefill.Worker != nil {
 		if isStopped {
 			llmSvc.MarkPrefillWorkloadNotReady("Stopped", "Service is stopped")
 		} else {
 			llmSvc.MarkPrefillWorkloadUnset()
 		}
+		return Delete(ctx, r, llmSvc, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      prefillDeploymentName(llmSvc),
+				Namespace: llmSvc.GetNamespace(),
+			},
+		})
+	}
 
-		if err := Delete(ctx, r, llmSvc, prefill); err != nil {
-			return fmt.Errorf("failed to delete prefill main deployment: %w", err)
-		}
-		return nil
+	prefill, err := r.expectedPrefillMainDeployment(ctx, llmSvc, config)
+	if err != nil {
+		return fmt.Errorf("failed to get expected prefill deployment: %w", err)
 	}
 	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, prefill, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
 		return fmt.Errorf("failed to reconcile prefill deployment %s/%s: %w", prefill.GetNamespace(), prefill.GetName(), err)

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -128,7 +128,7 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 		},
 	}
 
-	if llmSvc.Spec.Template != nil {
+	if llmSvc.Spec.Template != nil && !utils.GetForceStopRuntime(llmSvc) {
 		d.Spec.Template.Spec = *llmSvc.Spec.Template.DeepCopy()
 
 		var serviceAccount *corev1.ServiceAccount = nil
@@ -232,7 +232,7 @@ func (r *LLMISVCReconciler) expectedPrefillMainDeployment(ctx context.Context, l
 		}
 	}
 
-	if llmSvc.Spec.Prefill != nil && llmSvc.Spec.Prefill.Template != nil {
+	if llmSvc.Spec.Prefill != nil && llmSvc.Spec.Prefill.Template != nil && !utils.GetForceStopRuntime(llmSvc) {
 		d.Spec.Template.Spec = *llmSvc.Spec.Prefill.Template.DeepCopy()
 
 		var existingServiceAccount *corev1.ServiceAccount = nil


### PR DESCRIPTION
When a referenced LLMInferenceServiceConfig is deleted before stopping
the service, the reconciler would fail on combineBaseRefsConfig and block
resource cleanup, leaving pods running and the service stuck in Stopping.

Introduce reconcileBaseRefs which catches the config-not-found error when
the stop annotation is set, marks PresetsCombined with a warning, and
continues reconciliation using the service's own spec so all managed
resources (Deployment, LWS, router, scheduler) are properly deleted.

Also fixes multi-node ServiceAccount cleanup when stopped.