### PR TITLE
feat(isvc): add dual-protocol (REST/gRPC) routing for Standard mode

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1032,6 +1032,13 @@ jobs:
         timeout-minutes: 30
         run: |
           ./test/scripts/gh-actions/run-e2e-tests.sh "raw" "6" ${{ matrix.network-layer }}
+      
+      # Run dual protocol (gRPC/REST) test only for gatewayapi as it is the only one supporting it currently.
+      - name: Run E2E tests - Dual Protocol
+        if: matrix.network-layer == 'envoy-gatewayapi' || matrix.network-layer == 'istio-gatewayapi'
+        timeout-minutes: 10
+        run: |
+          ./test/scripts/gh-actions/run-e2e-tests.sh "dual_protocol" "6" ${{ matrix.network-layer }}
 
       - name: Patch inferenceservice config for path based routing
         if: matrix.network-layer == 'envoy-gatewayapi' || matrix.network-layer == 'istio-gatewayapi'

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -135,6 +135,88 @@ func addIsvcHeaders(name string, namespace string) gwapiv1.HTTPRouteFilter {
 	}
 }
 
+// detectServiceProtocolPorts queries the Service to extract protocol port information.
+// It analyzes the service ports to identify REST and gRPC ports based on appProtocol annotations
+// and port names. Only the first port of each type is detected and returned.
+// Returns the REST port, gRPC port, and any error encountered.
+func detectServiceProtocolPorts(ctx context.Context, client client.Client, serviceName, namespace string) (restPort, grpcPort int32, err error) {
+	// Query the Service
+	svc := &corev1.Service{}
+	err = client.Get(ctx, types.NamespacedName{
+		Name:      serviceName,
+		Namespace: namespace,
+	}, svc)
+	if err != nil {
+		// Service may not exist yet in early reconciliation paths. In that case, gracefully fall back to default routing.
+		if apierr.IsNotFound(err) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+
+	// Analyze ports to identify REST and gRPC
+	for _, port := range svc.Spec.Ports {
+		// Check if this is a gRPC port based on appProtocol or port name
+		switch {
+		case port.AppProtocol != nil && *port.AppProtocol == "kubernetes.io/h2c":
+			if grpcPort == 0 {
+				grpcPort = port.Port
+			}
+		case isGrpcPortByName(port.Name):
+			if grpcPort == 0 {
+				grpcPort = port.Port
+			}
+		default:
+			// HTTP port
+			if restPort == 0 {
+				restPort = port.Port
+			}
+		}
+	}
+	return restPort, grpcPort, nil
+}
+
+// isGrpcPortByName checks if a port name indicates gRPC protocol
+func isGrpcPortByName(portName string) bool {
+	portNameLower := strings.ToLower(portName)
+	return strings.Contains(portNameLower, "grpc") || strings.Contains(portNameLower, "h2c")
+}
+
+// createGRPCRouteMatches creates HTTPRouteMatch entries that match gRPC requests
+// gRPC requests are identified by:
+// 1. Path: /inference.GRPCInferenceService/* (gRPC v2 protocol)
+// 2. Content-Type: application/grpc* (includes application/grpc+proto, application/grpc+json)
+func createGRPCRouteMatches() []gwapiv1.HTTPRouteMatch {
+	return []gwapiv1.HTTPRouteMatch{
+		{
+			Path: &gwapiv1.HTTPPathMatch{
+				Type:  ptr.To(gwapiv1.PathMatchRegularExpression),
+				Value: ptr.To("^/inference\\.GRPCInferenceService/.*$"),
+			},
+			Headers: []gwapiv1.HTTPHeaderMatch{
+				{
+					Type:  ptr.To(gwapiv1.HeaderMatchRegularExpression),
+					Name:  gwapiv1.HTTPHeaderName("content-type"),
+					Value: "^application/grpc.*",
+				},
+			},
+		},
+	}
+}
+
+// createHTTPRouteMatches creates HTTPRouteMatch entries that match HTTP/REST requests
+// This matches all requests that are NOT gRPC (no content-type restriction for broader compatibility)
+func createHTTPRouteMatches(pathPrefix string) []gwapiv1.HTTPRouteMatch {
+	return []gwapiv1.HTTPRouteMatch{
+		{
+			Path: &gwapiv1.HTTPPathMatch{
+				Type:  ptr.To(gwapiv1.PathMatchRegularExpression),
+				Value: ptr.To(pathPrefix),
+			},
+		},
+	}
+}
+
 func createHTTPRouteRule(routeMatches []gwapiv1.HTTPRouteMatch, filters []gwapiv1.HTTPRouteFilter,
 	serviceName, namespace string, port int32, timeout *gwapiv1.Duration,
 ) gwapiv1.HTTPRouteRule {
@@ -166,10 +248,10 @@ func createHTTPRouteRule(routeMatches []gwapiv1.HTTPRouteMatch, filters []gwapiv
 	return rule
 }
 
-func createRawPredictorHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig,
+func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig,
 	isvcConfig *v1beta1.InferenceServicesConfig,
 ) (*gwapiv1.HTTPRoute, error) {
-	httpRouteRules := make([]gwapiv1.HTTPRouteRule, 0, 1)
+	httpRouteRules := make([]gwapiv1.HTTPRouteRule, 0, 2)
 	allowedHosts := make([]gwapiv1.Hostname, 0, 1)
 
 	if !isvc.Status.IsConditionReady(v1beta1.PredictorReady) {
@@ -191,9 +273,28 @@ func createRawPredictorHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *
 		return nil, fmt.Errorf("failed to generate predictor ingress host: %w", err)
 	}
 	allowedHosts = append(allowedHosts, gwapiv1.Hostname(predictorHost))
-	routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
 	timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Predictor.TimeoutSeconds)
-	httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, predictorName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
+
+	// Detect dual-protocol configuration
+	restPort, grpcPort, err := detectServiceProtocolPorts(ctx, client, predictorName, isvc.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect protocol ports for predictor service: %w", err)
+	}
+
+	if grpcPort != 0 && restPort != 0 {
+		// Generate separate rules for gRPC and HTTP with header-based matching
+		// gRPC rule FIRST (more specific - matches Content-Type: application/grpc* and gRPC path)
+		grpcMatches := createGRPCRouteMatches()
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(grpcMatches, filters, predictorName, isvc.Namespace, grpcPort, timeout))
+
+		// HTTP rule SECOND (fallback - matches all other requests)
+		httpMatches := createHTTPRouteMatches(constants.FallbackPrefix())
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(httpMatches, filters, predictorName, isvc.Namespace, restPort, timeout))
+	} else {
+		// Fall back to old default behavior
+		routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, predictorName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
+	}
 
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(isvcConfig.ServiceAnnotationDisallowedList, key)
@@ -227,10 +328,10 @@ func createRawPredictorHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *
 	return &httpRoute, nil
 }
 
