### PR TITLE
Fix off-by-one in pickupRoute causing ~1% nil pointer panic on Splitter requests

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -177,11 +177,11 @@ func callService(serviceUrl string, input []byte, headers http.Header) ([]byte, 
 }
 
 func pickupRoute(routes []v1alpha1.InferenceStep) *v1alpha1.InferenceStep {
-	randomNumber, err := rand.Int(rand.Reader, big.NewInt(101))
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(100))
 	if err != nil {
 		panic(err)
 	}
-	// generate num [0,100)
+	// generate num [0, 100)
 	point := int(randomNumber.Int64())
 	end := 0
 	for _, route := range routes {

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -908,6 +908,44 @@ func TestCallServiceWhenMultipleHeadersToPropagateUsingInvalidPattern(t *testing
 	require.Equal(t, expectedResponse, response)
 }
 
+func TestPickupRouteAlwaysReturnsRoute(t *testing.T) {
+	weight40 := int64(40)
+	weight60 := int64(60)
+	routes := []v1alpha1.InferenceStep{
+		{
+			StepName: "route1",
+			Weight:   &weight40,
+		},
+		{
+			StepName: "route2",
+			Weight:   &weight60,
+		},
+	}
+	// Run many iterations to ensure pickupRoute never returns nil.
+	// Before the fix (big.NewInt(101)), the random value 100 would cause a nil return
+	// approximately 1% of the time.
+	for i := 0; i < 1000; i++ {
+		route := pickupRoute(routes)
+		require.NotNilf(t, route, "pickupRoute returned nil on iteration %d", i)
+		assert.Contains(t, []string{"route1", "route2"}, route.StepName)
+	}
+}
+
+func TestPickupRouteSingleRoute(t *testing.T) {
+	weight100 := int64(100)
+	routes := []v1alpha1.InferenceStep{
+		{
+			StepName: "only-route",
+			Weight:   &weight100,
+		},
+	}
+	for i := 0; i < 200; i++ {
+		route := pickupRoute(routes)
+		require.NotNilf(t, route, "pickupRoute returned nil on iteration %d", i)
+		assert.Equal(t, "only-route", route.StepName)
+	}
+}
+
 func TestServerTimeout(t *testing.T) {
 	testCases := []struct {
 		name                string


### PR DESCRIPTION
## Problem

`pickupRoute` uses `rand.Int(rand.Reader, big.NewInt(101))` to generate a random value, which produces integers in **[0, 100] inclusive**. Route weights sum to 100, so when the random value is exactly 100, the loop condition `point < end` is never satisfied and the function returns `nil`. The nil pointer is then dereferenced in `handleSplitterORSwitchNode` (accessing `route.StepName`), panicking the router process.

This has a ~1/101 probability (~0.99%) of occurring on **every Splitter request**.

The existing comment even says `// generate num [0,100)`, confirming the intent was an exclusive upper bound.

## Fix

Change `big.NewInt(101)` to `big.NewInt(100)` so the generated range is [0, 100), matching the comment and ensuring a route is always selected when weights sum to 100.

## Tests added

Two new tests (`TestPickupRouteAlwaysReturnsRoute`, `TestPickupRouteSingleRoute`) run 1200+ iterations of `pickupRoute` and assert it never returns nil.