### PR TITLE
ci: add workflow to auto-assign reviewers on new PRs

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -15,7 +15,9 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: master
 
       - name: Pick random reviewers and request review
         env:
@@ -23,6 +25,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
+          set -euo pipefail
           # Parse the reviewers list from the OWNERS file
           REVIEWERS=$(yq e '.reviewers[]' OWNERS)
 
@@ -45,6 +48,6 @@ jobs:
           echo "Selected reviewers:"
           echo "$SELECTED"
 
-          for REVIEWER in $SELECTED; do
+          echo "$SELECTED" | while IFS= read -r REVIEWER; do
             gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER"
           done

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,50 @@
+name: Auto-assign PR Reviewers
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-reviewers:
+    name: Assign Reviewers
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pick random reviewers and request review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Parse the reviewers list from the OWNERS file
+          REVIEWERS=$(yq e '.reviewers[]' OWNERS)
+
+          # Remove the PR author from the candidate list
+          CANDIDATES=$(echo "$REVIEWERS" | grep -v "^${PR_AUTHOR}$" || true)
+
+          if [ -z "$CANDIDATES" ]; then
+            echo "No eligible reviewers found after excluding the PR author."
+            exit 0
+          fi
+
+          COUNT=$(echo "$CANDIDATES" | wc -l | tr -d ' ')
+          NUM_TO_PICK=2
+          if [ "$COUNT" -lt "$NUM_TO_PICK" ]; then
+            NUM_TO_PICK=$COUNT
+          fi
+
+          SELECTED=$(echo "$CANDIDATES" | shuf -n "$NUM_TO_PICK")
+
+          echo "Selected reviewers:"
+          echo "$SELECTED"
+
+          for REVIEWER in $SELECTED; do
+            gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER"
+          done


### PR DESCRIPTION
Adds a GitHub Actions workflow that triggers when a PR is opened, picks two random reviewers from the OWNERS file's reviewers section (excluding the PR author), and requests their review.

**Release note**:
```release-note
NONE
```
