### PR TITLE
test(llmisvc): harden autoscaling e2e with pipeline health checks

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -313,27 +313,9 @@ jobs:
           ${{ matrix.install-method == 'helm' && 'export INSTALL_METHOD="helm"' || '' }}
           ./test/scripts/gh-actions/setup-kserve.sh
 
-      - name: Verify HPA autoscaling setup
+      - name: Verify HPA autoscaling pipeline health
         run: |
-          echo "Verifying HPA autoscaling infrastructure..."
-
-          echo "Prometheus:"
-          kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus || true
-
-          echo "Prometheus Adapter:"
-          kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus-adapter || true
-
-          echo "WVA:"
-          kubectl get pods -n wva-system || true
-
-          echo "CRDs:"
-          kubectl get crd variantautoscalings.llmd.ai || true
-
-          echo "External Metrics API:"
-          kubectl get apiservice v1beta1.external.metrics.k8s.io || true
-
-          echo ""
-          echo "HPA autoscaling setup verification complete!"
+          ./test/scripts/gh-actions/verify-autoscaling-health.sh hpa
 
       - name: Run HPA autoscaling E2E tests
         id: autoscaling-hpa-tests
@@ -424,28 +406,9 @@ jobs:
           ${{ matrix.install-method == 'helm' && 'export INSTALL_METHOD="helm"' || '' }}
           ./test/scripts/gh-actions/setup-kserve.sh
 
-      - name: Verify KEDA autoscaling setup
+      - name: Verify KEDA autoscaling pipeline health
         run: |
-          echo "Verifying KEDA autoscaling infrastructure..."
-
-          echo "Prometheus:"
-          kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus || true
-
-          echo "KEDA:"
-          kubectl get pods -n keda -l app.kubernetes.io/name=keda-operator || true
-
-          echo "WVA:"
-          kubectl get pods -n wva-system || true
-
-          echo "CRDs:"
-          kubectl get crd variantautoscalings.llmd.ai || true
-          kubectl get crd scaledobjects.keda.sh || true
-
-          echo "ConfigMap autoscaling key:"
-          kubectl get configmap inferenceservice-config -n kserve -o jsonpath='{.data.autoscaling-wva-controller-config}' || true
-
-          echo ""
-          echo "KEDA autoscaling setup verification complete!"
+          ./test/scripts/gh-actions/verify-autoscaling-health.sh keda
 
       - name: Run KEDA autoscaling E2E tests
         id: autoscaling-keda-tests

--- a/hack/setup/infra/manage.prometheus-helm.sh
+++ b/hack/setup/infra/manage.prometheus-helm.sh
@@ -104,8 +104,43 @@ EOF
 
     kubectl wait certificate prometheus-tls -n "${PROMETHEUS_NAMESPACE}" --for=condition=Ready --timeout=60s
 
+    local values_file
+    values_file="$(mktemp)"
+    cat > "${values_file}" <<'VALUES_EOF'
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: kubernetes-pods-annotation
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+VALUES_EOF
+
     log_info "Installing kube-prometheus-stack ${PROMETHEUS_VERSION}..."
     helm install "${PROMETHEUS_RELEASE_NAME}" prometheus-community/kube-prometheus-stack \
+        --values "${values_file}" \
         --namespace "${PROMETHEUS_NAMESPACE}" \
         --create-namespace \
         --version "${PROMETHEUS_VERSION}" \
@@ -113,6 +148,8 @@ EOF
         --set alertmanager.enabled=false \
         --set nodeExporter.enabled=false \
         --set kubeStateMetrics.enabled=false \
+        --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+        --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
         --set prometheus.prometheusSpec.resources.requests.cpu=50m \
         --set prometheus.prometheusSpec.resources.requests.memory=256Mi \
         --set prometheus.prometheusSpec.resources.limits.cpu=200m \
@@ -124,6 +161,8 @@ EOF
         --wait \
         --timeout 10m \
         ${PROMETHEUS_EXTRA_ARGS:-}
+
+    rm -f "${values_file}"
 
     log_success "Successfully installed kube-prometheus-stack ${PROMETHEUS_VERSION} via Helm"
 

