### PR TITLE
feat(release): add Copilot CLI release automation

### DIFF
--- a/.github/agents/release-orchestrator.agent.md
+++ b/.github/agents/release-orchestrator.agent.md
@@ -1,0 +1,416 @@
+---
+name: release-orchestrator
+description: Full KServe release orchestrator for Copilot CLI. Handles version bump, CI monitoring, merge, branch/tag, publish, and validation interactively.
+---
+
+You are a release orchestrator for KServe, designed for interactive CLI use.
+You guide the user through the entire release process step by step, asking for approval at key decision points.
+
+## STRICT RULES
+
+1. Do NOT run `make test`, `make lint`, `make py-lint`, or any validation/build commands
+2. ALWAYS ask for user approval before merge, publish, and destructive actions
+3. Do NOT skip approval points even if the user says "do everything automatically"
+
+## Checkpoint System
+
+Save state before long-running operations so the session can be resumed after interruption.
+
+**Checkpoint file**: `/tmp/kserve-release-checkpoint.json` in the repo root
+
+**Save checkpoint** (write this file before any long-running step):
+```bash
+cat > /tmp/kserve-release-checkpoint.json << EOF
+{
+  "version": "{VERSION}",
+  "prior_version": "{PRIOR_VERSION}",
+  "pr_repo": "{PR_REPO}",
+  "branch_repo": "{BRANCH_REPO}",
+  "release_type": "{RC0|RC1|FINAL}",
+  "phase": "{PHASE_NAME}",
+  "bump_pr": {PR_NUMBER_OR_NULL},
+  "cherrypick_pr": {PR_NUMBER_OR_NULL},
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+```
+
+**On session start**: Check if checkpoint exists:
+```bash
+cat /tmp/kserve-release-checkpoint.json
+```
+If found, show contents and ask: "Resume from checkpoint? (y/n)"
+- **y**: Skip completed phases, continue from `phase` field
+- **n**: Start fresh, delete checkpoint
+
+**Delete checkpoint** after successful completion:
+```bash
+rm -f /tmp/kserve-release-checkpoint.json
+```
+
+**Checkpoint phases** (save at these points):
+- `CONFIRMED` — after version/repo confirmed, before bump PR
+- `BUMP_PR_CREATED` — after bump PR created, before CI watch
+- `CI_PASSED` — after CI passes, before merge
+- `BUMP_MERGED` — after bump PR merged, before cherry-pick (RC1+ only)
+- `CHERRYPICK_PR_CREATED` — after cherry-pick PR created, before CI watch
+- `BRANCH_TAG_DONE` — after branch/tag verified, before publish
+- `PUBLISHED` — after release published, before downstream validation
+
+## What to do
+
+### Phase 1: Prepare
+
+1. Read current version:
+   ```bash
+   grep "KSERVE_VERSION=" kserve-deps.env | cut -d'=' -f2 | sed 's/^v//'
+   ```
+   Call this `CURRENT_VERSION`.
+
+2. Set up target repositories:
+
+   Two repos are needed throughout the release process:
+   - **PR_REPO**: where PRs and releases are created (default: `kserve/kserve`)
+   - **BRANCH_REPO**: where bump/cherry-pick branches are pushed (default: your personal fork, e.g., `jooho/kserve`)
+
+   Auto-detect:
+   ```bash
+   BRANCH_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   BRANCH_OWNER=$(echo "$BRANCH_REPO" | cut -d/ -f1)
+   PR_REPO=$(gh repo view --json parent --jq '.parent.nameWithOwner // empty')
+   if [[ -z "$PR_REPO" ]]; then
+     PR_REPO="$BRANCH_REPO"
+   fi
+   ```
+
+   ALWAYS ask each separately every session (do not skip even if previously answered).
+   Show both `{PR_REPO}` and `{BRANCH_REPO}` as selectable options for each question:
+
+   - "PR/release target repo:"
+     1. {PR_REPO} (Recommended)
+     2. {BRANCH_REPO}
+     3. Other (type your answer)
+
+   - "Branch push repo:"
+     1. {BRANCH_REPO} (Recommended)
+     2. {PR_REPO}
+     3. Other (type your answer)
+
+   Update `BRANCH_OWNER` after final selection.
+
+3. If the user did not specify a version, suggest candidates:
+   - Next RC: `X.Y.Z-rc(N+1)`
+   - Minor bump: `X.(Y+1).0-rc0`
+   - Final release: `X.Y.Z` (strip `-rcN`)
+   Present as numbered list and ask user to pick.
+
+4. Validate version format: must match `X.Y.Z` or `X.Y.Z-rcN`.
+
+5. **APPROVAL POINT**: "Release v{VERSION} from v{CURRENT_VERSION}. PR target: {PR_REPO}, branch push: {BRANCH_REPO}. Proceed? (y/n)"
+
+### Phase 2: Version Bump
+
+1. Get prior version and detect release type:
+   ```bash
+   PRIOR_VERSION=$(grep "KSERVE_VERSION=" kserve-deps.env | cut -d'=' -f2 | sed 's/^v//')
+   ```
+   - If VERSION ends with `-rc0` → **RC0 flow**
+   - If VERSION ends with `-rc1`, `-rc2`, etc., or has no `-rcN` suffix → **RC1+ / Final flow**
+
+2. Run bump:
+   ```bash
+   yes "" | make bump-version NEW_VERSION={VERSION} PRIOR_VERSION={PRIOR_VERSION}
+   ```
+   This is the ONLY make command you should run.
+
+3. **Save checkpoint** before creating PR:
+   ```bash
+   cat > /tmp/kserve-release-checkpoint.json << EOF
+   {"version":"{VERSION}","prior_version":"{PRIOR_VERSION}","pr_repo":"{PR_REPO}","branch_repo":"{BRANCH_REPO}","release_type":"{TYPE}","phase":"CONFIRMED","bump_pr":null,"cherrypick_pr":null,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+   EOF
+   ```
+
+4. Commit and create PR:
+   - **RC0**: title `release: prepare release v{VERSION}` (triggers `release-branch-tag.yml` on merge)
+   - **RC1+ / Final**: title `chore: bump version to v{VERSION}` (does NOT trigger `release-branch-tag.yml`)
+
+   ```bash
+   git checkout -b release-bump-v{VERSION}
+   git add -A
+   git commit -S -s -m "{TITLE}"
+   git push origin release-bump-v{VERSION}
+   gh pr create --repo {UPSTREAM_REPO} --base master \
+     --head {FORK_OWNER}:release-bump-v{VERSION} \
+     --title "{TITLE}" \
+     --label release \
+     [--label cherrypick-approved]  # RC1+ only — DO NOT add for Final release
+     --body "Automated version bump from v{PRIOR_VERSION} to v{VERSION}."
+   ```
+   > `{FORK_OWNER}` is extracted from `{FORK_REPO}` (e.g., `jooho` from `jooho/kserve`).
+
+5. **Save checkpoint** after PR created:
+   ```bash
+   # Update /tmp/kserve-release-checkpoint.json with bump_pr number and phase
+   # phase: BUMP_PR_CREATED, bump_pr: {PR_NUMBER}
+   ```
+
+### Phase 2B: Cherry-pick (RC1+ only — skip entirely for Final)
+
+Skip this phase for RC0. After the bump PR (Phase 2) merges to master:
+
+1. Find all PRs merged to master with `cherrypick-approved` label but NOT `cherrypicked`.
+   PRs already labeled `cherrypicked` have been backported before — skip them:
+   ```bash
+   gh pr list --repo {PR_REPO} --state merged \
+     --label cherrypick-approved \
+     --json number,title,mergeCommit,mergedAt,labels \
+     --jq '[.[] | select(.labels | map(.name) | contains(["cherrypicked"]) | not)] | sort_by(.mergedAt)'
+   ```
+   > `sort_by(.mergedAt)` = ascending = oldest commit first. Apply in this order to minimize conflicts.
+
+2. Fetch the release branch and create a cherry-pick branch:
+   ```bash
+   git fetch origin release-{MAJOR}.{MINOR}
+   git checkout -b cherrypick/v{VERSION} origin/release-{MAJOR}.{MINOR}
+   ```
+
+3. Cherry-pick each PR's merge commit in order (oldest first):
+   ```bash
+   git cherry-pick -x {MERGE_COMMIT_SHA}
+   ```
+   - On conflict: attempt auto-resolve
+   - If not confident: report conflict details and ask user to resolve, then `git cherry-pick --continue`
+
+4. Push and create PR targeting the release branch:
+   ```bash
+   git push origin cherrypick/v{VERSION}
+   gh pr create --repo {PR_REPO} \
+     --base release-{MAJOR}.{MINOR} \
+     --head {BRANCH_OWNER}:cherrypick/v{VERSION} \
+     --title "release: prepare release v{VERSION}" \
+     --label release \
+     --body "Cherry-pick backport for v{VERSION}.\n\nPRs included:\n{PR_LIST}"
+   ```
+   > Title starts with `release: prepare` — merging this PR triggers `release-branch-tag.yml`
+
+5. **Save checkpoint** after cherry-pick PR created:
+   ```bash
+   # phase: CHERRYPICK_PR_CREATED, cherrypick_pr: {PR_NUMBER}
+   ```
+
+6. Report: "Cherry-pick PR #{number} created: {URL}"
+7. → Continue to **Phase 3: Monitor CI** (for cherry-pick PR)
+
+### Phase 3: Monitor CI
+
+1. Wait for ALL CI checks to complete:
+   ```bash
+   gh pr checks {PR_NUMBER} --repo {PR_REPO} --watch
+   ```
+   `--watch` blocks automatically until all checks conclude. No manual polling needed.
+
+2. If any check fails, post `/rerun-all` comment and watch again:
+   ```bash
+   gh pr comment {PR_NUMBER} --repo {PR_REPO} --body "/rerun-all"
+   gh pr checks {PR_NUMBER} --repo {PR_REPO} --watch
+   ```
+
+3. If checks still fail after re-run, check how many e2e tests failed.
+   E2e test checks are from workflows named `E2E Tests` or `LLMInferenceService E2E Tests`.
+
+   - 3 or more e2e failures: report to user as likely flaky infrastructure.
+   - Fewer than 3: show failed check names and log excerpts.
+
+   Ask: "CI still failing. Retry, skip, or abort? (retry/skip/abort)"
+
+4. When all checks pass:
+   - **Save checkpoint**: `phase: CI_PASSED`
+   - Report: "All CI checks passed."
+
+### Phase 4: Merge
+
+**APPROVAL POINT**: "CI passed. Ready to merge PR #{PR_NUMBER}? (y/n)"
+
+On approval:
+```bash
+gh pr merge {PR_NUMBER} --repo {PR_REPO} --squash
+```
+Report: "PR #{PR_NUMBER} merged."
+**Save checkpoint**: `phase: BUMP_MERGED`
+
+**RC1+ / Final only**: After cherry-pick PR merges, add `cherrypicked` label to all PRs that were cherry-picked:
+```bash
+gh pr edit {CHERRY_PICKED_PR_NUMBER} --repo {PR_REPO} --add-label cherrypicked
+```
+Repeat for each PR in the cherry-pick list.
+
+### Phase 5: Verify Branch & Tag
+
+**RC0**: workflow triggers automatically on bump PR merge.
+
+**RC1+ / Final**: cherry-pick PR targets `release-X.Y` (not master) → does NOT auto-trigger. Manually trigger:
+```bash
+gh workflow run release-branch-tag.yml \
+  --repo {PR_REPO} \
+  -f version=v{VERSION} \
+  -f dry_run=false
+```
+
+1. Wait for `Prepare Release (Branch & Tag)` workflow (poll every 30s, max 10min):
+   ```bash
+   gh run list --repo {PR_REPO} --workflow=release-branch-tag.yml --limit 1 --json status,conclusion
+   ```
+
+2. Verify branch exists (rc0 only):
+   ```bash
+   gh api repos/{PR_REPO}/branches/release-{MAJOR}.{MINOR}
+   ```
+
+3. Verify tag exists:
+   ```bash
+   gh api repos/{PR_REPO}/git/ref/tags/v{VERSION}
+   ```
+
+4. Report: "Branch `release-{MAJOR}.{MINOR}` and tag `v{VERSION}` created."
+   **Save checkpoint**: `phase: BRANCH_TAG_DONE`
+
+### Phase 6: Publish Release
+
+1. **APPROVAL POINT**: "Ready to create draft release v{VERSION}? (y/n)"
+
+2. On approval:
+   ```bash
+   ./hack/release/publish-release.sh v{VERSION} --repo={PR_REPO} --draft
+   ```
+
+3. Show draft release URL.
+
+4. **APPROVAL POINT**: "Draft looks good? Publish it? (y/n)"
+
+5. On approval:
+   ```bash
+   gh release edit v{VERSION} --repo={PR_REPO} --draft=false
+   ```
+
+6. Report final release URL.
+   **Save checkpoint**: `phase: PUBLISHED`
+
+### Phase 7: Validate Downstream
+
+1. Poll downstream workflows (every 60s, max 15min):
+   ```bash
+   gh run list --repo {PR_REPO} --workflow=python-publish.yml --limit 1 --json status,conclusion
+   gh run list --repo {PR_REPO} --workflow=helm-publish.yml --limit 1 --json status,conclusion
+   ```
+
+2. Report:
+   - PyPI publish: pass/fail
+   - Helm publish: pass/fail
+
+### Phase 8: Artifact Validation
+
+Run validation:
+```bash
+./hack/release/validate-release.sh v{VERSION} --repo={PR_REPO}
+```
+
+Report pass/fail per item.
+
+### Phase 9: Smoke Test
+
+**APPROVAL POINT**: "Run installation smoke test with kind? (y/n)"
+
+On approval, execute the following steps autonomously:
+
+**Step 1: Check image availability before proceeding**
+
+Check that the KServe controller image is available on Docker Hub:
+```bash
+docker manifest inspect docker.io/kserve/kserve-controller:v{VERSION}
+```
+- If image exists → proceed to Step 2
+- If image does not exist → notify user:
+  > "⏳ Docker images for v{VERSION} are not yet available (image build pipeline still running, typically takes a few hours after release publish).
+  > Please say **'smoke test 실행해줘'** when you're ready to run it later.
+  > You can also ask me to wait and poll automatically."
+
+  If user asks to wait/poll: re-check every 5 minutes, up to 4 hours, then notify when image is available and proceed automatically.
+
+**Step 2: Create kind cluster**
+```bash
+./hack/setup/dev/manage.kind-with-registry.sh
+```
+
+**Step 3: Install KServe**
+```bash
+./hack/kserve-install.sh --type kserve,localmodel,llmisvc --raw --kserve-version v{VERSION}
+```
+
+**Step 4: Test ISVC (sklearn-iris) — then cleanup before LLMIsvc**
+
+Deploy and wait for ISVC to be Ready (poll every 30s, timeout 10min):
+```bash
+kubectl apply -f docs/samples/v1beta1/sklearn/v1/sklearn.yaml -n kserve
+```
+Poll until Ready:
+```bash
+kubectl get isvc sklearn-iris -n kserve -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+```
+- If `True` → report "✅ ISVC sklearn-iris is Ready" then delete it:
+  ```bash
+  kubectl delete isvc sklearn-iris -n kserve
+  kubectl wait --for=delete pod -l serving.kserve.io/inferenceservice=sklearn-iris -n kserve --timeout=120s
+  ```
+- If timeout (10min) → report failure with:
+  ```bash
+  kubectl get pods -n kserve
+  kubectl describe isvc sklearn-iris -n kserve
+  ```
+  Ask: "ISVC smoke test timed out. Abort or wait longer? (abort/wait)"
+
+**Step 4: Test LLMIsvc (facebook-opt-125m) — after ISVC cleanup**
+
+Deploy and wait for LLMIsvc to be Ready (poll every 30s, timeout 20min):
+```bash
+kubectl apply -f docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml -n kserve
+```
+Poll until Ready:
+```bash
+kubectl get llmisvc facebook-opt-125m-single -n kserve -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+```
+- If `True` → report "✅ LLMIsvc facebook-opt-125m-single is Ready" then delete it:
+  ```bash
+  kubectl delete llmisvc facebook-opt-125m-single -n kserve
+  ```
+  Then notify user: "✅ Smoke test passed! ISVC and LLMIsvc both verified. v{VERSION} release complete!"
+
+  **Delete checkpoint** (release fully complete):
+  ```bash
+  rm -f /tmp/kserve-release-checkpoint.json
+  ```
+- If timeout (20min) → report failure with:
+  ```bash
+  kubectl get pods -n kserve
+  kubectl describe llmisvc facebook-opt-125m-single -n kserve
+  ```
+  Ask: "LLMIsvc smoke test timed out. Abort or wait longer? (abort/wait)"
+
+To clean up: `./hack/setup/dev/manage.kind-with-registry.sh --uninstall`
+
+## Approval Points Summary
+
+1. **Phase 1** — Confirm version and target repo
+2. **Phase 4** — Merge PR after CI passes
+3. **Phase 6** — Create draft release
+4. **Phase 6** — Publish draft release
+5. **Phase 9** — Run smoke test
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| bump-version fails | Show error, ask user how to proceed |
+| CI timeout (60min) | Report, ask retry or abort |
+| CI failure after rerun | Show logs, ask retry/skip/abort |
+| Branch/tag missing | Suggest re-running release-branch-tag.yml manually |
+| Publish fails | Show error, provide manual command |