-func createRawTransformerHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig,
+func createRawTransformerHTTPRoute(ctx context.Context, client client.Client, isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig,
 	isvcConfig *v1beta1.InferenceServicesConfig,
 ) (*gwapiv1.HTTPRoute, error) {
-	httpRouteRules := make([]gwapiv1.HTTPRouteRule, 0, 1)
+	httpRouteRules := make([]gwapiv1.HTTPRouteRule, 0, 2)
 	allowedHosts := make([]gwapiv1.Hostname, 0, 1)
 
 	if !isvc.Status.IsConditionReady(v1beta1.TransformerReady) {
@@ -251,10 +352,27 @@ func createRawTransformerHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig
 		return nil, fmt.Errorf("failed to generate transformer ingress host: %w", err)
 	}
 	allowedHosts = append(allowedHosts, gwapiv1.Hostname(transformerHost))
-	routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
 	timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Transformer.TimeoutSeconds)
-	httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, transformerName, isvc.Namespace,
-		constants.CommonDefaultHttpPort, timeout))
+	// Detect dual-protocol configuration
+	restPort, grpcPort, err := detectServiceProtocolPorts(ctx, client, transformerName, isvc.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect protocol ports for transformer service: %w", err)
+	}
+
+	if grpcPort != 0 && restPort != 0 {
+		// Generate separate rules for gRPC and HTTP with header-based matching
+		// gRPC rule FIRST (more specific - matches Content-Type: application/grpc* and gRPC path)
+		grpcMatches := createGRPCRouteMatches()
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(grpcMatches, filters, transformerName, isvc.Namespace, grpcPort, timeout))
+
+		// HTTP rule SECOND (fallback - matches all other requests)
+		httpMatches := createHTTPRouteMatches(constants.FallbackPrefix())
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(httpMatches, filters, transformerName, isvc.Namespace, restPort, timeout))
+	} else {
+		// Fall back to old default behavior
+		routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, transformerName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
+	}
 
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(isvcConfig.ServiceAnnotationDisallowedList, key)
@@ -288,10 +406,10 @@ func createRawTransformerHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig
 	return &httpRoute, nil
 }
 
