### PR TITLE
feat(llmisvc): emit k8s events on llmisvc readiness transitions

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap"
 
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/reconciler"
 
 	"github.com/go-logr/logr"
@@ -74,6 +75,14 @@ var ChildResourcesLabelSelector = metav1.LabelSelector{
 // childResourcesPredicate filters events to only those from resources owned by LLMInferenceService
 // This prevents unnecessary reconciliation triggers from unrelated resources
 var childResourcesPredicate, _ = predicate.LabelSelectorPredicate(ChildResourcesLabelSelector)
+
+// LLMInferenceServiceState describes the readiness of the LLMInferenceService.
+type LLMInferenceServiceState string
+
+const (
+	LLMInferenceServiceReadyState    LLMInferenceServiceState = "LLMInferenceServiceReady"
+	LLMInferenceServiceNotReadyState LLMInferenceServiceState = "LLMInferenceServiceNotReady"
+)
 
 // LLMISVCReconciler reconciles an LLMInferenceService object.
 // It orchestrates the reconciliation of child resources based on the spec.
@@ -232,17 +241,20 @@ func (r *LLMISVCReconciler) finalize(ctx context.Context, llmSvc *v1alpha2.LLMIn
 	return nil
 }
 
-// updateStatus updates the status of the LLMInferenceService with retry on conflict
-// This prevents race conditions when multiple controllers update the same resource
+// updateStatus updates the status of the LLMInferenceService with retry on conflict.
+// It also emits K8s Events on readiness state transitions (Ready <-> NotReady),
+// mirroring the pattern used by the InferenceService controller.
 func (r *LLMISVCReconciler) updateStatus(ctx context.Context, desired *v1alpha2.LLMInferenceService) error {
+	logger := log.FromContext(ctx)
+
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Always fetch the latest version to avoid conflicts
 		latest := &v1alpha2.LLMInferenceService{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(desired), latest); err != nil {
 			return client.IgnoreNotFound(err)
 		}
 
-		// Skip update if status hasn't changed
+		wasReady := llmInferenceServiceReadiness(latest.Status)
+
 		if equality.Semantic.DeepEqual(latest.Status, desired.Status) {
 			return nil
 		}
@@ -250,11 +262,56 @@ func (r *LLMISVCReconciler) updateStatus(ctx context.Context, desired *v1alpha2.
 		latest.Status = desired.Status
 
 		if err := r.Client.Status().Update(ctx, latest); err != nil {
+			logger.Error(err, "Failed to update LLMInferenceService status", "LLMInferenceService", desired.Name)
+			r.Eventf(desired, corev1.EventTypeWarning, "UpdateFailed",
+				"Failed to update status for LLMInferenceService %q: %v", desired.Name, err)
 			return fmt.Errorf("failed to update status for LLMInferenceService: %w", err)
+		}
+
+		isReady := llmInferenceServiceReadiness(desired.Status)
+		isReadyFalse := llmInferenceServiceReadinessFalse(desired.Status)
+		if wasReady && isReadyFalse {
+			r.Eventf(desired, corev1.EventTypeWarning, string(LLMInferenceServiceNotReadyState),
+				"LLMInferenceService [%v] is no longer Ready because of: %v", desired.GetName(), r.GetFailConditions(desired))
+		} else if !wasReady && isReady {
+			r.Eventf(desired, corev1.EventTypeNormal, string(LLMInferenceServiceReadyState),
+				"LLMInferenceService [%v] is Ready", desired.GetName())
 		}
 
 		return nil
 	})
+}
+
+func llmInferenceServiceReadiness(status v1alpha2.LLMInferenceServiceStatus) bool {
+	return status.Conditions != nil &&
+		status.GetCondition(apis.ConditionReady) != nil &&
+		status.GetCondition(apis.ConditionReady).Status == corev1.ConditionTrue
+}
+
+func llmInferenceServiceReadinessFalse(status v1alpha2.LLMInferenceServiceStatus) bool {
+	readyCondition := status.GetCondition(apis.ConditionReady)
+	return readyCondition != nil && readyCondition.Status == corev1.ConditionFalse
+}
+
+// GetFailConditions returns a comma-separated list of sub-condition Types whose Status is False.
+// The top-level apis.ConditionReady is intentionally excluded because it is the aggregate that
+// is being reported on; including it would be self-referential ("Ready is no longer Ready
+// because of: Ready, ...").
+func (r *LLMISVCReconciler) GetFailConditions(svc *v1alpha2.LLMInferenceService) string {
+	msg := ""
+	for _, cond := range svc.Status.Conditions {
+		if cond.Type == apis.ConditionReady {
+			continue
+		}
+		if string(cond.Status) == "False" {
+			if msg == "" {
+				msg = string(cond.Type)
+			} else {
+				msg = fmt.Sprintf("%s, %s", msg, string(cond.Type))
+			}
+		}
+	}
+	return msg
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -272,7 +272,7 @@ func (r *LLMISVCReconciler) updateStatus(ctx context.Context, desired *v1alpha2.
 		isReadyFalse := llmInferenceServiceReadinessFalse(desired.Status)
 		if wasReady && isReadyFalse {
 			r.Eventf(desired, corev1.EventTypeWarning, string(LLMInferenceServiceNotReadyState),
-				"LLMInferenceService [%v] is no longer Ready because of: %v", desired.GetName(), r.GetFailConditions(desired))
+				"LLMInferenceService [%v] is no longer Ready because of: %v", desired.GetName(), GetFailConditions(desired))
 		} else if !wasReady && isReady {
 			r.Eventf(desired, corev1.EventTypeNormal, string(LLMInferenceServiceReadyState),
 				"LLMInferenceService [%v] is Ready", desired.GetName())
@@ -297,13 +297,13 @@ func llmInferenceServiceReadinessFalse(status v1alpha2.LLMInferenceServiceStatus
 // The top-level apis.ConditionReady is intentionally excluded because it is the aggregate that
 // is being reported on; including it would be self-referential ("Ready is no longer Ready
 // because of: Ready, ...").
-func (r *LLMISVCReconciler) GetFailConditions(svc *v1alpha2.LLMInferenceService) string {
+func GetFailConditions(svc *v1alpha2.LLMInferenceService) string {
 	msg := ""
 	for _, cond := range svc.Status.Conditions {
 		if cond.Type == apis.ConditionReady {
 			continue
 		}
-		if string(cond.Status) == "False" {
+		if cond.Status == corev1.ConditionFalse {
 			if msg == "" {
 				msg = string(cond.Type)
 			} else {

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
@@ -21,18 +21,21 @@ import (
 
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
 	. "github.com/kserve/kserve/pkg/testing"
@@ -704,4 +707,102 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})
+
+	Context("Readiness Event Emission", func() {
+		It("should emit a Warning LLMInferenceServiceNotReady Event with WorkerWorkloadReady when transitioning Ready to NotReady", func(ctx SpecContext) {
+			svcName := "test-llm-mn-event-notready"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithReplicas(2),
+				WithParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+					WithTensorParallelism(2),
+				)),
+				WithTemplate(SimpleWorkerPodSpec()),
+				WithWorker(SimpleWorkerPodSpec()),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() { testNs.DeleteAndWait(ctx, llmSvc) }()
+
+			lwsName := types.NamespacedName{
+				Name:      kmeta.ChildName(svcName, "-kserve-mn"),
+				Namespace: testNs.Name,
+			}
+
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, lwsName, &lwsapi.LeaderWorkerSet{})
+			}).WithContext(ctx).Should(Succeed())
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
+			ensureLWSReady(ctx, envTest.Client, lwsName)
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition("Ready", "True"))
+			}).WithContext(ctx).Should(Succeed())
+
+			setLWSNotReady(ctx, envTest.Client, lwsName)
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition("Ready", "False"))
+			}).WithContext(ctx).Should(Succeed())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				ev := findEvent(ctx, envTest.Client, llmSvc, string(llmisvc.LLMInferenceServiceNotReadyState))
+				g.Expect(ev).NotTo(BeNil(), "Expected a Warning LLMInferenceServiceNotReady Event")
+				g.Expect(ev.Message).To(ContainSubstring(string(v1alpha2.WorkerWorkloadReady)))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
 })
