### PR TITLE
fix: set LatestDeploymentReady condition for Standard mode InferenceService

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -517,28 +517,6 @@ func (ss *InferenceServiceStatus) PropagateCrossComponentStatus(componentList []
 	ss.SetCondition(conditionType, crossComponentCondition)
 }
 
-// PropagateRawDeploymentReadyStatus sets LatestDeploymentReady for Standard (raw Deployment) mode
-// by aggregating the component-level Ready conditions. Configuration sub-conditions
-// (PredictorConfigurationReady etc.) are only populated in Serverless mode, so Standard
-// mode derives deployment readiness directly from the component Ready conditions instead.
-func (ss *InferenceServiceStatus) PropagateRawDeploymentReadyStatus(componentList []ComponentType) {
-	crossComponentCondition := &apis.Condition{
-		Type:   LatestDeploymentReady,
-		Status: corev1.ConditionTrue,
-	}
-	for _, component := range componentList {
-		readyCondition := readyConditionsMap[component]
-		if !ss.IsConditionReady(readyCondition) {
-			crossComponentCondition.Status = corev1.ConditionFalse
-			if ss.IsConditionUnknown(readyCondition) {
-				crossComponentCondition.Status = corev1.ConditionUnknown
-			}
-			crossComponentCondition.Reason = string(readyCondition) + " not ready"
-		}
-	}
-	ss.SetCondition(LatestDeploymentReady, crossComponentCondition)
-}
-
 func (ss *InferenceServiceStatus) PropagateStatus(component ComponentType, serviceStatus *knservingv1.ServiceStatus) {
 	if len(ss.Components) == 0 {
 		ss.Components = make(map[ComponentType]ComponentStatusSpec)
@@ -791,4 +769,32 @@ func (ss *InferenceServiceStatus) PropagateModelStatus(statusSpec ComponentStatu
 		}
 	}
 	return true
+}
+
+// PropagateRawConfigurationStatus sets PredictorConfigurationReady (and equivalents for
+// Transformer/Explainer) for Standard mode by reading the Deployment's Progressing condition.
+// This mirrors what PropagateStatus does for Knative via the ConfigurationsReady condition,
+// allowing PropagateCrossComponentStatus to set LatestDeploymentReady correctly in Standard mode.
+func (ss *InferenceServiceStatus) PropagateRawConfigurationStatus(component ComponentType, deploymentList []*appsv1.Deployment) {
+    configConditionType := configurationConditionsMap[component]
+    progressingCondition := getDeploymentCondition(deploymentList, appsv1.DeploymentProgressing)
+
+    configCondition := &apis.Condition{
+        Type:   configConditionType,
+        Status: corev1.ConditionFalse,
+    }
+    if progressingCondition != nil && progressingCondition.Status == corev1.ConditionTrue &&
+        progressingCondition.Reason == "NewReplicaSetAvailable" {
+        configCondition.Status = corev1.ConditionTrue
+        configCondition.Reason = progressingCondition.Reason
+        configCondition.Message = progressingCondition.Message
+    } else if progressingCondition != nil && progressingCondition.Status == corev1.ConditionTrue {
+        configCondition.Status = corev1.ConditionUnknown
+        configCondition.Reason = progressingCondition.Reason
+        configCondition.Message = progressingCondition.Message
+    } else if progressingCondition != nil {
+        configCondition.Reason = progressingCondition.Reason
+        configCondition.Message = progressingCondition.Message
+    }
+    ss.SetCondition(configConditionType, configCondition)
 }

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -37,7 +37,7 @@ type InferenceServiceStatus struct {
 	// - TransformerReady: transformer readiness condition; <br/>
 	// - ExplainerReady: explainer readiness condition; <br/>
 	// - RoutesReady (serverless mode only): aggregated routing condition, i.e. endpoint readiness condition; <br/>
-	// - LatestDeploymentReady (serverless mode only): aggregated configuration condition, i.e. latest deployment readiness condition; <br/>
+	// - LatestDeploymentReady: aggregated deployment readiness condition; set in both Serverless and Standard modes; <br/>
 	// - Ready: aggregated condition; <br/>
 	duckv1.Status `json:",inline"`
 	// Addressable endpoint for the InferenceService
@@ -515,6 +515,28 @@ func (ss *InferenceServiceStatus) PropagateCrossComponentStatus(componentList []
 		}
 	}
 	ss.SetCondition(conditionType, crossComponentCondition)
