### PR TITLE
fix(ci): upgrade github-script to v8 and harden auto-merge checks

### DIFF
--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -11,17 +11,25 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const yaml = require('js-yaml');
             const { owner, repo } = context.repo;
 
             // Load approvers from the OWNERS file
-            const { data: ownersFile } = await github.rest.repos.getContent({ owner, repo, path: 'OWNERS' });
-            const owners = yaml.load(Buffer.from(ownersFile.content, 'base64').toString());
-            const approvers = (owners.approvers || []).map(a => a.toLowerCase());
+            const { data: ownersFile } = await github.rest.repos.getContent({ owner, repo, path: 'OWNERS', ref: 'master' });
+            const ownersContent = Buffer.from(ownersFile.content, 'base64').toString();
+            const approvers = [];
+            let inApprovers = false;
+            for (const line of ownersContent.split('\n')) {
+              if (/^approvers:\s*$/.test(line)) { inApprovers = true; continue; }
+              if (/^\S/.test(line)) { inApprovers = false; continue; }
+              if (inApprovers) {
+                const m = line.match(/^\s*-\s+(.+)/);
+                if (m) approvers.push(m[1].trim().toLowerCase());
+              }
+            }
 
             const prs = await github.paginate(github.rest.issues.listForRepo, {
               owner, repo, state: 'open', labels: 'lgtm',
@@ -34,9 +42,19 @@ jobs:
               const { data: reviews } = await github.rest.pulls.listReviews({
                 owner, repo, pull_number: issue.number,
               });
-              const approvedByApprover = reviews.some(
-                r => r.state === 'APPROVED' && approvers.includes(r.user.login.toLowerCase())
-              );
+              let approvedByApprover = false;
+              for (const r of reviews) {
+                if (r.state !== 'APPROVED') continue;
+                if (!approvers.includes(r.user.login.toLowerCase())) continue;
+                const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner, repo, username: r.user.login,
+                });
+                if (perm.permission === 'admin' || perm.permission === 'write') {
+                  approvedByApprover = true;
+                  break;
+                }
+              }
+
               if (!approvedByApprover) {
                 core.info(`PR #${issue.number} has lgtm but no approved review from an OWNERS approver, skipping`);
                 continue;


### PR DESCRIPTION
chore:  Resolve "Cannot find module 'js-yaml'" by replacing the js-yaml
        dependency with inline YAML parsing. Upgrade actions/github-script from
        v7.1.0 (Node.js 20) to v8.0.0 (Node.js 24) to address the upcoming
        deprecation. Pin OWNERS file read to master branch and verify the
        approver has write permission to prevent privilege escalation.


**Release note**:
```release-note
NONE
```
