### PR TITLE
fix(ingress): eliminate ExternalName service no-op update churn

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -337,7 +337,9 @@ func (ir *IngressReconciler) reconcileExternalService(ctx context.Context, isvc 
 			}
 
 			// Return if no differences to reconcile.
-			if equality.Semantic.DeepEqual(desired, existing) {
+			// DeepDerivative treats zero/nil fields in desired as "don't care",
+			// so server-populated metadata fields on existing don't cause false diffs.
+			if equality.Semantic.DeepDerivative(desired, existing) {
 				return nil
 			}
 
@@ -349,8 +351,22 @@ func (ir *IngressReconciler) reconcileExternalService(ctx context.Context, isvc 
 			log.Info("Reconciling external service diff (-desired, +observed):", "diff", diff)
 			log.Info("Updating external service", "namespace", existing.Namespace, "name", existing.Name)
 			existing.Spec = desired.Spec
-			existing.Labels = desired.Labels
-			existing.Annotations = desired.Annotations
+			if desired.Labels != nil {
+				if existing.Labels == nil {
+					existing.Labels = make(map[string]string)
+				}
+				for k, v := range desired.Labels {
+					existing.Labels[k] = v
+				}
+			}
+			if desired.Annotations != nil {
+				if existing.Annotations == nil {
+					existing.Annotations = make(map[string]string)
+				}
+				for k, v := range desired.Annotations {
+					existing.Annotations[k] = v
+				}
+			}
 			err = ir.client.Update(ctx, existing)
 			if err != nil {
 				return errors.Wrapf(err, "fails to update external name service")

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -2245,3 +2245,66 @@ func TestIngressReconciler_Reconcile_SkipVirtualService(t *testing.T) {
 	err = client.Get(t.Context(), types.NamespacedName{Name: "skip-vs", Namespace: "default"}, existingVS)
 	g.Expect(apierr.IsNotFound(err)).To(gomega.BeTrue())
 }
+
+func TestReconcileExternalService_NoUpdateWhenUnchanged(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = istioclientv1beta1.AddToScheme(scheme)
+
+	localGatewayService := "knative-local-gateway.istio-system.svc.cluster.local"
+	ingressConfig := &v1beta1.IngressConfig{
+		IngressGateway:             constants.KnativeIngressGateway,
+		KnativeLocalGatewayService: localGatewayService,
+		LocalGateway:               constants.KnativeLocalGateway,
+		LocalGatewayServiceName:    localGatewayService,
+		DisableIstioVirtualHost:    false,
+	}
+
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "test"},
+	}
+
+	// Simulate an existing ExternalName service with labels and annotations
+	// set by another controller - this is the state after initial creation
+	// and external controller reconciliation.
+	existingSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-model",
+			Namespace: "test",
+			Labels: map[string]string{
+				"opendatahub.io/managed": "true",
+				"some-other-label":       "value",
+			},
+			Annotations: map[string]string{
+				"serving.cert-manager.io/certificate": "some-cert",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(isvc, v1beta1.SchemeGroupVersion.WithKind("InferenceService")),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ExternalName:    localGatewayService,
+			Type:            corev1.ServiceTypeExternalName,
+			SessionAffinity: corev1.ServiceAffinityNone,
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(isvc, existingSvc).Build()
+	isvcConfig := &v1beta1.InferenceServicesConfig{}
+	reconciler := NewIngressReconciler(cl, kubernetesfake.NewSimpleClientset(), scheme, ingressConfig, isvcConfig, true)
+
+	// Reconcile - this should be a no-op since the spec hasn't changed
+	err := reconciler.reconcileExternalService(t.Context(), isvc, ingressConfig)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// Verify the service still has its original labels and annotations
+	svc := &corev1.Service{}
+	err = cl.Get(t.Context(), types.NamespacedName{Name: "my-model", Namespace: "test"}, svc)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(svc.Labels).To(gomega.HaveKeyWithValue("opendatahub.io/managed", "true"), "labels from other controllers should be preserved")
+	g.Expect(svc.Labels).To(gomega.HaveKeyWithValue("some-other-label", "value"), "labels from other controllers should be preserved")
+	g.Expect(svc.Annotations).To(gomega.HaveKeyWithValue("serving.cert-manager.io/certificate", "some-cert"), "annotations from other controllers should be preserved")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`reconcileExternalService()` compares a minimal desired Service object against the fully-populated existing object using `equality.Semantic.DeepEqual`. This always fails because the desired object lacks server-populated fields (ClusterIP, UID, resourceVersion, managedFields).

Every reconcile cycle produces an API write that overwrites Labels and Annotations with nil - even when the Spec is identical. This strips metadata set by other controllers and generates unnecessary cross-controller reconciliation churn.

The fix replaces `DeepEqual` with `DeepDerivative`, which treats zero/nil fields in the desired object as "don't care". Server-populated metadata no longer causes false diffs. The unconditional Labels/Annotations overwrite is also removed - the reconciler should not be wiping metadata that other controllers set.

**Feature/Issue validation/testing**:

- [x] Unit test that creates an ExternalName service with labels and annotations from an external controller, reconciles with unchanged spec, and asserts metadata is preserved
- [x] Full ingress reconciler test suite passes

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release notes**:

```release-note
NONE
```