### PR TITLE
e2e: reduce verbose payload logging in e2e tests

### DIFF
--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -47,7 +47,7 @@ def grpc_client(host, cluster_ip):
     logger.info("gRPC target host: %s", host)
     return InferenceGRPCClient(
         cluster_ip,
-        verbose=True,
+        verbose=False,
         channel_args=[
             ("grpc.ssl_target_name_override", host),
         ],

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -69,7 +69,7 @@ async def rest_v1_client():
         config=RESTConfig(
             transport=transport,
             timeout=180,
-            verbose=True,
+            verbose=False,
             protocol=PredictorProtocol.REST_V1,
         )
     )
@@ -97,7 +97,7 @@ async def rest_v2_client():
         config=RESTConfig(
             transport=transport,
             timeout=180,
-            verbose=True,
+            verbose=False,
             protocol=PredictorProtocol.REST_V2,
         )
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables verbose logging on the inference clients used in e2e tests by setting `verbose=False`. This eliminates multi-KB payload dumps (full gRPC tensor arrays, base64-encoded images, prediction outputs) from CI logs, making it easier to find actual test failures.

**Which issue(s) this PR fixes**:

N/A

**Feature/Issue validation/testing**:

- [x] No behavioral changes — only disables verbose client logging
- [x] `ruff format` and `ruff check` pass

**Special notes for your reviewer**:

Three `verbose=True` → `verbose=False` changes:
- `test/e2e/conftest.py` — REST v1 and v2 client fixtures
- `test/e2e/common/utils.py` — gRPC client helper

No changes to the inference client library itself.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Disable verbose payload logging on inference clients in e2e tests to reduce CI log noise.
```