### PR TITLE
fix: improve checkpoint system consistency in release orchestrator

### DIFF
--- a/.github/agents/release-orchestrator.agent.md
+++ b/.github/agents/release-orchestrator.agent.md
@@ -18,11 +18,15 @@ You guide the user through the entire release process step by step, asking for a
 
 ## Checkpoint System
 
-Save state before long-running operations so the session can be resumed after interruption.
+Save state after each completed step so the session can be resumed from the next step.
+
+Two checkpoint patterns:
+- **After completion** (default): save after a local action finishes (PR created, merged, published, etc.)
+- **Before external wait** (exception): save before entering a long external wait (CI check ~30min, image build ~1-2hr). Resume checks the external status first, then continues or keeps waiting.
 
 **Checkpoint file**: `~/.kserve_release/checkpoint.json` in the repo root
 
-**Save checkpoint** (write this file before any long-running step):
+**Save checkpoint** (write this file at each checkpoint phase):
 ```bash
 mkdir -p ~/.kserve_release
 cat > ~/.kserve_release/checkpoint.json << EOF
@@ -45,8 +49,22 @@ EOF
 cat ~/.kserve_release/checkpoint.json
 ```
 If found, show contents and ask: "Resume from checkpoint? (y/n)"
-- **y**: Skip completed phases, continue from `phase` field
+- **y**: Skip completed phases, resume using the mapping below
 - **n**: Start fresh, delete checkpoint