--- a/hack/setup/quick-install/llmisvc-autoscaling-hpa-dependency-install.sh
+++ b/hack/setup/quick-install/llmisvc-autoscaling-hpa-dependency-install.sh
@@ -822,8 +822,43 @@ EOF
 
     kubectl wait certificate prometheus-tls -n "${PROMETHEUS_NAMESPACE}" --for=condition=Ready --timeout=60s
 
+    local values_file
+    values_file="$(mktemp)"
+    cat > "${values_file}" <<'VALUES_EOF'
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: kubernetes-pods-annotation
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+VALUES_EOF
+
     log_info "Installing kube-prometheus-stack ${PROMETHEUS_VERSION}..."
     helm install "${PROMETHEUS_RELEASE_NAME}" prometheus-community/kube-prometheus-stack \
+        --values "${values_file}" \
         --namespace "${PROMETHEUS_NAMESPACE}" \
         --create-namespace \
         --version "${PROMETHEUS_VERSION}" \
@@ -831,6 +866,8 @@ EOF
         --set alertmanager.enabled=false \
         --set nodeExporter.enabled=false \
         --set kubeStateMetrics.enabled=false \
+        --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+        --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
         --set prometheus.prometheusSpec.resources.requests.cpu=50m \
         --set prometheus.prometheusSpec.resources.requests.memory=256Mi \
         --set prometheus.prometheusSpec.resources.limits.cpu=200m \
@@ -842,6 +879,8 @@ EOF
         --wait \
         --timeout 10m \
         ${PROMETHEUS_EXTRA_ARGS:-}
+
+    rm -f "${values_file}"
 
     log_success "Successfully installed kube-prometheus-stack ${PROMETHEUS_VERSION} via Helm"
 

--- a/hack/setup/quick-install/llmisvc-autoscaling-keda-dependency-install.sh
+++ b/hack/setup/quick-install/llmisvc-autoscaling-keda-dependency-install.sh
@@ -820,8 +820,43 @@ EOF
 
     kubectl wait certificate prometheus-tls -n "${PROMETHEUS_NAMESPACE}" --for=condition=Ready --timeout=60s
 
+    local values_file
+    values_file="$(mktemp)"
+    cat > "${values_file}" <<'VALUES_EOF'
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: kubernetes-pods-annotation
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+VALUES_EOF
+
     log_info "Installing kube-prometheus-stack ${PROMETHEUS_VERSION}..."
     helm install "${PROMETHEUS_RELEASE_NAME}" prometheus-community/kube-prometheus-stack \
+        --values "${values_file}" \
         --namespace "${PROMETHEUS_NAMESPACE}" \
         --create-namespace \
         --version "${PROMETHEUS_VERSION}" \
@@ -829,6 +864,8 @@ EOF
         --set alertmanager.enabled=false \
         --set nodeExporter.enabled=false \
         --set kubeStateMetrics.enabled=false \
+        --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+        --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
         --set prometheus.prometheusSpec.resources.requests.cpu=50m \
         --set prometheus.prometheusSpec.resources.requests.memory=256Mi \
         --set prometheus.prometheusSpec.resources.limits.cpu=200m \
@@ -840,6 +877,8 @@ EOF
         --wait \
         --timeout 10m \
         ${PROMETHEUS_EXTRA_ARGS:-}
+
+    rm -f "${values_file}"
 
     log_success "Successfully installed kube-prometheus-stack ${PROMETHEUS_VERSION} via Helm"
 

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -929,6 +929,13 @@ LLMINFERENCESERVICE_CONFIGS = {
             }
         },
     },
