### PR TITLE
feat(llmisvc): default to FlowControl enabled with sample and docs

### DIFF
--- a/docs/samples/llmisvc/flow-control/README.md
+++ b/docs/samples/llmisvc/flow-control/README.md
@@ -1,0 +1,84 @@
+# Flow Control
+
+Example configuration enabling the experimental FlowControl feature for priority-based queuing, fairness, and saturation management.
+
+## Overview
+
+The Flow Control layer acts as a gatekeeper between routing and scheduling. It decides *if* and *when* a request should proceed to be scheduled onto a backend. When the system is saturated, requests are queued and dispatched through a **3-tier dispatch hierarchy**:
+
+1. **Priority (Band Selection)** — High-priority traffic is served first
+2. **Fairness (Flow Selection)** — Requests are distributed fairly between tenants/models within a priority band (e.g., round-robin)
+3. **Ordering (Request Selection)** — Requests within a flow are ordered (e.g., FCFS, SLO deadline)
+
+## Prerequisites
+
+- Kubernetes cluster with GPU nodes
+- Model weights accessible via HuggingFace or PVC
+
+## Example
+
+### [`llm-inference-service-flow-control.yaml`](llm-inference-service-flow-control.yaml)
+
+Deploys Qwen2.5-7B-Instruct with 2 replicas and FlowControl enabled with three priority bands.
+
+**Priority Bands:**
+
+| Priority | Ordering Policy | Fairness Policy | Use Case |
+|----------|----------------|-----------------|----------|
+| 1 | `slo-deadline-ordering-policy` | `round-robin-fairness-policy` | Latency-sensitive requests with SLO targets |
+| 0 | FCFS (default) | `round-robin-fairness-policy` | Standard requests (default when no `InferenceObjective` is set) |
+| -1 | FCFS (default) | `round-robin-fairness-policy` | Best-effort or background requests |
+
+**Saturation Thresholds:**
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `queueDepthThreshold` | 3 | Backend waiting queue size above which a pod is considered to have insufficient capacity |
+| `kvCacheUtilThreshold` | 0.8 | KV cache utilization above which a pod is considered to have insufficient capacity |
+
+When saturation reaches 1.0, head-of-line blocking is enforced and requests are queued until capacity is available.
+
+## Request Headers
+
+Clients set priority, tenant identity, and SLO targets via headers:
+
+| Header | Purpose | Default |
+|--------|---------|---------|
+| `x-gateway-inference-objective` | References an `InferenceObjective` CR; its `.spec.priority` determines the request's priority band | Priority 0 |
+| `x-gateway-inference-fairness-id` | Identifies the tenant/flow for fairness within a priority band | `default-flow` |
+| `x-slo-ttft-ms` | Time-to-first-token target in milliseconds; `slo-deadline-ordering-policy` computes deadline as `received_time + value` | No deadline (ordered last) |
+
+```bash
+curl -H "x-gateway-inference-objective: premium-slo" \
+     -H "x-gateway-inference-fairness-id: tenant-a" \
+     -H "x-slo-ttft-ms: 500" \
+     -H "Content-Type: application/json" \
+     -d '{"model": "Qwen/Qwen2.5-7B-Instruct", "prompt": "...", "max_tokens": 100}' \
+     https://<route>/v1/completions
+```
+
+Each unique `(fairnessID, priority)` pair is a separate flow. Requests arriving with a priority that does not match any configured band are automatically handled — a new band is dynamically provisioned using the `defaultPriorityBand` template and garbage-collected after 10 minutes of inactivity.
+
+## Deployment
+
+```bash
+kubectl apply -f llm-inference-service-flow-control.yaml
+```
+
+## Tuning
+
+### Saturation and vLLM
+
+Per-pod saturation is `Max(WaitingQueueSize / queueDepthThreshold, KVCacheUsage / kvCacheUtilThreshold)`, averaged across pods. The EPP starts queuing when this reaches 1.0. Both inputs come from vLLM metrics (`vllm:num_requests_waiting` and `vllm:kv_cache_usage_perc`), so three vLLM flags directly affect when saturation triggers:
+
+**`--max-num-seqs`** — Caps concurrent sequences per instance. Requests beyond this limit, along with requests deferred for other reasons (e.g., LoRA budget, KV transfer), enter the engine's waiting queue. The `queueDepthThreshold` monitors this queue via `vllm:num_requests_waiting`. A lower `queueDepthThreshold` relative to `--max-num-seqs` causes the EPP to start queuing sooner, reducing tail latency at the cost of throughput. A higher value lets the engine absorb more backlog before the EPP intervenes.
+
+**`--gpu-memory-utilization`** — Fraction of GPU memory available to the model executor, from which the engine derives the KV cache block budget. A lower value reduces total KV cache capacity, causing `kvCacheUtilThreshold` to trigger sooner under the same request load.
+
+**`--max-model-len`** — Caps maximum sequence length (prompt + output). A request's KV cache consumption is proportional to its actual sequence length. Higher `--max-model-len` allows longer sequences, which consume more KV cache per request, so fewer can run concurrently before `kvCacheUtilThreshold` triggers.
+
+### Other Parameters
+
+- **`maxBytes`** — Global capacity limit; new requests are rejected if exceeded
+- **`defaultRequestTTL`** — Fallback timeout for requests without a deadline
+- **Omit `priorityBands`** to let the system dynamically provision bands with FCFS ordering, `global-strict-fairness-policy` (no tenant isolation — a noisy neighbor can starve other flows), and 1GB capacity. Use explicit bands with `round-robin-fairness-policy` for multi-tenant fairness.

