### PR TITLE
ci: add network-layer parameter support to e2e tests infrastructure

### DIFF
--- a/test/e2e/batcher/test_batcher.py
+++ b/test/e2e/batcher/test_batcher.py
@@ -30,7 +30,7 @@ kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/c
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_batcher(rest_v1_client):
+async def test_batcher(rest_v1_client, network_layer):
     service_name = "isvc-sklearn-batcher"
 
     predictor = V1beta1PredictorSpec(
@@ -77,7 +77,11 @@ async def test_batcher(rest_v1_client):
             print(pod)
         raise e
     results = await predict_isvc(
-        rest_v1_client, service_name, "./data/iris_batch_input.json", is_batch=True
+        rest_v1_client,
+        service_name,
+        "./data/iris_batch_input.json",
+        is_batch=True,
+        network_layer=network_layer,
     )
     assert all(x == results[0] for x in results)
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/batcher/test_batcher_custom_port.py
+++ b/test/e2e/batcher/test_batcher_custom_port.py
@@ -32,7 +32,7 @@ kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/c
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_batcher_custom_port(rest_v1_client):
+async def test_batcher_custom_port(rest_v1_client, network_layer):
     service_name = "isvc-sklearn-batcher-custom"
 
     predictor = V1beta1PredictorSpec(
@@ -81,7 +81,11 @@ async def test_batcher_custom_port(rest_v1_client):
             print(pod)
         raise e
     results = await predict_isvc(
-        rest_v1_client, service_name, "./data/iris_batch_input.json", is_batch=True
+        rest_v1_client,
+        service_name,
+        "./data/iris_batch_input.json",
+        is_batch=True,
+        network_layer=network_layer,
     )
     assert all(x == results[0] for x in results)
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -329,14 +329,44 @@ async def predict_modelmesh(
         return response
 
 
+def _get_gateway_from_config():
+    """Read the gateway namespace and name from kserveIngressGateway in the inferenceservice-config ConfigMap.
+
+    The controller stores the gateway reference as "namespace/name" in the ingress config.
+    This follows the same parsing logic used by the Go controller in configmap.go.
+    Returns (namespace, name).
+    """
+    api = k8s_client.CoreV1Api(k8s_client.ApiClient())
+    cm = api.read_namespaced_config_map(
+        name="inferenceservice-config", namespace=KSERVE_NAMESPACE
+    )
+    ingress_config = json.loads(cm.data.get("ingress", "{}"))
+    gateway = ingress_config.get("kserveIngressGateway", "")
+    parts = gateway.split("/")
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return KSERVE_NAMESPACE, "kserve-ingress-gateway"
+
+
 def get_isvc_endpoint(isvc, network_layer: str = "istio"):
     scheme = urlparse(isvc["status"]["url"]).scheme
     host = urlparse(isvc["status"]["url"]).netloc
     path = urlparse(isvc["status"]["url"]).path
-    if os.environ.get("CI_USE_ISVC_HOST") == "1":
+    logger.info(f"Host from isvc status URL = {host}")
+    logger.info(f"Network layer = {network_layer}")
+    if network_layer == "openshift-route":
         cluster_ip = host
+        logger.info(f"Using external route host: {cluster_ip}")
     elif network_layer == "istio" or network_layer == "istio-ingress":
         cluster_ip = get_cluster_ip()
+        logger.info(f"Using internal cluster IP: {cluster_ip}")
+    elif network_layer == "gateway-api":
+        gw_ns, gw_name = _get_gateway_from_config()
+        logger.info(f"Using gateway from config: {gw_ns}/{gw_name}")
+        cluster_ip = get_cluster_ip(
+            namespace=gw_ns,
+            labels={"serving.kserve.io/gateway": gw_name},
+        )
     elif network_layer == "envoy-gatewayapi":
         cluster_ip = get_cluster_ip(
             namespace="envoy-gateway-system",
@@ -357,9 +387,12 @@ def generate(
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
     chat_completions=True,
+    network_layer: str = "istio",
 ):
     url_suffix = "v1/chat/completions" if chat_completions else "v1/completions"
-    res = _openai_request(service_name, input_json, version, url_suffix)
+    res = _openai_request(
+        service_name, input_json, version, url_suffix, network_layer=network_layer
+    )
     return _process_non_streaming_response(res)
 
 
@@ -367,8 +400,11 @@ def embed(
     service_name,
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
-    res = _openai_request(service_name, input_json, version, "v1/embeddings")
+    res = _openai_request(
+        service_name, input_json, version, "v1/embeddings", network_layer=network_layer
+    )
     return _process_non_streaming_response(res)
 
 
@@ -376,13 +412,19 @@ def rerank(
     service_name,
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
-    res = _openai_request(service_name, input_json, version, "v1/rerank")
+    res = _openai_request(
+        service_name, input_json, version, "v1/rerank", network_layer=network_layer
+    )
     return _process_non_streaming_response(res)
 
 
 def _get_openai_endpoint_and_host(
-    service_name, url_suffix, version=constants.KSERVE_V1BETA1_VERSION
+    service_name,
+    url_suffix,
+    version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
     """
     Get the OpenAI endpoint for the given service name.
@@ -390,6 +432,7 @@ def _get_openai_endpoint_and_host(
         service_name: The name of the inference service
         url_suffix: The suffix for the OpenAI endpoint (e.g., "v1/chat/completions")
         version: The version of the inference service. Defaults to v1beta1
+        network_layer: The network layer to use for endpoint resolution
     Returns:
         A tuple containing the OpenAI endpoint URL and the host name
     """
@@ -399,7 +442,7 @@ def _get_openai_endpoint_and_host(
     isvc = kfs_client.get(
         service_name, namespace=KSERVE_TEST_NAMESPACE, version=version
     )
-    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc)
+    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc, network_layer)
     return f"{scheme}://{cluster_ip}{path}/openai/{url_suffix}", host
 
 
@@ -409,11 +452,14 @@ def _openai_request(
     version=constants.KSERVE_V1BETA1_VERSION,
     url_suffix="",
     stream=False,
+    network_layer: str = "istio",
 ):
     with open(input_json) as json_file:
         data = json.load(json_file)
 
-        url, host = _get_openai_endpoint_and_host(service_name, url_suffix, version)
+        url, host = _get_openai_endpoint_and_host(
+            service_name, url_suffix, version, network_layer
+        )
         headers = {"Host": host, "Content-Type": "application/json"}
 
         logger.info("Sending Header = %s", headers)
@@ -441,13 +487,19 @@ def chat_completion_stream(
     service_name,
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
     """
     Make a chat completion streaming request to the inference service and collect all chunks.
     Returns a tuple containing full response text and all chunks received.
     """
     res = _openai_request(
-        service_name, input_json, version, "v1/chat/completions", stream=True
+        service_name,
+        input_json,
+        version,
+        "v1/chat/completions",
+        stream=True,
+        network_layer=network_layer,
     )
 
     chunks = []
@@ -472,13 +524,19 @@ def completion_stream(
     service_name,
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
     """
     Make a streaming request to the text completion inference service and collect all chunks.
     Returns a tuple containing full response text and all chunks received.
     """
     res = _openai_request(
-        service_name, input_json, version, "v1/completions", stream=True
+        service_name,
+        input_json,
+        version,
+        "v1/completions",
+        stream=True,
+        network_layer=network_layer,
     )
     chunks = []
     full_content = ""

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -110,7 +110,7 @@ def pytest_addoption(parser):
         "--network-layer",
         default="istio",
         type=str,
-        help="Network layer to used for testing. Default is istio. Allowed values are istio-ingress, envoy-gatewayapi, istio-gatewayapi",
+        help="Network layer to used for testing. Default is istio. Allowed values are istio, istio-ingress, envoy-gatewayapi, istio-gatewayapi, openshift-route, gateway-api",
     )
 
 

--- a/test/e2e/custom/test_custom_model_grpc.py
+++ b/test/e2e/custom/test_custom_model_grpc.py
@@ -279,7 +279,7 @@ async def test_predictor_grpc_with_transformer_http(rest_v2_client):
 
 @pytest.mark.transformer
 @pytest.mark.asyncio(scope="session")
-async def test_predictor_rest_with_transformer_rest(rest_v2_client):
+async def test_predictor_rest_with_transformer_rest(rest_v2_client, network_layer):
     service_name = "model-rest-trans-rest"
     model_name = "custom-model"
 
@@ -341,6 +341,7 @@ async def test_predictor_rest_with_transformer_rest(rest_v2_client):
         service_name,
         "./data/custom_model_input_v2.json",
         model_name=model_name,
+        network_layer=network_layer,
     )
     points = ["%.3f" % point for point in list(res.outputs[0].data)]
     assert points == ["14.976", "14.037", "13.966", "12.252", "12.086"]
@@ -365,6 +366,7 @@ async def test_predictor_rest_with_transformer_rest(rest_v2_client):
         service_name,
         infer_request,
         model_name=model_name,
+        network_layer=network_layer,
     )
     points = ["%.3f" % point for point in list(res.outputs[0].data)]
     assert points == ["14.976", "14.037", "13.966", "12.252", "12.086"]

--- a/test/e2e/graph/test_inference_graph.py
+++ b/test/e2e/graph/test_inference_graph.py
@@ -36,7 +36,7 @@ IG_TEST_RESOURCES_BASE_LOCATION = "graph/test-resources"
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_inference_graph(rest_v1_client):
+async def test_inference_graph(rest_v1_client, network_layer):
     logger.info("Starting test test_inference_graph")
     sklearn_name_1 = "isvc-sklearn-graph-1"
     sklearn_name_2 = "isvc-sklearn-graph-2"
@@ -147,6 +147,7 @@ async def test_inference_graph(rest_v1_client):
         rest_v1_client,
         graph_name,
         os.path.join(IG_TEST_RESOURCES_BASE_LOCATION, "iris_input.json"),
+        network_layer=network_layer,
     )
     assert res["predictions"] == [1, 1]
 
@@ -222,7 +223,7 @@ def setup_isvcs_for_test(suffix):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario1(rest_v1_client):
+async def test_ig_scenario1(rest_v1_client, network_layer):
     """
     Scenario: Sequence graph with 2 steps that are both soft dependencies.
      success_isvc(soft) -> error_isvc (soft)
@@ -286,6 +287,7 @@ async def test_ig_scenario1(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "custom_predictor_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -299,7 +301,7 @@ async def test_ig_scenario1(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario2(rest_v1_client):
+async def test_ig_scenario2(rest_v1_client, network_layer):
     """
     Scenario: Sequence graph with 2 steps that are both soft dependencies.
        error_isvc (soft) -> success_isvc(soft)
@@ -358,6 +360,7 @@ async def test_ig_scenario2(rest_v1_client):
         rest_v1_client,
         graph_name,
         os.path.join(IG_TEST_RESOURCES_BASE_LOCATION, "custom_predictor_input.json"),
+        network_layer=network_layer,
     )
     assert response == {"predictions": [{"message": "SUCCESS"}]}
 
@@ -369,7 +372,7 @@ async def test_ig_scenario2(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario3(rest_v1_client):
+async def test_ig_scenario3(rest_v1_client, network_layer):
     """
      Scenario: Sequence graph with 2 steps - first is hard (and returns non-200) and second is soft dependency.
      error_isvc(hard) -> success_isvc (soft)
@@ -424,6 +427,7 @@ async def test_ig_scenario3(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "custom_predictor_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -437,7 +441,7 @@ async def test_ig_scenario3(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario4(rest_v1_client):
+async def test_ig_scenario4(rest_v1_client, network_layer):
     """
     Scenario: Switch graph with 1 step as hard dependency and other one as soft dependency.
     Will be testing 3 cases in this test case:
@@ -498,6 +502,7 @@ async def test_ig_scenario4(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_error_picker_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -510,6 +515,7 @@ async def test_ig_scenario4(rest_v1_client):
         os.path.join(
             IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_success_picker_input.json"
         ),
+        network_layer=network_layer,
     )
     assert response == {"predictions": [{"message": "SUCCESS"}]}
 
@@ -521,6 +527,7 @@ async def test_ig_scenario4(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_no_match_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {
@@ -537,7 +544,7 @@ async def test_ig_scenario4(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario5(rest_v1_client):
+async def test_ig_scenario5(rest_v1_client, network_layer):
     """
     Scenario: Switch graph where a match would happen for error node and then error would return but IG will continue
     execution and call the next step in the flow as error step will be a soft dependency.
@@ -590,6 +597,7 @@ async def test_ig_scenario5(rest_v1_client):
         os.path.join(
             IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_error_picker_input.json"
         ),
+        network_layer=network_layer,
     )
     assert response == {"predictions": [{"message": "SUCCESS"}]}
 
@@ -601,7 +609,7 @@ async def test_ig_scenario5(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario6(rest_v1_client):
+async def test_ig_scenario6(rest_v1_client, network_layer):
     """
     Scenario: Switch graph where a match would happen for error node and then error would return and IG will NOT
     continue execution and call the next step in the flow as error step will be a HARD dependency.
@@ -655,6 +663,7 @@ async def test_ig_scenario6(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_error_picker_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -668,7 +677,7 @@ async def test_ig_scenario6(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario7(rest_v1_client):
+async def test_ig_scenario7(rest_v1_client, network_layer):
     """
     Scenario: Ensemble graph with 2 steps, where both the steps are soft deps.
 
@@ -721,6 +730,7 @@ async def test_ig_scenario7(rest_v1_client):
         os.path.join(
             IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_success_picker_input.json"
         ),
+        network_layer=network_layer,
     )
     assert response == {
         "rootStep1": {"predictions": [{"message": "SUCCESS"}]},
@@ -735,7 +745,7 @@ async def test_ig_scenario7(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario8(rest_v1_client):
+async def test_ig_scenario8(rest_v1_client, network_layer):
     """
     Scenario: Ensemble graph with 3 steps, where 2 steps are soft and 1 step is hard and returns non-200
 
@@ -789,6 +799,7 @@ async def test_ig_scenario8(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_success_picker_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -801,7 +812,7 @@ async def test_ig_scenario8(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario9(rest_v1_client):
+async def test_ig_scenario9(rest_v1_client, network_layer):
     """
     Scenario: Splitter graph where a match would happen for error node and then error would return but IG will continue
     execution and call the next step in the flow as error step will be a soft dependency.
@@ -852,6 +863,7 @@ async def test_ig_scenario9(rest_v1_client):
         rest_v1_client,
         graph_name,
         os.path.join(IG_TEST_RESOURCES_BASE_LOCATION, "iris_input.json"),
+        network_layer=network_layer,
     )
     assert response == {"predictions": [{"message": "SUCCESS"}]}
 
@@ -863,7 +875,7 @@ async def test_ig_scenario9(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario10(rest_v1_client):
+async def test_ig_scenario10(rest_v1_client, network_layer):
     """
     Scenario: Splitter graph where a match would happen for error node and then error would return and IG will NOT
     continue execution and call the next step in the flow as error step will be a HARD dependency.
@@ -915,6 +927,7 @@ async def test_ig_scenario10(rest_v1_client):
             rest_v1_client,
             graph_name,
             os.path.join(IG_TEST_RESOURCES_BASE_LOCATION, "iris_input.json"),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}

--- a/test/e2e/helm/test_kserve_sklearn.py
+++ b/test/e2e/helm/test_kserve_sklearn.py
@@ -33,7 +33,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
 @pytest.mark.helm
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_kserve(rest_v2_client):
+async def test_sklearn_kserve(rest_v2_client, network_layer):
     service_name = "isvc-sklearn-helm"
     protocol_version = "v2"
 
@@ -78,6 +78,7 @@ async def test_sklearn_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 

--- a/test/e2e/logger/test_logger.py
+++ b/test/e2e/logger/test_logger.py
@@ -34,7 +34,7 @@ kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/c
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_kserve_logger(rest_v1_client):
+async def test_kserve_logger(rest_v1_client, network_layer):
     msg_dumper = "message-dumper"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -96,7 +96,12 @@ async def test_kserve_logger(rest_v1_client):
         for pod in pods.items:
             print(pod)
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     pods = kserve_client.core_api.list_namespaced_pod(
         KSERVE_TEST_NAMESPACE,

--- a/test/e2e/logger/test_marshaller.py
+++ b/test/e2e/logger/test_marshaller.py
@@ -40,7 +40,7 @@ kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/c
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_immediate(rest_v1_client):
+async def test_json_immediate(rest_v1_client, network_layer):
     """JSON marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -55,7 +55,12 @@ async def test_json_immediate(rest_v1_client):
         kserve_client.create(isvc)
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(s3, LOGGER_BUCKET, prefix, 2, timeout=60)
@@ -84,7 +89,7 @@ async def test_json_immediate(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_size_batch(rest_v1_client):
+async def test_json_size_batch(rest_v1_client, network_layer):
     """JSON marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -101,7 +106,10 @@ async def test_json_size_batch(rest_v1_client):
 
         for _ in range(5):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -118,7 +126,7 @@ async def test_json_size_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_timed_batch(rest_v1_client):
+async def test_json_timed_batch(rest_v1_client, network_layer):
     """JSON marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 records.
@@ -138,7 +146,10 @@ async def test_json_timed_batch(rest_v1_client):
         # Phase 1: fill the batch
         for _ in range(2):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -148,7 +159,12 @@ async def test_json_timed_batch(rest_v1_client):
             verify_json_object(body, expected_records=2)
 
         # Phase 2: partial batch flushed by timer
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(
@@ -168,7 +184,7 @@ async def test_json_timed_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_immediate(rest_v1_client):
+async def test_csv_immediate(rest_v1_client, network_layer):
     """CSV marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -183,7 +199,12 @@ async def test_csv_immediate(rest_v1_client):
         kserve_client.create(isvc)
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(s3, LOGGER_BUCKET, prefix, 2, timeout=60)
@@ -206,7 +227,7 @@ async def test_csv_immediate(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_size_batch(rest_v1_client):
+async def test_csv_size_batch(rest_v1_client, network_layer):
     """CSV marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -223,7 +244,10 @@ async def test_csv_size_batch(rest_v1_client):
 
         for _ in range(5):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -240,7 +264,7 @@ async def test_csv_size_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_timed_batch(rest_v1_client):
+async def test_csv_timed_batch(rest_v1_client, network_layer):
     """CSV marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 rows.
@@ -259,7 +283,10 @@ async def test_csv_timed_batch(rest_v1_client):
 
         for _ in range(2):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -268,7 +295,12 @@ async def test_csv_timed_batch(rest_v1_client):
             body = get_s3_object_body(s3, LOGGER_BUCKET, obj["Key"])
             verify_csv_object(body, expected_records=2)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(
@@ -288,7 +320,7 @@ async def test_csv_timed_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_immediate(rest_v1_client):
+async def test_parquet_immediate(rest_v1_client, network_layer):
     """Parquet marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -303,7 +335,12 @@ async def test_parquet_immediate(rest_v1_client):
         kserve_client.create(isvc)
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(s3, LOGGER_BUCKET, prefix, 2, timeout=60)
@@ -326,7 +363,7 @@ async def test_parquet_immediate(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_size_batch(rest_v1_client):
+async def test_parquet_size_batch(rest_v1_client, network_layer):
     """Parquet marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -343,7 +380,10 @@ async def test_parquet_size_batch(rest_v1_client):
 
         for _ in range(5):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -360,7 +400,7 @@ async def test_parquet_size_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_timed_batch(rest_v1_client):
+async def test_parquet_timed_batch(rest_v1_client, network_layer):
     """Parquet marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 rows.
@@ -379,7 +419,10 @@ async def test_parquet_timed_batch(rest_v1_client):
 
         for _ in range(2):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -388,7 +431,12 @@ async def test_parquet_timed_batch(rest_v1_client):
             body = get_s3_object_body(s3, LOGGER_BUCKET, obj["Key"])
             verify_parquet_object(body, expected_records=2)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(

--- a/test/e2e/modelcache/test_localmodelcache_sklearn.py
+++ b/test/e2e/modelcache/test_localmodelcache_sklearn.py
@@ -44,7 +44,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
 @pytest.mark.modelcache
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_modelcache(rest_v1_client):
+async def test_sklearn_modelcache(rest_v1_client, network_layer):
     """
     Test LocalModelCache with sklearn predictor.
     This test is ARM64 compatible as sklearn server has multi-arch images.
@@ -174,7 +174,12 @@ async def test_sklearn_modelcache(rest_v1_client):
         )
 
     # Test inference with the cached model
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/modelcache/test_localmodelnamespacecache.py
+++ b/test/e2e/modelcache/test_localmodelnamespacecache.py
@@ -48,7 +48,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
 @pytest.mark.modelcache
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_modelnamespacecache(rest_v1_client):
+async def test_sklearn_modelnamespacecache(rest_v1_client, network_layer):
     service_name = "sklearn-modelnamespacecache-worker1"
     storage_uri = "gs://kfserving-examples/models/sklearn/1.0/model"
     nodes = ["minikube-m02", "minikube-m03"]
@@ -174,7 +174,12 @@ async def test_sklearn_modelnamespacecache(rest_v1_client):
             "aks-agentpool-27350515-vmss000000",
         )
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
     # Wait for the isvc to be deleted to avoid modelcache still in use error when deleting the model cache

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -251,7 +251,7 @@ def test_huggingface_openai_text_completion_streaming():
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v2_sequence_classification(rest_v2_client):
+async def test_huggingface_v2_sequence_classification(rest_v2_client, network_layer):
     service_name = "hf-bert-sequence-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -297,6 +297,7 @@ async def test_huggingface_v2_sequence_classification(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/bert_sequence_classification_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1]
 
@@ -305,7 +306,7 @@ async def test_huggingface_v2_sequence_classification(rest_v2_client):
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v1_fill_mask(rest_v1_client):
+async def test_huggingface_v1_fill_mask(rest_v1_client, network_layer):
     service_name = "hf-bert-fill-mask-v1"
     protocol_version = "v1"
     predictor = V1beta1PredictorSpec(
@@ -345,6 +346,7 @@ async def test_huggingface_v1_fill_mask(rest_v1_client):
         rest_v1_client,
         service_name,
         "./data/bert_fill_mask_v1.json",
+        network_layer=network_layer,
     )
     assert res["predictions"] == ["paris", "france"]
 
@@ -353,7 +355,7 @@ async def test_huggingface_v1_fill_mask(rest_v1_client):
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v2_token_classification(rest_v2_client):
+async def test_huggingface_v2_token_classification(rest_v2_client, network_layer):
     service_name = "hf-bert-token-classification-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -400,6 +402,7 @@ async def test_huggingface_v2_token_classification(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/bert_token_classification_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
@@ -455,7 +458,7 @@ def test_huggingface_openai_text_2_text():
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v2_text_embedding(rest_v2_client):
+async def test_huggingface_v2_text_embedding(rest_v2_client, network_layer):
     service_name = "hf-text-embedding-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -502,7 +505,10 @@ async def test_huggingface_v2_text_embedding(rest_v2_client):
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
     res = await predict_isvc(
-        rest_v2_client, service_name, "./data/text_embedding_input_v2.json"
+        rest_v2_client,
+        service_name,
+        "./data/text_embedding_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == huggingface_text_embedding_expected_output
 
@@ -578,6 +584,7 @@ async def test_huggingface_openai_text_embedding():
 @pytest.mark.asyncio(scope="session")
 async def test_huggingface_v2_sequence_classification_with_raw_logits(
     rest_v2_client,
+    network_layer,
 ):
     service_name = "hf-bert-sequence-v2-prob"
     protocol_version = "v2"
@@ -625,6 +632,7 @@ async def test_huggingface_v2_sequence_classification_with_raw_logits(
         rest_v2_client,
         service_name,
         "./data/bert_sequence_classification_v2.json",
+        network_layer=network_layer,
     )
 
     result = res.outputs[0].data[0]
@@ -645,6 +653,7 @@ async def test_huggingface_v2_sequence_classification_with_raw_logits(
 @pytest.mark.asyncio(scope="session")
 async def test_huggingface_v2_sequence_classification_with_probabilities(
     rest_v2_client,
+    network_layer,
 ):
     service_name = "hf-bert-sequence-v2-logits"
     protocol_version = "v2"
@@ -692,6 +701,7 @@ async def test_huggingface_v2_sequence_classification_with_probabilities(
         rest_v2_client,
         service_name,
         "./data/bert_sequence_classification_v2.json",
+        network_layer=network_layer,
     )
     output = ast.literal_eval(res.outputs[0].data[0])
     assert output == {0: 0.0094, 1: 0.9906}

--- a/test/e2e/predictor/test_lightgbm.py
+++ b/test/e2e/predictor/test_lightgbm.py
@@ -37,7 +37,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc, predict_grpc
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_lightgbm_kserve(rest_v1_client):
+async def test_lightgbm_kserve(rest_v1_client, network_layer):
     service_name = "isvc-lightgbm"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -65,7 +65,12 @@ async def test_lightgbm_kserve(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v3.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v3.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
@@ -73,7 +78,7 @@ async def test_lightgbm_kserve(rest_v1_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_lightgbm_runtime_kserve(rest_v1_client):
+async def test_lightgbm_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-lightgbm-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -104,13 +109,28 @@ async def test_lightgbm_runtime_kserve(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v3.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v3.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v4.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v4.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v5.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v5.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
@@ -118,7 +138,7 @@ async def test_lightgbm_runtime_kserve(rest_v1_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_lightgbm_v2_runtime_mlserver(rest_v2_client):
+async def test_lightgbm_v2_runtime_mlserver(rest_v2_client, network_layer):
     service_name = "isvc-lightgbm-v2-runtime"
     protocol_version = "v2"
 
@@ -163,6 +183,7 @@ async def test_lightgbm_v2_runtime_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [
         8.796664107010673e-06,
@@ -179,7 +200,7 @@ async def test_lightgbm_v2_runtime_mlserver(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_lightgbm_v2_kserve(rest_v2_client):
+async def test_lightgbm_v2_kserve(rest_v2_client, network_layer):
     service_name = "isvc-lightgbm-v2-kserve"
 
     predictor = V1beta1PredictorSpec(
@@ -216,6 +237,7 @@ async def test_lightgbm_v2_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [
         8.796664107010673e-06,

--- a/test/e2e/predictor/test_mlflow.py
+++ b/test/e2e/predictor/test_mlflow.py
@@ -32,7 +32,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_mlflow_v2_runtime_kserve(rest_v2_client):
+async def test_mlflow_v2_runtime_kserve(rest_v2_client, network_layer):
     service_name = "isvc-mlflow-v2-runtime"
     protocol_version = "v2"
 
@@ -75,6 +75,7 @@ async def test_mlflow_v2_runtime_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/mlflow_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [5.576883936610762]
 

--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -49,7 +49,11 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 @pytest.mark.mms
 @pytest.mark.asyncio(scope="session")
 async def test_mms_sklearn_kserve(
-    protocol_version: str, storage_uri: str, rest_v1_client, rest_v2_client
+    protocol_version: str,
+    storage_uri: str,
+    rest_v1_client,
+    rest_v2_client,
+    network_layer,
 ):
     service_name = f"isvc-sklearn-mms-{protocol_version}"
     # Define an inference service
@@ -124,6 +128,7 @@ async def test_mms_sklearn_kserve(
                 service_name,
                 "./data/iris_input.json",
                 model_name=model_name,
+                network_layer=network_layer,
             )
             for model_name in model_names
         ]
@@ -136,6 +141,7 @@ async def test_mms_sklearn_kserve(
                 service_name,
                 "./data/iris_input_v2.json",
                 model_name=model_name,
+                network_layer=network_layer,
             )
             for model_name in model_names
         ]
@@ -164,7 +170,11 @@ async def test_mms_sklearn_kserve(
 @pytest.mark.mms
 @pytest.mark.asyncio(scope="session")
 async def test_mms_xgboost_kserve(
-    protocol_version: str, storage_uri: str, rest_v1_client, rest_v2_client
+    protocol_version: str,
+    storage_uri: str,
+    rest_v1_client,
+    rest_v2_client,
+    network_layer,
 ):
     service_name = f"isvc-xgboost-mms-{protocol_version}"
     # Define an inference service
@@ -240,6 +250,7 @@ async def test_mms_xgboost_kserve(
                 service_name,
                 "./data/iris_input.json",
                 model_name=model_name,
+                network_layer=network_layer,
             )
             for model_name in model_names
         ]
@@ -252,6 +263,7 @@ async def test_mms_xgboost_kserve(
                 service_name,
                 "./data/iris_input_v2.json",
                 model_name=model_name,
+                network_layer=network_layer,
             )
             for model_name in model_names
         ]

--- a/test/e2e/predictor/test_paddle.py
+++ b/test/e2e/predictor/test_paddle.py
@@ -36,7 +36,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc, predict_grpc
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_paddle(rest_v1_client):
+async def test_paddle(rest_v1_client, network_layer):
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         paddle=V1beta1PaddleServerSpec(
@@ -73,7 +73,9 @@ async def test_paddle(rest_v1_client):
             logging.info(pod)
         raise e
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/jay.json")
+    res = await predict_isvc(
+        rest_v1_client, service_name, "./data/jay.json", network_layer=network_layer
+    )
     assert np.argmax(res["predictions"][0]) == 17
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -81,7 +83,7 @@ async def test_paddle(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_paddle_runtime(rest_v1_client):
+async def test_paddle_runtime(rest_v1_client, network_layer):
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         model=V1beta1ModelSpec(
@@ -121,7 +123,9 @@ async def test_paddle_runtime(rest_v1_client):
             logging.info(pod)
         raise e
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/jay.json")
+    res = await predict_isvc(
+        rest_v1_client, service_name, "./data/jay.json", network_layer=network_layer
+    )
     assert np.argmax(res["predictions"][0]) == 17
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -129,7 +133,7 @@ async def test_paddle_runtime(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_paddle_v2_kserve(rest_v2_client):
+async def test_paddle_v2_kserve(rest_v2_client, network_layer):
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         model=V1beta1ModelSpec(
@@ -174,6 +178,7 @@ async def test_paddle_v2_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/jay-v2.json",
+        network_layer=network_layer,
     )
     assert np.argmax(res.outputs[0].data) == 17
 
@@ -182,7 +187,7 @@ async def test_paddle_v2_kserve(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_paddle_v2_grpc():
+async def test_paddle_v2_grpc(network_layer):
     service_name = "isvc-paddle-v2-grpc"
     model_name = "paddle"
     predictor = V1beta1PredictorSpec(
@@ -229,7 +234,10 @@ async def test_paddle_v2_grpc():
     json_file = open("./data/jay-v2-grpc.json")
     payload = json.load(json_file)["inputs"]
     response = await predict_grpc(
-        service_name=service_name, payload=payload, model_name=model_name
+        service_name=service_name,
+        payload=payload,
+        model_name=model_name,
+        network_layer=network_layer,
     )
     prediction = response.outputs[0].data
     assert np.argmax(prediction) == 17

--- a/test/e2e/predictor/test_pmml.py
+++ b/test/e2e/predictor/test_pmml.py
@@ -34,7 +34,7 @@ from ..common.utils import predict_isvc
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_pmml_kserve(rest_v1_client):
+async def test_pmml_kserve(rest_v1_client, network_layer):
     service_name = "isvc-pmml"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -62,7 +62,12 @@ async def test_pmml_kserve(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
     start = time.perf_counter()
-    res = await predict_isvc(rest_v1_client, service_name, "./data/pmml_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/pmml_input.json",
+        network_layer=network_layer,
+    )
     end = time.perf_counter()
     print(f"Time taken: {end - start}")
     logger.info(f"Time taken: {end - start}")
@@ -80,7 +85,7 @@ async def test_pmml_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_pmml_runtime_kserve(rest_v1_client):
+async def test_pmml_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-pmml-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -110,7 +115,12 @@ async def test_pmml_runtime_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/pmml_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/pmml_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [
         {
             "Species": "setosa",
@@ -125,7 +135,7 @@ async def test_pmml_runtime_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_pmml_v2_kserve(rest_v2_client):
+async def test_pmml_v2_kserve(rest_v2_client, network_layer):
     service_name = "isvc-pmml-v2-kserve"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -160,6 +170,7 @@ async def test_pmml_v2_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/pmml-input-v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs == [
         InferOutput(

--- a/test/e2e/predictor/test_predictive.py
+++ b/test/e2e/predictor/test_predictive.py
@@ -34,7 +34,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_sklearn_v1(rest_v1_client):
+async def test_predictive_sklearn_v1(rest_v1_client, network_layer):
     service_name = "isvc-predictive-sklearn"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -63,14 +63,19 @@ async def test_predictive_sklearn_v1(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_xgboost_v1(rest_v1_client):
+async def test_predictive_xgboost_v1(rest_v1_client, network_layer):
     service_name = "isvc-predictive-xgboost"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -99,14 +104,19 @@ async def test_predictive_xgboost_v1(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_lightgbm_v1(rest_v1_client):
+async def test_predictive_lightgbm_v1(rest_v1_client, network_layer):
     service_name = "isvc-predictive-lightgbm"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -136,14 +146,19 @@ async def test_predictive_lightgbm_v1(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v3.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v3.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_sklearn_v2(rest_v2_client):
+async def test_predictive_sklearn_v2(rest_v2_client, network_layer):
     service_name = "isvc-predictive-sklearn-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -185,6 +200,7 @@ async def test_predictive_sklearn_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -193,7 +209,7 @@ async def test_predictive_sklearn_v2(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_xgboost_v2(rest_v2_client):
+async def test_predictive_xgboost_v2(rest_v2_client, network_layer):
     service_name = "isvc-predictive-xgboost-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -235,6 +251,7 @@ async def test_predictive_xgboost_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -243,7 +260,7 @@ async def test_predictive_xgboost_v2(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_lightgbm_v2(rest_v2_client):
+async def test_predictive_lightgbm_v2(rest_v2_client, network_layer):
     service_name = "isvc-predictive-lightgbm-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -285,6 +302,7 @@ async def test_predictive_lightgbm_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     # LightGBM returns probability predictions in v2 format
     # We verify the highest probability class matches expected result

--- a/test/e2e/predictor/test_sklearn.py
+++ b/test/e2e/predictor/test_sklearn.py
@@ -42,7 +42,7 @@ from ..common.utils import (
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_kserve(rest_v1_client):
+async def test_sklearn_kserve(rest_v1_client, network_layer):
     service_name = "isvc-sklearn"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -69,14 +69,19 @@ async def test_sklearn_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_v2_mlserver(rest_v2_client):
+async def test_sklearn_v2_mlserver(rest_v2_client, network_layer):
     service_name = "sklearn-v2-mlserver"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -116,6 +121,7 @@ async def test_sklearn_v2_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -125,7 +131,7 @@ async def test_sklearn_v2_mlserver(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_runtime_kserve(rest_v1_client):
+async def test_sklearn_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-sklearn-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -158,7 +164,12 @@ async def test_sklearn_runtime_kserve(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
     tasks = [
-        predict_isvc(rest_v1_client, service_name, "./data/news_grouping_input_v1.json")
+        predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/news_grouping_input_v1.json",
+            network_layer=network_layer,
+        )
         for _ in range(25)
     ]
     responses = await asyncio.gather(*tasks)
@@ -183,7 +194,7 @@ async def test_sklearn_runtime_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_v2_runtime_mlserver(rest_v2_client):
+async def test_sklearn_v2_runtime_mlserver(rest_v2_client, network_layer):
     service_name = "isvc-sklearn-v2-runtime"
     protocol_version = "v2"
 
@@ -228,6 +239,7 @@ async def test_sklearn_v2_runtime_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -236,7 +248,7 @@ async def test_sklearn_v2_runtime_mlserver(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_v2(rest_v2_client):
+async def test_sklearn_v2(rest_v2_client, network_layer):
     service_name = "isvc-sklearn-v2"
 
     predictor = V1beta1PredictorSpec(
@@ -273,6 +285,7 @@ async def test_sklearn_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -280,6 +293,7 @@ async def test_sklearn_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2_binary.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -287,6 +301,7 @@ async def test_sklearn_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2_all_binary.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -344,7 +359,7 @@ async def test_sklearn_v2_grpc():
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_v2_mixed(rest_v2_client):
+async def test_sklearn_v2_mixed(rest_v2_client, network_layer):
     service_name = "isvc-sklearn-v2-mixed"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -380,6 +395,7 @@ async def test_sklearn_v2_mixed(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/sklearn_mixed_v2.json",
+        network_layer=network_layer,
     )
     assert response.outputs[0].data == [12.202832815138274]
 

--- a/test/e2e/predictor/test_tensorflow.py
+++ b/test/e2e/predictor/test_tensorflow.py
@@ -31,7 +31,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_tensorflow_kserve(rest_v1_client):
+async def test_tensorflow_kserve(rest_v1_client, network_layer):
     service_name = "isvc-tensorflow"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -58,7 +58,12 @@ async def test_tensorflow_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/flower_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/flower_input.json",
+        network_layer=network_layer,
+    )
     assert np.argmax(res["predictions"][0].get("scores")) == 0
 
     # Delete the InferenceService
@@ -67,7 +72,7 @@ async def test_tensorflow_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_tensorflow_runtime_kserve(rest_v1_client):
+async def test_tensorflow_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-tensorflow-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -97,7 +102,12 @@ async def test_tensorflow_runtime_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/flower_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/flower_input.json",
+        network_layer=network_layer,
+    )
     assert np.argmax(res["predictions"][0].get("scores")) == 0
 
     # Delete the InferenceService

--- a/test/e2e/predictor/test_torchserve.py
+++ b/test/e2e/predictor/test_torchserve.py
@@ -34,7 +34,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc, predict_grpc
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_torchserve_kserve(rest_v1_client):
+async def test_torchserve_kserve(rest_v1_client, network_layer):
     service_name = "mnist"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -64,7 +64,10 @@ async def test_torchserve_kserve(rest_v1_client):
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/torchserve_input.json"
+        rest_v1_client,
+        service_name,
+        "./data/torchserve_input.json",
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -72,7 +75,7 @@ async def test_torchserve_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_torchserve_v2_kserve(rest_v2_client):
+async def test_torchserve_v2_kserve(rest_v2_client, network_layer):
     service_name = "mnist-v2"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -106,6 +109,7 @@ async def test_torchserve_v2_kserve(rest_v2_client):
         service_name,
         "./data/torchserve_input_v2.json",
         model_name="mnist",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -166,7 +170,7 @@ async def test_torchserve_grpc_v2():
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_torchserve_runtime_kserve(rest_v1_client):
+async def test_torchserve_runtime_kserve(rest_v1_client, network_layer):
     service_name = "mnist-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -199,7 +203,11 @@ async def test_torchserve_runtime_kserve(rest_v1_client):
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/torchserve_input.json", model_name="mnist"
+        rest_v1_client,
+        service_name,
+        "./data/torchserve_input.json",
+        model_name="mnist",
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_triton.py
+++ b/test/e2e/predictor/test_triton.py
@@ -33,7 +33,7 @@ from ..common.utils import predict_isvc
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_triton(rest_v2_client):
+async def test_triton(rest_v2_client, network_layer):
     service_name = "isvc-triton"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -85,6 +85,7 @@ async def test_triton(rest_v2_client):
         service_name,
         "./data/cifar10_input_v2.json",
         model_name="cifar10",
+        network_layer=network_layer,
     )
     assert np.argmax(res.outputs[0].data) == 3
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -93,7 +94,7 @@ async def test_triton(rest_v2_client):
 @pytest.mark.transformer
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_triton_runtime_with_transformer(rest_v1_client):
+async def test_triton_runtime_with_transformer(rest_v1_client, network_layer):
     service_name = "isvc-triton-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -159,7 +160,11 @@ async def test_triton_runtime_with_transformer(rest_v1_client):
             print(deployment)
         raise e
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/image.json", model_name="cifar10"
+        rest_v1_client,
+        service_name,
+        "./data/image.json",
+        model_name="cifar10",
+        network_layer=network_layer,
     )
     assert np.argmax(res["predictions"][0]) == 5
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_xgboost.py
+++ b/test/e2e/predictor/test_xgboost.py
@@ -36,7 +36,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc, predict_grpc
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_kserve(rest_v1_client):
+async def test_xgboost_kserve(rest_v1_client, network_layer):
     service_name = "isvc-xgboost"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -63,7 +63,12 @@ async def test_xgboost_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
@@ -71,7 +76,7 @@ async def test_xgboost_kserve(rest_v1_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_v2_mlserver(rest_v2_client):
+async def test_xgboost_v2_mlserver(rest_v2_client, network_layer):
     service_name = "isvc-xgboost-v2-mlserver"
     protocol_version = "v2"
 
@@ -113,6 +118,7 @@ async def test_xgboost_v2_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1.0, 1.0]
 
@@ -122,7 +128,7 @@ async def test_xgboost_v2_mlserver(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_single_model_file(rest_v2_client):
+async def test_xgboost_single_model_file(rest_v2_client, network_layer):
     service_name = "xgboost-v2-mlserver"
     protocol_version = "v2"
 
@@ -164,6 +170,7 @@ async def test_xgboost_single_model_file(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1.0, 1.0]
 
@@ -173,7 +180,7 @@ async def test_xgboost_single_model_file(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_runtime_kserve(rest_v1_client):
+async def test_xgboost_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-xgboost-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -203,7 +210,12 @@ async def test_xgboost_runtime_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
@@ -211,7 +223,7 @@ async def test_xgboost_runtime_kserve(rest_v1_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_v2_runtime_mlserver(rest_v2_client):
+async def test_xgboost_v2_runtime_mlserver(rest_v2_client, network_layer):
     service_name = "isvc-xgboost-v2-runtime"
     protocol_version = "v2"
 
@@ -256,6 +268,7 @@ async def test_xgboost_v2_runtime_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1.0, 1.0]
 
@@ -265,7 +278,7 @@ async def test_xgboost_v2_runtime_mlserver(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_v2(rest_v2_client):
+async def test_xgboost_v2(rest_v2_client, network_layer):
     service_name = "isvc-xgboost-v2"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -301,6 +314,7 @@ async def test_xgboost_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1.0, 1.0]
 

--- a/test/e2e/qpext/test_qpext.py
+++ b/test/e2e/qpext/test_qpext.py
@@ -39,7 +39,7 @@ METRICS_PATH = "metrics"
 
 
 @pytest.mark.asyncio(scope="session")
-async def test_qpext_kserve(rest_v2_client):
+async def test_qpext_kserve(rest_v2_client, network_layer):
     # test the qpext using the sklearn predictor
     service_name = "sklearn-v2-metrics"
     protocol_version = "v2"
@@ -91,6 +91,7 @@ async def test_qpext_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 

--- a/test/e2e/storagespec/test_s3_storagespec.py
+++ b/test/e2e/storagespec/test_s3_storagespec.py
@@ -32,7 +32,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_s3_storagespec_kserve(rest_v1_client):
+async def test_sklearn_s3_storagespec_kserve(rest_v1_client, network_layer):
     service_name = "isvc-sklearn-s3"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -63,6 +63,11 @@ async def test_sklearn_s3_storagespec_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/transformer/test_collocation.py
+++ b/test/e2e/transformer/test_collocation.py
@@ -40,7 +40,7 @@ from ..common.utils import (
 
 @pytest.mark.collocation
 @pytest.mark.asyncio(scope="session")
-async def test_transformer_collocation(rest_v1_client):
+async def test_transformer_collocation(rest_v1_client, network_layer):
     service_name = "custom-model-transformer-collocation"
     model_name = "mnist"
     predictor = V1beta1PredictorSpec(
@@ -126,7 +126,11 @@ async def test_transformer_collocation(rest_v1_client):
     is_ready = await is_model_ready(rest_v1_client, service_name, model_name) is True
     assert is_ready is True
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/transformer.json", model_name=model_name
+        rest_v1_client,
+        service_name,
+        "./data/transformer.json",
+        model_name=model_name,
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -134,7 +138,7 @@ async def test_transformer_collocation(rest_v1_client):
 
 @pytest.mark.collocation
 @pytest.mark.asyncio(scope="session")
-async def test_transformer_collocation_runtime(rest_v1_client):
+async def test_transformer_collocation_runtime(rest_v1_client, network_layer):
     service_name = "custom-model-trans-collocation-runtime"
     model_name = "mnist"
     predictor = V1beta1PredictorSpec(
@@ -210,7 +214,11 @@ async def test_transformer_collocation_runtime(rest_v1_client):
     is_ready = await is_model_ready(rest_v1_client, service_name, model_name) is True
     assert is_ready is True
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/transformer.json", model_name=model_name
+        rest_v1_client,
+        service_name,
+        "./data/transformer.json",
+        model_name=model_name,
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/transformer/test_transformer.py
+++ b/test/e2e/transformer/test_transformer.py
@@ -31,7 +31,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 
 @pytest.mark.transformer
 @pytest.mark.asyncio(scope="session")
-async def test_transformer(rest_v1_client):
+async def test_transformer(rest_v1_client, network_layer):
     service_name = "isvc-transformer"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -98,7 +98,11 @@ async def test_transformer(rest_v1_client):
             print(pod)
         raise e
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/transformer.json", model_name="mnist"
+        rest_v1_client,
+        service_name,
+        "./data/transformer.json",
+        model_name="mnist",
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -31,7 +31,10 @@ export GITHUB_SHA="${TAG:-latest}"
 echo "Starting E2E functional tests ..."
 MARKER="${1}"
 PARALLELISM="${2:-1}"
-NETWORK_LAYER="${3:-'istio'}"
+NETWORK_LAYER="${3:-istio}"
+
+: "${SKIP_DELETION_ON_FAILURE:=true}"
+export SKIP_DELETION_ON_FAILURE
 
 echo "Parallelism requested for pytest is ${PARALLELISM}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `openshift-route` and `gateway-api` network layers to the e2e test infrastructure, enabling tests to run against different ingress configurations without relying on environment variables like `CI_USE_ISVC_HOST`.

Changes:
- `test/e2e/common/utils.py`: Add `openshift-route` and `gateway-api` network layer support to `get_isvc_endpoint()`, add `_get_gateway_from_config()` for dynamic gateway discovery from the `inferenceservice-config` ConfigMap, thread `network_layer` parameter through all OpenAI helper functions (`generate`, `embed`, `rerank`, `chat_completion_stream`, `completion_stream`)
- `test/e2e/conftest.py`: Update `--network-layer` help text with new allowed values
- `test/scripts/gh-actions/run-e2e-tests.sh`: Fix embedded quotes bug in default `NETWORK_LAYER` value, add `SKIP_DELETION_ON_FAILURE` env var support
- `test/e2e/graph/test_inference_graph.py`: Add `network_layer` fixture usage, add `networking.kserve.io/visibility: exposed` label for raw mode tests
- 24 test files across batcher, custom, helm, logger, modelcache, predictor, qpext, storagespec, and transformer suites: Add `network_layer` parameter threading

**Which issue(s) this PR fixes**:


**Feature/Issue validation/testing**:

- [ ] Verified `network_layer` parameter is correctly threaded through all test functions
- [ ] Verified `openshift-route` network layer uses the ISVC host directly
- [ ] Verified `gateway-api` network layer reads gateway config from ConfigMap
- [ ] Verified existing `istio`, `istio-ingress`, `envoy-gatewayapi`, `istio-gatewayapi` layers are unchanged

**Special notes for your reviewer**:

This is the upstream portion of a larger change. The downstream OpenShift CI integration (deployment profile mapping, OpenShift-specific scripts) will be submitted separately to opendatahub-io/kserve.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Add openshift-route and gateway-api network layer support to e2e test infrastructure
```