+
+**Resume mapping** (phase → next action):
+
+| Checkpoint phase | Pattern | Resume from |
+|---|---|---|
+| `CONFIRMED` | after completion | Phase 2: create bump branch, run bump, create PR |
+| `BUMP_PR_CREATED` | before external wait | Phase 3: check CI status on `bump_pr`, watch if still running |
+| `CI_PASSED` | after completion | Phase 4: merge PR (verify not already merged first) |
+| `BUMP_MERGED` | after completion | RC0 → Phase 5 (branch/tag). RC1+/Final → Phase 2B (cherry-pick). Check `release_type` |
+| `CHERRYPICK_PR_CREATED` | before external wait | Phase 3: check CI status on `cherrypick_pr`, watch if still running |
+| `BRANCH_TAG_DONE` | before external wait | Phase 7: check image build status, wait if still running |
+| `DRAFT_CREATED` | after completion | Phase 7: image validation |
+| `SMOKE_TESTED` | after completion | Phase 9: publish release |
+| `PUBLISHED` | after completion | Phase 10: full validation |
 
 **Delete checkpoint** after successful completion:
 ```bash
@@ -55,11 +73,11 @@ rm -f ~/.kserve_release/checkpoint.json
 
 **Checkpoint phases** (save at these points):
 - `CONFIRMED` — after version/repo confirmed, before bump PR
-- `BUMP_PR_CREATED` — after bump PR created, before CI watch
+- `BUMP_PR_CREATED` — after bump PR created, **before CI wait** (external wait)
 - `CI_PASSED` — after CI passes, before merge
 - `BUMP_MERGED` — after bump PR merged, before cherry-pick (RC1+ only)
-- `CHERRYPICK_PR_CREATED` — after cherry-pick PR created, before CI watch
-- `BRANCH_TAG_DONE` — after branch/tag verified, before draft release
+- `CHERRYPICK_PR_CREATED` — after cherry-pick PR created, **before CI wait** (external wait)
+- `BRANCH_TAG_DONE` — after branch/tag created, **before image build wait** (external wait, ~1-2hr)
 - `DRAFT_CREATED` — after draft release created, before image validation
 - `SMOKE_TESTED` — after smoke test passed, before publish
 - `PUBLISHED` — after release published, before downstream validation
@@ -115,6 +133,14 @@ rm -f ~/.kserve_release/checkpoint.json
 
 5. **APPROVAL POINT**: "Release v{VERSION} from v{CURRENT_VERSION}. PR target: {PR_REPO}, branch push: {BRANCH_REPO}. Proceed? (y/n)"
 
+6. **Save checkpoint** after version confirmed:
+   ```bash
+   mkdir -p ~/.kserve_release
+   cat > ~/.kserve_release/checkpoint.json << EOF
+   {"version":"{VERSION}","prior_version":"{CURRENT_VERSION}","pr_repo":"{PR_REPO}","branch_repo":"{BRANCH_REPO}","release_type":"{TYPE}","phase":"CONFIRMED","bump_pr":null,"cherrypick_pr":null,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+   EOF
+   ```
+
 ### Phase 2: Version Bump
 
 1. Fetch latest upstream master and create bump branch:
@@ -136,16 +162,8 @@ rm -f ~/.kserve_release/checkpoint.json
    ```
    This is the ONLY make command you should run.
 
-4. **Save checkpoint** before creating PR:
-   ```bash
-   cat > ~/.kserve_release/checkpoint.json << EOF
-   {"version":"{VERSION}","prior_version":"{PRIOR_VERSION}","pr_repo":"{PR_REPO}","branch_repo":"{BRANCH_REPO}","release_type":"{TYPE}","phase":"CONFIRMED","bump_pr":null,"cherrypick_pr":null,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-   EOF
-   ```
-
-5. Commit and create PR:
-   - **RC0**: title `release: prepare release v{VERSION}`
-   - **RC1+ / Final**: title `release: prepare release v{VERSION}`
+4. Commit and create PR:
+   Title: `release: prepare release v{VERSION}` (all release types)
 
    ```bash
    git add -A
@@ -155,17 +173,17 @@ rm -f ~/.kserve_release/checkpoint.json
      --head {BRANCH_OWNER}:release-bump-v{VERSION} \
      --title "{TITLE}" \
      --label release \
-     [--label cherrypick-approved]  # RC1+ only — DO NOT add for Final release
+     [--label cherrypick-approved]  # RC1+ and Final — NOT for RC0
      --body "Automated version bump from v{PRIOR_VERSION} to v{VERSION}."
    ```
 
-6. **Save checkpoint** after PR created:
+5. **Save checkpoint** after PR created:
    ```bash
    # Update ~/.kserve_release/checkpoint.json with bump_pr number and phase
    # phase: BUMP_PR_CREATED, bump_pr: {PR_NUMBER}
    ```
 
-### Phase 2B: Cherry-pick (RC1+ only — skip entirely for Final)
+### Phase 2B: Cherry-pick (RC1+ and Final — skip only for RC0)
 
 Skip this phase for RC0. After the bump PR (Phase 2) merges to master:
 
@@ -188,16 +206,26 @@ Skip this phase for RC0. After the bump PR (Phase 2) merges to master:
 
 2. Fetch the release branch and create a cherry-pick branch:
    ```bash
-   git fetch origin release-{MAJOR}.{MINOR}
-   git checkout -b cherrypick/v{VERSION} origin/release-{MAJOR}.{MINOR}
+   git fetch upstream release-{MAJOR}.{MINOR}
+   git checkout -b cherrypick/v{VERSION} upstream/release-{MAJOR}.{MINOR}
    ```
 
 3. Cherry-pick each PR's merge commit in `mergedAt` order:
    ```bash
    git cherry-pick -x -S -s {MERGE_COMMIT_SHA}
    ```
-   - On conflict: attempt auto-resolve
-   - If not confident: report conflict details and ask user to resolve, then `git cherry-pick --continue`
+   - **On conflict**: first try automatic resolution:
+
+     ```bash
+     # Delete conflicted uv.lock files (common conflict source)
+     git diff --name-only --diff-filter=U | grep "uv.lock" | xargs rm -f
+     # Regenerate dependencies and fix formatting
+     make precommit
+     git add -A
+     git cherry-pick --continue
+     ```
+
+   - If conflicts persist: report conflict details and ask user to resolve manually, then `git cherry-pick --continue`
 
 4. Push and create PR targeting the release branch:
    ```bash


### PR DESCRIPTION
Improve checkpoint system consistency in the release orchestrator agent.

## Changes
- Fix checkpoint principle: save after completion (default), save before external wait (CI/image build) as exception pattern
- Add resume mapping table with explicit phase-to-action routing 
- Move CONFIRMED checkpoint from Phase 2 (before PR) to Phase 1 (after version confirmed) for consistent timing
- Mark external wait checkpoints (BUMP_PR_CREATED, CHERRYPICK_PR_CREATED, BRANCH_TAG_DONE) explicitly in phases list

## Benefits
- Clearer resume logic when release process is interrupted
- Consistent checkpoint timing across all phases
- Better distinction between completion checkpoints vs external wait checkpoints