--- a/.github/workflows/release-branch-tag.yml
+++ b/.github/workflows/release-branch-tag.yml
@@ -1,0 +1,129 @@
+name: Prepare Release (Branch & Tag)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., v0.17.0-rc0, v0.17.0-rc1, v0.17.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry-run mode (validate only, no changes)'
+        required: false
+        type: boolean
+        default: true
+  pull_request:
+    types: [closed]
+    branches: [master]
+    paths:
+      - 'kserve-deps.env'
+
+# Prevent concurrent releases
+concurrency:
+  group: release-workflow
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    # For PR trigger: only run when merged AND title matches release pattern
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.title, 'release: prepare'))
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          else
+            # Read version from kserve-deps.env (set by make bump-version)
+            VERSION=$(grep "KSERVE_VERSION=" kserve-deps.env | cut -d'=' -f2)
+            if [[ -z "$VERSION" ]]; then
+              echo "Could not read KSERVE_VERSION from kserve-deps.env"
+              exit 1
+            fi
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        run: |
+          ./hack/setup/cli/install-yq.sh
+
+      - name: Check OWNERS permissions
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Checking permissions for user: ${{ github.actor }}"
+
+          # Extract allowed users from OWNERS file
+          ALLOWED_USERS=$(yq eval '.project-leads[], .approvers[], .reviewers[]' OWNERS)
+
+          # Check if current user is in the allowed list
+          if ! echo "$ALLOWED_USERS" | grep -q "^${{ github.actor }}$"; then
+            echo ""
+            echo "Permission denied!"
+            echo "   Only users listed in OWNERS (reviewer+) can run this workflow."
+            echo "   Current user: ${{ github.actor }}"
+            echo ""
+            echo "Allowed users:"
+            echo "$ALLOWED_USERS"
+            exit 1
+          fi
+
+          echo "Permission granted for ${{ github.actor }}"
+
+      - name: Check if release already exists
+        if: steps.version.outputs.dry_run == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo ""
+            echo "Release $VERSION already exists!"
+            echo ""
+            gh release view "$VERSION" --json url,createdAt -q '"URL: " + .url + "\nCreated: " + .createdAt'
+            exit 1
+          fi
+
+          echo "Release $VERSION does not exist yet"
+
+      - name: Create Branch and Tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ steps.version.outputs.dry_run }}" == "true" ]]; then
+            ./hack/release/create-branch-tag.sh "${{ steps.version.outputs.version }}" --dry-run --github-actions
+          else
+            ./hack/release/create-branch-tag.sh "${{ steps.version.outputs.version }}" --github-actions
+          fi
+
+      - name: Next steps
+        if: steps.version.outputs.dry_run == 'false'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo ""
+          echo "Branch and tag created for $VERSION"
+          echo ""
+          echo "Next steps:"
+          echo "  1. Go to https://github.com/${{ github.repository }}/releases/new"
+          echo "  2. Choose tag: $VERSION"
+          echo "  3. Generate release notes"
+          echo "  4. Check 'Set as pre-release' if this is an RC version"
+          echo "  5. Publish the release"
+          echo ""
+          echo "Publishing will automatically trigger:"
+          echo "  - Helm charts publication (helm-publish workflow)"
+          echo "  - Python packages publication (python-publish workflow)"

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ istio-*
 # Claude code
 .claude/
 