-func createRawExplainerHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig,
+func createRawExplainerHTTPRoute(ctx context.Context, client client.Client, isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig,
 	isvcConfig *v1beta1.InferenceServicesConfig,
 ) (*gwapiv1.HTTPRoute, error) {
-	httpRouteRules := make([]gwapiv1.HTTPRouteRule, 0, 1)
+	httpRouteRules := make([]gwapiv1.HTTPRouteRule, 0, 2)
 	allowedHosts := make([]gwapiv1.Hostname, 0, 1)
 
 	if !isvc.Status.IsConditionReady(v1beta1.ExplainerReady) {
@@ -314,10 +432,28 @@ func createRawExplainerHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *
 	allowedHosts = append(allowedHosts, gwapiv1.Hostname(explainerHost))
 
 	// Add explainer host rules
-	routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
 	timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Explainer.TimeoutSeconds)
-	httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, explainerName, isvc.Namespace,
-		constants.CommonDefaultHttpPort, timeout))
+
+	// Detect dual-protocol configuration
+	restPort, grpcPort, err := detectServiceProtocolPorts(ctx, client, explainerName, isvc.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect protocol ports for explainer service: %w", err)
+	}
+
+	if grpcPort != 0 && restPort != 0 {
+		// Generate separate rules for gRPC and HTTP with header-based matching
+		// gRPC rule FIRST (more specific - matches Content-Type: application/grpc* and gRPC path)
+		grpcMatches := createGRPCRouteMatches()
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(grpcMatches, filters, explainerName, isvc.Namespace, grpcPort, timeout))
+
+		// HTTP rule SECOND (fallback - matches all other requests)
+		httpMatches := createHTTPRouteMatches(constants.FallbackPrefix())
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(httpMatches, filters, explainerName, isvc.Namespace, restPort, timeout))
+	} else {
+		// Fall back to old default behavior
+		routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, explainerName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
+	}
 
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(isvcConfig.ServiceAnnotationDisallowedList, key)
@@ -351,10 +487,10 @@ func createRawExplainerHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *
 	return &httpRoute, nil
 }
 
