### PR TITLE
fix(helm): align imagePullPolicy defaults with kustomize base

### DIFF
--- a/charts/_common/kserve-llmisvc-resources-specific.yaml
+++ b/charts/_common/kserve-llmisvc-resources-specific.yaml
@@ -5,7 +5,7 @@ kserve:
     controller:
       image: kserve/llmisvc-controller
       tag: ''
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Always
       imagePullSecrets: []
       labels: {}
       podLabels: {}

--- a/charts/_common/kserve-resources-specific.yaml
+++ b/charts/_common/kserve-resources-specific.yaml
@@ -63,6 +63,7 @@ kserve:
     affinity: {}
     image: kserve/kserve-controller
     tag: ''
+    imagePullPolicy: Always
     imagePullSecrets: []
     resources:
       limits:

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -72,7 +72,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.llmisvc.controller.extraVolumeMounts | list | `[]` |  |
 | kserve.llmisvc.controller.extraVolumes | list | `[]` |  |
 | kserve.llmisvc.controller.image | string | `"kserve/llmisvc-controller"` |  |
-| kserve.llmisvc.controller.imagePullPolicy | string | `"IfNotPresent"` |  |
+| kserve.llmisvc.controller.imagePullPolicy | string | `"Always"` |  |
 | kserve.llmisvc.controller.imagePullSecrets | list | `[]` |  |
 | kserve.llmisvc.controller.labels | object | `{}` |  |
 | kserve.llmisvc.controller.livenessProbe.enabled | bool | `true` |  |

--- a/charts/kserve-llmisvc-resources/files/llmisvc/deployment-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/deployment-patch.yaml
@@ -81,7 +81,7 @@ spec:
       containers:
       - name: manager
         image: "{{ .Values.kserve.llmisvc.controller.image }}:{{ .Values.kserve.llmisvc.controller.tag | default .Values.kserve.version }}"
-        imagePullPolicy: {{ include "llm-isvc-resources.imagePullPolicy" . }}
+        imagePullPolicy: {{ .Values.kserve.llmisvc.controller.imagePullPolicy }}
         command:
           - /manager
         {{- with .Values.kserve.llmisvc.controller.containerSecurityContext }}

--- a/charts/kserve-llmisvc-resources/templates/_helpers.tpl
+++ b/charts/kserve-llmisvc-resources/templates/_helpers.tpl
@@ -68,12 +68,6 @@ Return the proper image name
 {{- printf "%s:%s" $repositoryName $tag -}}
 {{- end }}
 
