### PR TITLE
fix(localmodel): use NodeSelector for jobs to fix PVC access

### DIFF
--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -198,7 +198,7 @@ func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode
 			TTLSecondsAfterFinished: &jobTTLSecondsAfterFinished,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeName:      nodeName,
+					NodeSelector:  map[string]string{"kubernetes.io/hostname": nodeName},
 					Containers:    []corev1.Container{*container},
 					RestartPolicy: corev1.RestartPolicyNever,
 					Volumes:       volumes,

--- a/pkg/controller/v1alpha1/localmodelnode/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller_test.go
@@ -1190,6 +1190,12 @@ var _ = Describe("LocalModelNode controller", func() {
 			Expect(pvcVolume.PersistentVolumeClaim).NotTo(BeNil())
 			Expect(pvcVolume.PersistentVolumeClaim.ClaimName).To(Equal("sklearn-model-sklearn-nodegroup"),
 				"PVC name should use NodeGroup from modelInfo, not the first matching nodegroup from getNodeGroupFromNode")
+
+			Expect(job.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{
+				"kubernetes.io/hostname": nodeName,
+			}), "Job should use NodeSelector for scheduler-based placement")
+			Expect(job.Spec.Template.Spec.NodeName).To(BeEmpty(),
+				"Job should not use NodeName to allow the scheduler to establish PVC-to-node binding")
 		})
 
 		It("Should append -download suffix to PVC name for namespace-scoped models", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Download jobs for LocalModelCache use `NodeName` to pin pods to specific nodes, which bypasses the Kubernetes scheduler entirely. The [Node authorizer](https://kubernetes.io/docs/reference/access-authn-authz/node/) verifies that kubelets can only access PVCs related to pods bound to their node through a graph-based relationship model. When a pod is placed via `NodeName`, the scheduler never establishes this relationship, and the kubelet is denied access to the download PVC:

```
no relationship found between node 'minikube-m03' and this object
```

This has become more visible with Kubernetes 1.34, where the Node authorizer enforces stricter per-node scoping ([KEP-4601](https://github.com/kubernetes/enhancements/issues/4601), now stable). The `test-modelcache` E2E test was failing almost every run, blocking 19+ open PRs.

Switches to `NodeSelector` with `kubernetes.io/hostname`, which routes through the scheduler. The scheduler establishes the PVC-to-node binding that the Node authorizer requires, while still targeting the exact same node.

No migration concerns - download jobs are ephemeral (1h TTL), PVs/PVCs and on-disk models are unchanged, and no CRD changes are involved.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] All 12 `localmodelnode` controller tests pass
- [x] All 17 `localmodel` reconciler tests pass
- [x] Added test assertion verifying `NodeSelector` is set and `NodeName` is empty on download jobs
- [x] `test-modelcache (kustomize)` E2E passes in CI

**Special notes for your reviewer**:

The switch from `NodeName` to `NodeSelector` changes scheduling behavior: the scheduler now evaluates taints and resource pressure on the target node. Previously `NodeName` silently bypassed these checks. This is strictly better - if a node is in trouble, you want the download job to stay `Pending` rather than being force-placed. The download job still targets the exact same node via the `kubernetes.io/hostname` label.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fix LocalModelCache download jobs failing on K8s 1.34+ by switching from NodeName to NodeSelector, allowing the scheduler to establish proper PVC-to-node binding for the Node authorizer.
```