### PR TITLE
fix(predictor): name kserve-container in multi-container CustomPredictor

### DIFF
--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -66,7 +66,18 @@ func (c *CustomPredictor) Default(config *InferenceServicesConfig) {
 	if len(c.Containers) == 0 {
 		c.Containers = append(c.Containers, corev1.Container{})
 	}
-	if len(c.Containers) == 1 || len(c.Containers[0].Name) == 0 {
+	// Ensure at least one container is named "kserve-container". GetContainer
+	// looks up the predictor container by this name, so when none of the
+	// user-supplied containers carry it the reconciler dereferences a nil
+	// pointer and panics (#4986).
+	hasKServeContainer := false
+	for _, container := range c.Containers {
+		if container.Name == constants.InferenceServiceContainerName {
+			hasKServeContainer = true
+			break
+		}
+	}
+	if !hasKServeContainer {
 		c.Containers[0].Name = constants.InferenceServiceContainerName
 	}
 	setResourceRequirementDefaults(config, &c.Containers[0].Resources)

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -219,6 +219,82 @@ func TestCustomPredictorDefaulter(t *testing.T) {
 				},
 			},
 		},
+		"MultipleContainersNoneNamedKServeContainer": {
+			// When the user supplies multiple containers (e.g. collocated
+			// predictor + transformer) but none is named "kserve-container",
+			// the defaulter must rename the first container to
+			// "kserve-container". Otherwise GetContainer returns nil and the
+			// reconciler panics with a nil pointer dereference (issue #4986).
+			spec: PredictorSpec{
+				PodSpec: PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "my-predictor",
+							Image: "custom-predictor:0.1.0",
+						},
+						{
+							Name:  constants.TransformerContainerName,
+							Image: "transformer:0.1.0",
+						},
+					},
+				},
+			},
+			expected: PredictorSpec{
+				PodSpec: PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "custom-predictor:0.1.0",
+							Resources: corev1.ResourceRequirements{
+								Requests: defaultResource,
+								Limits:   defaultResource,
+							},
+						},
+						{
+							Name:  constants.TransformerContainerName,
+							Image: "transformer:0.1.0",
+						},
+					},
+				},
+			},
+		},
+		"MultipleContainersFirstAlreadyNamedKServeContainer": {
+			// When the first container is already named "kserve-container",
+			// the defaulter must not touch any container name (collocation
+			// pattern).
+			spec: PredictorSpec{
+				PodSpec: PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "custom-predictor:0.1.0",
+						},
+						{
+							Name:  constants.TransformerContainerName,
+							Image: "transformer:0.1.0",
+						},
+					},
+				},
+			},
+			expected: PredictorSpec{
+				PodSpec: PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "custom-predictor:0.1.0",
+							Resources: corev1.ResourceRequirements{
+								Requests: defaultResource,
+								Limits:   defaultResource,
+							},
+						},
+						{
+							Name:  constants.TransformerContainerName,
+							Image: "transformer:0.1.0",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, scenario := range scenarios {


### PR DESCRIPTION
**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes
- [x] All commits are signed off

**Issue Link** : Fixes #4986

**Describe the changes**

When a `CustomPredictor` has two or more containers and none is named `kserve-container`, the defaulter left the spec unchanged, so KServe never identified its predictor container and the controller hit a nil-pointer dereference while reconciling the InferenceService.

This renames the first container to `kserve-container` only when no container already carries that name. The single-container path and the collocation case (a container already named `kserve-container`) are unchanged.

**Checklist:**
- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Are there any breaking changes? (No. Only the previously-panicking shape changes behavior)

### Test cases added

`TestCustomPredictorDefaulter` covers: multi-container with none named `kserve-container` (the panic-trigger shape, first container renamed); multi-container collocation with `kserve-container` already present (no rename); single unnamed container (renamed); single named container (no-op).
