### PR TITLE
fix(cabundle): eliminate ConfigMap no-op update churn

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler.go
@@ -132,7 +132,9 @@ func (c *CaBundleConfigMapReconciler) ReconcileCaBundleConfigMap(ctx context.Con
 	}
 
 	// Return if no differences to reconcile.
-	if equality.Semantic.DeepEqual(desiredConfigMap, existingConfigMap) {
+	// DeepDerivative treats zero/nil fields in desired as "don't care",
+	// so server-populated metadata fields on existing don't cause false diffs.
+	if equality.Semantic.DeepDerivative(desiredConfigMap, existingConfigMap) {
 		return nil
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package cabundleconfigmap
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler_test.go
@@ -23,9 +23,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	rtesting "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
@@ -482,5 +486,64 @@ func TestReconcileCaBundleConfigMap_Update(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestReconcileCaBundleConfigMap_NoUpdateWhenUnchanged(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	bundleData := map[string]string{"cabundle.crt": "TEST_BUNDLE"}
+
+	// Simulate an existing ConfigMap as it would appear from the API server -
+	// with server-populated metadata fields that the desired object won't have.
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cabundle",
+			Namespace:       "test-ns",
+			ResourceVersion: "12345",
+			UID:             "some-uid",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "some-controller",
+			},
+		},
+		Data: bundleData,
+	}
+
+	desiredCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cabundle",
+			Namespace: "test-ns",
+		},
+		Data: bundleData,
+	}
+
+	clientset := fake.NewSimpleClientset()
+	_, err := clientset.CoreV1().ConfigMaps(existingCM.Namespace).Create(t.Context(), existingCM, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating test configmap: %v", err)
+	}
+
+	// Track whether Update was called on the controller-runtime client.
+	// The reconciler uses clientset for Get but client for Update.
+	updateCalled := false
+	interceptor := rtesting.NewClientBuilder().WithScheme(scheme).WithObjects(existingCM).WithInterceptorFuncs(interceptor.Funcs{
+		Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			updateCalled = true
+			return client.Update(ctx, obj, opts...)
+		},
+	}).Build()
+	reconciler := &CaBundleConfigMapReconciler{
+		client:    interceptor,
+		clientset: clientset,
+	}
+
+	err = reconciler.ReconcileCaBundleConfigMap(t.Context(), desiredCM)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if updateCalled {
+		t.Errorf("Expected no update when data is unchanged, but Update was called")
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`ReconcileCaBundleConfigMap()` compares a minimal desired ConfigMap against the fully-populated existing object using `equality.Semantic.DeepEqual`. Despite the name, `Semantic.DeepEqual` compares all struct fields recursively - including server-populated metadata like `ResourceVersion`, `UID`, and `CreationTimestamp`. Since the desired object never has these fields set, the comparison always fails and every reconcile cycle produces an unnecessary Update call even when the Data is identical.

The fix replaces `DeepEqual` with `DeepDerivative`, which treats zero/nil fields in the first argument as "don't care". Server-populated metadata on the existing object no longer causes false diffs.

**Feature/Issue validation/testing**:

- [x] Unit test that creates a ConfigMap with server-populated metadata (ResourceVersion, UID, labels from another controller), reconciles with unchanged data, and asserts no Update call is made via interceptor
- [x] Full cabundle reconciler test suite passes

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release notes**:
```release-note
NONE
```