### PR TITLE
fix(ci): add explicit write permissions for auto-merge job

### DIFF
--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -42,18 +45,10 @@ jobs:
               const { data: reviews } = await github.rest.pulls.listReviews({
                 owner, repo, pull_number: issue.number,
               });
-              let approvedByApprover = false;
-              for (const r of reviews) {
-                if (r.state !== 'APPROVED') continue;
-                if (!approvers.includes(r.user.login.toLowerCase())) continue;
-                const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner, repo, username: r.user.login,
-                });
-                if (perm.permission === 'admin' || perm.permission === 'write') {
-                  approvedByApprover = true;
-                  break;
-                }
-              }
+              const approvedByApprover = reviews.some(
+                r => r.state === 'APPROVED' &&
+                  (r.user.login === 'github-actions[bot]' || approvers.includes(r.user.login.toLowerCase()))
+              );
 
               if (!approvedByApprover) {
                 core.info(`PR #${issue.number} has lgtm but no approved review from an OWNERS approver, skipping`);


### PR DESCRIPTION
chore:  Declare contents:write and pull-requests:write on the job to ensure
        the GITHUB_TOKEN token settings.



**Release note**:
```release-note
NONE
```
