### PR TITLE
fix(e2e): disable vLLM V1 engine for CPU e2e tests

### DIFF
--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -60,6 +60,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                     "env": [
                         {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                        {"name": "VLLM_USE_V1", "value": "0"},
                         *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                     ],
                     "resources": {
@@ -80,6 +81,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                     "env": [
                         {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                        {"name": "VLLM_USE_V1", "value": "0"},
                         *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                     ],
                     "resources": {
@@ -113,6 +115,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                         "env": [
                             {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                             {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                            {"name": "VLLM_USE_V1", "value": "0"},
                             *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                         ],
                         "resources": {
@@ -347,6 +350,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                     ],
                     "env": [
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                        {"name": "VLLM_USE_V1", "value": "0"},
                         *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                     ],
                     "resources": {
@@ -371,6 +375,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                     ],
                     "env": [
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
+                        {"name": "VLLM_USE_V1", "value": "0"},
                         *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                     ],
                     "resources": {

--- a/test/e2e/modelcache/test_localmodelcache.py
+++ b/test/e2e/modelcache/test_localmodelcache.py
@@ -122,6 +122,10 @@ async def test_vllm_modelcache():
                     name="VLLM_CPU_KVCACHE_SPACE",
                     value="1",
                 ),
+                client.V1EnvVar(
+                    name="VLLM_USE_V1",
+                    value="0",
+                ),
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},

--- a/test/e2e/predictor/test_huggingface_vllm_cpu.py
+++ b/test/e2e/predictor/test_huggingface_vllm_cpu.py
@@ -62,6 +62,10 @@ def test_huggingface_vllm_cpu_openai_chat_completions():
                     name="VLLM_CPU_KVCACHE_SPACE",
                     value="1",
                 ),
+                client.V1EnvVar(
+                    name="VLLM_USE_V1",
+                    value="0",
+                ),
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -116,6 +120,10 @@ def test_huggingface_vllm_cpu_text_completion_streaming():
                 client.V1EnvVar(
                     name="VLLM_CPU_KVCACHE_SPACE",
                     value="1",
+                ),
+                client.V1EnvVar(
+                    name="VLLM_USE_V1",
+                    value="0",
                 ),
             ],
             resources=V1ResourceRequirements(
@@ -174,6 +182,10 @@ def test_huggingface_vllm_cpu_openai_completions():
                     name="VLLM_CPU_KVCACHE_SPACE",
                     value="1",
                 ),
+                client.V1EnvVar(
+                    name="VLLM_USE_V1",
+                    value="0",
+                ),
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -227,6 +239,10 @@ def test_huggingface_vllm_openai_chat_completions_streaming():
                 client.V1EnvVar(
                     name="VLLM_CPU_KVCACHE_SPACE",
                     value="1",
+                ),
+                client.V1EnvVar(
+                    name="VLLM_USE_V1",
+                    value="0",
                 ),
             ],
             resources=V1ResourceRequirements(
@@ -287,6 +303,10 @@ def test_huggingface_vllm_cpu_rerank():
                 client.V1EnvVar(
                     name="VLLM_CPU_KVCACHE_SPACE",
                     value="1",
+                ),
+                client.V1EnvVar(
+                    name="VLLM_USE_V1",
+                    value="0",
                 ),
             ],
             resources=V1ResourceRequirements(


### PR DESCRIPTION
## Summary
- Adds `VLLM_USE_V1=0` env var to all CPU-based vLLM e2e tests
- Fixes V1 engine crash on CPU-only CI runners after vLLM 0.20.0 upgrade (#5206)

## Root Cause

vLLM 0.20.0 enables the V1 engine by default. When the GPU image runs on CPU-only CI runners, the V1 `cpu_worker.py` calls `torch.ops._C.init_cpu_memory_env()` — a C extension only present in the dedicated vllm-cpu build. The GPU build lacks this extension, causing:

```
AttributeError: '_OpNamespace' '_C' object has no attribute 'init_cpu_memory_env'
```

This causes pod crash-loops and test timeouts.

## Fix

Set `VLLM_USE_V1=0` in all CPU e2e test specs to force vLLM to use the V0 engine, which gracefully falls back to CPU via PyTorch without requiring vLLM's custom CPU allocator.

## Test plan
- [x] CI `test-huggingface-server-vllm` job passes with this change
- [x] CI `test-llm-inference-service` job passes
- [x] CI `test-localmodel-cache` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)