--- a/docs/samples/llmisvc/flow-control/llm-inference-service-flow-control.yaml
+++ b/docs/samples/llmisvc/flow-control/llm-inference-service-flow-control.yaml
@@ -1,0 +1,69 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: qwen2-7b-flow-control
+spec:
+  model:
+    uri: hf://Qwen/Qwen2.5-7B-Instruct
+    name: Qwen/Qwen2.5-7B-Instruct
+  replicas: 2
+  router:
+    scheduler:
+      config:
+        inline:
+          apiVersion: inference.networking.x-k8s.io/v1alpha1
+          kind: EndpointPickerConfig
+          plugins:
+            - type: single-profile-handler
+            - type: queue-scorer
+            - type: prefix-cache-scorer
+            - type: max-score-picker
+            - type: slo-deadline-ordering-policy
+            - type: round-robin-fairness-policy
+          schedulingProfiles:
+            - name: default
+              plugins:
+                - pluginRef: queue-scorer
+                  weight: 2
+                - pluginRef: prefix-cache-scorer
+                  weight: 3
+                - pluginRef: max-score-picker
+          saturationDetector:
+            queueDepthThreshold: 3
+            kvCacheUtilThreshold: 0.8
+          featureGates:
+            - flowControl
+          flowControl:
+            maxBytes: 1073741824
+            defaultRequestTTL: 1m
+            priorityBands:
+              - priority: 1
+                orderingPolicyRef: slo-deadline-ordering-policy
+                fairnessPolicyRef: round-robin-fairness-policy
+              - priority: 0
+                fairnessPolicyRef: round-robin-fairness-policy
+              - priority: -1
+                fairnessPolicyRef: round-robin-fairness-policy
+    route: { }
+    gateway: { }
+  template:
+    containers:
+      - name: main
+        resources:
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            nvidia.com/gpu: "1"
+          requests:
+            cpu: '2'
+            memory: 16Gi
+            nvidia.com/gpu: "1"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 5

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -516,6 +516,8 @@ schedulingProfiles:
   - pluginRef: prefix-cache-scorer
     weight: 3
   - pluginRef: max-score-picker
+featureGates:
+- flowControl
 `
 	default:
 		return `
@@ -534,6 +536,8 @@ schedulingProfiles:
   - pluginRef: prefix-cache-scorer
     weight: 3
   - pluginRef: max-score-picker
+featureGates:
+- flowControl
 `
 	}
 }


### PR DESCRIPTION
 - Enable `flowControl` feature gate in default `EndpointPickerConfig` for single-profile and prefill-decode paths
  - Add flow-control sample with three priority bands (1, 0, -1), SLO deadline ordering, and round-robin fairness
  - Add README with request headers, priority band configuration, and saturation tuning guidance