### PR TITLE
fix(llmisvc): surface scheduler port mismatch as status condition

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -213,7 +213,11 @@ func (r *LLMISVCReconciler) reconcileV1Alpha2InferencePool(ctx context.Context, 
 }
 
 func (r *LLMISVCReconciler) reconcileSchedulerService(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
-	expected := r.expectedSchedulerService(ctx, llmSvc)
+	expected, err := r.expectedSchedulerService(ctx, llmSvc)
+	if err != nil {
+		llmSvc.MarkSchedulerWorkloadNotReady("SchedulerPortMismatch", err.Error())
+		return err
+	}
 	if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, expected)
 	}
@@ -225,8 +229,7 @@ func (r *LLMISVCReconciler) reconcileSchedulerService(ctx context.Context, llmSv
 	return nil
 }
 
-func (r *LLMISVCReconciler) expectedSchedulerService(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) *corev1.Service {
-	logger := log.FromContext(ctx)
+func (r *LLMISVCReconciler) expectedSchedulerService(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) (*corev1.Service, error) {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      llmSvc.Spec.Router.EPPServiceName(llmSvc),
@@ -255,9 +258,9 @@ func (r *LLMISVCReconciler) expectedSchedulerService(ctx context.Context, llmSvc
 			}
 		}
 
-		if len(desiredPorts) != len(actualPorts) {
-			// TODO should this be raised as failing condition? + check if grpc port matches what's defined in the inferencepool
-			logger.Info("some ports are not matching", "desired", desiredPorts, "actual", maps.Keys(actualPorts))
+		missingPorts := desiredPorts.Difference(sets.KeySet(actualPorts))
+		if missingPorts.Len() > 0 {
+			return nil, fmt.Errorf("scheduler container is missing required ports: %v", missingPorts.UnsortedList())
 		}
 
 		servicePorts := make([]corev1.ServicePort, 0, len(actualPorts))
@@ -279,7 +282,7 @@ func (r *LLMISVCReconciler) expectedSchedulerService(ctx context.Context, llmSvc
 
 	log.FromContext(ctx).V(2).Info("Expected router EPP service", "service", svc)
 
-	return svc
+	return svc, nil
 }
 
 func (r *LLMISVCReconciler) expectedSchedulerInferencePool(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) *igwapi.InferencePool {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -1491,4 +1492,42 @@ plugins:
 			}
 		})
 	}
+}
+
+func TestSchedulerPortMismatch(t *testing.T) {
+	g := NewWithT(t)
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{
+				Scheduler: &v1alpha2.SchedulerSpec{
+					Template: &corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "main",
+								Ports: []corev1.ContainerPort{
+									// grpc-health, metrics, zmq intentionally missing
+									{
+										Name:          "grpc",
+										ContainerPort: 9002,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	r := &LLMISVCReconciler{Client: fake.NewClientBuilder().Build()}
+	_, err := r.expectedSchedulerService(context.Background(), llmSvc)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("missing required ports"))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes `expectedSchedulerService` return an error listing the missing ports, and `reconcileSchedulerService` calls `MarkSchedulerWorkloadNotReady` with reason `SchedulerPortMismatch` so the failure surfaces in `status.conditions`.

When a custom scheduler `PodTemplateSpec` omits one or more required container ports (`grpc`, `grpc-health`, `metrics`, `zmq`), the controller previously logged a warning and continued. 

The resulting `Service` was created with missing ports, rendering the EPP unreachable to the Gateway with no observable signal in `LLMInferenceService` status.

**Which issue(s) this PR fixes**:

fixes #5441

Closes the `TODO` in `scheduler.go`: `// TODO should this be raised as failing condition?`

**Feature/Issue validation/testing**:

- `TestSchedulerPortMismatch`: verifies that a scheduler template missing required ports returns an error with the missing port names
- Ran `make precommit` successfully.

**Special notes for your reviewer**:

This is my first PR to `kserve`, so I’m happy to iterate based on any feedback. Thanks!