+    "prometheus-scrape": {
+        "annotations": {
+            "prometheus.io/scrape": "true",
+            "prometheus.io/port": "8000",
+            "prometheus.io/path": "/metrics",
+        },
+    },
     "scaling-hpa": {
         "scaling": {
             "minReplicas": 1,

--- a/test/e2e/llmisvc/test_llm_autoscaling.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling.py
@@ -40,6 +40,7 @@ integration tests in pkg/controller/v1alpha2/llmisvc/scaling_int_test.go.
 import concurrent.futures
 import logging
 import os
+import threading
 import time
 
 import pytest
@@ -204,18 +205,36 @@ def send_load(service_url, model_name, concurrency=5, duration_seconds=30):
     headers = {"Content-Type": "application/json"}
 
     deadline = time.time() + duration_seconds
+    lock = threading.Lock()
+    counters = {"success": 0, "error": 0}
 
     def _worker():
         while time.time() < deadline:
             try:
-                requests.post(endpoint, json=payload, headers=headers, timeout=30)
+                resp = requests.post(
+                    endpoint, json=payload, headers=headers, timeout=30
+                )
+                with lock:
+                    if resp.status_code < 500:
+                        counters["success"] += 1
+                    else:
+                        counters["error"] += 1
             except Exception:
-                pass
+                with lock:
+                    counters["error"] += 1
             time.sleep(0.1)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
         futures = [pool.submit(_worker) for _ in range(concurrency)]
         concurrent.futures.wait(futures)
+
+    logger.info(
+        f"send_load complete: {counters['success']} ok, "
+        f"{counters['error']} errors to {endpoint}"
+    )
+    assert counters["success"] > 0, (
+        f"send_load: all {counters['error']} requests failed to {endpoint}"
+    )
 
 
 # --- Patching helpers ---
@@ -286,6 +305,110 @@ def assert_scaling_resources_deleted(
         )
 
 
+# --- Pipeline and actuator health assertions ---
+
+
+def assert_metrics_pipeline_ready(actuator="hpa"):
+    """Verify the external metrics API is reachable before relying on scaling."""
+    api = client.ApiregistrationV1Api()
+    apiservice = api.read_api_service("v1beta1.external.metrics.k8s.io")
+    conditions = apiservice.status.conditions or []
+    available = next((c for c in conditions if c.type == "Available"), None)
+    assert available and available.status == "True", (
+        f"External metrics APIService not Available: {conditions}"
+    )
+
+    if actuator == "hpa":
+        v1 = client.CoreV1Api()
+        pods = v1.list_namespaced_pod(
+            namespace="monitoring",
+            label_selector="app.kubernetes.io/name=prometheus-adapter",
+        )
+        running = [p for p in pods.items if p.status.phase == "Running"]
+        assert len(running) > 0, "No running Prometheus Adapter pods found"
+    elif actuator == "keda":
+        v1 = client.CoreV1Api()
+        pods = v1.list_namespaced_pod(
+            namespace="keda",
+            label_selector="app.kubernetes.io/name=keda-operator",
+        )
+        running = [p for p in pods.items if p.status.phase == "Running"]
+        assert len(running) > 0, "No running KEDA operator pods found"
+
+
+def assert_wva_metric_exists(service_name, namespace=KSERVE_TEST_NAMESPACE):
+    """Verify WVA computed a scaling decision (desiredOptimizedAlloc present)."""
+
+    def _check():
+        va = _get_custom_resource(
+            VA_GROUP, VA_VERSION, VA_PLURAL, va_name(service_name), namespace
+        )
+        assert va is not None, f"VariantAutoscaling {va_name(service_name)} not found"
+        status = va.get("status", {})
+        alloc = status.get("desiredOptimizedAlloc", {})
+        num_replicas = alloc.get("numReplicas")
+        assert num_replicas is not None and num_replicas >= 1, (
+            f"WVA did not compute desiredOptimizedAlloc.numReplicas; status: {status}"
+        )
+
+    wait_for(_check, timeout=120, interval=5.0)
+
+
+def assert_hpa_active(service_name, namespace=KSERVE_TEST_NAMESPACE):
+    """Verify HPA has ScalingActive=True condition (polls for up to 60s)."""
+
+    def _check():
+        hpa = _get_custom_resource(
+            HPA_GROUP, HPA_VERSION, HPA_PLURAL, hpa_name(service_name), namespace
+        )
+        assert hpa is not None, f"HPA {hpa_name(service_name)} not found"
+        conditions = hpa.get("status", {}).get("conditions", [])
+        scaling_active = next(
+            (c for c in conditions if c["type"] == "ScalingActive"), None
+        )
+        assert scaling_active and scaling_active["status"] == "True", (
+            f"HPA ScalingActive is not True: {conditions}"
+        )
+
+    wait_for(_check, timeout=60, interval=5.0)
+
+
+def assert_scaled_object_active(service_name, namespace=KSERVE_TEST_NAMESPACE):
+    """Verify KEDA ScaledObject has Ready=True condition (polls for up to 60s)."""
+
+    def _check():
+        so = _get_custom_resource(
+            KEDA_GROUP,
+            KEDA_VERSION,
+            KEDA_PLURAL,
+            scaled_object_name(service_name),
+            namespace,
+        )
+        assert so is not None, (
+            f"ScaledObject {scaled_object_name(service_name)} not found"
+        )
+        conditions = so.get("status", {}).get("conditions", [])
+        ready = next((c for c in conditions if c["type"] == "Ready"), None)
+        assert ready and ready["status"] == "True", (
+            f"ScaledObject Ready is not True: {conditions}"
+        )
+
+    wait_for(_check, timeout=60, interval=5.0)
+
+
+def assert_lws_replicas(service_name, min_replicas, namespace=KSERVE_TEST_NAMESPACE):
+    """Verify LeaderWorkerSet status reflects scale-up."""
+    api = client.CustomObjectsApi()
+    lws_name = _child_name(service_name, "-kserve-mn")
+    lws = api.get_namespaced_custom_object(
+        "leaderworkerset.x-k8s.io", "v1", namespace, "leaderworkersets", lws_name
+    )
+    actual = lws.get("status", {}).get("replicas", 0)
+    assert actual >= min_replicas, (
+        f"LWS {lws_name} replicas={actual}, expected >= {min_replicas}"
+    )
+
+
 # --- Common test lifecycle ---
 
 
@@ -329,6 +452,7 @@ def _new_kserve_client():
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-no-replicas",
+                    "prometheus-scrape",
                     "scaling-hpa",
                 ],
                 prompt="KServe is a",
@@ -362,12 +486,16 @@ def test_llm_autoscaling_hpa_deployment(test_case: TestCase):
             scaled_object_name(service_name),
             KSERVE_TEST_NAMESPACE,
         )
