### PR TITLE
docs: remove Envoy references from LLMISVC godocs

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
@@ -300,13 +300,13 @@ type IngressSpec struct {
 // SchedulerSpec defines the Inference Gateway extension configuration.
 //
 // The SchedulerSpec configures the connection from the Gateway to the model deployment leveraging the LLM optimized
-// request Scheduler, also known as the Endpoint Picker (EPP) which determines the exact pod that should handle the
-// request and responds back to Envoy with the target pod, Envoy will then forward the request to the chosen pod.
+// request Scheduler, also known as the Endpoint Picker (EPP). The EPP determines the exact pod that should handle the
+// request and responds back to the Gateway with the target pod. The Gateway will then forward the request to the chosen pod.
 //
 // The Scheduler is only effective when having multiple inference pod replicas.
 //
-// Step 1: Gateway (Envoy) &lt;-- ExtProc --&gt; EPP (select the optimal replica to handle the request)
-// Step 2: Gateway (Envoy) &lt;-- forward request --&gt; Inference Pod X
+// Step 1 (endpoint selection): Gateway <-- ExtProc --> EPP (select the optimal replica to handle the request)
+// Step 2 (endpoint routing): Gateway <-- forward request/response --> Inference Pod X
 type SchedulerSpec struct {
 	// Pool configuration for the InferencePool, which is part of the Inference Gateway extension.
 	// +optional

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
@@ -282,13 +282,13 @@ type IngressSpec struct {
 // SchedulerSpec defines the Inference Gateway extension configuration.
 //
 // The SchedulerSpec configures the connection from the Gateway to the model deployment leveraging the LLM optimized
-// request Scheduler, also known as the Endpoint Picker (EPP) which determines the exact pod that should handle the
-// request and responds back to Envoy with the target pod, Envoy will then forward the request to the chosen pod.
+// request Scheduler, also known as the Endpoint Picker (EPP). The EPP determines the exact pod that should handle the
+// request and responds back to the Gateway with the target pod. The Gateway will then forward the request to the chosen pod.
 //
 // The Scheduler is only effective when having multiple inference pod replicas.
 //
-// Step 1: Gateway (Envoy) &lt;-- ExtProc --&gt; EPP (select the optimal replica to handle the request)
-// Step 2: Gateway (Envoy) &lt;-- forward request --&gt; Inference Pod X
+// Step 1 (endpoint selection): Gateway <-- ExtProc --> EPP (select the optimal replica to handle the request)
+// Step 2 (endpoint routing): Gateway <-- forward request/response --> Inference Pod X
 type SchedulerSpec struct {
 	// Pool configuration for the InferencePool, which is part of the Inference Gateway extension.
 	// +optional


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates LLMInferenceService godocs to avoid implying Gateway API Inference Extension (GAIE) only supports Envoy-based proxies.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes: #5474

**Feature/Issue validation/testing**:

- `go test ./pkg/apis/serving/v1alpha1 ./pkg/apis/serving/v1alpha2`

**Special notes for your reviewer**:

None.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```