### PR TITLE
fix: move tidy after generate in precommit to fix go.sum instability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ sync-helm-multi-resource-helpers:
 	done
 
 # This runs all necessary steps to prepare for a commit.
-precommit: ensure-go-version-upgrade sync-deps sync-img-env vet tidy go-lint py-fmt py-lint generate manifests uv-lock generate-quick-install-scripts generate-chart-manifests sync-helm-common-helpers sync-helm-common-resource-helpers sync-helm-multi-resource-helpers verify-pinned-actions verify-minimal-crd-sync
+precommit: ensure-go-version-upgrade sync-deps sync-img-env vet go-lint py-fmt py-lint generate tidy manifests uv-lock generate-quick-install-scripts generate-chart-manifests sync-helm-common-helpers sync-helm-common-resource-helpers sync-helm-multi-resource-helpers verify-pinned-actions verify-minimal-crd-sync
 
 # This is used by CI to ensure that the precommit checks are met.
 check: precommit


### PR DESCRIPTION
## Summary

- Move `tidy` to run after `generate` in the `precommit` Makefile target
- The `generate` target calls `go run` (via `hack/update-openapigen.sh`) which can re-add transitive dependency entries to `go.sum`
- Previously `tidy` ran before `generate`, so those entries persisted and caused `precommit-check` CI failures depending on Go module cache state
- Now `tidy` runs after `generate`, ensuring `go.sum` is always in its canonical tidied state

## Test plan

- [x] Ran `make precommit` locally — only the Makefile change shows in `git diff`