### PR TITLE
fix: normalize legacy deploymentMode in status

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -582,7 +582,7 @@ func validateCollocationStorageURI(predictorSpec PredictorSpec) error {
 
 // validates if the deploymentMode specified in the annotation is not different from the one recorded in the status
 func validateDeploymentMode(newIsvc *InferenceService, oldIsvc *InferenceService) error {
-	statusDeploymentMode := oldIsvc.Status.DeploymentMode
+	statusDeploymentMode := string(constants.ParseDeploymentMode(oldIsvc.Status.DeploymentMode))
 	if len(statusDeploymentMode) != 0 {
 		annotations := newIsvc.Annotations
 		annotationDeploymentMode, ok := annotations[constants.DeploymentMode]

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1420,6 +1420,45 @@ func TestDeploymentModeUpdate(t *testing.T) {
 	g.Expect(warnings).Should(gomega.BeEmpty())
 	g.Expect(err).Should(gomega.Succeed())
 
+	// Test: Legacy status "RawDeployment" should accept normalized annotation "Standard"
+	oldIsvcLegacy := makeTestInferenceService()
+	oldIsvcLegacy.Status = InferenceServiceStatus{
+		DeploymentMode: string(constants.LegacyRawDeployment),
+	}
+	updatedIsvcLegacy := oldIsvcLegacy.DeepCopy()
+	updatedIsvcLegacy.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.Standard),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcLegacy, updatedIsvcLegacy)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Legacy status "Serverless" should accept normalized annotation "Knative"
+	oldIsvcLegacySl := makeTestInferenceService()
+	oldIsvcLegacySl.Status = InferenceServiceStatus{
+		DeploymentMode: string(constants.LegacyServerless),
+	}
+	updatedIsvcLegacySl := oldIsvcLegacySl.DeepCopy()
+	updatedIsvcLegacySl.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.Knative),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcLegacySl, updatedIsvcLegacySl)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Legacy status "RawDeployment" with different mode "Knative" should still be rejected
+	oldIsvcLegacyReject := makeTestInferenceService()
+	oldIsvcLegacyReject.Status = InferenceServiceStatus{
+		DeploymentMode: string(constants.LegacyRawDeployment),
+	}
+	updatedIsvcLegacyReject := oldIsvcLegacyReject.DeepCopy()
+	updatedIsvcLegacyReject.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.Knative),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcLegacyReject, updatedIsvcLegacyReject)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).ShouldNot(gomega.Succeed())
+
 	// Test: Mismatched deploymentMode should be allowed during deletion (DeletionTimestamp set)
 	// This allows finalizer cleanup when annotation differs from status
 	deletingIsvc := oldIsvc.DeepCopy()

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -223,7 +223,7 @@ case 2: serving.kserve.org/deploymentMode is set
 func GetDeploymentMode(statusDeploymentMode string, annotations map[string]string, deployConfig *v1beta1.DeployConfig) constants.DeploymentModeType {
 	// First priority is the deploymentMode recorded in the status
 	if len(statusDeploymentMode) != 0 {
-		return constants.DeploymentModeType(statusDeploymentMode)
+		return constants.ParseDeploymentMode(statusDeploymentMode)
 	}
 
 	// Second priority, if the status doesn't have the deploymentMode recorded, is explicit annotations

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -1316,9 +1316,10 @@ func TestUpdateImageTag(t *testing.T) {
 func TestGetDeploymentMode(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	scenarios := map[string]struct {
-		annotations  map[string]string
-		deployConfig *DeployConfig
-		expected     constants.DeploymentModeType
+		statusDeploymentMode string
+		annotations          map[string]string
+		deployConfig         *DeployConfig
+		expected             constants.DeploymentModeType
 	}{
 		"Standard": {
 			annotations: map[string]string{
@@ -1348,11 +1349,23 @@ func TestGetDeploymentMode(t *testing.T) {
 			},
 			expected: constants.Knative,
 		},
+		"LegacyRawDeploymentInStatus": {
+			statusDeploymentMode: string(constants.LegacyRawDeployment),
+			annotations:          map[string]string{},
+			deployConfig:         &DeployConfig{},
+			expected:             constants.Standard,
+		},
+		"LegacyServerlessInStatus": {
+			statusDeploymentMode: string(constants.LegacyServerless),
+			annotations:          map[string]string{},
+			deployConfig:         &DeployConfig{},
+			expected:             constants.Knative,
+		},
 	}
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			deploymentMode := GetDeploymentMode("", scenario.annotations, scenario.deployConfig)
+			deploymentMode := GetDeploymentMode(scenario.statusDeploymentMode, scenario.annotations, scenario.deployConfig)
 			if !g.Expect(deploymentMode).To(gomega.Equal(scenario.expected)) {
 				t.Errorf("got %v, want %v", deploymentMode, scenario.expected)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

After the deploymentMode rename (RawDeployment -> Standard, Serverless -> Knative in #5025), ISVCs created on older versions retain the legacy value in `status.DeploymentMode`. The defaulting webhook normalizes the annotation to the new name, but `validateDeploymentMode` compares the normalized annotation against the un-normalized status and rejects updates. This also causes `GetDeploymentMode` to return the legacy value to the controller, which writes it back to status -- so the status never self-corrects.

This PR uses `ParseDeploymentMode` to normalize legacy status values in:
- `GetDeploymentMode` -- so the controller returns and writes canonical values
- `validateDeploymentMode` -- so validation passes during the window before the controller reconciles

**Which issue(s) this PR fixes**:

Fixes a regression from #5025 where upgraded ISVCs with legacy `status.DeploymentMode` values become un-updatable.

**Feature/Issue validation/testing**:

- [x] Unit tests: `TestGetDeploymentMode` with `LegacyRawDeploymentInStatus` and `LegacyServerlessInStatus` cases
- [x] Unit tests: `TestDeploymentModeUpdate` with legacy status accepted for same-mode, rejected for cross-mode

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fix legacy status.DeploymentMode values (RawDeployment/Serverless) not being normalized after upgrade, causing validation to reject updates on ISVCs created before the deployment mode rename.
```

Made with [Cursor](https://cursor.com)