+
+func ensureLWSReady(ctx context.Context, c client.Client, lwsName types.NamespacedName) {
+	if envTest.UsingExistingCluster() {
+		return
+	}
+
+	Eventually(func(g Gomega, ctx context.Context) {
+		lws := &lwsapi.LeaderWorkerSet{}
+		g.Expect(c.Get(ctx, lwsName, lws)).To(Succeed())
+
+		lws.Status.Conditions = []metav1.Condition{
+			{
+				Type:               string(lwsapi.LeaderWorkerSetAvailable),
+				Status:             metav1.ConditionTrue,
+				Reason:             "AllReplicasAvailable",
+				Message:            "All replicas are available",
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+		g.Expect(c.Status().Update(ctx, lws)).To(Succeed())
+	}).WithContext(ctx).Should(Succeed())
+}
+
+func setLWSNotReady(ctx context.Context, c client.Client, lwsName types.NamespacedName) {
+	Eventually(func(g Gomega, ctx context.Context) {
+		lws := &lwsapi.LeaderWorkerSet{}
+		g.Expect(c.Get(ctx, lwsName, lws)).To(Succeed())
+
+		lws.Status.Conditions = []metav1.Condition{
+			{
+				Type:               string(lwsapi.LeaderWorkerSetAvailable),
+				Status:             metav1.ConditionFalse,
+				Reason:             "ReplicasUnavailable",
+				Message:            "Not all replicas are available",
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+		g.Expect(c.Status().Update(ctx, lws)).To(Succeed())
+	}).WithContext(ctx).Should(Succeed())
+}

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -1503,6 +1503,121 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			})
 		})
 	})