+# bkit
+.bkit/
+

--- a/hack/release/create-branch-tag.sh
+++ b/hack/release/create-branch-tag.sh
@@ -1,0 +1,560 @@
+#!/usr/bin/env bash
+# Helper script to create KServe releases
+
+set -eo pipefail
+
+# Detect the upstream remote (kserve/kserve)
+detect_upstream_remote() {
+    # Check all remotes for kserve/kserve
+    for remote in $(git remote); do
+        local url=$(git remote get-url "$remote" 2>/dev/null || echo "")
+        if [[ "$url" == *"kserve/kserve"* ]]; then
+            echo "$remote"
+            return 0
+        fi
+    done
+
+    # Not found
+    echo ""
+    return 1
+}
+
+# ============================================================
+# Color codes for output
+# ============================================================
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+BLUE='\033[34m'
+NC='\033[0m' # No Color
+
+# ============================================================
+# Global variables
+# ============================================================
+VERSION=""
+DRY_RUN=false
+VALIDATE_ONLY=false
+GITHUB_ACTIONS_MODE=false
+BASE_VERSION=""
+RC=""
+BRANCH=""
+RELEASE_TYPE=""
+
+# ============================================================
+# Helper functions
+# ============================================================
+
+print_error() {
+    echo -e "${RED}❌ $1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+print_section() {
+    echo ""
+    echo -e "${GREEN}$1${NC}"
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 <version> [OPTIONS]
+
+Create a KServe release (branch and tag)
+
+Arguments:
+  version           Release version (e.g., v0.17.0-rc0, v0.17.0-rc1, v0.17.0)
+
+Options:
+  --dry-run         Validate and show execution plan without making changes
+  --validate-only   Only run validation checks and exit
+  --github-actions  Enable GitHub CLI checks (for CI environment)
+  -h, --help        Show this help message
+
+Examples:
+  # Validate version and show execution plan
+  $0 v0.17.0-rc0 --dry-run
+
+  # Create RC0 (branch + tag)
+  $0 v0.17.0-rc0
+
+  # Create RC1 (tag only)
+  $0 v0.17.0-rc1
+
+  # Create final release (tag only)
+  $0 v0.17.0
+
+Release Types:
+  v0.17.0-rc0  → RC0 (creates release-0.17 branch + tag)
+  v0.17.0-rc1  → RC1+ (creates tag on existing branch)
+  v0.17.0      → Final (creates tag on existing branch)
+
+Note:
+  - This script creates branches and tags only
+  - GitHub Release is created by GitHub Actions workflow
+  - Requires push access to kserve/kserve repository
+
+EOF
+    exit 0
+}
+
+# ============================================================
+# Validation functions
+# ============================================================
+
+validate_version_format() {
+    print_section "🔍 Phase 1: Validating version format..."
+
+    local pattern="^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$"
+    if [[ ! $VERSION =~ $pattern ]]; then
+        print_error "Invalid version format: $VERSION"
+        echo ""
+        echo "Valid formats:"
+        echo "  - v0.17.0-rc0 (Release Candidate 0)"
+        echo "  - v0.17.0-rc1 (Release Candidate 1)"
+        echo "  - v0.17.0     (Final Release)"
+        exit 1
+    fi
+
+    print_success "Version format is valid"
+}
+
+parse_version() {
+    print_section "🔍 Parsing version components..."
+
+    # Remove leading 'v'
+    local version_no_v=$(echo "$VERSION" | sed 's/^v//')
+
+    # Extract base version (e.g., 0.17.0)
+    BASE_VERSION=$(echo "$version_no_v" | sed 's/-rc[0-9]*$//')
+
+    # Extract major.minor only for branch name (e.g., 0.17)
+    # KServe uses release-0.16, release-0.17 (not release-0.16.0)
+    local major_minor=$(echo "$BASE_VERSION" | cut -d. -f1,2)
+
+    # Extract RC suffix (e.g., rc0, rc1, or empty for final)
+    RC=$(echo "$version_no_v" | grep -o 'rc[0-9]*$' || echo "")
+
+    # Determine release type
+    if [[ "$RC" == "rc0" ]]; then
+        RELEASE_TYPE="RC0 (Initial Release Candidate)"
+    elif [[ "$RC" =~ ^rc[1-9][0-9]*$ ]]; then
+        RELEASE_TYPE="RC${RC#rc}+ (Bug Fix Release Candidate)"
+    elif [[ -z "$RC" ]]; then
+        RELEASE_TYPE="Final Release"
+    else
+        print_error "Invalid RC format: $RC"
+        exit 1
+    fi
+
+    BRANCH="release-${major_minor}"
+
+    echo "  Base Version: $BASE_VERSION"
+    echo "  RC Suffix: ${RC:-none}"
+    echo "  Release Type: $RELEASE_TYPE"
+    echo "  Target Branch: $BRANCH"
+    print_success "Version parsed successfully"
+}
+
+validate_kserve_deps() {
+    print_section "🔍 Phase 2: Validating kserve-deps.env..."
+
+    if [[ ! -f "kserve-deps.env" ]]; then
+        print_error "kserve-deps.env file not found!"
+        exit 1
+    fi
+
+    local current_version=$(grep KSERVE_VERSION= kserve-deps.env | cut -d= -f2)
+
+    if [[ "$current_version" != "$VERSION" ]]; then
+        print_error "Version mismatch!"
+        echo "   Input version: $VERSION"
+        echo "   kserve-deps.env: $current_version"
+        echo ""
+        echo "Please run prepare-for-release.sh first:"
+        echo "  ./hack/release/prepare-for-release.sh <prior_version> <new_version>"
+        exit 1
+    fi
+
+    print_success "kserve-deps.env version matches: $current_version"
+}
+
+validate_tag_duplicate() {
+    print_section "🔍 Phase 3: Checking for duplicate tag..."
+
+    if git rev-parse "$VERSION" >/dev/null 2>&1; then
+        print_error "Tag $VERSION already exists!"
+        echo ""
+        echo "Existing tag information:"
+        git show -s --format='%h %ci %s' "$VERSION"
+        exit 1
+    fi
+
+    print_success "Tag $VERSION does not exist (OK)"
+}
+
+validate_github_release_duplicate() {
+    print_section "🔍 Phase 4: Checking for duplicate GitHub Release..."
+
+    # Skip actual check if --github-actions is not set
+    if [[ "$GITHUB_ACTIONS_MODE" == false ]]; then
+        print_info "GitHub Release check requires --github-actions flag"
+        return
+    fi
+
+    # Check if gh CLI is available
+    if ! command -v gh >/dev/null 2>&1; then
+        print_warning "gh CLI not found, skipping GitHub Release duplicate check"
+        print_info "Install gh CLI to enable this check: https://cli.github.com/"
+        return
+    fi
+
+    # Check if release exists
+    if gh release view "$VERSION" --repo kserve/kserve >/dev/null 2>&1; then
+        print_error "GitHub Release $VERSION already exists!"
+        echo ""
+        echo "Existing release information:"
+        gh release view "$VERSION" --repo kserve/kserve --json name,tagName,isPrerelease,createdAt,url \
+            --template '{{printf "  Name: %s\n  Tag: %s\n  Pre-release: %v\n  Created: %s\n  URL: %s\n" .name .tagName .isPrerelease .createdAt .url}}'
+        exit 1
+    fi
+
+    print_success "GitHub Release $VERSION does not exist (OK)"
+}
+
+validate_branch_rc0() {
+    if [[ "$RC" != "rc0" ]]; then
+        return
+    fi
+
+    print_section "🔍 Phase 5: Checking release branch (RC0 mode)..."
+
+    if git ls-remote --heads "$UPSTREAM_REMOTE" "$BRANCH" 2>/dev/null | grep -q "$BRANCH"; then
+        print_error "Branch $BRANCH already exists!"
+        echo "   RC0 should create a new release branch."
+        echo ""
+        echo "If you want to create RC1+, use version like: v${BASE_VERSION}-rc1"
+        exit 1
+    fi
+
+    print_success "Branch $BRANCH does not exist (OK for RC0)"
+}
+
+validate_branch_rc1_plus() {
+    if [[ "$RC" == "rc0" ]]; then
+        return
+    fi
+
+    print_section "🔍 Phase 6: Checking release branch (RC1+/Final mode)..."
+
+    if ! git ls-remote --heads "$UPSTREAM_REMOTE" "$BRANCH" 2>/dev/null | grep -q "$BRANCH"; then
+        print_error "Branch $BRANCH does not exist!"
+        echo "   RC1+ and Final releases require an existing release branch."
+        echo ""
+        echo "Please create RC0 first: v${BASE_VERSION}-rc0"
+        exit 1
+    fi
+
+    print_success "Branch $BRANCH exists (OK for RC1+/Final)"
+}
+
+# ============================================================
+# Execution functions
+# ============================================================
+
+show_dry_run_plan() {
+    echo ""
+    echo "=================================================="
+    echo -e "${BLUE}🔍 DRY-RUN MODE - No changes will be made${NC}"
+    echo "=================================================="
+    echo ""
+    echo "📋 Release Information:"
+    echo "  Version:      $VERSION"
+    echo "  Type:         $RELEASE_TYPE"
+    echo "  Branch:       $BRANCH"
+    if [[ "$RC" == "rc0" ]]; then
+        echo "  Base:         master"
+    else
+        echo "  Base:         $BRANCH (existing)"
+    fi
+    echo ""
+    echo "🔨 Actions to be performed by this script:"
+    if [[ "$RC" == "rc0" ]]; then
+        echo "  1. Create release branch: $BRANCH (from master)"
+        echo "  2. Push branch to remote"
+        echo "  3. Create tag: $VERSION"
+        echo "  4. Push tag to remote"
+    else
+        echo "  1. Checkout existing branch: $BRANCH"
+        echo "  2. Create tag: $VERSION"
+        echo "  3. Push tag to remote"
+    fi
+    echo ""
+    echo "🔨 Additional actions (performed by GitHub Actions):"
+    if [[ -n "$RC" ]]; then
+        echo "  - Create GitHub pre-release: $VERSION"
+    else
+        echo "  - Create GitHub final release: $VERSION"
+    fi
+    echo ""
+    echo "=================================================="
+    print_success "All validations passed!"
+    echo "=================================================="
+    echo ""
+    echo "🚀 To execute this release, run:"
+    echo "   ./hack/release/create-branch-tag.sh $VERSION"
+    echo ""
+}
+
+handle_error() {
+    echo ""
+    echo "=================================================="
+    print_error "Error occurred! Rolling back..."
+    echo "=================================================="
+
+    # Delete tag if created
+    if git rev-parse "$VERSION" >/dev/null 2>&1; then
+        echo "Deleting local tag $VERSION..."
+        git tag -d "$VERSION" 2>/dev/null || true
+    fi
+
+    if git ls-remote --tags "$UPSTREAM_REMOTE" 2>/dev/null | grep -q "refs/tags/$VERSION"; then
+        echo "Deleting remote tag $VERSION..."
+        git push --delete "$UPSTREAM_REMOTE" "$VERSION" 2>/dev/null || true
+    fi
+
+    # Delete branch if created (RC0 only)
+    if [[ "$RC" == "rc0" ]]; then
+        if git ls-remote --heads "$UPSTREAM_REMOTE" "$BRANCH" 2>/dev/null | grep -q "$BRANCH"; then
+            echo "Deleting remote branch $BRANCH..."
+            git push --delete "$UPSTREAM_REMOTE" "$BRANCH" 2>/dev/null || true
+        fi
+    fi
+
+    echo "=================================================="
+    print_error "Rollback completed"
+    echo "=================================================="
+    exit 1
+}
+
+create_rc0() {
+    print_section "Step 1: Creating release branch from master..."
+
+    git checkout master
+    git pull "$UPSTREAM_REMOTE" master
+    git checkout -b "$BRANCH"
+    git push "$UPSTREAM_REMOTE" "$BRANCH"
+
+    print_success "Created and pushed branch: $BRANCH"
+}
+
+create_rc1_plus_or_final() {
+    print_section "Step 1: Checking out existing release branch..."
+
+    git fetch "$UPSTREAM_REMOTE" "$BRANCH"
+    git checkout "$BRANCH"
+    git pull "$UPSTREAM_REMOTE" "$BRANCH"
+
+    print_success "Checked out branch: $BRANCH"
+}
+
+create_tag() {
+    print_section "Step 2: Creating tag..."
+
+    git tag "$VERSION"
+    git push "$UPSTREAM_REMOTE" "$VERSION"
+
+    print_success "Created and pushed tag: $VERSION"
+}
+
+
+execute_release() {
+    echo ""
+    echo "=================================================="
+    print_info "🚀 EXECUTION MODE - Creating release..."
+    echo "=================================================="
+    echo ""
+
+    # Setup error handler
+    trap 'handle_error' ERR
+
+    # Configure git
+    if ! git config user.email >/dev/null 2>&1; then
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+    fi
+
+    # Execute based on release type
+    if [[ "$RC" == "rc0" ]]; then
+        create_rc0
+    else
+        create_rc1_plus_or_final
+    fi
+
+    create_tag
+
+    echo ""
+    echo "=================================================="
+    print_success "Branch and tag created successfully!"
+    echo "=================================================="
+    echo ""
+    echo "Branch: $BRANCH"
+    echo "Tag: $VERSION"
+    echo ""
+    echo "Next steps:"
+    echo "  ✅ Branch and tag created successfully"
+    echo ""
+    echo "  Next: Create GitHub Release (requires project lead)"
+    echo "  URL: https://github.com/kserve/kserve/releases/new?tag=$VERSION"
+    echo ""
+}
+
+# ============================================================
+# Main script
+# ============================================================
+
+main() {
+    # Check if running from repository root
+    if [[ ! -f "kserve-deps.env" ]]; then
+        print_error "This script must be run from the repository root directory"
+        exit 1
+    fi
+
+    # Parse arguments
+    if [[ $# -eq 0 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+        usage
+    fi
+
+    VERSION="$1"
+    shift
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --validate-only)
+                VALIDATE_ONLY=true
+                shift
+                ;;
+            --github-actions)
+                GITHUB_ACTIONS_MODE=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                usage
+                ;;
+        esac
+    done
+
+    # Validate option combinations
+    if [[ "$DRY_RUN" == true ]] && [[ "$VALIDATE_ONLY" == true ]]; then
+        print_error "Cannot use --dry-run and --validate-only together"
+        echo ""
+        echo "Choose one:"
+        echo "  --validate-only : Only run validations"
+        echo "  --dry-run       : Run validations and show execution plan"
+        exit 1
+    fi
+
+    # Print header
+    echo "=================================================="
+    echo "KServe Release Automation"
+    echo "=================================================="
+    echo "Version: $VERSION"
+    echo "Dry-run: $DRY_RUN"
+    echo "Validate-only: $VALIDATE_ONLY"
+    echo "GitHub Actions Mode: $GITHUB_ACTIONS_MODE"
+    echo "=================================================="
+
+    # Determine upstream remote
+    if [[ "$GITHUB_ACTIONS_MODE" == true ]]; then
+        # GitHub Actions always uses origin
+        UPSTREAM_REMOTE="origin"
+        echo "Using remote: $UPSTREAM_REMOTE (GitHub Actions)"
+    else
+        # Auto-detect for local/fork usage
+        UPSTREAM_REMOTE=$(detect_upstream_remote)
+
+        if [[ -z "$UPSTREAM_REMOTE" ]]; then
+            echo ""
+            print_error "No remote pointing to kserve/kserve found!"
+            echo ""
+            echo "Please add upstream remote:"
+            echo "  git remote add upstream git@github.com:kserve/kserve.git"
+            echo ""
+            echo "Or if using HTTPS:"
+            echo "  git remote add upstream https://github.com/kserve/kserve.git"
+            echo ""
+            echo "Or run with --github-actions flag to use origin remote"
+            exit 1
+        fi
+
+        echo "Using remote: $UPSTREAM_REMOTE (auto-detected)"
+    fi
+    echo "=================================================="
+
+    # Run validations
+    validate_version_format
+    parse_version
+    validate_kserve_deps
+    validate_tag_duplicate
+    validate_github_release_duplicate
+    validate_branch_rc0
+    validate_branch_rc1_plus
+
+    # Exit if validate-only mode
+    if [[ "$VALIDATE_ONLY" == true ]]; then
+        echo ""
+        print_success "All validations passed!"
+        exit 0
+    fi
+
+    # Show dry-run plan and exit if dry-run mode
+    if [[ "$DRY_RUN" == true ]]; then
+        show_dry_run_plan
+        exit 0
+    fi
+
+    # Block local execution - only allow in GitHub Actions
+    if [[ "${GITHUB_ACTIONS:-false}" != "true" ]]; then
+        echo ""
+        echo "=================================================="
+        print_error "Direct execution is not allowed!"
+        echo "=================================================="
+        echo ""
+        echo "This script can only be executed in GitHub Actions"
+        echo "to prevent accidental releases."
+        echo ""
+        echo "To create a release:"
+        echo "  1. Go to: https://github.com/kserve/kserve/actions"
+        echo "  2. Select 'Create Release' workflow"
+        echo "  3. Click 'Run workflow'"
+        echo "  4. Enter version and set dry_run=false"
+        echo ""
+        echo "For local testing:"
+        echo "  ./hack/release/create-branch-tag.sh <version> --validate-only"
+        echo "  ./hack/release/create-branch-tag.sh <version> --dry-run"
+        echo ""
+        exit 1
+    fi
+
+    # Execute release
+    execute_release
+}
+
+main "$@"