-{{/*
-Return the proper image pull policy
-*/}}
-{{- define "llm-isvc-resources.imagePullPolicy" -}}
-{{- .Values.kserve.llmisvc.controller.imagePullPolicy | default "IfNotPresent" }}
-{{- end }}
 
 {{/*
 Return the proper image pull secrets

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -109,7 +109,7 @@ kserve:
     controller:
       image: kserve/llmisvc-controller
       tag: ''
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Always
       imagePullSecrets: []
       labels: {}
       podLabels: {}

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -46,6 +46,7 @@ $ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --v
 | kserve.controller.gateway.pathTemplate | string | `""` |  |
 | kserve.controller.gateway.urlScheme | string | `"http"` |  |
 | kserve.controller.image | string | `"kserve/kserve-controller"` |  |
+| kserve.controller.imagePullPolicy | string | `"Always"` |  |
 | kserve.controller.imagePullSecrets | list | `[]` |  |
 | kserve.controller.knativeAddressableResolver.enabled | bool | `false` |  |
 | kserve.controller.labels | object | `{}` |  |

--- a/charts/kserve-resources/files/kserve/deployment-patch.yaml
+++ b/charts/kserve-resources/files/kserve/deployment-patch.yaml
@@ -59,7 +59,7 @@ spec:
           {{- end }}
       - name: manager
         image: "{{ .Values.kserve.controller.image }}:{{ .Values.kserve.controller.tag | default .Values.kserve.version }}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.kserve.controller.imagePullPolicy }}
         securityContext:
           {{- with .Values.kserve.controller.containerSecurityContext}}
           {{- toYaml . | nindent 10 }}

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -169,6 +169,7 @@ kserve:
     affinity: {}
     image: kserve/kserve-controller
     tag: ''
+    imagePullPolicy: Always
     imagePullSecrets: []
     resources:
       limits:

--- a/hack/setup/infra/manage.kserve-helm.sh
+++ b/hack/setup/infra/manage.kserve-helm.sh
@@ -142,11 +142,22 @@ if [ "${SET_KSERVE_VERSION}" != "" ]; then
 fi
 
 # Build chart arrays based on ENABLE_* flags
+# When a specific version is set, override imagePullPolicy to IfNotPresent
+# to match kustomize version-template overlay behavior for dev/test scenarios
+PULL_POLICY_KSERVE=""
+PULL_POLICY_LLMISVC=""
+PULL_POLICY_LOCALMODEL=""
+if [ -n "${SET_KSERVE_VERSION}" ]; then
+    PULL_POLICY_KSERVE="--set kserve.controller.imagePullPolicy=IfNotPresent"
+    PULL_POLICY_LLMISVC="--set kserve.llmisvc.controller.imagePullPolicy=IfNotPresent"
+    PULL_POLICY_LOCALMODEL="--set kserve.localmodel.controller.imagePullPolicy=IfNotPresent --set kserve.localmodelnode.controller.imagePullPolicy=IfNotPresent"
+fi
+
 if is_positive "${ENABLE_KSERVE}"; then
     log_info "KServe is enabled"
     CRD_CHARTS+=("kserve-crd")
     RESOURCE_CHARTS+=("kserve-resources")
-    RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-}")
+    RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-} ${PULL_POLICY_KSERVE}")
     TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
 fi
 
@@ -154,7 +165,7 @@ if is_positive "${ENABLE_LLMISVC}"; then
     log_info "LLMIsvc is enabled"
     CRD_CHARTS+=("kserve-llmisvc-crd")
     RESOURCE_CHARTS+=("kserve-llmisvc-resources")
-    RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-}")
+    RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-} ${PULL_POLICY_LLMISVC}")
     TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
 fi
 
@@ -162,7 +173,7 @@ if is_positive "${ENABLE_LOCALMODEL}"; then
     log_info "LocalModel is enabled"
     CRD_CHARTS+=("kserve-localmodel-crd")
     RESOURCE_CHARTS+=("kserve-localmodel-resources")
-    RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-}")
+    RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-} ${PULL_POLICY_LOCALMODEL}")
     TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
 fi
 # INCLUDE_IN_GENERATED_SCRIPT_END

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -1569,11 +1569,22 @@ main() {
         fi
         
         # Build chart arrays based on ENABLE_* flags
+        # When a specific version is set, override imagePullPolicy to IfNotPresent
+        # to match kustomize version-template overlay behavior for dev/test scenarios
+        PULL_POLICY_KSERVE=""
+        PULL_POLICY_LLMISVC=""
+        PULL_POLICY_LOCALMODEL=""
+        if [ -n "${SET_KSERVE_VERSION}" ]; then
+            PULL_POLICY_KSERVE="--set kserve.controller.imagePullPolicy=IfNotPresent"
+            PULL_POLICY_LLMISVC="--set kserve.llmisvc.controller.imagePullPolicy=IfNotPresent"
+            PULL_POLICY_LOCALMODEL="--set kserve.localmodel.controller.imagePullPolicy=IfNotPresent --set kserve.localmodelnode.controller.imagePullPolicy=IfNotPresent"
+        fi
+        
         if is_positive "${ENABLE_KSERVE}"; then
             log_info "KServe is enabled"
             CRD_CHARTS+=("kserve-crd")
             RESOURCE_CHARTS+=("kserve-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-} ${PULL_POLICY_KSERVE}")
             TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
         fi
         
@@ -1581,7 +1592,7 @@ main() {
             log_info "LLMIsvc is enabled"
             CRD_CHARTS+=("kserve-llmisvc-crd")
             RESOURCE_CHARTS+=("kserve-llmisvc-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-} ${PULL_POLICY_LLMISVC}")
             TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
         fi
         
@@ -1589,7 +1600,7 @@ main() {
             log_info "LocalModel is enabled"
             CRD_CHARTS+=("kserve-localmodel-crd")
             RESOURCE_CHARTS+=("kserve-localmodel-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-} ${PULL_POLICY_LOCALMODEL}")
             TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
         fi
 

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -1155,11 +1155,22 @@ main() {
         fi
         
         # Build chart arrays based on ENABLE_* flags
+        # When a specific version is set, override imagePullPolicy to IfNotPresent
+        # to match kustomize version-template overlay behavior for dev/test scenarios
+        PULL_POLICY_KSERVE=""
+        PULL_POLICY_LLMISVC=""
+        PULL_POLICY_LOCALMODEL=""
+        if [ -n "${SET_KSERVE_VERSION}" ]; then
+            PULL_POLICY_KSERVE="--set kserve.controller.imagePullPolicy=IfNotPresent"
+            PULL_POLICY_LLMISVC="--set kserve.llmisvc.controller.imagePullPolicy=IfNotPresent"
+            PULL_POLICY_LOCALMODEL="--set kserve.localmodel.controller.imagePullPolicy=IfNotPresent --set kserve.localmodelnode.controller.imagePullPolicy=IfNotPresent"
+        fi
+        
         if is_positive "${ENABLE_KSERVE}"; then
             log_info "KServe is enabled"
             CRD_CHARTS+=("kserve-crd")
             RESOURCE_CHARTS+=("kserve-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-} ${PULL_POLICY_KSERVE}")
             TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
         fi
         
@@ -1167,7 +1178,7 @@ main() {
             log_info "LLMIsvc is enabled"
             CRD_CHARTS+=("kserve-llmisvc-crd")
             RESOURCE_CHARTS+=("kserve-llmisvc-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-} ${PULL_POLICY_LLMISVC}")
             TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
         fi
         
@@ -1175,7 +1186,7 @@ main() {
             log_info "LocalModel is enabled"
             CRD_CHARTS+=("kserve-localmodel-crd")
             RESOURCE_CHARTS+=("kserve-localmodel-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-} ${PULL_POLICY_LOCALMODEL}")
             TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
         fi
 

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -1488,11 +1488,22 @@ main() {
         fi
         
         # Build chart arrays based on ENABLE_* flags
+        # When a specific version is set, override imagePullPolicy to IfNotPresent
+        # to match kustomize version-template overlay behavior for dev/test scenarios
+        PULL_POLICY_KSERVE=""
+        PULL_POLICY_LLMISVC=""
+        PULL_POLICY_LOCALMODEL=""
+        if [ -n "${SET_KSERVE_VERSION}" ]; then
+            PULL_POLICY_KSERVE="--set kserve.controller.imagePullPolicy=IfNotPresent"
+            PULL_POLICY_LLMISVC="--set kserve.llmisvc.controller.imagePullPolicy=IfNotPresent"
+            PULL_POLICY_LOCALMODEL="--set kserve.localmodel.controller.imagePullPolicy=IfNotPresent --set kserve.localmodelnode.controller.imagePullPolicy=IfNotPresent"
+        fi
+        
         if is_positive "${ENABLE_KSERVE}"; then
             log_info "KServe is enabled"
             CRD_CHARTS+=("kserve-crd")
             RESOURCE_CHARTS+=("kserve-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-} ${PULL_POLICY_KSERVE}")
             TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
         fi
         
@@ -1500,7 +1511,7 @@ main() {
             log_info "LLMIsvc is enabled"
             CRD_CHARTS+=("kserve-llmisvc-crd")
             RESOURCE_CHARTS+=("kserve-llmisvc-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-} ${PULL_POLICY_LLMISVC}")
             TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
         fi
         
@@ -1508,7 +1519,7 @@ main() {
             log_info "LocalModel is enabled"
             CRD_CHARTS+=("kserve-localmodel-crd")
             RESOURCE_CHARTS+=("kserve-localmodel-resources")
-            RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-}")
+            RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-} ${PULL_POLICY_LOCALMODEL}")
             TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
         fi
 


### PR DESCRIPTION
Kustomize base uses `Always` for all controllers but helm charts had inconsistent defaults — kserve and llmisvc used `IfNotPresent` while localmodel used `Always`.

This aligns all helm chart defaults to `Always` and makes `imagePullPolicy` configurable via `values.yaml` using direct value references (consistent with how `image` is referenced).

Also adds automatic `IfNotPresent` override when using `--kserve-version` to support locally built images that are not in a remote registry. For the latest version, it will use `Always`.

Changes:
- `charts/_common/kserve-resources-specific.yaml`: add `imagePullPolicy: Always`
- `charts/_common/kserve-llmisvc-resources-specific.yaml`: `IfNotPresent` → `Always`
- `charts/kserve-resources/files/kserve/deployment-patch.yaml`: hardcoded → values reference
- `charts/kserve-llmisvc-resources/files/llmisvc/deployment-patch.yaml`: helper → values reference
- `charts/kserve-llmisvc-resources/templates/_helpers.tpl`: remove unused `imagePullPolicy` helper
- `hack/setup/infra/manage.kserve-helm.sh`: auto-set `IfNotPresent` for `--kserve-version`