+
+	Context("Readiness Event Emission", func() {
+		It("should emit a Normal LLMInferenceServiceReady Event when transitioning NotReady to Ready", func(ctx SpecContext) {
+			svcName := "test-llm-event-ready"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() { testNs.DeleteAndWait(ctx, llmSvc) }()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
+			ensureWorkloadDeploymentReady(ctx, envTest.Client, llmSvc)
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition("Ready", "True"))
+			}).WithContext(ctx).Should(Succeed())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(findEvent(ctx, envTest.Client, llmSvc, string(llmisvc.LLMInferenceServiceReadyState))).NotTo(BeNil(),
+					"Expected a Normal LLMInferenceServiceReady Event")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should emit a Warning LLMInferenceServiceNotReady Event with MainWorkloadReady when transitioning Ready to NotReady", func(ctx SpecContext) {
+			svcName := "test-llm-event-notready"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() { testNs.DeleteAndWait(ctx, llmSvc) }()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
+			ensureWorkloadDeploymentReady(ctx, envTest.Client, llmSvc)
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition("Ready", "True"))
+			}).WithContext(ctx).Should(Succeed())
+
+			setWorkloadDeploymentNotReady(ctx, envTest.Client, llmSvc)
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition("Ready", "False"))
+			}).WithContext(ctx).Should(Succeed())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				ev := findEvent(ctx, envTest.Client, llmSvc, string(llmisvc.LLMInferenceServiceNotReadyState))
+				g.Expect(ev).NotTo(BeNil(), "Expected a Warning LLMInferenceServiceNotReady Event")
+				g.Expect(ev.Message).To(ContainSubstring(string(v1alpha2.MainWorkloadReady)))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should not emit a readiness Event when status is unchanged", func(ctx SpecContext) {
+			svcName := "test-llm-event-noop"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() { testNs.DeleteAndWait(ctx, llmSvc) }()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
+			ensureWorkloadDeploymentReady(ctx, envTest.Client, llmSvc)
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition("Ready", "True"))
+			}).WithContext(ctx).Should(Succeed())
+
+			baselineCount := countReadinessEvents(ctx, envTest.Client, llmSvc)
+
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = map[string]string{}
+					}
+					llmSvc.Annotations["test-noop-trigger"] = time.Now().String()
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			Consistently(func(g Gomega, ctx context.Context) {
+				g.Expect(countReadinessEvents(ctx, envTest.Client, llmSvc)).To(Equal(baselineCount),
+					"No new readiness Events should be emitted when status is unchanged")
+			}, 5*time.Second, 500*time.Millisecond).WithContext(ctx).Should(Succeed())
+		})
+	})
 })
 
 func LLMInferenceServiceIsReady(llmSvc *v1alpha2.LLMInferenceService, assertFns ...func(g Gomega, current *v1alpha2.LLMInferenceService)) func(g Gomega, ctx context.Context) error {
@@ -1784,4 +1899,83 @@ func customRouteSpec(ctx context.Context, c client.Client, nsName, gatewayRefNam
 	httpRouteSpec := &route.Spec
 
 	return httpRouteSpec
+}
+
+func ensureWorkloadDeploymentReady(ctx context.Context, c client.Client, llmSvc *v1alpha2.LLMInferenceService) {
+	if envTest.UsingExistingCluster() {
+		return
+	}
+
+	deployName := types.NamespacedName{
+		Name:      kmeta.ChildName(llmSvc.GetName(), "-kserve"),
+		Namespace: llmSvc.GetNamespace(),
+	}
+
+	Eventually(func(g Gomega, ctx context.Context) {
+		dep := &appsv1.Deployment{}
+		g.Expect(c.Get(ctx, deployName, dep)).To(Succeed())
+
+		dep.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionTrue,
+			},
+		}
+		g.Expect(c.Status().Update(ctx, dep)).To(Succeed())
+	}).WithContext(ctx).Should(Succeed())
+}
+
+func setWorkloadDeploymentNotReady(ctx context.Context, c client.Client, llmSvc *v1alpha2.LLMInferenceService) {
+	deployName := types.NamespacedName{
+		Name:      kmeta.ChildName(llmSvc.GetName(), "-kserve"),
+		Namespace: llmSvc.GetNamespace(),
+	}
+
+	Eventually(func(g Gomega, ctx context.Context) {
+		dep := &appsv1.Deployment{}
+		g.Expect(c.Get(ctx, deployName, dep)).To(Succeed())
+
+		dep.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Type:    appsv1.DeploymentAvailable,
+				Status:  corev1.ConditionFalse,
+				Reason:  "MinimumReplicasUnavailable",
+				Message: "Deployment does not have minimum availability",
+			},
+		}
+		g.Expect(c.Status().Update(ctx, dep)).To(Succeed())
+	}).WithContext(ctx).Should(Succeed())
+}
+
+func findEvent(ctx context.Context, c client.Client, llmSvc *v1alpha2.LLMInferenceService, reason string) *corev1.Event {
+	events := &corev1.EventList{}
+	if err := c.List(ctx, events, client.InNamespace(llmSvc.GetNamespace())); err != nil {
+		return nil
+	}
+	for i := range events.Items {
+		ev := &events.Items[i]
+		if ev.InvolvedObject.Kind == "LLMInferenceService" &&
+			ev.InvolvedObject.Name == llmSvc.GetName() &&
+			ev.Reason == reason {
+			return ev
+		}
+	}
+	return nil
+}
+
+func countReadinessEvents(ctx context.Context, c client.Client, llmSvc *v1alpha2.LLMInferenceService) int {
+	events := &corev1.EventList{}
+	if err := c.List(ctx, events, client.InNamespace(llmSvc.GetNamespace())); err != nil {
+		return 0
+	}
+	count := 0
+	for _, ev := range events.Items {
+		if ev.InvolvedObject.Kind == "LLMInferenceService" &&
+			ev.InvolvedObject.Name == llmSvc.GetName() &&
+			(ev.Reason == string(llmisvc.LLMInferenceServiceReadyState) ||
+				ev.Reason == string(llmisvc.LLMInferenceServiceNotReadyState)) {
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 
@@ -48,16 +49,17 @@ func SetupTestEnv(ctx context.Context) *pkgtest.Client {
 	systemNs := constants.KServeNamespace
 
 	llmCtrlFunc := func(cfg *rest.Config, mgr ctrl.Manager) error {
-		eventBroadcaster := record.NewBroadcaster()
 		clientSet, err := kubernetes.NewForConfig(cfg)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
+		eventBroadcaster := record.NewBroadcaster()
+		eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientSet.CoreV1().Events("")})
+
 		llmCtrl := llmisvc.LLMISVCReconciler{
-			Client:    mgr.GetClient(),
-			Config:    cfg,
-			Clientset: clientSet,
-			// TODO fix it to be set up similar to main.go, for now it's stub
-			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "v1beta1Controllers"}),
+			Client:        mgr.GetClient(),
+			Config:        cfg,
+			Clientset:     clientSet,
+			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "LLMInferenceServiceController"}),
 			Validator: func(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
 				_, err := (&v1alpha2.LLMInferenceServiceValidator{}).ValidateCreate(ctx, llmSvc)
 				return err


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Kubernetes Event emission on `LLMInferenceService` readiness state transitions,
mirroring the existing `InferenceService` pattern. When an LLMISVC transitions from
NotReady to Ready, a `Normal` Event with reason `LLMInferenceServiceReady` is emitted.
When it transitions from Ready to NotReady, a `Warning` Event with reason
`LLMInferenceServiceNotReady` is emitted, including the list of failing conditions in
the message. An `UpdateFailed` Warning Event is also emitted on status update errors.

This gives operators and monitoring systems a push-based signal for availability
changes without needing to poll the status subresource.

**Which issue(s) this PR fixes**:
Fixes #5436

**Feature/Issue validation/testing**:

- [x] 4 tests covering all readiness transition scenarios
- [x] End-to-end validation

### Validation 

Triggered transitions on multi-node LLMISVC `llama8b-pp2-tp1-open` two ways: by
scaling its LWS to 0 and back to 1, and by `kubectl delete pod` of the leader pod.
Both produced the same Events:

```
TYPE     REASON                       OBJECT                                    MESSAGE
Warning  LLMInferenceServiceNotReady  llminferenceservice/llama8b-pp2-tp1-open  LLMInferenceService [llama8b-pp2-tp1-open] is no longer Ready because of: WorkerWorkloadReady, WorkloadsReady
Normal   LLMInferenceServiceReady     llminferenceservice/llama8b-pp2-tp1-open  LLMInferenceService [llama8b-pp2-tp1-open] is Ready
```

**Notes for the reviewer**:

- No new RBAC rules required; the existing `events` verb permissions already cover
  Event emission.
- The `EventRecorder` in the envtest fixture was wired to
  `StartRecordingToSink(EventSinkImpl)` so that Events land in the test API server and
  can be asserted via `corev1.EventList`.
- The failing-conditions message naturally includes topology-specific condition names
  (e.g. `MainWorkloadReady` for single-node, `WorkerWorkloadReady` for multi-node)
  without any special-casing.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Emit Kubernetes Events on LLMInferenceService readiness state transitions.
```