### PR TITLE
fix: `hostPath` for `kserve-localmodelnode-agent` does not work for Talos

### DIFF
--- a/charts/kserve-localmodel-resources/README.md
+++ b/charts/kserve-localmodel-resources/README.md
@@ -36,6 +36,7 @@ $ helm install kserve-localmodel-resources oci://ghcr.io/kserve/charts/kserve-lo
 | kserve.localmodel.controller.resources.requests.memory | string | `"200Mi"` |  |
 | kserve.localmodel.controller.tag | string | `""` |  |
 | kserve.localmodelnode.controller.affinity | object | `{}` |  |
+| kserve.localmodelnode.controller.hostPath | string | `"/models"` |  |
 | kserve.localmodelnode.controller.image | string | `"kserve/kserve-localmodelnode-agent"` |  |
 | kserve.localmodelnode.controller.imagePullPolicy | string | `"Always"` |  |
 | kserve.localmodelnode.controller.nodeSelector.kserve/localmodel | string | `"worker"` |  |

--- a/charts/kserve-localmodel-resources/files/daemonset-patch.yaml
+++ b/charts/kserve-localmodel-resources/files/daemonset-patch.yaml
@@ -20,3 +20,8 @@ spec:
         imagePullPolicy: {{ .Values.kserve.localmodelnode.controller.imagePullPolicy }}
         resources:
           {{- toYaml .Values.kserve.localmodelnode.controller.resources | nindent 10 }}
+      volumes:
+      - hostPath:
+          path: {{ .Values.kserve.localmodelnode.controller.hostPath }}
+          type: DirectoryOrCreate
+        name: models

--- a/charts/kserve-localmodel-resources/files/daemonset-patch.yaml
+++ b/charts/kserve-localmodel-resources/files/daemonset-patch.yaml
@@ -22,6 +22,6 @@ spec:
           {{- toYaml .Values.kserve.localmodelnode.controller.resources | nindent 10 }}
       volumes:
       - hostPath:
-          path: {{ .Values.kserve.localmodelnode.controller.hostPath }}
+          path: {{ .Values.kserve.localmodelnode.controller.hostPath | default "/models" }}
           type: DirectoryOrCreate
         name: models

--- a/charts/kserve-localmodel-resources/values.yaml
+++ b/charts/kserve-localmodel-resources/values.yaml
@@ -37,3 +37,4 @@ kserve:
         kserve/localmodel: worker
       affinity: {}
       tolerations: []
+      hostPath: /models


### PR DESCRIPTION
**What this PR does / why we need it**:
`/model` is not a writeable path in Talos, so in order to support LocalModelCache in KServe, we need to be able to override the `hostPath`. It defaults to /model so no changes in the default behaviours.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A


**Feature/Issue validation/testing**:
I ran a `helm template` test with and without the `kserve.localmodelnode.controller.hostPath` set and here are the diff result:
```yaml
--- Default (hostPath: /models)
+++ Custom (hostPath: /custom/models)
@@ -306,7 +306,7 @@
       tolerations: []
       volumes:
       - hostPath:
-          path: /models
+          path: /custom/models
           type: DirectoryOrCreate
         name: models
```
**Special notes for your reviewer**:
Do I need to bump the Chart Version?

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
`hostPath` for `kserve-localmodelnode-agent` is now configurable, defaults to `/model`.
```