-func createRawTopLevelHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig,
+func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig,
 	isvcConfig *v1beta1.InferenceServicesConfig,
 ) (*gwapiv1.HTTPRoute, error) {
-	httpRouteRules := make([]gwapiv1.HTTPRouteRule, 0, 1)
+	httpRouteRules := make([]gwapiv1.HTTPRouteRule, 0, 2)
 	allowedHosts := make([]gwapiv1.Hostname, 0, 1)
 
 	if !isvc.Status.IsConditionReady(v1beta1.PredictorReady) {
@@ -421,14 +557,52 @@ func createRawTopLevelHTTPRoute(isvc *v1beta1.InferenceService, ingressConfig *v
 		}
 		timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Transformer.TimeoutSeconds)
 		// :predict routes to the transformer when there are both predictor and transformer
-		routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
-		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, transformerName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
+
+		// Detect dual-protocol for transformer
+		restPort, grpcPort, err := detectServiceProtocolPorts(ctx, client, transformerName, isvc.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to detect protocol ports for transformer service: %w", err)
+		}
+
+		if grpcPort != 0 && restPort != 0 {
+			// Generate separate rules for gRPC and HTTP with header-based matching
+			// gRPC rule FIRST (more specific - matches Content-Type: application/grpc* and gRPC path)
+			grpcMatches := createGRPCRouteMatches()
+			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(grpcMatches, filters, transformerName, isvc.Namespace, grpcPort, timeout))
+
+			// HTTP rule SECOND (fallback - matches all other requests)
+			httpMatches := createHTTPRouteMatches(constants.FallbackPrefix())
+			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(httpMatches, filters, transformerName, isvc.Namespace, restPort, timeout))
+		} else {
+			// Fall back to old default behavior
+			routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, transformerName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
+		}
 	} else {
 		// Scenario: When predictor without transformer and with/without explainer present
 		timeout := resolveTimeout(ingressConfig.DisableHTTPRouteTimeout, isvc.Spec.Predictor.TimeoutSeconds)
 		// Add toplevel host rules for predictor which routes all traffic to predictor
-		routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
-		httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, predictorName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
+
+		// Detect dual-protocol for predictor
+		restPort, grpcPort, err := detectServiceProtocolPorts(ctx, client, predictorName, isvc.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to detect protocol ports for predictor service: %w", err)
+		}
+
+		if grpcPort != 0 && restPort != 0 {
+			// Generate separate rules for gRPC and HTTP with header-based matching
+			// gRPC rule FIRST (more specific - matches Content-Type: application/grpc* and gRPC path)
+			grpcMatches := createGRPCRouteMatches()
+			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(grpcMatches, filters, predictorName, isvc.Namespace, grpcPort, timeout))
+
+			// HTTP rule SECOND (fallback - matches all other requests)
+			httpMatches := createHTTPRouteMatches(constants.FallbackPrefix())
+			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(httpMatches, filters, predictorName, isvc.Namespace, restPort, timeout))
+		} else {
+			// Fall back to old default behavior
+			routeMatch := []gwapiv1.HTTPRouteMatch{createHTTPRouteMatch(constants.FallbackPrefix())}
+			httpRouteRules = append(httpRouteRules, createHTTPRouteRule(routeMatch, filters, predictorName, isvc.Namespace, constants.CommonDefaultHttpPort, timeout))
+		}
 	}
 
 	// Add path based routing rules
