### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -25,6 +25,9 @@ on:
   #   types: [ checks_requested ]
 
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: agent
 

--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -23,6 +23,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: art-explainer
 

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -9,9 +9,13 @@ on:
         description: "The release tag, e.g. v0.12.0-rc1"
         required: true
 
+permissions: {}
+
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout source code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/comment-cherry-pick.yml
+++ b/.github/workflows/comment-cherry-pick.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Cherry Pick Request

--- a/.github/workflows/custom-model-grpc-publish.yml
+++ b/.github/workflows/custom-model-grpc-publish.yml
@@ -19,6 +19,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: custom-model-grpc
 

--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -18,6 +18,9 @@ on:
   merge_group:
     types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -14,6 +14,9 @@ on:
     types: [ checks_requested ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TAG: ${{ github.sha }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,14 +21,14 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
-permissions:
-    contents: write
-    pull-requests: write
+permissions: {}
 
 jobs:
     test:
         name: Test
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
 
             - name: Check out code into the Go module directory
@@ -75,6 +75,9 @@ jobs:
         needs: test
         runs-on: ubuntu-latest
         name: Check Coverage
+        permissions:
+            contents: write
+            pull-requests: write
         steps:
             - name: checkout
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -13,13 +13,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  packages: write
+permissions: {}
 
 jobs:
   upload-helm-charts:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout source

--- a/.github/workflows/huggingface-cpu-docker-publish.yml
+++ b/.github/workflows/huggingface-cpu-docker-publish.yml
@@ -22,6 +22,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: huggingfaceserver
 

--- a/.github/workflows/huggingface-docker-publish.yml
+++ b/.github/workflows/huggingface-docker-publish.yml
@@ -22,8 +22,11 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
-  IMAGE_NAME: huggingfaceserver 
+  IMAGE_NAME: huggingfaceserver
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/huggingface-vllm-docker-publish-manual.yml
+++ b/.github/workflows/huggingface-vllm-docker-publish-manual.yml
@@ -7,8 +7,11 @@ on:
         description: 'Huggingface vLLM image version to publish'
         required: true
 
+permissions:
+  contents: read
+
 env:
-  IMAGE_NAME: huggingfaceserver 
+  IMAGE_NAME: huggingfaceserver
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -24,6 +24,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: kserve-controller
 

--- a/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
+++ b/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
@@ -24,6 +24,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: llmisvc-controller
 

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -24,6 +24,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: kserve-localmodelnode-agent
 

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -24,6 +24,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: kserve-localmodel-controller
 

--- a/.github/workflows/lightgbm-docker-publish.yml
+++ b/.github/workflows/lightgbm-docker-publish.yml
@@ -23,6 +23,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: lgbserver
 

--- a/.github/workflows/paddle-docker-publish.yml
+++ b/.github/workflows/paddle-docker-publish.yml
@@ -23,6 +23,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: paddleserver
 

--- a/.github/workflows/pmml-docker-publish.yml
+++ b/.github/workflows/pmml-docker-publish.yml
@@ -23,6 +23,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: pmmlserver
 

--- a/.github/workflows/precommit-check.yml
+++ b/.github/workflows/precommit-check.yml
@@ -7,6 +7,9 @@ on:
   merge_group:
     types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/predictiveserver-docker-publish.yml
+++ b/.github/workflows/predictiveserver-docker-publish.yml
@@ -23,6 +23,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: predictiveserver
 

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -5,14 +5,15 @@ on:
   issue_comment:
     types: [created]
 
-# Required for the prow action to manage labels, assignees, milestones, etc.
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   prow-execute:
     runs-on: ubuntu-latest
+    # Required for the prow action to manage labels, assignees, milestones, etc.
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
         with:

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -6,6 +6,9 @@ on:
   schedule:
   - cron: "*/10 * * * *" # every 10 minutes
 
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -8,6 +8,9 @@ on: pull_request
 # merge_group:
 #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 jobs:
   remove-lgtm:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,6 +17,9 @@ on:
     types: [ checks_requested ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/qpext-docker-publish.yml
+++ b/.github/workflows/qpext-docker-publish.yml
@@ -24,6 +24,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: qpext
 

--- a/.github/workflows/re-run-actions.yml
+++ b/.github/workflows/re-run-actions.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   rerun_pr_tests:
     name: rerun_pr_tests

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -24,6 +24,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: router
 

--- a/.github/workflows/scheduled-go-security-scan.yml
+++ b/.github/workflows/scheduled-go-security-scan.yml
@@ -12,6 +12,9 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch: { }
 
+permissions:
+  contents: read
+
 jobs:
   go-security-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled-image-scan.yml
+++ b/.github/workflows/scheduled-image-scan.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * 0,3"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sklearnserver-docker-publish.yml
+++ b/.github/workflows/sklearnserver-docker-publish.yml
@@ -23,6 +23,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: sklearnserver
 

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -23,6 +23,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: storage-initializer
 

--- a/.github/workflows/tf2openapi-docker-publisher.yml
+++ b/.github/workflows/tf2openapi-docker-publisher.yml
@@ -24,6 +24,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: tf2openapi
 

--- a/.github/workflows/transformer-docker-publish.yml
+++ b/.github/workflows/transformer-docker-publish.yml
@@ -19,6 +19,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: image-transformer
   GRPC_IMAGE_NAME: custom-image-transformer-grpc

--- a/.github/workflows/xgbserver-docker-publisher.yml
+++ b/.github/workflows/xgbserver-docker-publisher.yml
@@ -23,6 +23,9 @@ on:
   # merge_group:
   #   types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: xgbserver
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

**Which issue(s) this PR fixes**:
Fixes #5424


**Feature/Issue validation/testing**:
- [ ] ~Test A~
- [ ] ~Test B~

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] ~Have you added unit/e2e tests that prove your fix is effective or that this feature works?~ (N/A — CI workflow permissions change)
- [ ] ~Has code been commented, particularly in hard-to-understand areas?~ (N/A — CI workflow permissions change)
- [ ] ~Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?~ (N/A — CI workflow permissions change)

**Release note**:

```release-note
NONE
```
