### PR TITLE
fix(router): correct off-by-one in splitter pickupRoute random range

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -177,11 +177,10 @@ func callService(serviceUrl string, input []byte, headers http.Header) ([]byte, 
 }
 
 func pickupRoute(routes []v1alpha1.InferenceStep) *v1alpha1.InferenceStep {
-	randomNumber, err := rand.Int(rand.Reader, big.NewInt(101))
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(100))
 	if err != nil {
 		panic(err)
 	}
-	// generate num [0,100)
 	point := int(randomNumber.Int64())
 	end := 0
 	for _, route := range routes {
@@ -246,6 +245,11 @@ func routeStep(nodeName string, graph v1alpha1.InferenceGraphSpec, input []byte,
 
 	if currentNode.RouterType == v1alpha1.Splitter {
 		route := pickupRoute(currentNode.Steps)
+		if route == nil {
+			err := errors.New("No route was selected by the splitter")
+			log.Error(err, "failed to pick a route", "nodeName", nodeName)
+			return nil, 500, err
+		}
 		return handleSplitterORSwitchNode(route, graph, input, headers)
 	}
 	if currentNode.RouterType == v1alpha1.Switch {

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -246,7 +246,7 @@ func routeStep(nodeName string, graph v1alpha1.InferenceGraphSpec, input []byte,
 	if currentNode.RouterType == v1alpha1.Splitter {
 		route := pickupRoute(currentNode.Steps)
 		if route == nil {
-			err := errors.New("No route was selected by the splitter")
+			err := errors.New("no route was selected by the splitter")
 			log.Error(err, "failed to pick a route", "nodeName", nodeName)
 			return nil, 500, err
 		}

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -1056,7 +1056,7 @@ func TestPickupRouteNeverReturnsNil(t *testing.T) {
 		},
 	}
 
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		route := pickupRoute(routes)
 		require.NotNil(t, route, "pickupRoute returned nil on iteration %d", i)
 	}
@@ -1081,14 +1081,14 @@ func TestPickupRouteAlwaysReturnsRouteForAllRandValues(t *testing.T) {
 		},
 	}
 
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		route := pickupRoute(routes)
 		require.NotNil(t, route, "pickupRoute returned nil on iteration %d", i)
 	}
 }
 
 func TestCryptoRandIntUpperBoundWithFix(t *testing.T) {
-	for i := 0; i < 100_000; i++ {
+	for i := range 100_000 {
 		n, err := crand.Int(crand.Reader, big.NewInt(100))
 		require.NoError(t, err)
 		require.True(t, n.Int64() >= 0 && n.Int64() < 100,

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -18,8 +18,10 @@ package main
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"encoding/json"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -1032,5 +1034,64 @@ func TestServerTimeout(t *testing.T) {
 				assert.Equal(t, http.StatusOK, resp.StatusCode)
 			}
 		})
+	}
+}
+
+func TestPickupRouteNeverReturnsNil(t *testing.T) {
+	w1, w2 := int64(20), int64(80)
+	routes := []v1alpha1.InferenceStep{
+		{
+			StepName: "model1",
+			InferenceTarget: v1alpha1.InferenceTarget{
+				ServiceURL: "http://example.com/model1",
+			},
+			Weight: &w1,
+		},
+		{
+			StepName: "model2",
+			InferenceTarget: v1alpha1.InferenceTarget{
+				ServiceURL: "http://example.com/model2",
+			},
+			Weight: &w2,
+		},
+	}
+
+	for i := 0; i < 10000; i++ {
+		route := pickupRoute(routes)
+		require.NotNil(t, route, "pickupRoute returned nil on iteration %d", i)
+	}
+}
+
+func TestPickupRouteAlwaysReturnsRouteForAllRandValues(t *testing.T) {
+	w1, w2 := int64(30), int64(70)
+	routes := []v1alpha1.InferenceStep{
+		{
+			StepName: "model1",
+			InferenceTarget: v1alpha1.InferenceTarget{
+				ServiceURL: "http://example.com/model1",
+			},
+			Weight: &w1,
+		},
+		{
+			StepName: "model2",
+			InferenceTarget: v1alpha1.InferenceTarget{
+				ServiceURL: "http://example.com/model2",
+			},
+			Weight: &w2,
+		},
+	}
+
+	for i := 0; i < 10000; i++ {
+		route := pickupRoute(routes)
+		require.NotNil(t, route, "pickupRoute returned nil on iteration %d", i)
+	}
+}
+
+func TestCryptoRandIntUpperBoundWithFix(t *testing.T) {
+	for i := 0; i < 100_000; i++ {
+		n, err := crand.Int(crand.Reader, big.NewInt(100))
+		require.NoError(t, err)
+		require.True(t, n.Int64() >= 0 && n.Int64() < 100,
+			"rand.Int(100) returned out-of-range value %d on iteration %d", n.Int64(), i)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an off-by-one error in the InferenceGraph Splitter router that can cause a nil pointer dereference panic, crashing the router process.

The `pickupRoute` function used `rand.Int(rand.Reader, big.NewInt(101))` which returns values in `[0, 100]`. When route weights sum to 100 (the expected case), a random value of `point=100` causes no route to match—the loop condition `point < end` evaluates to `100 < 100 = false`—so `pickupRoute` returns `nil`. The caller in `routeStep` then dereferences this nil pointer, panicking:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

The probability of this occurring is ~1/101 per Splitter request (~1%).

This PR:
1. Changes `big.NewInt(101)` → `big.NewInt(100)` so the random range becomes `[0, 99]`, guaranteeing a route is always selected when weights sum to 100.
2. Adds a defensive nil guard in `routeStep` for the Splitter case, matching the existing pattern already used by the Switch case, so that even if `pickupRoute` returns nil for any reason, the router returns a 500 error instead of panicking.

**Which issue(s) this PR fixes**:
Fixes #5408

**Feature/Issue validation/testing**:

- [x] `TestPickupRouteNeverReturnsNil` — runs `pickupRoute` 10,000× with weights 20/80, asserts non-nil every iteration
- [x] `TestPickupRouteAlwaysReturnsRouteForAllRandValues` — same with weights 30/70
- [x] `TestCryptoRandIntUpperBoundWithFix` — verifies `crand.Int(big.NewInt(100))` never returns ≥100 over 100,000 iterations
- [x] All existing router tests pass (14/14)
- [x] E2E on Kind cluster: deployed InferenceGraph with Splitter (sklearn-iris:20, xgboost-iris:80), sent 1,200 requests (200 sequential + 1,000 parallel) — **zero failures, zero pod restarts**

<details>
<summary>Unit test results</summary>

```
=== RUN   TestPickupRouteNeverReturnsNil
--- PASS: TestPickupRouteNeverReturnsNil (0.01s)
=== RUN   TestPickupRouteAlwaysReturnsRouteForAllRandValues
--- PASS: TestPickupRouteAlwaysReturnsRouteForAllRandValues (0.01s)
=== RUN   TestCryptoRandIntUpperBoundWithFix
--- PASS: TestCryptoRandIntUpperBoundWithFix (0.09s)
PASS
ok  	github.com/kserve/kserve/cmd/router	0.159s
```

</details>

<details>
<summary>E2E test results (Kind cluster)</summary>

```
=== Sending 200 inference requests to splitter ===
=== Results ===
Success: 200
Failed: 0

=== Sending 1000 inference requests in parallel (10 concurrent) ===
   1000 200
=== Done ===
```

</details>

**Special notes for your reviewer**:

The misleading comment `// generate num [0,100)` was removed — the code with `big.NewInt(101)` was actually generating `[0, 100]` (inclusive), contradicting the comment. With `big.NewInt(100)` the behavior now matches `[0, 100)` = `[0, 99]`.

Credit to @ruseel for identifying and reporting this issue with detailed analysis and test commits.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fix off-by-one in InferenceGraph Splitter router that could cause a nil pointer panic (~1% probability per request) when the random value equals the total weight sum.
```