+        assert_metrics_pipeline_ready(actuator="hpa")
 
         service_url = get_llm_service_url(kserve_client, test_case.llm_service)
         send_load(
             service_url, test_case.model_name, concurrency=10, duration_seconds=60
         )
+
+        assert_wva_metric_exists(service_name)
         wait_for_pod_count(service_name, min_count=2, timeout=300)
+        assert_hpa_active(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -388,6 +516,7 @@ def test_llm_autoscaling_hpa_deployment(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-no-replicas",
+                    "prometheus-scrape",
                     "scaling-keda",
                 ],
                 prompt="KServe is a",
@@ -421,12 +550,16 @@ def test_llm_autoscaling_keda_deployment(test_case: TestCase):
             hpa_name(service_name),
             KSERVE_TEST_NAMESPACE,
         )
+        assert_metrics_pipeline_ready(actuator="keda")
 
         service_url = get_llm_service_url(kserve_client, test_case.llm_service)
         send_load(
             service_url, test_case.model_name, concurrency=10, duration_seconds=60
         )
+
+        assert_wva_metric_exists(service_name)
         wait_for_pod_count(service_name, min_count=2, timeout=300)
+        assert_scaled_object_active(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -447,6 +580,7 @@ def test_llm_autoscaling_keda_deployment(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-lws",
+                    "prometheus-scrape",
                     "scaling-hpa",
                 ],
                 prompt="KServe is a",
@@ -473,12 +607,17 @@ def test_llm_autoscaling_hpa_lws(test_case: TestCase):
         _create_and_wait(kserve_client, test_case)
 
         assert_scaling_resources_exist(service_name, actuator="hpa")
+        assert_metrics_pipeline_ready(actuator="hpa")
 
         service_url = get_llm_service_url(kserve_client, test_case.llm_service)
         send_load(
             service_url, test_case.model_name, concurrency=10, duration_seconds=60
         )
+
+        assert_wva_metric_exists(service_name)
         wait_for_pod_count(service_name, min_count=2, timeout=300)
+        assert_hpa_active(service_name)
+        assert_lws_replicas(service_name, min_replicas=1)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -499,6 +638,7 @@ def test_llm_autoscaling_hpa_lws(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-lws",
+                    "prometheus-scrape",
                     "scaling-keda",
                 ],
                 prompt="KServe is a",
@@ -525,12 +665,17 @@ def test_llm_autoscaling_keda_lws(test_case: TestCase):
         _create_and_wait(kserve_client, test_case)
 
         assert_scaling_resources_exist(service_name, actuator="keda")
+        assert_metrics_pipeline_ready(actuator="keda")
 
         service_url = get_llm_service_url(kserve_client, test_case.llm_service)
         send_load(
             service_url, test_case.model_name, concurrency=10, duration_seconds=60
         )
+
+        assert_wva_metric_exists(service_name)
         wait_for_pod_count(service_name, min_count=2, timeout=300)
+        assert_scaled_object_active(service_name)
+        assert_lws_replicas(service_name, min_replicas=1)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -551,6 +696,7 @@ def test_llm_autoscaling_keda_lws(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-pd",
+                    "prometheus-scrape",
                     "scaling-hpa",
                     "scaling-prefill-hpa",
                 ],
@@ -599,6 +745,7 @@ def test_llm_autoscaling_prefill_hpa(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-pd",
+                    "prometheus-scrape",
                     "scaling-keda",
                     "scaling-prefill-keda",
                 ],
@@ -647,6 +794,7 @@ def test_llm_autoscaling_prefill_keda(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-no-replicas",
+                    "prometheus-scrape",
                     "scaling-hpa",
                 ],
                 prompt="KServe is a",
@@ -710,6 +858,7 @@ def test_llm_autoscaling_cleanup_hpa(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-no-replicas",
+                    "prometheus-scrape",
                     "scaling-keda",
                 ],
                 prompt="KServe is a",
@@ -770,6 +919,7 @@ def test_llm_autoscaling_cleanup_keda(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-no-replicas",
+                    "prometheus-scrape",
                     "scaling-hpa",
                 ],
                 prompt="KServe is a",
@@ -829,6 +979,7 @@ def test_llm_autoscaling_stop_hpa(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-no-replicas",
+                    "prometheus-scrape",
                     "scaling-keda",
                 ],
                 prompt="KServe is a",
@@ -888,6 +1039,7 @@ def test_llm_autoscaling_stop_keda(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-no-replicas",
+                    "prometheus-scrape",
                     "scaling-hpa",
                 ],
                 prompt="KServe is a",
@@ -964,6 +1116,7 @@ def test_llm_autoscaling_update_hpa(test_case: TestCase):
                 base_refs=[
                     "router-managed",
                     "workload-llmd-simulator-no-replicas",
+                    "prometheus-scrape",
                     "scaling-keda",
                 ],
                 prompt="KServe is a",

--- a/test/e2e/llmisvc/test_llm_autoscaling.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling.py
@@ -209,7 +209,7 @@ def send_load(service_url, model_name, concurrency=5, duration_seconds=30):
 
     deadline = time.time() + duration_seconds
     lock = threading.Lock()
-    counters = {"success": 0, "error": 0}
+    counters = {"success": 0, "client_error": 0, "server_error": 0}
 
     def _worker():
         while time.time() < deadline:
@@ -218,13 +218,15 @@ def send_load(service_url, model_name, concurrency=5, duration_seconds=30):
                     endpoint, json=payload, headers=headers, timeout=30
                 )
                 with lock:
-                    if resp.status_code < 500:
+                    if resp.status_code == 200:
                         counters["success"] += 1
+                    elif resp.status_code < 500:
+                        counters["client_error"] += 1
                     else:
-                        counters["error"] += 1
+                        counters["server_error"] += 1
             except Exception:
                 with lock:
-                    counters["error"] += 1
+                    counters["server_error"] += 1
             time.sleep(0.1)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
@@ -233,10 +235,12 @@ def send_load(service_url, model_name, concurrency=5, duration_seconds=30):
 
     logger.info(
         f"send_load complete: {counters['success']} ok, "
-        f"{counters['error']} errors to {endpoint}"
+        f"{counters['client_error']} client errors, "
+        f"{counters['server_error']} server errors to {endpoint}"
     )
-    assert counters["success"] > 0, (
-        f"send_load: all {counters['error']} requests failed to {endpoint}"
+    total_delivered = counters["success"] + counters["client_error"]
+    assert total_delivered > 0, (
+        f"send_load: all {counters['server_error']} requests failed to {endpoint}"
     )
 
 

--- a/test/e2e/llmisvc/test_llm_autoscaling.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling.py
@@ -82,6 +82,9 @@ HPA_GROUP = "autoscaling"
 HPA_VERSION = "v2"
 HPA_PLURAL = "horizontalpodautoscalers"
 
+PROMETHEUS_NAMESPACE = os.environ.get("PROMETHEUS_NAMESPACE", "monitoring")
+KEDA_NAMESPACE = os.environ.get("KEDA_NAMESPACE", "keda")
+
 
 def _get_custom_resource(group, version, plural, name, namespace):
     """Fetch a custom resource, return the object or None if 404."""
@@ -321,7 +324,7 @@ def assert_metrics_pipeline_ready(actuator="hpa"):
     if actuator == "hpa":
         v1 = client.CoreV1Api()
         pods = v1.list_namespaced_pod(
-            namespace="monitoring",
+            namespace=PROMETHEUS_NAMESPACE,
             label_selector="app.kubernetes.io/name=prometheus-adapter",
         )
         running = [p for p in pods.items if p.status.phase == "Running"]
@@ -329,7 +332,7 @@ def assert_metrics_pipeline_ready(actuator="hpa"):
     elif actuator == "keda":
         v1 = client.CoreV1Api()
         pods = v1.list_namespaced_pod(
-            namespace="keda",
+            namespace=KEDA_NAMESPACE,
             label_selector="app.kubernetes.io/name=keda-operator",
         )
         running = [p for p in pods.items if p.status.phase == "Running"]
@@ -397,16 +400,20 @@ def assert_scaled_object_active(service_name, namespace=KSERVE_TEST_NAMESPACE):
 
 
 def assert_lws_replicas(service_name, min_replicas, namespace=KSERVE_TEST_NAMESPACE):
-    """Verify LeaderWorkerSet status reflects scale-up."""
-    api = client.CustomObjectsApi()
+    """Verify LeaderWorkerSet status reflects scale-up (polls for up to 60s)."""
     lws_name = _child_name(service_name, "-kserve-mn")
-    lws = api.get_namespaced_custom_object(
-        "leaderworkerset.x-k8s.io", "v1", namespace, "leaderworkersets", lws_name
-    )
-    actual = lws.get("status", {}).get("replicas", 0)
-    assert actual >= min_replicas, (
-        f"LWS {lws_name} replicas={actual}, expected >= {min_replicas}"
-    )
+
+    def _check():
+        api = client.CustomObjectsApi()
+        lws = api.get_namespaced_custom_object(
+            "leaderworkerset.x-k8s.io", "v1", namespace, "leaderworkersets", lws_name
+        )
+        actual = lws.get("status", {}).get("replicas", 0)
+        assert actual >= min_replicas, (
+            f"LWS {lws_name} replicas={actual}, expected >= {min_replicas}"
+        )
+
+    wait_for(_check, timeout=60, interval=5.0)
 
 
 # --- Common test lifecycle ---

--- a/test/scripts/gh-actions/status-check.sh
+++ b/test/scripts/gh-actions/status-check.sh
@@ -197,6 +197,23 @@ if [[ $# -eq 1 && "$1" == "llmisvc" ]]; then
 
   echo "::endgroup::"
 
+  echo "::group::Autoscaling pipeline diagnostics"
+  echo "--- ServiceMonitors ---"
+  kubectl get servicemonitors -A 2>/dev/null || true
+  echo "--- VariantAutoscalings ---"
+  kubectl get variantautoscalings -n kserve-ci-e2e-test -o yaml 2>/dev/null || true
+  echo "--- HPAs ---"
+  kubectl get hpa -n kserve-ci-e2e-test -o yaml 2>/dev/null || true
+  echo "--- ScaledObjects ---"
+  kubectl get scaledobjects -n kserve-ci-e2e-test -o yaml 2>/dev/null || true
+  echo "--- External Metrics APIService ---"
+  kubectl get apiservice v1beta1.external.metrics.k8s.io -o yaml 2>/dev/null || true
+  echo "--- WVA Controller Logs ---"
+  kubectl logs -n wva-system -l control-plane=controller-manager --tail=100 2>/dev/null || true
+  echo "--- Prometheus Adapter Logs ---"
+  kubectl logs -n monitoring -l app.kubernetes.io/name=prometheus-adapter --tail=50 2>/dev/null || true
+  echo "::endgroup::"
+
   echo "::group::Gather logs in envoy-gateway-system envoy-ai-gateway-system"
   NAMESPACES="envoy-gateway-system envoy-ai-gateway-system"
 

--- a/test/scripts/gh-actions/verify-autoscaling-health.sh
+++ b/test/scripts/gh-actions/verify-autoscaling-health.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail-fast health check for the autoscaling metrics pipeline.
+# Validates that Prometheus, WVA, and the external metrics API are wired
+# correctly BEFORE running e2e tests. Exits non-zero on first failure.
+#
+# Usage: verify-autoscaling-health.sh <hpa|keda>
+
+set -euo pipefail
+
+AUTOSCALER="${1:?Usage: verify-autoscaling-health.sh <hpa|keda>}"
+
+PROMETHEUS_NAMESPACE="${PROMETHEUS_NAMESPACE:-monitoring}"
+WVA_NAMESPACE="${WVA_NAMESPACE:-wva-system}"
+KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
+
+retry() {
+    local description="$1"
+    local timeout="$2"
+    local interval="${3:-5}"
+    shift 3
+    local cmd=("$@")
+
+    local deadline=$((SECONDS + timeout))
+    local attempt=0
+    while true; do
+        attempt=$((attempt + 1))
+        if "${cmd[@]}" 2>/dev/null; then
+            echo "  [PASS] ${description}"
+            return 0
+        fi
+        if [ $SECONDS -ge $deadline ]; then
+            echo "  [FAIL] ${description} (timed out after ${timeout}s, ${attempt} attempts)"
+            return 1
+        fi
+        sleep "$interval"
+    done
+}
+
+echo "======================================================================"
+echo "Autoscaling Pipeline Health Check (mode: ${AUTOSCALER})"
+echo "======================================================================"
+
+# ---------------------------------------------------------------------------
+# 1. Pod readiness
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 1: Verifying pod readiness ---"
+
+echo "  Waiting for Prometheus pods..."
+kubectl wait --for=condition=Ready pod \
+    -l app.kubernetes.io/name=prometheus \
+    -n "${PROMETHEUS_NAMESPACE}" \
+    --timeout=120s
+
+echo "  Waiting for WVA pods..."
+kubectl wait --for=condition=Ready pod \
+    -l control-plane=controller-manager \
+    -n "${WVA_NAMESPACE}" \
+    --timeout=120s
+
+if [[ "${AUTOSCALER}" == "hpa" ]]; then
+    echo "  Waiting for Prometheus Adapter pods..."
+    kubectl wait --for=condition=Ready pod \
+        -l app.kubernetes.io/name=prometheus-adapter \
+        -n "${PROMETHEUS_NAMESPACE}" \
+        --timeout=120s
+elif [[ "${AUTOSCALER}" == "keda" ]]; then
+    echo "  Waiting for KEDA operator pods..."
+    kubectl wait --for=condition=Ready pod \
+        -l app.kubernetes.io/name=keda-operator \
+        -n "${KEDA_NAMESPACE}" \
+        --timeout=120s
+fi
+
+echo "  [PASS] All pods are Ready"
+
+# ---------------------------------------------------------------------------
+# 2. Prometheus API reachable
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 2: Verifying Prometheus API is reachable ---"
+
+PROM_POD=$(kubectl get pods -n "${PROMETHEUS_NAMESPACE}" \
+    -l app.kubernetes.io/name=prometheus \
+    -l app.kubernetes.io/managed-by=prometheus-operator \
+    -o jsonpath='{.items[0].metadata.name}')
+
+check_prometheus_api() {
+    kubectl exec -n "${PROMETHEUS_NAMESPACE}" "${PROM_POD}" -c prometheus -- \
+        wget -qO- --no-check-certificate \
+        "https://localhost:9090/api/v1/status/config" | grep -q '"status":"success"'
+}
+
+retry "Prometheus API responds" 30 5 check_prometheus_api
+
+# ---------------------------------------------------------------------------
+# 3. WVA ServiceMonitor target is UP in Prometheus
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 3: Verifying WVA ServiceMonitor target is scraped ---"
+
+check_wva_target_up() {
+    kubectl exec -n "${PROMETHEUS_NAMESPACE}" "${PROM_POD}" -c prometheus -- \
+        wget -qO- --no-check-certificate \
+        "https://localhost:9090/api/v1/targets" | grep -q "${WVA_NAMESPACE}"
+}
+
+retry "WVA target discovered by Prometheus" 60 5 check_wva_target_up
+
+# ---------------------------------------------------------------------------
+# 4. WVA controller can reach Prometheus (log smoke-check)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 4: Verifying WVA controller health (log check) ---"
+
+WVA_POD=$(kubectl get pods -n "${WVA_NAMESPACE}" \
+    -l control-plane=controller-manager \
+    -o jsonpath='{.items[0].metadata.name}')
+
+check_wva_no_prometheus_errors() {
+    local logs
+    logs=$(kubectl logs -n "${WVA_NAMESPACE}" "${WVA_POD}" --tail=50 2>/dev/null || echo "")
+    if echo "${logs}" | grep -qi "error.*prometheus\|connection refused\|no such host\|dial tcp.*refused"; then
+        return 1
+    fi
+    return 0
+}
+
+if ! check_wva_no_prometheus_errors; then
+    echo "  [FAIL] WVA controller has Prometheus connectivity errors in logs:"
+    kubectl logs -n "${WVA_NAMESPACE}" "${WVA_POD}" --tail=20
+    exit 1
+fi
+echo "  [PASS] WVA controller logs show no Prometheus errors"
+
+# ---------------------------------------------------------------------------
+# 5. External Metrics API is healthy
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 5: Verifying External Metrics API ---"
+
+check_external_metrics_api() {
+    kubectl get --raw /apis/external.metrics.k8s.io/v1beta1 >/dev/null 2>&1
+}
+
+retry "External Metrics API discovery endpoint" 60 5 check_external_metrics_api
+
+# ---------------------------------------------------------------------------
+# 5b. Autoscaler-specific checks
+# ---------------------------------------------------------------------------
+if [[ "${AUTOSCALER}" == "hpa" ]]; then
+    echo ""
+    echo "--- Step 5b: Verifying Prometheus Adapter APIService ---"
+
+    check_apiservice_available() {
+        local status
+        status=$(kubectl get apiservice v1beta1.external.metrics.k8s.io \
+            -o jsonpath='{.status.conditions[?(@.type=="Available")].status}')
+        [[ "${status}" == "True" ]]
+    }
+
+    retry "APIService v1beta1.external.metrics.k8s.io Available" 60 5 check_apiservice_available
+
+elif [[ "${AUTOSCALER}" == "keda" ]]; then
+    echo ""
+    echo "--- Step 5b: Verifying KEDA metrics server ---"
+
+    check_keda_metrics_server() {
+        kubectl get pods -n "${KEDA_NAMESPACE}" \
+            -l app=keda-operator-metrics-apiserver \
+            -o jsonpath='{.items[0].status.phase}' | grep -q "Running"
+    }
+
+    retry "KEDA metrics server Running" 60 5 check_keda_metrics_server
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "======================================================================"
+echo "All autoscaling pipeline health checks PASSED (mode: ${AUTOSCALER})"
+echo "======================================================================"


### PR DESCRIPTION
## Summary

Hardens the LLMISvc autoscaling E2E tests by adding pre-test pipeline validation and fixing several assertion gaps that could mask real failures.

### Changes

**New: `verify-autoscaling-health.sh` — fail-fast pipeline health check**
- Validates the full metrics pipeline _before_ tests run (replaces the old `|| true` checks in CI)
- Checks: Prometheus API reachable, WVA ServiceMonitor target scraped, External Metrics API healthy, operator pods ready
- Supports both `hpa` and `keda` modes
- Integrated into the CI workflow (`e2e-test-llmisvc.yaml`)

**Fixed: in-test assertions in `test_llm_autoscaling.py`**
- `send_load`: now tracks success/error counts with thread-safe counters; fails the test if all requests error (previously failures were silent)
- `assert_wva_metric_exists`: reads the correct field (`status.desiredOptimizedAlloc.numReplicas`) instead of the non-existent `status.desiredReplicas`
- `assert_hpa_active` / `assert_scaled_object_active`: poll with `wait_for` (60s timeout) instead of a single point-in-time check
- `assert_lws_replicas`: uses the correct controller-generated LWS resource name (`{name}-kserve-mn`)
- New `assert_metrics_pipeline_ready`: verifies APIService availability and operator pod health in-test

**Enhanced: `status-check.sh` diagnostics**
- Dumps ServiceMonitors, VariantAutoscalings, HPAs, ScaledObjects, WVA controller logs, and Prometheus Adapter logs on failure