+}
+
+// PropagateRawDeploymentReadyStatus sets LatestDeploymentReady for Standard (raw Deployment) mode
+// by aggregating the component-level Ready conditions. Configuration sub-conditions
+// (PredictorConfigurationReady etc.) are only populated in Serverless mode, so Standard
+// mode derives deployment readiness directly from the component Ready conditions instead.
+func (ss *InferenceServiceStatus) PropagateRawDeploymentReadyStatus(componentList []ComponentType) {
+	crossComponentCondition := &apis.Condition{
+		Type:   LatestDeploymentReady,
+		Status: corev1.ConditionTrue,
+	}
+	for _, component := range componentList {
+		readyCondition := readyConditionsMap[component]
+		if !ss.IsConditionReady(readyCondition) {
+			crossComponentCondition.Status = corev1.ConditionFalse
+			if ss.IsConditionUnknown(readyCondition) {
+				crossComponentCondition.Status = corev1.ConditionUnknown
+			}
+			crossComponentCondition.Reason = string(readyCondition) + " not ready"
+		}
+	}
+	ss.SetCondition(LatestDeploymentReady, crossComponentCondition)
 }
 
 func (ss *InferenceServiceStatus) PropagateStatus(component ComponentType, serviceStatus *knservingv1.ServiceStatus) {

--- a/pkg/apis/serving/v1beta1/inference_service_status_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status_test.go
@@ -1996,3 +1996,86 @@ func TestInferenceServiceStatus_ClearCondition(t *testing.T) {
 	// Try clearing a condition that was never set
 	status.ClearCondition(TransformerReady)
 }
+
+func TestPropagateRawDeploymentReadyStatus(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Helper to set a component-level ready condition
+	setComponentCondition := func(ss *InferenceServiceStatus, condType apis.ConditionType, status corev1.ConditionStatus) {
+		ss.SetCondition(condType, &apis.Condition{
+			Type:   condType,
+			Status: status,
+		})
+	}
+
+	t.Run("All components ready sets LatestDeploymentReady True", func(t *testing.T) {
+		ss := &InferenceServiceStatus{}
+		ss.InitializeConditions()
+		setComponentCondition(ss, PredictorReady, corev1.ConditionTrue)
+		setComponentCondition(ss, TransformerReady, corev1.ConditionTrue)
+		setComponentCondition(ss, ExplainerReady, corev1.ConditionTrue)
+
+		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent, TransformerComponent, ExplainerComponent})
+		cond := ss.GetCondition(LatestDeploymentReady)
+		g.Expect(cond).NotTo(gomega.BeNil())
+		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionTrue))
+	})
+
+	t.Run("Predictor not ready sets LatestDeploymentReady False", func(t *testing.T) {
+		ss := &InferenceServiceStatus{}
+		ss.InitializeConditions()
+		setComponentCondition(ss, PredictorReady, corev1.ConditionFalse)
+
+		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent})
+		cond := ss.GetCondition(LatestDeploymentReady)
+		g.Expect(cond).NotTo(gomega.BeNil())
+		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionFalse))
+		g.Expect(cond.Reason).To(gomega.Equal("PredictorReady not ready"))
+	})
+
+	t.Run("Predictor unknown sets LatestDeploymentReady Unknown", func(t *testing.T) {
+		ss := &InferenceServiceStatus{}
+		ss.InitializeConditions()
+		setComponentCondition(ss, PredictorReady, corev1.ConditionUnknown)
+
+		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent})
+		cond := ss.GetCondition(LatestDeploymentReady)
+		g.Expect(cond).NotTo(gomega.BeNil())
+		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionUnknown))
+		g.Expect(cond.Reason).To(gomega.Equal("PredictorReady not ready"))
+	})
+
+	t.Run("One of multiple components not ready sets LatestDeploymentReady False", func(t *testing.T) {
+		ss := &InferenceServiceStatus{}
+		ss.InitializeConditions()
+		setComponentCondition(ss, PredictorReady, corev1.ConditionTrue)
+		setComponentCondition(ss, TransformerReady, corev1.ConditionFalse)
+
+		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent, TransformerComponent})
+		cond := ss.GetCondition(LatestDeploymentReady)
+		g.Expect(cond).NotTo(gomega.BeNil())
+		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionFalse))
+		g.Expect(cond.Reason).To(gomega.Equal("TransformerReady not ready"))
+	})
+
+	t.Run("Predictor only ready sets LatestDeploymentReady True", func(t *testing.T) {
+		ss := &InferenceServiceStatus{}
+		ss.InitializeConditions()
+		setComponentCondition(ss, PredictorReady, corev1.ConditionTrue)
+
+		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent})
+		cond := ss.GetCondition(LatestDeploymentReady)
+		g.Expect(cond).NotTo(gomega.BeNil())
+		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionTrue))
+	})
+
+	t.Run("Empty component list sets LatestDeploymentReady True", func(t *testing.T) {
+		ss := &InferenceServiceStatus{}
+		ss.InitializeConditions()
+
+		ss.PropagateRawDeploymentReadyStatus([]ComponentType{})
+		cond := ss.GetCondition(LatestDeploymentReady)
+		g.Expect(cond).NotTo(gomega.BeNil())
+		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionTrue))
+	})
+}