@@ -519,7 +693,7 @@ func isHTTPRouteReady(httpRouteStatus gwapiv1.HTTPRouteStatus) (bool, *string, *
 }
 
 func (r *RawHTTPRouteReconciler) reconcilePredictorHTTPRoute(ctx context.Context, isvc *v1beta1.InferenceService) error {
-	desired, err := createRawPredictorHTTPRoute(isvc, r.ingressConfig, r.isvcConfig)
+	desired, err := createRawPredictorHTTPRoute(ctx, r.client, isvc, r.ingressConfig, r.isvcConfig)
 	if err != nil {
 		return err
 	}
@@ -582,7 +756,7 @@ func (r *RawHTTPRouteReconciler) reconcilePredictorHTTPRoute(ctx context.Context
 }
 
 func (r *RawHTTPRouteReconciler) reconcileTransformerHTTPRoute(ctx context.Context, isvc *v1beta1.InferenceService) error {
-	desired, err := createRawTransformerHTTPRoute(isvc, r.ingressConfig, r.isvcConfig)
+	desired, err := createRawTransformerHTTPRoute(ctx, r.client, isvc, r.ingressConfig, r.isvcConfig)
 	if err != nil {
 		return err
 	}
@@ -642,7 +816,7 @@ func (r *RawHTTPRouteReconciler) reconcileTransformerHTTPRoute(ctx context.Conte
 }
 
 func (r *RawHTTPRouteReconciler) reconcileExplainerHTTPRoute(ctx context.Context, isvc *v1beta1.InferenceService) error {
-	desired, err := createRawExplainerHTTPRoute(isvc, r.ingressConfig, r.isvcConfig)
+	desired, err := createRawExplainerHTTPRoute(ctx, r.client, isvc, r.ingressConfig, r.isvcConfig)
 	if err != nil {
 		return err
 	}
@@ -702,7 +876,7 @@ func (r *RawHTTPRouteReconciler) reconcileExplainerHTTPRoute(ctx context.Context
 }
 
 func (r *RawHTTPRouteReconciler) reconcileTopLevelHTTPRoute(ctx context.Context, isvc *v1beta1.InferenceService) error {
-	desired, err := createRawTopLevelHTTPRoute(isvc, r.ingressConfig, r.isvcConfig)
+	desired, err := createRawTopLevelHTTPRoute(ctx, r.client, isvc, r.ingressConfig, r.isvcConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -1287,7 +1287,11 @@ func TestCreateRawTopLevelHTTPRoute(t *testing.T) {
 				ServiceAnnotationDisallowedList: []string{},
 				ServiceLabelDisallowedList:      []string{},
 			}
-			httpRoute, err := createRawTopLevelHTTPRoute(tc.isvc, tc.ingressConfig, isvcConfig)
+			ctx := context.TODO()
+
+			fakeClient := fake.NewClientBuilder().Build()
+
+			httpRoute, err := createRawTopLevelHTTPRoute(ctx, fakeClient, tc.isvc, tc.ingressConfig, isvcConfig)
 
 			g.Expect(err).ToNot(HaveOccurred())
 			if tc.expected != nil {
@@ -1451,7 +1455,11 @@ func TestCreateRawPredictorHTTPRoute(t *testing.T) {
 				ServiceAnnotationDisallowedList: []string{},
 				ServiceLabelDisallowedList:      []string{},
 			}
-			httpRoute, err := createRawPredictorHTTPRoute(tc.isvc, tc.ingressConfig, isvcConfig)
+			ctx := context.TODO()
+
+			fakeClient := fake.NewClientBuilder().Build()
+
+			httpRoute, err := createRawPredictorHTTPRoute(ctx, fakeClient, tc.isvc, tc.ingressConfig, isvcConfig)
 
 			g.Expect(err).ToNot(HaveOccurred())
 			if tc.expected != nil {
@@ -1617,7 +1625,11 @@ func TestCreateRawTransformerHTTPRoute(t *testing.T) {
 				ServiceAnnotationDisallowedList: []string{},
 				ServiceLabelDisallowedList:      []string{},
 			}
-			httpRoute, err := createRawTransformerHTTPRoute(tc.isvc, tc.ingressConfig, isvcConfig)
+			ctx := context.TODO()
+
+			fakeClient := fake.NewClientBuilder().Build()
+
+			httpRoute, err := createRawTransformerHTTPRoute(ctx, fakeClient, tc.isvc, tc.ingressConfig, isvcConfig)
 
 			g.Expect(err).ToNot(HaveOccurred())
 			if tc.expected != nil {
@@ -1783,7 +1795,11 @@ func TestCreateRawExplainerHTTPRoute(t *testing.T) {
 				ServiceAnnotationDisallowedList: []string{},
 				ServiceLabelDisallowedList:      []string{},
 			}
-			httpRoute, err := createRawExplainerHTTPRoute(tc.isvc, tc.ingressConfig, isvcConfig)
+			ctx := context.TODO()
+
+			fakeClient := fake.NewClientBuilder().Build()
+
+			httpRoute, err := createRawExplainerHTTPRoute(ctx, fakeClient, tc.isvc, tc.ingressConfig, isvcConfig)
 
 			g.Expect(err).ToNot(HaveOccurred())
 			if tc.expected != nil {
@@ -2676,7 +2692,11 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 		})
 
 		// Create HTTPRoute with not ready status - needs to have the correct spec to avoid being updated
-		desiredPredictorRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		ctx := context.TODO()
+
+		fakeClient := fake.NewClientBuilder().Build()
+
+		desiredPredictorRoute, err := createRawPredictorHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredPredictorRoute).NotTo(BeNil())
 
@@ -2743,7 +2763,11 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 		})
 
 		// Create ready predictor HTTPRoute but not ready transformer HTTPRoute
-		desiredPredictorRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		ctx := context.TODO()
+
+		fakeClient := fake.NewClientBuilder().Build()
+
+		desiredPredictorRoute, err := createRawPredictorHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredPredictorRoute).NotTo(BeNil())
 
@@ -2770,7 +2794,7 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 			},
 		}
 
-		desiredTransformerRoute, err := createRawTransformerHTTPRoute(isvc, ingressConfig, isvcConfig)
+		desiredTransformerRoute, err := createRawTransformerHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredTransformerRoute).NotTo(BeNil())
 
