### PR TITLE
fix(samples): use sha256_cbor for precise-prefix kv-cache routing

### DIFF
--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/README.md
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/README.md
@@ -69,7 +69,7 @@ Key vLLM settings for cache routing:
 
 ```yaml
 VLLM_ADDITIONAL_ARGS:
-  - --prefix-caching-hash-algo sha256_cbor_64bit
+  - --prefix-caching-hash-algo sha256_cbor
   - --block-size 64
   - --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
   - --kv-events-config '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://...:5557","topic":"kv@${POD_IP}@..."}'

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
@@ -56,7 +56,7 @@ spec:
         env:
           # Configure vLLM for prefix caching with KV cache event publishing
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--prefix-caching-hash-algo sha256 --block-size 64 --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --kv-events-config '{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://{{ ChildName .ObjectMeta.Name `-epp-service` }}:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen2.5-7B-Instruct\"}'"
+            value: "--prefix-caching-hash-algo sha256_cbor --block-size 64 --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --kv-events-config '{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://{{ ChildName .ObjectMeta.Name `-epp-service` }}:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen2.5-7B-Instruct\"}'"
           # Pod IP used in KV cache event topic
           - name: POD_IP
             valueFrom:


### PR DESCRIPTION

**What this PR does / why we need it**:

The `precise-prefix-kv-cache-routing` sample passes `--prefix-caching-hash-algo sha256` to vLLM, but the EPP's `precise-prefix-cache-scorer` plugin requires the cbor variant so that its hash predictions align with vLLM's prefix-cache block hashes. With mismatched algorithms the scheduler can't predict which decode pod holds a cached prefix, the router falls back to non-prefix-aware scoring, and the sample's prefix-cache routing demonstration produces no cache hits.

This PR aligns both the sample YAML and the accompanying `README.md` snippet (which currently documents `sha256_cbor_64bit`) to `sha256_cbor`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] YAML well-formedness verified locally.
- [x] Diff limited to the two intended one-token changes (sample env-var value + README code block).

Algorithm correctness for `sha256_cbor` is already exercised by existing tests on NVIDIA and AMD hardware; no new test is added for this sample-only update.

**Special notes for your reviewer**:

Sample-only change. No controller, CRD, or image versions are modified.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works? — N/A, sample doc fix; algorithm covered by existing tests.
- [ ] Has code been commented, particularly in hard-to-understand areas? — N/A.
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? — README in the same sample directory is updated in this PR; no `kserve/website` content references this sample.

**Release note**:
```release-note
NONE
```