### PR TITLE
fix(llmisvc): set workload service appProtocol based on TLS config

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -96,7 +96,7 @@ func (r *LLMISVCReconciler) reconcileWorkload(ctx context.Context, llmSvc *v1alp
 	}
 
 	// Create Service to expose workload pods
-	if err := r.reconcileWorkloadService(ctx, llmSvc); err != nil {
+	if err := r.reconcileWorkloadService(ctx, llmSvc, config); err != nil {
 		llmSvc.MarkMainWorkloadNotReady("ReconcileWorkloadServiceError", err.Error())
 		return fmt.Errorf("failed to reconcile workload service: %w", err)
 	}
@@ -117,7 +117,11 @@ func (r *LLMISVCReconciler) reconcileWorkload(ctx context.Context, llmSvc *v1alp
 	return nil
 }
 
-func (r *LLMISVCReconciler) reconcileWorkloadService(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
+func (r *LLMISVCReconciler) reconcileWorkloadService(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
+	workloadServiceProtocol := "http"
+	if config != nil && config.EnableTLS {
+		workloadServiceProtocol = "https"
+	}
 	expected := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"),
@@ -142,9 +146,9 @@ func (r *LLMISVCReconciler) reconcileWorkloadService(ctx context.Context, llmSvc
 			// "main receiver" port.
 			Ports: []corev1.ServicePort{
 				{
-					Name:        "https",
+					Name:        workloadServiceProtocol,
 					Protocol:    corev1.ProtocolTCP,
-					AppProtocol: ptr.To("https"),
+					AppProtocol: ptr.To(workloadServiceProtocol),
 					Port:        8000,
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.Int,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the LLMInferenceService workload Service port metadata to respect `config.EnableTLS`.

Previously, the workload Service was always generated with:

```go
Name:        "https",
AppProtocol: ptr.To("https"),
```

even when the vLLM workload was deployed without TLS and served plain HTTP on port 8000.

With Gateway API implementations such as Traefik, appProtocol: https can make the gateway treat the workload Service as an HTTPS upstream. This causes backend TLS failures for non-TLS vLLM workloads.

This PR sets the workload Service port name and appProtocol to:

- http when config.EnableTLS is false
- https when config.EnableTLS is true

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:

Fixes #5531

**Feature/Issue validation/testing**:

Manually verified with a non-TLS vLLM backend:

- HTTP request to the workload Service succeeds:
  - `curl http://facebook-opt-125m-single-kserve-workload-svc:8000/v1/models`

  - returns `200 OK`

- HTTPS request to the same non-TLS workload Service fails:
  - `curl -vk https://facebook-opt-125m-single-kserve-workload-svc:8000/v1/models`

  - fails with `wrong version number`

- After changing the generated Service metadata from `https` to `http`, the Traefik Gateway API path succeeds:
  - `curl http://172.16.200.184/kserve-test/facebook-opt-125m-single/v1/models`

  - returns `200 OK`

Local test:

```bash

go test ./pkg/controller/v1alpha2/llmisvc/...
ok      github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc 250.805s
?       github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture [no test files]
```

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

This change preserves the existing `https` Service metadata when LLMInferenceService TLS is enabled, while avoiding advertising HTTPS for non-TLS vLLM workloads.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
LLMInferenceService workload Service port metadata now respects the TLS configuration, using HTTP metadata for non-TLS workloads and HTTPS metadata when TLS is enabled.
```
