### PR TITLE
fix(llmisvc): handle expert false templates

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -432,7 +432,7 @@ spec:
           --served-model-name "{{ .Spec.Model.Name }}" \
           --port 8001 \
           --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
-          {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
           {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
           --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
@@ -735,7 +735,7 @@ spec:
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" \
           --port 8001 \
-          {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
           {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
           --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
@@ -1185,7 +1185,7 @@ spec:
             --served-model-name "{{ .Spec.Model.Name }}" \
             --port 8000 \
             --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
-            {{- if .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+            {{- if and .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
             {{- if .Spec.Prefill.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
             --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
             --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
@@ -1428,7 +1428,7 @@ spec:
             /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" \
             --port 8000 \
-            {{- if .Spec.Prefill.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+            {{- if and .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
             {{- if .Spec.Prefill.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
             --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
             --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
@@ -2137,7 +2137,7 @@ spec:
           --served-model-name "{{ .Spec.Model.Name }}" \
           --port 8000 \
           --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
-          {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
           {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
           --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
@@ -2380,7 +2380,7 @@ spec:
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" \
           --port 8000 \
-          {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
           {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
           --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -220,7 +220,7 @@ spec:
               --served-model-name "{{ .Spec.Model.Name }}" \
               --port 8001 \
               --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
-              {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+              {{- if and .Spec.Parallelism .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
               {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
               --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
@@ -465,7 +465,7 @@ spec:
               /mnt/models \
               --served-model-name "{{ .Spec.Model.Name }}" \
               --port 8001 \
-              {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+              {{- if and .Spec.Parallelism .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
               {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
               --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -162,7 +162,7 @@ spec:
                 --served-model-name "{{ .Spec.Model.Name }}" \
                 --port 8000 \
                 --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
-                {{- if .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+                {{- if and .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
                 {{- if .Spec.Prefill.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
                 --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
                 --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
@@ -407,7 +407,7 @@ spec:
                 /mnt/models \
                 --served-model-name "{{ .Spec.Model.Name }}" \
                 --port 8000 \
-                {{- if .Spec.Prefill.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+                {{- if and .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
                 {{- if .Spec.Prefill.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
                 --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
                 --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -161,7 +161,7 @@ spec:
               --served-model-name "{{ .Spec.Model.Name }}" \
               --port 8000 \
               --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
-              {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+              {{- if and .Spec.Parallelism .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
               {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
               --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
@@ -406,7 +406,7 @@ spec:
               /mnt/models \
               --served-model-name "{{ .Spec.Model.Name }}" \
               --port 8000 \
-              {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+              {{- if and .Spec.Parallelism .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
               {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
               --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -396,6 +396,8 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 		return nil, fmt.Errorf("failed to marshal config for template processing: %w", err)
 	}
 	buf := bytes.NewBuffer(nil)
+	templateSvc := llmSvc.DeepCopy()
+	templateSvc.Spec = *llmSvcCfg.Spec.DeepCopy()
 	var gc templateGlobalConfig
 	if reconcilerConfig != nil {
 		gc = templateGlobalConfig{
@@ -409,7 +411,7 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 		*v1alpha2.LLMInferenceService
 		GlobalConfig templateGlobalConfig
 	}{
-		LLMInferenceService: llmSvc,
+		LLMInferenceService: templateSvc,
 		GlobalConfig:        gc,
 	}
 	t, err := template.New("config").

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -1665,6 +1665,56 @@ func TestReplaceVariables(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "template uses merged spec when base config overrides expert to false",
+			cfg: &v1alpha2.LLMInferenceServiceConfig{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Parallelism: &v1alpha2.ParallelismSpec{
+							Expert: false,
+						},
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Env: []corev1.EnvVar{
+										{Name: "EXPERT_ENABLED", Value: "{{ if .Spec.Parallelism.Expert }}true{{ else }}false{{ end }}"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Parallelism: &v1alpha2.ParallelismSpec{
+							Expert: true,
+						},
+					},
+				},
+			},
+			want: &v1alpha2.LLMInferenceServiceConfig{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Parallelism: &v1alpha2.ParallelismSpec{
+							Expert: false,
+						},
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Env: []corev1.EnvVar{
+										{Name: "EXPERT_ENABLED", Value: "false"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #5439

## Summary
- render llmisvc templates against the merged effective spec so `expert: false` survives baseRef composition
- guard expert-parallel flag injection in data-parallel presets when parallelism is unset
- add a focused regression test for merged spec rendering