@@ -2807,7 +2831,7 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 		}
 
 		// Create ready top-level HTTPRoute
-		desiredTopLevelRoute, err := createRawTopLevelHTTPRoute(isvc, ingressConfig, isvcConfig)
+		desiredTopLevelRoute, err := createRawTopLevelHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredTopLevelRoute).NotTo(BeNil())
 
@@ -2886,7 +2910,11 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 		})
 
 		// Create ready predictor HTTPRoute but not ready explainer HTTPRoute
-		desiredPredictorRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		ctx := context.TODO()
+
+		fakeClient := fake.NewClientBuilder().Build()
+
+		desiredPredictorRoute, err := createRawPredictorHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredPredictorRoute).NotTo(BeNil())
 
@@ -2913,7 +2941,7 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 			},
 		}
 
-		desiredExplainerRoute, err := createRawExplainerHTTPRoute(isvc, ingressConfig, isvcConfig)
+		desiredExplainerRoute, err := createRawExplainerHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredExplainerRoute).NotTo(BeNil())
 
@@ -2938,7 +2966,7 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 			},
 		}
 
-		desiredTopLevelRoute, err := createRawTopLevelHTTPRoute(isvc, ingressConfig, isvcConfig)
+		desiredTopLevelRoute, err := createRawTopLevelHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredTopLevelRoute).NotTo(BeNil())
 
@@ -3003,7 +3031,9 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 		})
 
 		// Create ready predictor HTTPRoute but not ready top-level HTTPRoute
-		desiredTopLevelRoute, err := createRawTopLevelHTTPRoute(isvc, ingressConfig, isvcConfig)
+		ctx := context.TODO()
+		fakeClient := fake.NewClientBuilder().Build()
+		desiredTopLevelRoute, err := createRawTopLevelHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredTopLevelRoute).NotTo(BeNil())
 
@@ -3032,7 +3062,7 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 			},
 		}
 
-		desiredPredictorRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		desiredPredictorRoute, err := createRawPredictorHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredPredictorRoute).NotTo(BeNil())
 
@@ -3105,7 +3135,11 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		})
 
-		desiredPredictorRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		ctx := context.TODO()
+
+		fakeClient := fake.NewClientBuilder().Build()
+
+		desiredPredictorRoute, err := createRawPredictorHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredPredictorRoute).NotTo(BeNil())
 
@@ -3131,7 +3165,7 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 			},
 		}
 
-		desiredTransformerRoute, err := createRawTransformerHTTPRoute(isvc, ingressConfig, isvcConfig)
+		desiredTransformerRoute, err := createRawTransformerHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredTransformerRoute).NotTo(BeNil())
 
@@ -3157,7 +3191,7 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 			},
 		}
 
