### PR TITLE
fix: add timeout_keep_alive to work with Istio/Envoy

### DIFF
--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -128,6 +128,17 @@ parser.add_argument(
         "'asyncio', or 'uvloop'."
     ),
 )
+parser.add_argument(
+    "--timeout-keep-alive",
+    dest="timeout_keep_alive",
+    default=65,
+    type=int,
+    help=(
+        "Timeout for keep-alive connections in seconds. "
+        "The keep-alive timeout should be longer than the proxy idle timeout "
+        "to avoid intermittent 503 errors from the proxy (e.g. Istio/Envoy)."
+    ),
+)
 
 # Model arguments: The arguments are passed to the kserve.Model object
 parser.add_argument(
@@ -219,6 +230,7 @@ class ModelServer:
         enable_latency_logging: bool = args.enable_latency_logging,
         access_log_format: str = args.access_log_format,
         event_loop: str = args.event_loop,
+        timeout_keep_alive: int = args.timeout_keep_alive,
         grace_period: int = 30,
         predictor_config: Optional[PredictorConfig] = None,
     ):
@@ -241,6 +253,7 @@ class ModelServer:
                                (please refer to this Uvicorn
                                [github issue](https://github.com/encode/uvicorn/issues/527) for more info).
             event_loop: Uvicorn event loop. Default: ``'auto'``. It supports "auto", "asyncio", "uvloop".
+            timeout_keep_alive: Timeout for keep-alive connections in seconds. Default: ``65``.
             grace_period: The grace period in seconds to wait for the server to stop. Default: ``30``.
             predictor_config: Optional configuration for the predictor. Default: ``None``.
         """
@@ -253,6 +266,7 @@ class ModelServer:
         self.event_loop = event_loop
         self.max_threads = max_threads
         self.max_asyncio_workers = max_asyncio_workers
+        self.timeout_keep_alive = timeout_keep_alive
         self.enable_grpc = enable_grpc
         self.enable_docs_url = enable_docs_url
         self.enable_latency_logging = enable_latency_logging
@@ -333,6 +347,7 @@ class ModelServer:
                 grace_period=self.grace_period,
                 log_config_file=args.log_config_file,
                 event_loop=self.event_loop,
+                timeout_keep_alive=self.timeout_keep_alive,
             )
             self.servers.append(self._rest_multiprocess_server.start())
         else:
@@ -345,6 +360,7 @@ class ModelServer:
                 workers=self.workers,
                 grace_period=self.grace_period,
                 event_loop=self.event_loop,
+                timeout_keep_alive=self.timeout_keep_alive,
             )
             self.servers.append(self._rest_server.start())
         if self.enable_grpc:

--- a/python/kserve/kserve/protocol/rest/multiprocess/server.py
+++ b/python/kserve/kserve/protocol/rest/multiprocess/server.py
@@ -133,6 +133,7 @@ class RESTServerMultiProcess:
         grace_period: int = 30,
         log_config_file: Optional[str] = None,
         event_loop: str = "auto",
+        timeout_keep_alive: int = 65,
     ) -> None:
         self.log_config_file = log_config_file
         self._rest_server = RESTServer(
@@ -144,6 +145,7 @@ class RESTServerMultiProcess:
             workers,
             grace_period,
             event_loop,
+            timeout_keep_alive,
         )
         self._processes: List[RESTServerProcess] = []
         self.should_exit = asyncio.Event()

--- a/python/kserve/kserve/protocol/rest/server.py
+++ b/python/kserve/kserve/protocol/rest/server.py
@@ -77,6 +77,7 @@ class RESTServer:
         workers: int = 1,
         grace_period: int = 30,
         event_loop: str = "auto",
+        timeout_keep_alive: int = 65,
     ):
         self.dataplane = data_plane
         self.model_repository_extension = model_repository_extension
@@ -97,6 +98,7 @@ class RESTServer:
             # configured by kserve.
             log_config=None,
             timeout_graceful_shutdown=grace_period,
+            timeout_keep_alive=timeout_keep_alive,
             loop=event_loop,
         )
         self._server = uvicorn.Server(self.config)

--- a/python/kserve/test/test_rest_server.py
+++ b/python/kserve/test/test_rest_server.py
@@ -42,3 +42,42 @@ def test_config_loop_value(loop_value, expected, monkeypatch):
     )
 
     assert rs.config.loop == expected
+
+
+@pytest.mark.parametrize(
+    "timeout_keep_alive,expected",
+    [
+        (65, 65),  # default value
+        (120, 120),  # custom value
+        (5, 5),  # uvicorn default
+    ],
+)
+def test_config_timeout_keep_alive(timeout_keep_alive, expected, monkeypatch):
+    monkeypatch.setattr(rest_mod.RESTServer, "create_application", lambda self: None)
+    data_plane = Mock()
+    model_repo_ext = Mock()
+
+    rs = rest_mod.RESTServer(
+        app="dummy:app",
+        data_plane=data_plane,
+        model_repository_extension=model_repo_ext,
+        http_port=8080,
+        timeout_keep_alive=timeout_keep_alive,
+    )
+
+    assert rs.config.timeout_keep_alive == expected
+
+
+def test_config_timeout_keep_alive_default(monkeypatch):
+    monkeypatch.setattr(rest_mod.RESTServer, "create_application", lambda self: None)
+    data_plane = Mock()
+    model_repo_ext = Mock()
+
+    rs = rest_mod.RESTServer(
+        app="dummy:app",
+        data_plane=data_plane,
+        model_repository_extension=model_repo_ext,
+        http_port=8080,
+    )
+
+    assert rs.config.timeout_keep_alive == 65


### PR DESCRIPTION
**What this PR does / why we need it**:
  - Add --timeout-keep-alive CLI argument to configure uvicorn's keep-alive timeout, defaulting to 65s                                                    
  - Thread the parameter through ModelServer → RESTServer / RESTServerMultiProcess → uvicorn.Config
  - Add unit tests for the new configuration option     

**Which issue(s) this PR fixes**
Fixes #5446 

**Checklist**:

- [X] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