--- a/pkg/apis/serving/v1beta1/inference_service_status_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status_test.go
@@ -1997,84 +1997,88 @@ func TestInferenceServiceStatus_ClearCondition(t *testing.T) {
 	status.ClearCondition(TransformerReady)
 }
 
-func TestPropagateRawDeploymentReadyStatus(t *testing.T) {
+func TestPropagateRawConfigurationStatus(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	// Helper to set a component-level ready condition
-	setComponentCondition := func(ss *InferenceServiceStatus, condType apis.ConditionType, status corev1.ConditionStatus) {
-		ss.SetCondition(condType, &apis.Condition{
-			Type:   condType,
-			Status: status,
-		})
+	makeDeployment := func(progressingStatus corev1.ConditionStatus, reason, message string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:    appsv1.DeploymentProgressing,
+						Status:  progressingStatus,
+						Reason:  reason,
+						Message: message,
+					},
+				},
+			},
+		}
 	}
 
-	t.Run("All components ready sets LatestDeploymentReady True", func(t *testing.T) {
+	t.Run("Progressing True with NewReplicaSetAvailable sets configuration condition True", func(t *testing.T) {
 		ss := &InferenceServiceStatus{}
 		ss.InitializeConditions()
-		setComponentCondition(ss, PredictorReady, corev1.ConditionTrue)
-		setComponentCondition(ss, TransformerReady, corev1.ConditionTrue)
-		setComponentCondition(ss, ExplainerReady, corev1.ConditionTrue)
+		deployment := makeDeployment(corev1.ConditionTrue, "NewReplicaSetAvailable", "ReplicaSet has successfully progressed.")
 
-		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent, TransformerComponent, ExplainerComponent})
-		cond := ss.GetCondition(LatestDeploymentReady)
+		ss.PropagateRawConfigurationStatus(PredictorComponent, []*appsv1.Deployment{deployment})
+		cond := ss.GetCondition(PredictorConfigurationReady)
 		g.Expect(cond).NotTo(gomega.BeNil())
 		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionTrue))
+		g.Expect(cond.Reason).To(gomega.Equal("NewReplicaSetAvailable"))
 	})
 
-	t.Run("Predictor not ready sets LatestDeploymentReady False", func(t *testing.T) {
+	t.Run("Progressing True with other reason sets configuration condition Unknown", func(t *testing.T) {
 		ss := &InferenceServiceStatus{}
 		ss.InitializeConditions()
-		setComponentCondition(ss, PredictorReady, corev1.ConditionFalse)
+		deployment := makeDeployment(corev1.ConditionTrue, "ReplicaSetUpdated", "Waiting for rollout to finish.")
 
-		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent})
-		cond := ss.GetCondition(LatestDeploymentReady)
-		g.Expect(cond).NotTo(gomega.BeNil())
-		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionFalse))
-		g.Expect(cond.Reason).To(gomega.Equal("PredictorReady not ready"))
-	})
-
-	t.Run("Predictor unknown sets LatestDeploymentReady Unknown", func(t *testing.T) {
-		ss := &InferenceServiceStatus{}
-		ss.InitializeConditions()
-		setComponentCondition(ss, PredictorReady, corev1.ConditionUnknown)
-
-		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent})
-		cond := ss.GetCondition(LatestDeploymentReady)
+		ss.PropagateRawConfigurationStatus(PredictorComponent, []*appsv1.Deployment{deployment})
+		cond := ss.GetCondition(PredictorConfigurationReady)
 		g.Expect(cond).NotTo(gomega.BeNil())
 		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionUnknown))