-		desiredExplainerRoute, err := createRawExplainerHTTPRoute(isvc, ingressConfig, isvcConfig)
+		desiredExplainerRoute, err := createRawExplainerHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredExplainerRoute).NotTo(BeNil())
 
@@ -3183,7 +3217,7 @@ func TestRawHTTPRouteReconciler_Reconcile(t *testing.T) {
 			},
 		}
 
-		desiredTopLevelRoute, err := createRawTopLevelHTTPRoute(isvc, ingressConfig, isvcConfig)
+		desiredTopLevelRoute, err := createRawTopLevelHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(desiredTopLevelRoute).NotTo(BeNil())
 
@@ -3394,7 +3428,11 @@ func TestCreateRawPredictorHTTPRouteDisableTimeout(t *testing.T) {
 			EnableGatewayAPI:        true,
 			DisableHTTPRouteTimeout: true,
 		}
-		httpRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		ctx := context.TODO()
+
+		fakeClient := fake.NewClientBuilder().Build()
+
+		httpRoute, err := createRawPredictorHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(httpRoute).ToNot(BeNil())
 		for _, rule := range httpRoute.Spec.Rules {
@@ -3411,7 +3449,11 @@ func TestCreateRawPredictorHTTPRouteDisableTimeout(t *testing.T) {
 			EnableGatewayAPI:        true,
 			DisableHTTPRouteTimeout: false,
 		}
-		httpRoute, err := createRawPredictorHTTPRoute(isvc, ingressConfig, isvcConfig)
+		ctx := context.TODO()
+
+		fakeClient := fake.NewClientBuilder().Build()
+
+		httpRoute, err := createRawPredictorHTTPRoute(ctx, fakeClient, isvc, ingressConfig, isvcConfig)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(httpRoute).ToNot(BeNil())
 		for _, rule := range httpRoute.Spec.Rules {

--- a/test/e2e/predictor/test_grpc.py
+++ b/test/e2e/predictor/test_grpc.py
@@ -26,10 +26,11 @@ from kserve import (
     V1beta1LoggerSpec,
     constants,
 )
+from kserve.models.v1beta1_sk_learn_spec import V1beta1SKLearnSpec
 from kubernetes.client import V1ResourceRequirements
 from kubernetes import client
 from kubernetes.client import V1Container, V1ContainerPort
-from ..common.utils import KSERVE_TEST_NAMESPACE, predict_grpc
+from ..common.utils import KSERVE_TEST_NAMESPACE, predict_grpc, predict_isvc
 
 
 @pytest.mark.grpc
@@ -100,8 +101,8 @@ async def test_custom_model_grpc():
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    json_file = open("./data/custom_model_input.json")
-    data = json.load(json_file)
+    with open("./data/custom_model_input.json") as json_file:
+        data = json.load(json_file)
     payload = [
         {
             "name": "input-0",
@@ -138,3 +139,61 @@ async def test_custom_model_grpc():
     assert "org.kubeflow.serving.inference.response" in log
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
     kserve_client.delete(msg_dumper, KSERVE_TEST_NAMESPACE)
+
+
+@pytest.mark.grpc
+@pytest.mark.predictor
+@pytest.mark.asyncio(scope="session")
+async def test_sklearn_dual_protocol(rest_v2_client):
+    service_name = "sklearn-dual-protocol"
+    model_name = "sklearn-dual-protocol"
+
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            storage_uri="gs://kfserving-examples/models/sklearn/1.0/model",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+            ports=[
+                V1ContainerPort(container_port=8081, name="grpc-port", protocol="TCP"),
+                V1ContainerPort(container_port=8080, name="http-rest", protocol="TCP"),
+            ],
+        ),
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+
+    kserve_client.create(isvc)
+    kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+    # GRPC Request
+    with open("./data/iris_input_v2_grpc.json") as json_file:
+        payload = json.load(json_file)["inputs"]
+
+    response = await predict_grpc(
+        service_name=service_name, payload=payload, model_name=model_name
+    )
+    prediction = response.outputs[0].data
+    assert prediction == [1, 1]
+
+    # REST Request
+    res = await predict_isvc(
+        rest_v2_client,
+        service_name,
+        "./data/iris_input_v2.json",
+    )
+    assert res.outputs[0].data == [1, 1]
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_grpc.py
+++ b/test/e2e/predictor/test_grpc.py
@@ -141,10 +141,9 @@ async def test_custom_model_grpc():
     kserve_client.delete(msg_dumper, KSERVE_TEST_NAMESPACE)
 
 
-@pytest.mark.grpc
-@pytest.mark.predictor
+@pytest.mark.dual_protocol
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_dual_protocol(rest_v2_client):
+async def test_sklearn_dual_protocol(rest_v2_client, network_layer):
     service_name = "sklearn-dual-protocol"
     model_name = "sklearn-dual-protocol"
 
@@ -184,7 +183,10 @@ async def test_sklearn_dual_protocol(rest_v2_client):
         payload = json.load(json_file)["inputs"]
 
     response = await predict_grpc(
-        service_name=service_name, payload=payload, model_name=model_name
+        service_name=service_name,
+        payload=payload,
+        model_name=model_name,
+        network_layer=network_layer,
     )
     prediction = response.outputs[0].data
     assert prediction == [1, 1]
@@ -194,6 +196,7 @@ async def test_sklearn_dual_protocol(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_sklearn.py
+++ b/test/e2e/predictor/test_sklearn.py
@@ -330,8 +330,8 @@ async def test_sklearn_v2_grpc():
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    json_file = open("./data/iris_input_v2_grpc.json")
-    payload = json.load(json_file)["inputs"]
+    with open("./data/iris_input_v2_grpc.json") as json_file:
+        payload = json.load(json_file)["inputs"]
 
     response = await predict_grpc(
         service_name=service_name, payload=payload, model_name=model_name

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -32,3 +32,4 @@ markers =
     cluster_single_node: test targeting single node cluster
     cluster_multi_node: test targeting multi node cluster
     llmd_simulator: test using llm-d simulator
+    dual_protocol: test for dual protocol gRPC and REST predictor for Standard mode with Gateway API


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds **dual-protocol (REST + gRPC) routing support for InferenceService “Standard mode” when using Gateway API.** It does this by detecting REST and gRPC service ports from the Kubernetes Service and then generating two HTTPRoute rules: a more specific gRPC match first, followed by a REST/HTTP fallback match, enabling both protocols behind the same hostname.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
- Fixes #5377

**What changed:**
**Routing logic:**

-     Updates the HTTPRoute reconciler to query the backing Service and detect:
       1. A REST port (default/fallback)
       2. A gRPC port (based on appProtocol = kubernetes.io/h2c and/or port name heuristics like containing grpc/h2c)
-     When both ports exist, it generates two HTTPRoute rules (capacity increased from 1 → 2 in multiple places):
        1. gRPC rule first: matches gRPC traffic using path + content-type header regex (application/grpc.*)
        2. HTTP rule second: matches remaining HTTP/REST traffic (fallback)
-     When dual ports are not detected (or Service not found early), it falls back to prior behavior (single rule to the default HTTP port).

**Tests:**
-     Updates unit tests to account for function signature changes (now passing ctx and a client).
-     Adds an e2e scenario validating a single SKLearn InferenceService can be reached via both gRPC and REST when ports are exposed.

**Alternatives considered:**
**1. Create both a GRPCRoute and an HTTPRoute for the same host (dual Route kinds)**

   This was considered as a clean separation of protocols using dedicated Gateway API route types. But it **does not work if the host name is same for both routes.**

**Why it doesn’t work for same hostname**: per Gateway API docs, if an HTTPRoute (A) and GRPCRoute (B) are attached to the same Listener and their hostnames intersect (non-empty intersection), the implementation MUST accept exactly one of the two routes. That makes simultaneously attaching both route kinds for the same host non-viable, so this PR instead keeps everything within a single HTTPRoute and uses match rules to discriminate gRPC vs REST.