### PR TITLE
Propagate LatestDeploymentReady In Standard Mode

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -427,6 +427,45 @@ func (ss *InferenceServiceStatus) PropagateRawStatus(
 	}
 
 	ss.SetCondition(readyCondition, componentReadyCondition)
+
+	// Propagate configuration condition based on Progressing status
+	// This is needed for LatestDeploymentReady condition to work in standard deployment mode
+	configurationCondition := configurationConditionsMap[component]
+	componentConfigurationCondition := &apis.Condition{
+		Type:   configurationCondition,
+		Status: corev1.ConditionFalse,
+	}
+
+	if progressingCondition != nil {
+		if progressingCondition.IsFalse() {
+			if len(progressingCondition.Message) > 0 {
+				componentConfigurationCondition = &apis.Condition{
+					Type:    configurationCondition,
+					Status:  corev1.ConditionFalse,
+					Reason:  progressingCondition.Reason,
+					Message: progressingCondition.Message,
+				}
+			}
+		} else if progressingCondition.IsTrue() {
+			if progressingCondition.Reason == "NewReplicaSetAvailable" {
+				componentConfigurationCondition = &apis.Condition{
+					Type:    configurationCondition,
+					Status:  corev1.ConditionTrue,
+					Reason:  progressingCondition.Reason,
+					Message: progressingCondition.Message,
+				}
+			} else {
+				componentConfigurationCondition = &apis.Condition{
+					Type:    configurationCondition,
+					Status:  corev1.ConditionUnknown,
+					Reason:  progressingCondition.Reason,
+					Message: progressingCondition.Message,
+				}
+			}
+		}
+	}
+
+	ss.SetCondition(configurationCondition, componentConfigurationCondition)
 	ss.Components[component] = statusSpec
 	if len(deploymentList) > 0 {
 		ss.ObservedGeneration = deploymentList[0].Status.ObservedGeneration

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -340,6 +340,19 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.LatestDeploymentReady)
 		}
 	}
+	// reconcile LatestDeploymentReady condition for standard deployment
+	if deploymentMode == constants.Standard {
+		componentList := []v1beta1.ComponentType{v1beta1.PredictorComponent}
+		if isvc.Spec.Transformer != nil {
+			componentList = append(componentList, v1beta1.TransformerComponent)
+		}
+		if isvc.Spec.Explainer != nil {
+			componentList = append(componentList, v1beta1.ExplainerComponent)
+		}
+		if !forceStopRuntime {
+			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1.LatestDeploymentReady)
+		}
+	}
 	// Reconcile ingress
 	ingressConfig, err := v1beta1.NewIngressConfig(isvcConfigMap)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5458 


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