-		g.Expect(cond.Reason).To(gomega.Equal("PredictorReady not ready"))
+		g.Expect(cond.Reason).To(gomega.Equal("ReplicaSetUpdated"))
 	})
 
-	t.Run("One of multiple components not ready sets LatestDeploymentReady False", func(t *testing.T) {
+	t.Run("Progressing False sets configuration condition False", func(t *testing.T) {
 		ss := &InferenceServiceStatus{}
 		ss.InitializeConditions()
-		setComponentCondition(ss, PredictorReady, corev1.ConditionTrue)
-		setComponentCondition(ss, TransformerReady, corev1.ConditionFalse)
+		deployment := makeDeployment(corev1.ConditionFalse, "ProgressDeadlineExceeded", "Deployment exceeded deadline.")
 
-		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent, TransformerComponent})
-		cond := ss.GetCondition(LatestDeploymentReady)
+		ss.PropagateRawConfigurationStatus(PredictorComponent, []*appsv1.Deployment{deployment})
+		cond := ss.GetCondition(PredictorConfigurationReady)
 		g.Expect(cond).NotTo(gomega.BeNil())
 		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionFalse))
-		g.Expect(cond.Reason).To(gomega.Equal("TransformerReady not ready"))
+		g.Expect(cond.Reason).To(gomega.Equal("ProgressDeadlineExceeded"))
 	})
 
-	t.Run("Predictor only ready sets LatestDeploymentReady True", func(t *testing.T) {
+	t.Run("Empty deployment list sets configuration condition False", func(t *testing.T) {
 		ss := &InferenceServiceStatus{}
 		ss.InitializeConditions()
-		setComponentCondition(ss, PredictorReady, corev1.ConditionTrue)
 
-		ss.PropagateRawDeploymentReadyStatus([]ComponentType{PredictorComponent})
-		cond := ss.GetCondition(LatestDeploymentReady)
+		ss.PropagateRawConfigurationStatus(PredictorComponent, []*appsv1.Deployment{})
+		cond := ss.GetCondition(PredictorConfigurationReady)
+		g.Expect(cond).NotTo(gomega.BeNil())
+		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionFalse))
+	})
+
+	t.Run("TransformerComponent sets TransformerConfigurationReady", func(t *testing.T) {
+		ss := &InferenceServiceStatus{}
+		ss.InitializeConditions()
+		deployment := makeDeployment(corev1.ConditionTrue, "NewReplicaSetAvailable", "")
+
+		ss.PropagateRawConfigurationStatus(TransformerComponent, []*appsv1.Deployment{deployment})
+		cond := ss.GetCondition(TransformerConfigurationReady)
 		g.Expect(cond).NotTo(gomega.BeNil())
 		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionTrue))
 	})
 
