### PR TITLE
fix(llmisvc): prevent nil panic when router.route.http is unset

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -200,7 +200,7 @@ func (r *LLMISVCReconciler) expectedHTTPRoute(ctx context.Context, llmSvc *v1alp
 		},
 	}
 
-	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Route != nil && llmSvc.Spec.Router.Route.HTTP.Spec != nil {
+	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Route != nil && llmSvc.Spec.Router.Route.HTTP.HasSpec() {
 		httpRoute.Spec = *llmSvc.Spec.Router.Route.HTTP.Spec.DeepCopy()
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/router_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+// TestExpectedHTTPRouteRouterShapes asserts that expectedHTTPRoute does not panic
+// for any combination of nil/empty Router/Route/HTTP and that the produced
+// HTTPRoute carries an inline spec only when one was supplied.
+//
+// Regression: the third case ("route set, http nil") used to panic at
+// `llmSvc.Spec.Router.Route.HTTP.Spec != nil` because HTTP itself was nil.
+// See https://github.com/kserve/kserve/issues/<TBD>.
+func TestExpectedHTTPRouteRouterShapes(t *testing.T) {
+	hostname := gwapiv1.Hostname("example.com")
+
+	tests := []struct {
+		name        string
+		router      *v1alpha2.RouterSpec
+		wantNonZero bool // true => returned HTTPRoute.Spec should carry the user-supplied spec
+	}{
+		{
+			name:   "router nil",
+			router: nil,
+		},
+		{
+			name:   "route nil",
+			router: &v1alpha2.RouterSpec{},
+		},
+		{
+			// Regression: panic at router.go:203 before the fix.
+			name:   "route set, http nil",
+			router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{}},
+		},
+		{
+			// Exact shape from the bug report: gateway/route/scheduler all set to
+			// the empty object. With Scheduler != nil and Pool unset, expectedHTTPRoute
+			// also exercises the v1alpha2/v1 InferencePool migration block (router.go
+			// lines ~209-275), so this guards against a panic on that path too.
+			name: "router with gateway, route, scheduler all empty (issue reproducer)",
+			router: &v1alpha2.RouterSpec{
+				Gateway:   &v1alpha2.GatewaySpec{},
+				Route:     &v1alpha2.GatewayRoutesSpec{},
+				Scheduler: &v1alpha2.SchedulerSpec{},
+			},
+		},
+		{
+			name: "route set, http empty",
+			router: &v1alpha2.RouterSpec{
+				Route: &v1alpha2.GatewayRoutesSpec{HTTP: &v1alpha2.HTTPRouteSpec{}},
+			},
+		},
+		{
+			name: "route set, http with refs only (BYO HTTPRoute)",
+			router: &v1alpha2.RouterSpec{
+				Route: &v1alpha2.GatewayRoutesSpec{HTTP: &v1alpha2.HTTPRouteSpec{
+					Refs: []corev1.LocalObjectReference{{Name: "byo-route"}},
+				}},
+			},
+		},
+		{
+			name: "route set, http with inline spec",
+			router: &v1alpha2.RouterSpec{
+				Route: &v1alpha2.GatewayRoutesSpec{HTTP: &v1alpha2.HTTPRouteSpec{
+					Spec: &gwapiv1.HTTPRouteSpec{Hostnames: []gwapiv1.Hostname{hostname}},
+				}},
+			},
+			wantNonZero: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			scheme := runtime.NewScheme()
+			g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
+			g.Expect(gwapiv1.Install(scheme)).To(Succeed())
+
+			llmSvc := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-llm", Namespace: "llm-demo"},
+				Spec:       v1alpha2.LLMInferenceServiceSpec{Router: tt.router},
+			}
+
+			r := &LLMISVCReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			}
+
+			var got *gwapiv1.HTTPRoute
+			g.Expect(func() {
+				got = r.expectedHTTPRoute(context.Background(), llmSvc)
+			}).NotTo(Panic())
+
+			g.Expect(got).NotTo(BeNil())
+			g.Expect(got.Namespace).To(Equal("llm-demo"))
+			g.Expect(got.OwnerReferences).To(HaveLen(1))
+			g.Expect(got.OwnerReferences[0].Name).To(Equal("my-llm"))
+
+			if tt.wantNonZero {
+				g.Expect(got.Spec.Hostnames).To(ContainElement(hostname))
+			} else {
+				g.Expect(got.Spec.Hostnames).To(BeEmpty())
+				g.Expect(got.Spec.Rules).To(BeEmpty())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a nil pointer dereference in the `LLMInferenceService` (v1alpha2) router reconciler.

When `spec.router.route` is set to a non-nil object without an explicit `http` field — e.g.

```yaml
spec:
  router:
    gateway: {}
    route: {}        # route.http is nil
    scheduler: {}
```

the controller panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
  pkg/controller/v1alpha2/llmisvc/router.go:203 expectedHTTPRoute
  pkg/controller/v1alpha2/llmisvc/router.go:130 reconcileHTTPRoutes
  pkg/controller/v1alpha2/llmisvc/router.go:97  reconcileRouter
  pkg/controller/v1alpha2/llmisvc/controller.go:219 Reconcile
```

`GatewayRoutesSpec.HTTP` is `*HTTPRouteSpec`. The check at `router.go:203` was

```go
if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Route != nil && llmSvc.Spec.Router.Route.HTTP.Spec != nil {
```

which dereferences `.Spec` on `HTTP` without checking that `HTTP` itself is non-nil. Every other call site in the same file already routed through the nil-safe `HasRefs()` / `HasSpec()` helpers (see lines 153, 166, 486) — this one inlined the chain.

**Fix**: use the existing nil-safe `Route.HTTP.HasSpec()` helper. Behaviour for `route.http: {}`, `route.http: {refs: [...]}` and `route.http: {spec: ...}` is unchanged; `route: {}` now goes down the same "no inline spec" path instead of panicking.

**Which issue(s) this PR fixes**:
Fixes #<TBD>

**Feature/Issue validation/testing**:

- [x] New unit test `TestExpectedHTTPRouteRouterShapes` in `pkg/controller/v1alpha2/llmisvc/router_test.go` covers six shapes:
  - `router=nil`
  - `route=nil`
  - `route={}` (regression)
  - `router={gateway:{}, route:{}, scheduler:{}}` (exact reproducer from the bug report — also exercises the v1alpha2/v1 InferencePool migration block in `expectedHTTPRoute`)
  - `route.http={}`
  - `route.http={refs:[...]}` (BYO HTTPRoute)
  - `route.http={spec:...}` (managed HTTPRoute with inline spec)
- [x] Verified the regression and reproducer subtests panic on `master` and pass after the fix.
- [x] `go test ./pkg/controller/v1alpha2/llmisvc/...` passes locally.

```
=== RUN   TestExpectedHTTPRouteRouterShapes
--- PASS: TestExpectedHTTPRouteRouterShapes (0.00s)
    --- PASS: TestExpectedHTTPRouteRouterShapes/router_nil
    --- PASS: TestExpectedHTTPRouteRouterShapes/route_nil
    --- PASS: TestExpectedHTTPRouteRouterShapes/route_set,_http_nil
    --- PASS: TestExpectedHTTPRouteRouterShapes/router_with_gateway,_route,_scheduler_all_empty_(issue_reproducer)
    --- PASS: TestExpectedHTTPRouteRouterShapes/route_set,_http_empty
    --- PASS: TestExpectedHTTPRouteRouterShapes/route_set,_http_with_refs_only_(BYO_HTTPRoute)
    --- PASS: TestExpectedHTTPRouteRouterShapes/route_set,_http_with_inline_spec
PASS
```

**Special notes for your reviewer**:

Minimal one-line fix in production code (`router.go`); the rest of the diff is the new test file. No API or CRD schema changes. The `route: {}` case now follows the same "no managed HTTPRoute created without an inline spec" path as `route.http: {}`, which I believe is the intended behaviour based on how `HasSpec()` is used elsewhere in this file — happy to default-init `route.http` instead if reviewers prefer.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas? *(N/A — one-line fix using an existing helper)*
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? *(N/A — no behaviour change for valid configs)*

**Release note**:
```release-note
Fix a nil pointer panic in the LLMInferenceService controller when `spec.router.route` is set without `route.http`.
```