### PR TITLE
feat: support multiple OCI sources in storageUris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ $(shell perl -pi -e 's/memory:.*/memory: $(KSERVE_CONTROLLER_MEMORY_LIMIT)/' con
 GOTOOLCHAIN ?= auto
 ifeq (auto,$(GOTOOLCHAIN))
 ifeq (,$(FORCE_HOST_GO))
-export GOTOOLCHAIN := $(shell grep '^toolchain go' go.mod | cut -d' ' -f2)
+export GOTOOLCHAIN := $(or $(shell grep '^toolchain go' go.mod | cut -d' ' -f2),go$(shell grep '^go ' go.mod | head -1 | cut -d' ' -f2))
 else
 export GOTOOLCHAIN := local
 endif

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_tokenizer_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_tokenizer_test.go
@@ -235,7 +235,7 @@ func TestAttachOciModelArtifact_TargetContainer(t *testing.T) {
 			},
 			wantModelcarArgs: []string{
 				"sh", "-c",
-				fmt.Sprintf("mkdir -p %s && ln -sf /proc/$$$$/root/models %s && sleep infinity",
+				fmt.Sprintf("mkdir -p '%s' && ln -sf /proc/$$$$/root/models '%s' && sleep infinity",
 					constants.DefaultModelLocalMountPath,
 					path.Join(constants.DefaultModelLocalMountPath, "my-llama")),
 			},
@@ -251,7 +251,7 @@ func TestAttachOciModelArtifact_TargetContainer(t *testing.T) {
 			},
 			wantModelcarArgs: []string{
 				"sh", "-c",
-				fmt.Sprintf("mkdir -p %s && ln -sf /proc/$$$$/root/models %s && sleep infinity",
+				fmt.Sprintf("mkdir -p '%s' && ln -sf /proc/$$$$/root/models '%s' && sleep infinity",
 					path.Join(constants.DefaultModelLocalMountPath, "meta-llama"),
 					path.Join(constants.DefaultModelLocalMountPath, "meta-llama/Llama-2-7b")),
 			},
@@ -267,7 +267,7 @@ func TestAttachOciModelArtifact_TargetContainer(t *testing.T) {
 			},
 			wantModelcarArgs: []string{
 				"sh", "-c",
-				fmt.Sprintf("ln -sf /proc/$$$$/root/models %s && sleep infinity",
+				fmt.Sprintf("ln -sf /proc/$$$$/root/models '%s' && sleep infinity",
 					constants.DefaultModelLocalMountPath),
 			},
 		},

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -202,7 +202,7 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 //
 //	An error if the configuration fails, otherwise nil.
 func (r *LLMISVCReconciler) attachOciModelArtifact(modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, containerName string, modelPath string) error {
-	if err := utils.ConfigureModelcarToContainer(modelUri, podSpec, containerName, modelPath, storageConfig); err != nil {
+	if err := utils.ConfigureModelcarToContainer(modelUri, podSpec, containerName, modelPath, storageConfig, 0); err != nil {
 		return err
 	}
 

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -333,31 +333,45 @@ func CreateInitContainerWithConfig(storageConfig *types.StorageInitializerConfig
 	}
 }
 
+// shellQuote wraps s in single quotes for safe interpolation into a sh -c
+// command string. Any embedded single quotes are escaped using the standard
+// POSIX sequence: close the current quote, emit an escaped literal quote,
+// and re-open a new quoted segment ('\\"). This is safe for all byte values.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
 // modelcarCommand returns the shell command for the modelcar container.
 // When modelPath differs from the default, it prepends "mkdir -p" to create
 // the parent directory so that the symlink target exists. For the default path
 // the command is kept identical to the original to avoid unnecessary pod restarts
 // on upgrade.
+//
+// Paths are shell-quoted using shellQuote to prevent metacharacter injection.
+// The upstream validation (validateStorageURISpec) ensures paths are absolute
+// and contain no "..", but quoting provides defense-in-depth.
 func modelcarCommand(modelPath string) string {
 	// $$$$ gets escaped by YAML to $$, which is the current PID
 	if modelPath != constants.DefaultModelLocalMountPath {
 		return fmt.Sprintf("mkdir -p %s && ln -sf /proc/$$$$/root/models %s && sleep infinity",
-			path.Dir(modelPath), modelPath)
+			shellQuote(path.Dir(modelPath)), shellQuote(modelPath))
 	}
-	return fmt.Sprintf("ln -sf /proc/$$$$/root/models %s && sleep infinity", modelPath)
+	return fmt.Sprintf("ln -sf /proc/$$$$/root/models %s && sleep infinity", shellQuote(modelPath))
 }
 
 // CreateModelcarContainer creates the definition of a container holding a model intended to be used as a sidecar (modelcar).
 // The container is configured with CPU, memory, and UID settings from the storage initializer configuration.
 //
 // Parameters:
+//   - containerName: The name to assign to the modelcar container.
 //   - image: The container image to use for the modelcar.
 //   - modelPath: The path where the model should be mounted inside the container.
+//   - volumeName: The name of the shared volume for model data.
 //   - storageConfig: The storage initializer configuration.
 //
 // Returns:
 //   - *corev1.Container: The modelcar container definition.
-func CreateModelcarContainer(image string, modelPath string, storageConfig *types.StorageInitializerConfig) *corev1.Container {
+func CreateModelcarContainer(containerName string, image string, modelPath string, volumeName string, storageConfig *types.StorageInitializerConfig) *corev1.Container {
 	cpu := storageConfig.CpuModelcar
 	if cpu == "" {
 		cpu = constants.CpuModelcarDefault
@@ -368,11 +382,11 @@ func CreateModelcarContainer(image string, modelPath string, storageConfig *type
 	}
 
 	modelContainer := &corev1.Container{
-		Name:  constants.ModelcarContainerName,
+		Name:  containerName,
 		Image: image,
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      constants.StorageInitializerVolumeName,
+				Name:      volumeName,
 				MountPath: GetParentDirectory(modelPath),
 				ReadOnly:  false,
 			},
@@ -409,12 +423,13 @@ func CreateModelcarContainer(image string, modelPath string, storageConfig *type
 // This init container is intended to run before the main containers to pre-fetch and validate the modelcar image.
 //
 // Parameters:
+//   - containerName: The name to assign to the modelcar init container.
 //   - image: The container image to use for the modelcar init container.
 //   - storageConfig: The storage initializer configuration.
 //
 // Returns:
 //   - *corev1.Container: The modelcar init container definition.
-func CreateModelcarInitContainer(image string, storageConfig *types.StorageInitializerConfig) *corev1.Container {
+func CreateModelcarInitContainer(containerName string, image string, storageConfig *types.StorageInitializerConfig) *corev1.Container {
 	cpu := storageConfig.CpuModelcar
 	if cpu == "" {
 		cpu = constants.CpuModelcarDefault
@@ -425,7 +440,7 @@ func CreateModelcarInitContainer(image string, storageConfig *types.StorageIniti
 	}
 
 	modelContainer := &corev1.Container{
-		Name:  constants.ModelcarInitContainerName,
+		Name:  containerName,
 		Image: image,
 		Args: []string{
 			"sh",
@@ -450,6 +465,49 @@ func CreateModelcarInitContainer(image string, storageConfig *types.StorageIniti
 	return modelContainer
 }
 
+// MaxOCISourcesPerPod is the maximum number of OCI modelcar sidecars that can be
+// injected into a single pod. This prevents resource exhaustion from unbounded
+// sidecar injection — each OCI URI adds 2 containers (sidecar + init) and 1 volume.
+const MaxOCISourcesPerPod = 10
+
+// ModelcarNames generates unique container and volume names for a modelcar at the given OCI index.
+// When ociIndex is 0, the original constant names are returned for backward compatibility.
+func ModelcarNames(ociIndex int) (sidecarName, initName, volumeName string) {
+	if ociIndex == 0 {
+		return constants.ModelcarContainerName, constants.ModelcarInitContainerName, constants.StorageInitializerVolumeName
+	}
+	suffix := fmt.Sprintf("-%d", ociIndex)
+	return constants.ModelcarContainerName + suffix,
+		constants.ModelcarInitContainerName + suffix,
+		constants.StorageInitializerVolumeName + suffix
+}
+
+// ValidateOCIMountPaths checks that the given OCI mount paths will not cause volume
+// mount shadowing when injected. Each modelcar sidecar mounts an emptyDir at the
+// *parent directory* of its modelPath (via GetParentDirectory). If two OCI URIs share
+// the same parent directory, their volumes would be mounted at the same path on the
+// target container, causing the last mount to shadow all previous ones.
+//
+// Returns an error if a collision is detected.
+func ValidateOCIMountPaths(mountPaths []string) error {
+	if len(mountPaths) <= 1 {
+		return nil
+	}
+	parentDirSeen := make(map[string]string, len(mountPaths)) // parentDir -> first modelPath that used it
+	for _, mp := range mountPaths {
+		parentDir := GetParentDirectory(mp)
+		if prev, exists := parentDirSeen[parentDir]; exists {
+			return fmt.Errorf(
+				"OCI mount paths %q and %q share parent directory %q, which would cause volume mount shadowing; "+
+					"use mount paths with distinct parent directories",
+				prev, mp, parentDir,
+			)
+		}
+		parentDirSeen[parentDir] = mp
+	}
+	return nil
+}
+
 // ConfigureModelcarToContainer configures the OCI image specified in modelUri as a modelcar to the
 // specified target container of a given PodSpec. The configuration includes:
 //   - Adding an environment variable `async` to indicate to the runtime that the model directory may not be available immediately.
@@ -465,24 +523,33 @@ func CreateModelcarInitContainer(image string, storageConfig *types.StorageIniti
 //   - modelPath: The path where the model symlink should be created inside the container
 //     (e.g. /mnt/models or /mnt/models/my-llama for a model-name subdirectory).
 //   - storageConfig: The storage initializer configuration.
+//   - ociIndex: The index of this OCI URI within the storageUris list. Used to generate
+//     unique container/volume names when multiple OCI URIs are specified. Use 0 for
+//     single-URI or legacy scenarios to preserve backward compatibility.
 //
 // Returns:
 //   - error: An error if the target container is not found or if configuration fails; otherwise, nil.
-func ConfigureModelcarToContainer(modelUri string, podSpec *corev1.PodSpec, targetContainerName string, modelPath string, storageConfig *types.StorageInitializerConfig) error {
+func ConfigureModelcarToContainer(modelUri string, podSpec *corev1.PodSpec, targetContainerName string, modelPath string, storageConfig *types.StorageInitializerConfig, ociIndex int) error {
 	targetContainer := GetContainerWithName(podSpec, targetContainerName)
 	if targetContainer == nil {
 		return fmt.Errorf("no container found with name %s", targetContainerName)
 	}
+
+	sidecarName, initName, volumeName := ModelcarNames(ociIndex)
 
 	// Indicate to the runtime that it the model directory could be
 	// available a bit later only so that it should wait and retry when
 	// starting up
 	AddOrReplaceEnv(targetContainer, constants.ModelInitModeEnvVarKey, "async")
 
-	// Mount volume initialized by the modelcar container to the target container
+	// Mount volume initialized by the modelcar container to the target container.
+	// Each OCI URI gets its own emptyDir volume because the modelcar sidecar creates
+	// a symlink (via /proc/<PID>/root) that is specific to its container image.
+	// Sharing a single volume between multiple modelcar sidecars would cause symlink
+	// conflicts.
 	modelParentDir := GetParentDirectory(modelPath)
-	AddEmptyDirVolumeIfNotPresent(podSpec, constants.StorageInitializerVolumeName)
-	AddVolumeMountIfNotPresent(targetContainer, constants.StorageInitializerVolumeName, modelParentDir, false)
+	AddEmptyDirVolumeIfNotPresent(podSpec, volumeName)
+	AddVolumeMountIfNotPresent(targetContainer, volumeName, modelParentDir, false)
 
 	// If configured, run as the given user. There might be certain installations
 	// of Kubernetes where sharing the filesystem via the process namespace only works
@@ -496,16 +563,16 @@ func ConfigureModelcarToContainer(modelUri string, podSpec *corev1.PodSpec, targ
 
 	// Create the modelcar that is used as a sidecar in Pod and add it to the end
 	// of the containers (but only if not already have been added)
-	if GetContainerWithName(podSpec, constants.ModelcarContainerName) == nil {
+	if GetContainerWithName(podSpec, sidecarName) == nil {
 		// Extract image reference for modelcar from URI
 		image := strings.TrimPrefix(modelUri, constants.OciURIPrefix)
 
-		modelContainer := CreateModelcarContainer(image, modelPath, storageConfig)
+		modelContainer := CreateModelcarContainer(sidecarName, image, modelPath, volumeName, storageConfig)
 		podSpec.Containers = append(podSpec.Containers, *modelContainer)
 
 		// Add the model container as an init-container to pre-fetch the model before
 		// the runtimes starts.
-		modelInitContainer := CreateModelcarInitContainer(image, storageConfig)
+		modelInitContainer := CreateModelcarInitContainer(initName, image, storageConfig)
 		podSpec.InitContainers = append(podSpec.InitContainers, *modelInitContainer)
 	}
 

--- a/pkg/utils/storage_test.go
+++ b/pkg/utils/storage_test.go
@@ -21,6 +21,9 @@ import (
 
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/types"
 )
 
 func TestFindCommonParentPath(t *testing.T) {
@@ -230,4 +233,271 @@ func TestAddDefaultHuggingFaceEnvVars(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestModelcarNames(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("Index 0 returns original constants", func(t *testing.T) {
+		sidecar, init, volume := ModelcarNames(0)
+		g.Expect(sidecar).To(gomega.Equal(constants.ModelcarContainerName))
+		g.Expect(init).To(gomega.Equal(constants.ModelcarInitContainerName))
+		g.Expect(volume).To(gomega.Equal(constants.StorageInitializerVolumeName))
+	})
+
+	t.Run("Index 1 returns suffixed names", func(t *testing.T) {
+		sidecar, init, volume := ModelcarNames(1)
+		g.Expect(sidecar).To(gomega.Equal(constants.ModelcarContainerName + "-1"))
+		g.Expect(init).To(gomega.Equal(constants.ModelcarInitContainerName + "-1"))
+		g.Expect(volume).To(gomega.Equal(constants.StorageInitializerVolumeName + "-1"))
+	})
+
+	t.Run("Index 2 returns suffixed names", func(t *testing.T) {
+		sidecar, init, volume := ModelcarNames(2)
+		g.Expect(sidecar).To(gomega.Equal(constants.ModelcarContainerName + "-2"))
+		g.Expect(init).To(gomega.Equal(constants.ModelcarInitContainerName + "-2"))
+		g.Expect(volume).To(gomega.Equal(constants.StorageInitializerVolumeName + "-2"))
+	})
+}
+
+func TestConfigureModelcarToContainerMultipleOCI(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	storageConfig := &types.StorageInitializerConfig{}
+
+	t.Run("Single OCI URI produces original container names", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName},
+			},
+		}
+
+		err := ConfigureModelcarToContainer(
+			"oci://registry.example.com/model-a:v1",
+			podSpec,
+			constants.InferenceServiceContainerName,
+			constants.DefaultModelLocalMountPath,
+			storageConfig,
+			0,
+		)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Sidecar container should use the original constant name
+		modelcar := GetContainerWithName(podSpec, constants.ModelcarContainerName)
+		g.Expect(modelcar).ToNot(gomega.BeNil(), "modelcar sidecar should be present")
+		g.Expect(modelcar.Image).To(gomega.Equal("registry.example.com/model-a:v1"))
+
+		// Init container should use the original constant name
+		g.Expect(podSpec.InitContainers).To(gomega.HaveLen(1))
+		g.Expect(podSpec.InitContainers[0].Name).To(gomega.Equal(constants.ModelcarInitContainerName))
+
+		// Volume should use the original constant name
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+		g.Expect(podSpec.Volumes[0].Name).To(gomega.Equal(constants.StorageInitializerVolumeName))
+
+		// ShareProcessNamespace should be enabled
+		g.Expect(podSpec.ShareProcessNamespace).ToNot(gomega.BeNil())
+		g.Expect(*podSpec.ShareProcessNamespace).To(gomega.BeTrue())
+	})
+
+	t.Run("Two OCI URIs produce uniquely named sidecars", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName},
+			},
+		}
+
+		// First OCI URI (index 0) — uses original names
+		err := ConfigureModelcarToContainer(
+			"oci://registry.example.com/model-a:v1",
+			podSpec,
+			constants.InferenceServiceContainerName,
+			"/mnt/models/model-a",
+			storageConfig,
+			0,
+		)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Second OCI URI (index 1) — uses suffixed names
+		err = ConfigureModelcarToContainer(
+			"oci://registry.example.com/model-b:v2",
+			podSpec,
+			constants.InferenceServiceContainerName,
+			"/mnt/models/model-b",
+			storageConfig,
+			1,
+		)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// Should have 3 containers: kserve-container + modelcar + modelcar-1
+		g.Expect(podSpec.Containers).To(gomega.HaveLen(3), "should have kserve-container + 2 modelcar sidecars")
+
+		modelcarA := GetContainerWithName(podSpec, constants.ModelcarContainerName)
+		g.Expect(modelcarA).ToNot(gomega.BeNil(), "first modelcar sidecar should exist")
+		g.Expect(modelcarA.Image).To(gomega.Equal("registry.example.com/model-a:v1"))
+
+		modelcarB := GetContainerWithName(podSpec, constants.ModelcarContainerName+"-1")
+		g.Expect(modelcarB).ToNot(gomega.BeNil(), "second modelcar sidecar should exist")
+		g.Expect(modelcarB.Image).To(gomega.Equal("registry.example.com/model-b:v2"))
+
+		// Should have 2 init containers: modelcar-init + modelcar-init-1
+		g.Expect(podSpec.InitContainers).To(gomega.HaveLen(2), "should have 2 modelcar init containers")
+		g.Expect(podSpec.InitContainers[0].Name).To(gomega.Equal(constants.ModelcarInitContainerName))
+		g.Expect(podSpec.InitContainers[1].Name).To(gomega.Equal(constants.ModelcarInitContainerName + "-1"))
+
+		// Should have 2 volumes with distinct names
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(2), "should have 2 emptyDir volumes")
+		g.Expect(podSpec.Volumes[0].Name).To(gomega.Equal(constants.StorageInitializerVolumeName))
+		g.Expect(podSpec.Volumes[1].Name).To(gomega.Equal(constants.StorageInitializerVolumeName + "-1"))
+
+		// Verify the kserve-container has volume mounts for BOTH volumes
+		kserveContainer := GetContainerWithName(podSpec, constants.InferenceServiceContainerName)
+		g.Expect(kserveContainer).ToNot(gomega.BeNil())
+		g.Expect(kserveContainer.VolumeMounts).To(gomega.HaveLen(2), "kserve-container should have mounts for both volumes")
+
+		mountNames := make([]string, 0, 2)
+		for _, m := range kserveContainer.VolumeMounts {
+			mountNames = append(mountNames, m.Name)
+		}
+		g.Expect(mountNames).To(gomega.ContainElement(constants.StorageInitializerVolumeName))
+		g.Expect(mountNames).To(gomega.ContainElement(constants.StorageInitializerVolumeName + "-1"))
+
+		// Each modelcar sidecar should reference its own volume
+		g.Expect(modelcarA.VolumeMounts[0].Name).To(gomega.Equal(constants.StorageInitializerVolumeName))
+		g.Expect(modelcarB.VolumeMounts[0].Name).To(gomega.Equal(constants.StorageInitializerVolumeName + "-1"))
+	})
+
+	t.Run("Three OCI URIs produce three distinct sidecars", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName},
+			},
+		}
+
+		uris := []string{
+			"oci://registry.example.com/base-model:v1",
+			"oci://registry.example.com/adapter-a:v1",
+			"oci://registry.example.com/adapter-b:v1",
+		}
+		paths := []string{
+			"/mnt/models/base",
+			"/mnt/models/adapter-a",
+			"/mnt/models/adapter-b",
+		}
+
+		for i, uri := range uris {
+			err := ConfigureModelcarToContainer(uri, podSpec, constants.InferenceServiceContainerName, paths[i], storageConfig, i)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+		}
+
+		// 1 user container + 3 modelcar sidecars
+		g.Expect(podSpec.Containers).To(gomega.HaveLen(4))
+		g.Expect(podSpec.InitContainers).To(gomega.HaveLen(3))
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(3))
+
+		// Verify naming: modelcar, modelcar-1, modelcar-2
+		g.Expect(GetContainerWithName(podSpec, "modelcar")).ToNot(gomega.BeNil())
+		g.Expect(GetContainerWithName(podSpec, "modelcar-1")).ToNot(gomega.BeNil())
+		g.Expect(GetContainerWithName(podSpec, "modelcar-2")).ToNot(gomega.BeNil())
+	})
+
+	t.Run("Error when target container not found", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "some-other-container"},
+			},
+		}
+
+		err := ConfigureModelcarToContainer(
+			"oci://registry.example.com/model:v1",
+			podSpec,
+			constants.InferenceServiceContainerName,
+			constants.DefaultModelLocalMountPath,
+			storageConfig,
+			0,
+		)
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("no container found with name"))
+	})
+
+	t.Run("Idempotent - calling twice with same index does not duplicate", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName},
+			},
+		}
+
+		for range 2 {
+			err := ConfigureModelcarToContainer(
+				"oci://registry.example.com/model:v1",
+				podSpec,
+				constants.InferenceServiceContainerName,
+				constants.DefaultModelLocalMountPath,
+				storageConfig,
+				0,
+			)
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+		}
+
+		// Should still only have 1 modelcar sidecar and 1 init container
+		g.Expect(podSpec.Containers).To(gomega.HaveLen(2)) // kserve-container + 1 modelcar
+		g.Expect(podSpec.InitContainers).To(gomega.HaveLen(1))
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+	})
+}
+
+func TestValidateOCIMountPaths(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("Single path is always valid", func(t *testing.T) {
+		err := ValidateOCIMountPaths([]string{"/mnt/models"})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	t.Run("Empty paths are valid", func(t *testing.T) {
+		err := ValidateOCIMountPaths(nil)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	t.Run("Distinct parent directories are valid", func(t *testing.T) {
+		err := ValidateOCIMountPaths([]string{
+			"/mnt/model-a/data",
+			"/mnt/model-b/data",
+		})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	t.Run("Shared parent directory is rejected", func(t *testing.T) {
+		err := ValidateOCIMountPaths([]string{
+			"/mnt/models/model-a",
+			"/mnt/models/model-b",
+		})
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("volume mount shadowing"))
+		g.Expect(err.Error()).To(gomega.ContainSubstring("/mnt/models"))
+	})
+
+	t.Run("Three paths with collision on second pair", func(t *testing.T) {
+		err := ValidateOCIMountPaths([]string{
+			"/mnt/alpha/data",
+			"/mnt/beta/model-x",
+			"/mnt/beta/model-y", // collides with previous
+		})
+		g.Expect(err).To(gomega.HaveOccurred())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("/mnt/beta"))
+	})
+
+	t.Run("Default mount path used twice is rejected", func(t *testing.T) {
+		err := ValidateOCIMountPaths([]string{
+			constants.DefaultModelLocalMountPath,
+			constants.DefaultModelLocalMountPath,
+		})
+		g.Expect(err).To(gomega.HaveOccurred())
+	})
+}
+
+func TestMaxOCISourcesPerPod(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	// Ensure the constant is reasonable and matches documented limit
+	g.Expect(MaxOCISourcesPerPod).To(gomega.Equal(10),
+		"MaxOCISourcesPerPod should be 10 — each URI adds 2 containers + 1 volume")
 }

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -176,19 +176,19 @@ func (mi *StorageInitializerInjector) InjectModelcar(pod *corev1.Pod) error {
 			return fmt.Errorf("Invalid configuration: cannot find container: %s", constants.InferenceServiceContainerName)
 		} else {
 			// Use worker container for multi-node scenarios
-			if err := utils.ConfigureModelcarToContainer(srcURI, &pod.Spec, constants.WorkerContainerName, constants.DefaultModelLocalMountPath, mi.config); err != nil {
+			if err := utils.ConfigureModelcarToContainer(srcURI, &pod.Spec, constants.WorkerContainerName, constants.DefaultModelLocalMountPath, mi.config, 0); err != nil {
 				return err
 			}
 		}
 	} else {
-		if err := utils.ConfigureModelcarToContainer(srcURI, &pod.Spec, constants.InferenceServiceContainerName, constants.DefaultModelLocalMountPath, mi.config); err != nil {
+		if err := utils.ConfigureModelcarToContainer(srcURI, &pod.Spec, constants.InferenceServiceContainerName, constants.DefaultModelLocalMountPath, mi.config, 0); err != nil {
 			return err
 		}
 	}
 
 	// Configure modelcar for transformer container if it exists
 	if utils.GetContainerWithName(&pod.Spec, constants.TransformerContainerName) != nil {
-		return utils.ConfigureModelcarToContainer(srcURI, &pod.Spec, constants.TransformerContainerName, constants.DefaultModelLocalMountPath, mi.config)
+		return utils.ConfigureModelcarToContainer(srcURI, &pod.Spec, constants.TransformerContainerName, constants.DefaultModelLocalMountPath, mi.config, 0)
 	}
 
 	return nil
@@ -257,6 +257,21 @@ func CommonStorageInitialization(ctx context.Context, params *StorageInitializer
 				return errors.New("Invalid configuration: cannot find container")
 			}
 
+			ociIndex := 0
+			// Collect OCI mount paths for collision check and count validation
+			var ociMountPaths []string
+			for _, storageUri := range params.StorageURIs {
+				if strings.HasPrefix(storageUri.Uri, constants.OciURIPrefix) {
+					ociMountPaths = append(ociMountPaths, storageUri.MountPath)
+				}
+			}
+			if len(ociMountPaths) > utils.MaxOCISourcesPerPod {
+				return fmt.Errorf("too many OCI sources (%d); maximum is %d per pod", len(ociMountPaths), utils.MaxOCISourcesPerPod)
+			}
+			if err := utils.ValidateOCIMountPaths(ociMountPaths); err != nil {
+				return err
+			}
+
 			for _, storageUri := range params.StorageURIs {
 				if !strings.HasPrefix(storageUri.Uri, constants.OciURIPrefix) {
 					continue
@@ -265,17 +280,18 @@ func CommonStorageInitialization(ctx context.Context, params *StorageInitializer
 				if userContainer == nil {
 					targetContainerName = constants.WorkerContainerName
 				}
-				if err := utils.ConfigureModelcarToContainer(storageUri.Uri, params.PodSpec, targetContainerName, storageUri.MountPath, params.Config); err != nil {
+				if err := utils.ConfigureModelcarToContainer(storageUri.Uri, params.PodSpec, targetContainerName, storageUri.MountPath, params.Config, ociIndex); err != nil {
 					return err
 				}
 				// Also configure for transformer if present
 				if utils.GetContainerWithName(params.PodSpec, constants.TransformerContainerName) != nil {
-					if err := utils.ConfigureModelcarToContainer(storageUri.Uri, params.PodSpec, constants.TransformerContainerName, storageUri.MountPath, params.Config); err != nil {
+					if err := utils.ConfigureModelcarToContainer(storageUri.Uri, params.PodSpec, constants.TransformerContainerName, storageUri.MountPath, params.Config, ociIndex); err != nil {
 						return err
 					}
 				}
+				ociIndex++
 			}
-			return nil
+			// Fall through to handle any remaining non-OCI URIs in the list
 		}
 	}
 
@@ -327,6 +343,10 @@ func CommonStorageInitialization(ctx context.Context, params *StorageInitializer
 		// - PVC URIs are mounted directly as volumes (no download needed)
 		// - Other URIs require init container to download artifacts first
 		for _, storageUri := range params.StorageURIs {
+			if strings.HasPrefix(storageUri.Uri, constants.OciURIPrefix) {
+				// OCI URIs are already handled by modelcar injection above; skip.
+				continue
+			}
 			if strings.HasPrefix(storageUri.Uri, constants.PvcURIPrefix) {
 				pvcStorageURIs = append(pvcStorageURIs, storageUri)
 			} else {


### PR DESCRIPTION
## What
Follow-up to #5261. Adds full support for multiple OCI sources in the `storageUris` list, with safety guards and hardening.

## Problem
PR #5261 fixed a regression where `oci://` URIs in `storageUris` were not handled, but it only supported a **single** OCI URI. Multiple OCI URIs silently failed because:

1. `ConfigureModelcarToContainer` used **hardcoded** container/volume names (`modelcar`, `modelcar-init`, `kserve-provision-location`), so the guard `GetContainerWithName(podSpec, "modelcar") == nil` found the already-created container and skipped subsequent URIs.
2. The OCI handling block **returned early**, silently dropping any non-OCI URIs (e.g. `s3://`, `gs://`) in the same `storageUris` list.
3. `modelcarCommand` interpolated user-controlled mount paths into a `sh -c` command **without quoting**, creating a shell injection surface.
4. No upper bound existed on OCI sidecar count — a user could specify 50 OCI URIs, creating 100 containers per pod.

## Solution

### Multi-OCI support (commit 1)
- **`ModelcarNames(ociIndex)`** — new helper generating unique names per OCI URI:
  - Index 0: `modelcar`, `modelcar-init`, `kserve-provision-location` (backward compatible)
  - Index N: `modelcar-N`, `modelcar-init-N`, `kserve-provision-location-N`
- **`CreateModelcarContainer`** / **`CreateModelcarInitContainer`** — parameterized with `containerName` and `volumeName` instead of hardcoded constants
- **`ConfigureModelcarToContainer`** — new `ociIndex` param drives unique naming
- **`CommonStorageInitialization`** — tracks and passes `ociIndex` per OCI URI in the loop
- All legacy callers (`InjectModelcar` webhook, `LLMiSvc` controller) pass `ociIndex=0` — zero behavioral change for single-URI / legacy paths

### Safety guards (commit 2)
- **`MaxOCISourcesPerPod = 10`** — prevents unbounded sidecar injection (each OCI URI adds 2 containers + 1 volume)
- **`ValidateOCIMountPaths()`** — detects and rejects mount paths that share a parent directory, which would cause Kubernetes volume mount shadowing (last mount wins, previous models invisible)
- Code comments explaining why each OCI URI needs its own emptyDir volume (per-container `/proc/<PID>/root` symlinks)

### Mixed URI handling + shell hardening (commit 3)
- **Removed early `return nil`** after OCI processing — non-OCI URIs (s3://, gs://) in the same list now fall through to init-container processing
- **OCI URIs filtered** from downstream PVC/non-PVC classification to prevent double-processing
- **Single-quoted** all interpolated paths in `modelcarCommand` to prevent shell metacharacter injection (`;`, `` ` ``, `$()`)

## Files Changed

| File | Changes |
|------|---------|
| `pkg/utils/storage.go` | `ModelcarNames()`, `ValidateOCIMountPaths()`, `MaxOCISourcesPerPod`, parameterized container/volume creation, shell-quoted `modelcarCommand` |
| `pkg/utils/storage_test.go` | 16 new test cases: `TestModelcarNames` (3), `TestConfigureModelcarToContainerMultipleOCI` (5), `TestValidateOCIMountPaths` (6), `TestMaxOCISourcesPerPod` (1), constant sanity check (1) |
| `pkg/webhook/admission/pod/storage_initializer_injector.go` | OCI index tracking, pre-injection validation, mixed URI fall-through, OCI filtering in downstream loop |
| `pkg/controller/v1alpha2/llmisvc/workload_storage.go` | Pass `ociIndex=0` (single URI caller, backward compatible) |

## Testing
- All 16 new unit tests pass ✅
- Full `pkg/utils` test suite passes ✅
- Full project builds cleanly ✅
- LLMiSvc controller test failures are pre-existing on master (missing kubebuilder test env)

cc @israel-hdez @spolti @Jooho