### PR TITLE
fix(ci): stabilize version resolution in precommit

### DIFF
--- a/hack/setup/scripts/generate-versions-from-gomod.py
+++ b/hack/setup/scripts/generate-versions-from-gomod.py
@@ -106,7 +106,8 @@ def check_url_exists(url, timeout=5):
         req = Request(url, method="HEAD")
         with urllib.request.urlopen(req, timeout=timeout) as response:
             return 200 <= response.status < 400
-    except Exception:
+    except Exception as e:
+        print(f"    HEAD {url} failed: {e}")
         return False
 
 
@@ -114,8 +115,17 @@ def build_release_url(github_repo, version, filename):
     return f"https://github.com/{github_repo}/releases/download/{version}/{filename}"
 
 
-def find_available_version_with_url(base_version, github_repo, filename):
-    """Find closest version in same minor version (X.Y.z) with existing URL"""
+def find_available_version_with_url(
+    base_version, github_repo, filename, existing_version=None
+):
+    """Find closest version in same minor version (X.Y.z) with existing URL.
+
+    When base_version is a pseudo-version that doesn't have a release artifact,
+    the existing kserve-deps.env value is checked first - if it's in the same
+    minor series and its URL still works, it's reused without querying the
+    GitHub releases API. This avoids flaky HEAD-request failures in CI causing
+    version downgrades.
+    """
     if check_url_exists(build_release_url(github_repo, base_version, filename)):
         return base_version, True
 
@@ -123,6 +133,16 @@ def find_available_version_with_url(base_version, github_repo, filename):
         major, minor, patch = parse_semver(base_version)
     except Exception:
         return base_version, False
+
+    if existing_version:
+        try:
+            e_major, e_minor, _ = parse_semver(existing_version)
+            if (e_major, e_minor) == (major, minor) and check_url_exists(
+                build_release_url(github_repo, existing_version, filename)
+            ):
+                return existing_version, True
+        except Exception:
+            pass
 
     try:
         api_url = f"https://api.github.com/repos/{github_repo}/releases"
@@ -255,11 +275,17 @@ def main():
         else:
             raw_version = f"v{app_version}"
             base_version = strip_pseudo_version(raw_version)
+            is_pseudo = base_version != raw_version
 
             if url_verify:
                 github_repo, filename = url_verify
                 final_version, url_found = find_available_version_with_url(
-                    base_version, github_repo, filename
+                    base_version,
+                    github_repo,
+                    filename,
+                    existing_version=existing_versions.get(var_name)
+                    if is_pseudo
+                    else None,
                 )
                 if url_found:
                     if final_version == base_version:


### PR DESCRIPTION
**What this PR does / why we need it**:

The precommit check was intermittently failing in CI because `generate-versions-from-gomod.py` re-resolved dependency versions from scratch on every run. For pseudo-versions (e.g. `gateway-api v1.4.2-0.xxx`), the script queries the GitHub releases API and HEAD-checks each candidate's download URL. A transient HEAD-check failure caused it to skip the correct version (`v1.4.1`) and fall back to an older one (`v1.4.0`), producing a spurious diff against the committed `kserve-deps.env`.

Two changes:

- **Prefer existing `kserve-deps.env` value for pseudo-versions** - when the go.mod version is a pseudo-version and the base version has no release artifact, the script now checks whether the existing value is in the same minor series and its URL still verifies. If so, it's reused without hitting the releases API. For real release versions, the full resolution path is preserved to catch actual drift.

- **Log URL check failures** - `check_url_exists` was silently swallowing all exceptions, making it impossible to diagnose why CI picked a wrong version. Failures are now printed so the root cause is visible.

**Feature/Issue validation/testing**:

- [x] Verified script resolves `GATEWAY_API_VERSION=v1.4.1` correctly with `--no-cache`
- [x] Verified URL check failure logging works (404 for non-existent v1.4.2 release is now printed)

**Special notes for your reviewer**:

The pseudo-version detection uses the same regex as `strip_pseudo_version` - if the stripped version differs from the raw version, it's a pseudo-version. Only pseudo-versions get the existing-value shortcut; real releases always go through full resolution to preserve drift detection. We could use `go list` to get full json of deps instead and know exactly what we are dealing with, but it's a bigger change.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```