-	t.Run("Empty component list sets LatestDeploymentReady True", func(t *testing.T) {
+	t.Run("ExplainerComponent sets ExplainerConfigurationReady", func(t *testing.T) {
 		ss := &InferenceServiceStatus{}
 		ss.InitializeConditions()
+		deployment := makeDeployment(corev1.ConditionTrue, "NewReplicaSetAvailable", "")
 
-		ss.PropagateRawDeploymentReadyStatus([]ComponentType{})
-		cond := ss.GetCondition(LatestDeploymentReady)
+		ss.PropagateRawConfigurationStatus(ExplainerComponent, []*appsv1.Deployment{deployment})
+		cond := ss.GetCondition(ExplainerConfigurationReady)
 		g.Expect(cond).NotTo(gomega.BeNil())
 		g.Expect(cond.Status).To(gomega.Equal(corev1.ConditionTrue))
 	})

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -211,6 +211,7 @@ func (e *Explainer) reconcileExplainerRawDeployment(ctx context.Context, isvc *v
 	}
 	if !utils.GetForceStopRuntime(isvc) {
 		isvc.Status.PropagateRawStatus(v1beta1.ExplainerComponent, deployment, r.URL)
+		isvc.Status.PropagateRawConfigurationStatus(v1beta1.ExplainerComponent, deployment)
 	}
 	return nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -776,6 +776,7 @@ func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.In
 
 	if !utils.GetForceStopRuntime(isvc) {
 		isvc.Status.PropagateRawStatus(v1beta1.PredictorComponent, deploymentList, r.URL)
+		isvc.Status.PropagateRawConfigurationStatus(v1beta1.PredictorComponent, deploymentList)
 	}
 
 	return nil

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -247,6 +247,7 @@ func (p *Transformer) reconcileTransformerRawDeployment(ctx context.Context, isv
 	}
 	if !utils.GetForceStopRuntime(isvc) {
 		isvc.Status.PropagateRawStatus(v1beta1.TransformerComponent, deployment, r.URL)
+		isvc.Status.PropagateRawConfigurationStatus(v1beta1.TransformerComponent, deployment)
 	}
 	return nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -335,16 +335,10 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		componentList = append(componentList, v1beta1.ExplainerComponent)
 	}
 	if !forceStopRuntime {
-		switch deploymentMode {
-		case constants.Knative:
-			// RoutesReady aggregates route sub-conditions only populated in Serverless mode
+		if deploymentMode == constants.Knative {
 			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.RoutesReady)
-			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.LatestDeploymentReady)
-		case constants.Standard:
-			// Standard mode doesn't populate configuration sub-conditions, so derive
-			// LatestDeploymentReady directly from the component Ready conditions
-			isvc.Status.PropagateRawDeploymentReadyStatus(componentList)
 		}
+		isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.LatestDeploymentReady)
 	}
 
 	// Reconcile ingress

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -326,20 +326,27 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			isvc.Status.SetCondition(v1beta1.Stopped, resumeCondition)
 		}
 	}
-	// reconcile RoutesReady and LatestDeploymentReady conditions for serverless deployment
-	if deploymentMode == constants.Knative {
-		componentList := []v1beta1.ComponentType{v1beta1.PredictorComponent}
-		if isvc.Spec.Transformer != nil {
-			componentList = append(componentList, v1beta1.TransformerComponent)
-		}
-		if isvc.Spec.Explainer != nil {
-			componentList = append(componentList, v1beta1.ExplainerComponent)
-		}
-		if !forceStopRuntime {
+	// reconcile RoutesReady and LatestDeploymentReady conditions
+	componentList := []v1beta1.ComponentType{v1beta1.PredictorComponent}
+	if isvc.Spec.Transformer != nil {
+		componentList = append(componentList, v1beta1.TransformerComponent)
+	}
+	if isvc.Spec.Explainer != nil {
+		componentList = append(componentList, v1beta1.ExplainerComponent)
+	}
+	if !forceStopRuntime {
+		switch deploymentMode {
+		case constants.Knative:
+			// RoutesReady aggregates route sub-conditions only populated in Serverless mode
 			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.RoutesReady)
 			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.LatestDeploymentReady)
+		case constants.Standard:
+			// Standard mode doesn't populate configuration sub-conditions, so derive
+			// LatestDeploymentReady directly from the component Ready conditions
+			isvc.Status.PropagateRawDeploymentReadyStatus(componentList)
 		}
 	}
+
 	// Reconcile ingress
 	ingressConfig, err := v1beta1.NewIngressConfig(isvcConfigMap)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

In Standard deployment mode, `LatestDeploymentReady` wasn't set on the InferenceService status because the propagation call was gated behind `if deploymentMode == constants.Knative`.

The existing `PropagateCrossComponentStatus` couldn't be reused directly — it aggregates `PredictorConfigurationReady` / `TransformerConfigurationReady` / `ExplainerConfigurationReady`, which are only populated in Knative mode. Standard mode only sets the component-level `PredictorReady` / `TransformerReady` / `ExplainerReady` conditions.

This PR adds `PropagateRawDeploymentReadyStatus` which derives `LatestDeploymentReady` from those component Ready conditions and calls it in the reconciler for Standard mode.

**Which issue(s) this PR fixes**:

Fixes #5458


**Feature/Issue validation/testing**:

- [x] Unit tests added for PropagateRawDeploymentReadyStatus covering: all components ready, predictor not ready, predictor unknown, one of multiple components not ready, predictor only, empty component list
- [x] Full pkg/apis/serving/v1beta1 test suite passes with no regressions (go test ./pkg/apis/serving/v1beta1/...)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

Fix: LatestDeploymentReady condition is now propagated for InferenceServices using Standard deployment mode. Previously this condition was only set in Serverless (Knative) mode, causing downstream systems that depend on it to incorrectly assess deployment status.