--- a/hack/release/publish-release.sh
+++ b/hack/release/publish-release.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Publish a KServe GitHub Release with install artifacts.
+#
+# This script must be run with a user-authenticated `gh` token (not GITHUB_TOKEN)
+# so that the release is attributed to the user and downstream workflows
+# (pypi, helm) are triggered on publish.
+#
+# Usage:
+#   ./hack/release/publish-release.sh <version> [--draft] [--dry-run]
+#
+# Examples:
+#   ./hack/release/publish-release.sh v0.18.0-rc0
+#   ./hack/release/publish-release.sh v0.18.0-rc0 --draft
+#   ./hack/release/publish-release.sh v0.18.0 --dry-run
+
+set -eo pipefail
+
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+NC='\033[0m'
+
+usage() {
+    echo "Usage: $0 <version> [--draft] [--dry-run]"
+    echo ""
+    echo "Arguments:"
+    echo "  version     Release version with 'v' prefix (e.g., v0.18.0-rc0, v0.18.0)"
+    echo ""
+    echo "Options:"
+    echo "  --draft       Create as draft release"
+    echo "  --dry-run     Validate only, do not create release"
+    echo "  --repo=OWNER/REPO  Target repo (default: auto-detected from git remote)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 v0.18.0-rc0"
+    echo "  $0 v0.18.0-rc0 --draft"
+    echo "  $0 v0.18.0-rc0 --repo=kserve/kserve --draft"
+    echo "  $0 v0.18.0 --dry-run"
+    exit 1
+}
+
+# Parse arguments
+VERSION=""
+DRAFT=false
+DRY_RUN=false
+REPO="kserve/kserve"
+
+for arg in "$@"; do
+    case "$arg" in
+        --draft) DRAFT=true ;;
+        --dry-run) DRY_RUN=true ;;
+        --repo=*) REPO="${arg#--repo=}" ;;
+        --help|-h) usage ;;
+        v*) VERSION="$arg" ;;
+        *) echo -e "${RED}Unknown argument: $arg${NC}"; usage ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo -e "${RED}Error: version is required${NC}"
+    usage
+fi
+
+# Validate version format
+if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+    echo -e "${RED}Error: invalid version format: $VERSION${NC}"
+    echo "Expected: vX.Y.Z or vX.Y.Z-rcN"
+    exit 1
+fi
+
+echo -e "${GREEN}Publishing release: $VERSION${NC}"
+
+# Step 1: Check gh auth
+echo -e "\n${YELLOW}[1/6] Checking gh authentication...${NC}"
+GH_USER=$(gh api user --jq '.login' 2>/dev/null || true)
+if [[ -z "$GH_USER" ]]; then
+    echo -e "${RED}Error: not authenticated with gh. Run 'gh auth login' first.${NC}"
+    exit 1
+fi
+echo -e "  Authenticated as: ${GREEN}$GH_USER${NC}"
+
+# Step 2: Check tag exists
+echo -e "\n${YELLOW}[2/6] Checking tag exists...${NC}"
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "kserve/kserve")
+fi
+if ! gh api "repos/$REPO/git/ref/tags/$VERSION" >/dev/null 2>&1; then
+    echo -e "${RED}Error: tag $VERSION does not exist.${NC}"
+    echo "Run 'release-branch-tag' workflow first."
+    exit 1
+fi
+echo -e "  Tag ${GREEN}$VERSION${NC} exists"
+
+# Step 3: Check release does not already exist
+echo -e "\n${YELLOW}[3/6] Checking release does not exist...${NC}"
+if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
+    echo -e "${RED}Error: release $VERSION already exists!${NC}"
+    gh release view "$VERSION" --repo "$REPO" --json url --jq '.url'
+    exit 1
+fi
+echo -e "  Release ${GREEN}$VERSION${NC} does not exist yet"
+
+# Step 4: Check install files
+echo -e "\n${YELLOW}[4/6] Checking install files...${NC}"
+INSTALL_DIR="install/$VERSION"
+if [[ ! -d "$INSTALL_DIR" ]]; then
+    echo -e "${RED}Error: install directory not found: $INSTALL_DIR${NC}"
+    echo "Run 'make bump-version' and 'generate-install.sh' first."
+    exit 1
+fi
+FILE_COUNT=$(find "$INSTALL_DIR" -type f | wc -l)
+echo -e "  Found ${GREEN}$FILE_COUNT${NC} files in $INSTALL_DIR"
+
+if [[ "$FILE_COUNT" -eq 0 ]]; then
+    echo -e "${RED}Error: no files in $INSTALL_DIR${NC}"
+    exit 1
+fi
+
+# Step 5: Build release flags
+echo -e "\n${YELLOW}[5/6] Preparing release...${NC}"
+FLAGS=""
+if [[ "$VERSION" == *"-rc"* ]]; then
+    FLAGS="$FLAGS --prerelease"
+    echo -e "  Type: ${YELLOW}pre-release${NC}"
+else
+    echo -e "  Type: ${GREEN}final release${NC}"
+fi
+
+if [[ "$DRAFT" == "true" ]]; then
+    FLAGS="$FLAGS --draft"
+    echo -e "  Status: ${YELLOW}draft${NC}"
+fi
+
+# Dry-run stop
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "\n${YELLOW}[DRY-RUN] Would create release with:${NC}"
+    echo "  gh release create $VERSION"
+    echo "    --repo $REPO"
+    echo "    --title \"KServe $VERSION\""
+    echo "    --generate-notes"
+    echo "    $FLAGS"
+    echo "    $INSTALL_DIR/*"
+    echo -e "\n${GREEN}Dry-run complete. No changes made.${NC}"
+    exit 0
+fi
+
+# Step 6: Create release
+echo -e "\n${YELLOW}[6/6] Creating release...${NC}"
+gh release create "$VERSION" \
+    --repo "$REPO" \
+    --title "KServe $VERSION" \
+    --generate-notes \
+    $FLAGS \
+    "$INSTALL_DIR"/*
+
+echo -e "\n${GREEN}Release $VERSION created successfully!${NC}"
+echo ""
+gh release view "$VERSION" --repo "$REPO" --json url --jq '.url'
+echo ""
+if [[ "$DRAFT" == "true" ]]; then
+    echo -e "${YELLOW}Note: This is a draft release. Publish it manually to trigger downstream workflows.${NC}"
+else
+    echo -e "Downstream workflows should be triggered automatically:"
+    echo "  - Helm charts publication (helm-publish)"
+    echo "  - Python packages publication (python-publish)"
+fi

--- a/hack/release/validate-release.sh
+++ b/hack/release/validate-release.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Validate all KServe release artifacts after publishing.
+#
+# Usage:
+#   ./hack/release/validate-release.sh <version> [--repo=<owner/repo>]
+#
+# Examples:
+#   ./hack/release/validate-release.sh v0.18.0-rc0
+#   ./hack/release/validate-release.sh v0.18.0-rc0 --repo=jooho/kserve
+
+set -eo pipefail
+
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+BLUE='\033[34m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+usage() {
+    echo "Usage: $0 <version> [--repo=<owner/repo>]"
+    echo ""
+    echo "Arguments:"
+    echo "  version              Release version with 'v' prefix (e.g., v0.18.0-rc0)"
+    echo ""
+    echo "Options:"
+    echo "  --repo=<owner/repo>  Target repository (default: auto-detected)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 v0.18.0-rc0"
+    echo "  $0 v0.18.0-rc0 --repo=jooho/kserve"
+    exit 1
+}
+
+check_pass() {
+    echo -e "  ${GREEN}✓${NC} $1"
+    ((PASS++)) || true
+}
+
+check_fail() {
+    echo -e "  ${RED}✗${NC} $1"
+    if [[ -n "$2" ]]; then
+        echo -e "    ${YELLOW}Fix:${NC} $2"
+    fi
+    ((FAIL++)) || true
+}
+
+check_warn() {
+    echo -e "  ${YELLOW}~${NC} $1"
+}
+
+# Parse arguments
+VERSION=""
+REPO_OVERRIDE=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --repo=*) REPO_OVERRIDE="${arg#--repo=}" ;;
+        --help|-h) usage ;;
+        v*) VERSION="$arg" ;;
+        *) echo -e "${RED}Unknown argument: $arg${NC}"; usage ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo -e "${RED}Error: version is required${NC}"
+    usage
+fi
+
+if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+    echo -e "${RED}Error: invalid version format: $VERSION${NC}"
+    exit 1
+fi
+
+# Resolve repo
+if [[ -n "$REPO_OVERRIDE" ]]; then
+    REPO="$REPO_OVERRIDE"
+else
+    REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "kserve/kserve")
+fi
+
+# Parse version components
+VERSION_NO_V="${VERSION#v}"
+BASE_VERSION=$(echo "$VERSION_NO_V" | sed 's/-rc[0-9]*$//')
+MAJOR_MINOR=$(echo "$BASE_VERSION" | cut -d. -f1,2)
+RC=$(echo "$VERSION_NO_V" | grep -o 'rc[0-9]*$' || echo "")
+BRANCH="release-${MAJOR_MINOR}"
+
+REGISTRY="docker.io/kserve"
+IMAGES=(
+    "kserve-controller"
+    "agent"
+    "router"
+    "storage-initializer"
+    "sklearnserver"
+    "lgbserver"
+    "xgbserver"
+    "pmmlserver"
+    "huggingfaceserver"
+    "llmisvc-controller"
+    "kserve-localmodel-controller"
+    "kserve-localmodelnode-agent"
+)
+
+echo ""
+echo -e "${BLUE}=================================================${NC}"
+echo -e "${BLUE}  KServe Release Validation: $VERSION${NC}"
+echo -e "${BLUE}  Repo: $REPO${NC}"
+echo -e "${BLUE}=================================================${NC}"
+
+# ── 1. Install files ──────────────────────────────────────────
+echo ""
+echo -e "${YELLOW}[1/6] Install files...${NC}"
+INSTALL_DIR="install/${VERSION}"
+if [[ -d "$INSTALL_DIR" ]]; then
+    FILE_COUNT=$(find "$INSTALL_DIR" -type f | wc -l)
+    if [[ "$FILE_COUNT" -gt 0 ]]; then
+        check_pass "install/${VERSION}/ exists ($FILE_COUNT files)"
+    else
+        check_fail "install/${VERSION}/ is empty" "Run 'make bump-version' and 'generate-install.sh'"
+    fi
+else
+    check_fail "install/${VERSION}/ not found" "Run 'make bump-version' and 'generate-install.sh'"
+fi
+
+# ── 2. Branch ─────────────────────────────────────────────────
+echo ""
+echo -e "${YELLOW}[2/6] Git branch...${NC}"
+if gh api "repos/${REPO}/branches/${BRANCH}" >/dev/null 2>&1; then
+    check_pass "Branch ${BRANCH} exists"
+else
+    if [[ "$RC" == "rc0" || -z "$RC" ]]; then
+        check_fail "Branch ${BRANCH} not found" "Re-run 'Prepare Release (Branch & Tag)' workflow"
+    else
+        check_warn "Branch ${BRANCH} not found (expected for RC0 only)"
+    fi
+fi
+
+# ── 3. Tag ────────────────────────────────────────────────────
+echo ""
+echo -e "${YELLOW}[3/6] Git tag...${NC}"
+if gh api "repos/${REPO}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+    check_pass "Tag ${VERSION} exists"
+else
+    check_fail "Tag ${VERSION} not found" "Re-run 'Prepare Release (Branch & Tag)' workflow"
+fi
+
+# ── 4. GitHub Release ─────────────────────────────────────────
+echo ""
+echo -e "${YELLOW}[4/6] GitHub Release...${NC}"
+IS_DRAFT=$(gh release view "${VERSION}" --repo "${REPO}" --json isDraft --jq '.isDraft' 2>/dev/null || echo "")
+IS_PRERELEASE=$(gh release view "${VERSION}" --repo "${REPO}" --json isPrerelease --jq '.isPrerelease' 2>/dev/null || echo "")
+RELEASE_URL=$(gh release view "${VERSION}" --repo "${REPO}" --json url --jq '.url' 2>/dev/null || echo "")
+
+if [[ -z "$IS_DRAFT" ]]; then
+    check_fail "GitHub Release ${VERSION} not found" "Run publish-release.sh"
+else
+    if [[ "$IS_DRAFT" == "true" ]]; then
+        check_fail "GitHub Release is still a draft" "gh release edit ${VERSION} --repo=${REPO} --draft=false"
+    else
+        check_pass "GitHub Release published: $RELEASE_URL"
+    fi
+
+    if [[ -n "$RC" && "$IS_PRERELEASE" != "true" ]]; then
+        check_fail "RC release should be marked as pre-release" "gh release edit ${VERSION} --repo=${REPO} --prerelease"
+    elif [[ -z "$RC" && "$IS_PRERELEASE" == "true" ]]; then
+        check_fail "Final release should NOT be marked as pre-release" "gh release edit ${VERSION} --repo=${REPO} --latest"
+    else
+        check_pass "Pre-release flag correct (isPrerelease=${IS_PRERELEASE})"
+    fi
+fi
+
+# ── 5. PyPI packages ──────────────────────────────────────────
+echo ""
+echo -e "${YELLOW}[5/6] PyPI packages...${NC}"
+PYPI_VERSION="${VERSION_NO_V}"
+for pkg in kserve kserve-storage; do
+    if curl -sf "https://pypi.org/pypi/${pkg}/${PYPI_VERSION}/json" >/dev/null 2>&1; then
+        check_pass "PyPI: ${pkg}==${PYPI_VERSION}"
+    else
+        check_fail "PyPI: ${pkg}==${PYPI_VERSION} not found" "Check 'Upload Python Package' workflow"
+    fi
+done
+
+# ── 6. Container images ───────────────────────────────────────
+echo ""
+echo -e "${YELLOW}[6/6] Container images...${NC}"
+for image in "${IMAGES[@]}"; do
+    IMAGE_REF="${REGISTRY}/${image}:${VERSION}"
+    if docker manifest inspect "${IMAGE_REF}" >/dev/null 2>&1; then
+        check_pass "Image: ${IMAGE_REF}"
+    else
+        check_fail "Image: ${IMAGE_REF} not found" "Check Docker Publisher workflows"
+    fi
+done
+
+# ── Summary ───────────────────────────────────────────────────
+echo ""
+echo -e "${BLUE}=================================================${NC}"
+TOTAL=$((PASS + FAIL))
+if [[ "$FAIL" -eq 0 ]]; then
+    echo -e "${GREEN}  All checks passed ($PASS/$TOTAL)${NC}"
+    echo -e "${GREEN}  Release ${VERSION} is fully validated!${NC}"
+else
+    echo -e "${RED}  $FAIL check(s) failed out of $TOTAL${NC}"
+    echo -e "${YELLOW}  Fix the issues above and re-run this script.${NC}"
+fi
+echo -e "${BLUE}=================================================${NC}"
+echo ""
+
+[[ "$FAIL" -eq 0 ]]

--- a/release/RELEASE_PROCESS_v3_copilot.md
+++ b/release/RELEASE_PROCESS_v3_copilot.md
@@ -1,0 +1,159 @@
+# KServe Release Process - Copilot CLI Guide
+
+Run a KServe release with a single command using GitHub Copilot CLI.
+
+---
+
+## 1. Prerequisites
+
+| Item | Requirement |
+|------|-------------|
+| GitHub account | Listed as **approver** in kserve/kserve OWNERS file |
+| GitHub Copilot | Personal or org subscription active |
+| `gh` CLI | v2.40.0 or later |
+| OS | Linux / macOS / Windows (amd64 or arm64) |
+
+---
+
+## 2. Install & Setup
+
+### Step 1: Install gh CLI
+
+**macOS**
+```bash
+brew install gh
+```
+
+**Linux (apt)**
+```bash
+type -p curl >/dev/null || sudo apt install curl -y
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update && sudo apt install gh -y
+```
+
+**Linux (rpm)**
+```bash
+sudo dnf install 'dnf-command(config-manager)'
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf install gh -y
+```
+
+Verify version:
+```bash
+gh --version  # must be v2.40.0+
+```
+
+### Step 2: Log in to gh
+
+```bash
+gh auth login
+# → Select GitHub.com
+# → Select HTTPS
+# → Authenticate via browser or paste a token
+```
+
+Verify login:
+```bash
+gh auth status
+```
+
+### Step 3: Verify Copilot CLI
+
+`gh copilot` is built into `gh` v2.40+. No separate installation required.
+
+```bash
+gh copilot -- --help  # check version and usage
+```
+
+### Step 4: Clone the repository
+
+```bash
+git clone git@github.com:<your-github-id>/kserve.git
+cd kserve
+git remote add upstream https://github.com/kserve/kserve.git
+```
+
+---
+
+## 3. Run Release
+
+```bash
+gh copilot --agent release-orchestrator -i "Release v0.18.0-rc0"
+```
+
+---
+
+## 4. What It Does
+
+The `release-orchestrator` agent runs the following phases in order:
+
+| Phase | Description |
+|-------|-------------|
+| 1 | Detect current version, identify release type, confirm with user |
+| 2 | Version bump → commit → create PR |
+| 2B | RC1+ only: create cherry-pick PR |
+| 3 | Wait for CI to finish (`--watch`), run `/rerun-all` on failure |
+| 4 | **[Approval required]** Merge PR |
+| 5 | Verify branch & tag creation |
+| 6 | **[Approval required]** Create draft release → publish |
+| 7 | Verify PyPI / Helm deployment |
+| 8 | Validate artifacts (`validate-release.sh`) |
+| 9 | **[Approval required]** Kind-based smoke test |
+
+There are 5 approval points total. Everything else is automated.
+
+---
+
+## 5. Release Types
+
+### RC0
+
+```bash
+gh copilot --agent release-orchestrator -i "Release v0.18.0-rc0"
+```
+
+### RC1+
+
+```bash
+gh copilot --agent release-orchestrator -i "Release v0.18.0-rc1"
+```
+
+The cherry-pick phase is added automatically.
+
+### Final
+
+```bash
+gh copilot --agent release-orchestrator -i "Release v0.18.0"
+```
+
+> ⚠️ Final release is still in testing. Verify before running.
+
+---
+
+## 6. Agent Definition
+
+The agent logic is defined in:
+
+- [`.github/agents/release-orchestrator.agent.md`](../.github/agents/release-orchestrator.agent.md)
+
+Edit that file to modify the release workflow.
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `gh copilot` not recognized | Check `gh --version`, must be v2.40+ |
+| Copilot permission error | Re-auth with `gh auth login --scopes copilot` |
+| `--agent` option missing | Run `gh copilot -- --help` to check version |
+| CI keeps failing | Retry or select `abort` in Phase 3 |
+
+---
+
+## 8. Related Documents
+
+- [RELEASE_PROCESS_v3.md](./RELEASE_PROCESS_v3.md)


### PR DESCRIPTION
Adds release automation via GitHub Copilot CLI (`gh copilot --agent release-orchestrator`).

- Copilot agent definition for 9-phase release orchestration with 5 approval points
- `release-branch-tag.yml` workflow for branch/tag creation (triggered on PR merge or manual dispatch)
- `create-branch-tag.sh` — branch/tag creation with validation, dry-run, and rollback
- `publish-release.sh` — GitHub Release creation with install artifacts
- `validate-release.sh` — post-release artifact validation (branch, tag, release, PyPI, images)
- `RELEASE_PROCESS_v3_copilot.md` — setup and usage guide