### PR TITLE
fix(llmisvc): fix long-name HTTPRoute BackendRefs

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -272,10 +272,15 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 		llmSvcCfg.Spec.Router.Scheduler == nil {
 		for i := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules {
 			for j := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs {
-				if isDefaultBackendRef(llmSvc, llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].BackendRef) {
-					llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].Group = ptr.To[gwapiv1.Group]("")
-					llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].Kind = ptr.To[gwapiv1.Kind]("Service")
-					llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].Name = gwapiv1.ObjectName(kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"))
+				ref := &llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j]
+				if isDefaultBackendRef(llmSvc, ref.BackendRef) {
+					ref.Group = ptr.To[gwapiv1.Group]("")
+					ref.Kind = ptr.To[gwapiv1.Kind]("Service")
+					ref.Name = gwapiv1.ObjectName(kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"))
+				} else if isDefaultWorkloadServiceBackendRef(llmSvc, ref.BackendRef) {
+					// Ensure the workload service name uses ChildName for proper hash truncation
+					// when the combined name exceeds K8s 63-character limit.
+					ref.Name = gwapiv1.ObjectName(kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"))
 				}
 			}
 		}
@@ -289,8 +294,30 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 		llmSvcCfg.Spec.Router.Scheduler.Pool.HasRef() {
 		for i := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules {
 			for j := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs {
-				if isDefaultBackendRef(llmSvc, llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].BackendRef) {
-					llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].Name = gwapiv1.ObjectName(llmSvcCfg.Spec.Router.Scheduler.Pool.Ref.Name)
+				ref := &llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j]
+				if isDefaultBackendRef(llmSvc, ref.BackendRef) {
+					ref.Name = gwapiv1.ObjectName(llmSvcCfg.Spec.Router.Scheduler.Pool.Ref.Name)
+				} else if isDefaultWorkloadServiceBackendRef(llmSvc, ref.BackendRef) {
+					// Ensure the workload service name uses ChildName for proper hash truncation.
+					ref.Name = gwapiv1.ObjectName(kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"))
+				}
+			}
+		}
+	}
+
+	// Ensure all workload service BackendRefs use ChildName for proper hash truncation
+	// when a managed scheduler is configured (inline pool, not external ref).
+	// This covers the catch-all Service rule from templates or custom user configs.
+	if llmSvcCfg.Spec.Router != nil &&
+		llmSvcCfg.Spec.Router.Route != nil &&
+		llmSvcCfg.Spec.Router.Route.HTTP.HasSpec() &&
+		llmSvcCfg.Spec.Router.Scheduler != nil &&
+		!llmSvcCfg.Spec.Router.Scheduler.Pool.HasRef() {
+		for i := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules {
+			for j := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs {
+				ref := &llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j]
+				if isDefaultWorkloadServiceBackendRef(llmSvc, ref.BackendRef) {
+					ref.Name = gwapiv1.ObjectName(kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"))
 				}
 			}
 		}
@@ -524,9 +551,27 @@ func mergeSpecs(ctx context.Context, base, override v1alpha2.LLMInferenceService
 
 func isDefaultBackendRef(llmSvc *v1alpha2.LLMInferenceService, ref gwapiv1.BackendRef) bool {
 	defaultInfPoolName := (&v1alpha2.SchedulerSpec{}).InferencePoolName(llmSvc)
+	// Also match the simple (un-hashed) concatenation for long names where ChildName truncates
+	simpleInfPoolName := llmSvc.GetName() + "-inference-pool"
 	// Check Kind and Name only - Group can be either v1 or v1alpha2
 	return ptr.Deref[gwapiv1.Kind](ref.Kind, "") == "InferencePool" &&
-		string(ref.Name) == defaultInfPoolName
+		(string(ref.Name) == defaultInfPoolName || string(ref.Name) == simpleInfPoolName)
+}
+
+// isDefaultWorkloadServiceBackendRef returns true if the BackendRef is a core Service
+// pointing to the workload service, matching either the ChildName (hash-truncated) or
+// the plain concatenated name. This ensures that custom route configs or inline specs
+// that use simple concatenation (without ChildName) still get corrected when the
+// combined name exceeds the K8s 63-character limit.
+func isDefaultWorkloadServiceBackendRef(llmSvc *v1alpha2.LLMInferenceService, ref gwapiv1.BackendRef) bool {
+	kind := ptr.Deref[gwapiv1.Kind](ref.Kind, "Service")
+	group := ptr.Deref[gwapiv1.Group](ref.Group, "")
+	if kind != "Service" || group != "" {
+		return false
+	}
+	childName := kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc")
+	simpleName := llmSvc.GetName() + "-kserve-workload-svc"
+	return string(ref.Name) == childName || string(ref.Name) == simpleName
 }
 
 const (

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_backendref_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_backendref_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/kmeta"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+func TestIsDefaultBackendRef(t *testing.T) {
+	shortName := "my-llm-service"
+	longName := "my-very-long-llm-inference-service-name-that-exceeds"
+
+	tests := []struct {
+		name     string
+		llmName  string
+		ref      gwapiv1.BackendRef
+		expected bool
+	}{
+		{
+			name:    "InferencePool with ChildName (short name)",
+			llmName: shortName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+					Name: gwapiv1.ObjectName(kmeta.ChildName(shortName, "-inference-pool")),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "InferencePool with ChildName (long name, hashed)",
+			llmName: longName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+					Name: gwapiv1.ObjectName(kmeta.ChildName(longName, "-inference-pool")),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "InferencePool with simple concatenation (long name, NOT hashed)",
+			llmName: longName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+					Name: gwapiv1.ObjectName(longName + "-inference-pool"),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "Service kind should not match",
+			llmName: shortName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Kind: ptr.To(gwapiv1.Kind("Service")),
+					Name: gwapiv1.ObjectName(kmeta.ChildName(shortName, "-inference-pool")),
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "InferencePool with unrelated name",
+			llmName: shortName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+					Name: gwapiv1.ObjectName("unrelated-pool"),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llmSvc := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.llmName},
+			}
+			got := isDefaultBackendRef(llmSvc, tt.ref)
+			if got != tt.expected {
+				t.Errorf("isDefaultBackendRef() = %v, want %v (name=%q, refName=%q)",
+					got, tt.expected, tt.llmName, tt.ref.Name)
+			}
+		})
+	}
+}
+
+func TestIsDefaultWorkloadServiceBackendRef(t *testing.T) {
+	shortName := "my-llm-service"
+	longName := "my-very-long-llm-inference-service-name-that-exceeds"
+
+	tests := []struct {
+		name     string
+		llmName  string
+		ref      gwapiv1.BackendRef
+		expected bool
+	}{
+		{
+			name:    "Service with ChildName (short name)",
+			llmName: shortName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Group: ptr.To(gwapiv1.Group("")),
+					Kind:  ptr.To(gwapiv1.Kind("Service")),
+					Name:  gwapiv1.ObjectName(kmeta.ChildName(shortName, "-kserve-workload-svc")),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "Service with simple concatenation (short name, same result)",
+			llmName: shortName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Group: ptr.To(gwapiv1.Group("")),
+					Kind:  ptr.To(gwapiv1.Kind("Service")),
+					Name:  gwapiv1.ObjectName(shortName + "-kserve-workload-svc"),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "Service with ChildName (long name, hashed)",
+			llmName: longName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Group: ptr.To(gwapiv1.Group("")),
+					Kind:  ptr.To(gwapiv1.Kind("Service")),
+					Name:  gwapiv1.ObjectName(kmeta.ChildName(longName, "-kserve-workload-svc")),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "Service with simple concatenation (long name, NOT hashed) - the bug case",
+			llmName: longName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Group: ptr.To(gwapiv1.Group("")),
+					Kind:  ptr.To(gwapiv1.Kind("Service")),
+					Name:  gwapiv1.ObjectName(longName + "-kserve-workload-svc"),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "Service with default Kind (nil kind defaults to Service)",
+			llmName: longName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Name: gwapiv1.ObjectName(longName + "-kserve-workload-svc"),
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "InferencePool kind should not match",
+			llmName: shortName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+					Name: gwapiv1.ObjectName(kmeta.ChildName(shortName, "-kserve-workload-svc")),
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "Service with non-core group should not match",
+			llmName: shortName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Group: ptr.To(gwapiv1.Group("inference.networking.k8s.io")),
+					Kind:  ptr.To(gwapiv1.Kind("Service")),
+					Name:  gwapiv1.ObjectName(kmeta.ChildName(shortName, "-kserve-workload-svc")),
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "Service with unrelated name should not match",
+			llmName: shortName,
+			ref: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{
+					Kind: ptr.To(gwapiv1.Kind("Service")),
+					Name: gwapiv1.ObjectName("unrelated-service"),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llmSvc := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.llmName},
+			}
+			got := isDefaultWorkloadServiceBackendRef(llmSvc, tt.ref)
+			if got != tt.expected {
+				t.Errorf("isDefaultWorkloadServiceBackendRef() = %v, want %v (name=%q, refName=%q)",
+					got, tt.expected, tt.llmName, tt.ref.Name)
+			}
+		})
+	}
+}
+
+// TestLongNameChildNameDifference verifies that ChildName produces different output
+// than simple concatenation when the combined name exceeds 63 characters.
+func TestLongNameChildNameDifference(t *testing.T) {
+	longName := "my-very-long-llm-inference-service-name-that-exceeds"
+	suffix := "-kserve-workload-svc"
+
+	simpleName := longName + suffix
+	childName := kmeta.ChildName(longName, suffix)
+
+	if len(simpleName) <= 63 {
+		t.Fatalf("Test setup error: simpleName should exceed 63 chars, got %d", len(simpleName))
+	}
+	if len(childName) > 63 {
+		t.Fatalf("ChildName result should be <= 63 chars, got %d", len(childName))
+	}
+	if simpleName == childName {
+		t.Fatal("Expected simpleName and childName to differ for long names")
+	}
+
+	t.Logf("simpleName (%d chars): %s", len(simpleName), simpleName)
+	t.Logf("childName  (%d chars): %s", len(childName), childName)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes backendRef name normalization for LLMInferenceService router configuration when the LLMInferenceService name is long.

Previously, only default `InferencePool` backendRefs were normalized. However, workload `Service` backendRefs from templates or custom route configs could still use the plain concatenated name:

```text
<llmInferenceServiceName>-kserve-workload-svc
```

When the combined name exceeds the Kubernetes 63-character DNS label limit, the actual workload Service name is generated using `kmeta.ChildName()`, which applies truncation and hashing. In that case, the HTTPRoute backendRef could point to a non-existent Service.

This PR updates the reconciliation logic to:

- Normalize workload `Service` backendRefs using `kmeta.ChildName()`
- Match both hashed/truncated and plain concatenated workload Service names
- Match both default and plain concatenated default `InferencePool` names
- Apply workload `Service` backendRef normalization across scheduler-disabled, external scheduler pool ref, and managed scheduler pool configurations

This ensures that HTTPRoute backendRefs correctly reference the generated workload Service or configured scheduler pool for long LLMInferenceService names.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Feature/Issue validation/testing**:

- [x] Added unit tests for `isDefaultBackendRef`
- [x] Verified that default `InferencePool` backendRefs match both `kmeta.ChildName()`-generated names and plain concatenated names
- [x] Verified that non-`InferencePool` backendRefs do not match `isDefaultBackendRef`
- [x] Added unit tests for `isDefaultWorkloadServiceBackendRef`
- [x] Verified that workload `Service` backendRefs match both `kmeta.ChildName()`-generated names and plain concatenated names
- [x] Verified that `Service` backendRefs with nil `Kind` are treated as default Kubernetes `Service` backendRefs
- [x] Verified that only core Kubernetes `Service` backendRefs with the expected workload Service name are matched
- [x] Added a long-name test to confirm that plain concatenation can exceed the 63-character Kubernetes name limit while `kmeta.ChildName()` produces a valid truncated/hash-based name

**Logs**:

```text
go test ./pkg/controller/v1alpha2/llminferenceservice/...
```

**Special notes for your reviewer**:

This change is intended to prevent `HTTPRoute` backendRefs from pointing to a non-existent workload `Service` when an `LLMInferenceService` has a long name.

For long names, the generated workload `Service` uses `kmeta.ChildName()` to stay within the Kubernetes 63-character name limit, while some `HTTPRoute` backendRefs may still use the plain concatenated name. This can cause a mismatch between the actual `Service` name and the `HTTPRoute` backendRef name.

This PR normalizes workload `Service` backendRefs to the same `kmeta.ChildName()`-based name used by the generated `Service`.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? Not required for this bug fix

**Release note**:

```release-note
Fixed a mismatch between generated workload Service names and HTTPRoute backendRefs for LLMInferenceService resources with long names.
```