### PR TITLE
fix: prevent ClusterStorageContainer CRD deletion on helm upgrade

### DIFF
--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_clusterstoragecontainers.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_clusterstoragecontainers.yaml
@@ -1,4 +1,11 @@
 {{- $existing := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterstoragecontainers.serving.kserve.io" -}}
-{{- if not $existing }}
+{{- $render := true -}}
+{{- if $existing -}}
+  {{- $owner := get (default dict $existing.metadata.annotations) "meta.helm.sh/release-name" -}}
+  {{- if and $owner (ne $owner .Release.Name) -}}
+    {{- $render = false -}}
+  {{- end -}}
+{{- end -}}
+{{- if $render }}
 {{ .Files.Get "files/serving.kserve.io_clusterstoragecontainers.yaml" }}
 {{- end }}

--- a/charts/kserve-crd/templates/serving.kserve.io_clusterstoragecontainers.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_clusterstoragecontainers.yaml
@@ -1,4 +1,11 @@
 {{- $existing := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterstoragecontainers.serving.kserve.io" -}}
-{{- if not $existing }}
+{{- $render := true -}}
+{{- if $existing -}}
+  {{- $owner := get (default dict $existing.metadata.annotations) "meta.helm.sh/release-name" -}}
+  {{- if and $owner (ne $owner .Release.Name) -}}
+    {{- $render = false -}}
+  {{- end -}}
+{{- end -}}
+{{- if $render }}
 {{ .Files.Get "files/serving.kserve.io_clusterstoragecontainers.yaml" }}
 {{- end }}

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_clusterstoragecontainers.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_clusterstoragecontainers.yaml
@@ -1,4 +1,11 @@
 {{- $existing := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterstoragecontainers.serving.kserve.io" -}}
-{{- if not $existing }}
+{{- $render := true -}}
+{{- if $existing -}}
+  {{- $owner := get (default dict $existing.metadata.annotations) "meta.helm.sh/release-name" -}}
+  {{- if and $owner (ne $owner .Release.Name) -}}
+    {{- $render = false -}}
+  {{- end -}}
+{{- end -}}
+{{- if $render }}
 {{ .Files.Get "files/serving.kserve.io_clusterstoragecontainers.yaml" }}
 {{- end }}

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_clusterstoragecontainers.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_clusterstoragecontainers.yaml
@@ -1,4 +1,11 @@
 {{- $existing := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "clusterstoragecontainers.serving.kserve.io" -}}
-{{- if not $existing }}
+{{- $render := true -}}
+{{- if $existing -}}
+  {{- $owner := get (default dict $existing.metadata.annotations) "meta.helm.sh/release-name" -}}
+  {{- if and $owner (ne $owner .Release.Name) -}}
+    {{- $render = false -}}
+  {{- end -}}
+{{- end -}}
+{{- if $render }}
 {{ .Files.Get "files/serving.kserve.io_clusterstoragecontainers.yaml" }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
  
  The ClusterStorageContainer CRD template uses a lookup guard that skips rendering when the CRD already exists. On helm upgrade, Helm sees the  CRD is missing from the rendered manifest and deletes it — cascading to all ClusterStorageContainer instances.

  This replaces the guard with an ownership check: only skip rendering when the CRD is owned by a different Helm release. If the CRD doesn't exist or belongs to the current release, it renders normally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5534


**Feature/Issue validation/testing**:

## Manual Test Guide

### Setup

```bash
# Create a kind cluster
kind create cluster --name kserve-crd-test

# Clone kserve repo and checkout the fix branch
git clone https://github.com/Jooho/kserve --branch fix/crd-lookup-guard-ownership /tmp/kserve-src
cd /tmp/kserve-src
# Apply the fix to the 4 CRD template files (or checkout the fix branch)

# Extract v0.16.0 chart for baseline install
mkdir -p /tmp/kserve-v0.16.0
git archive v0.16.0 charts/kserve-crd | tar -x -C /tmp/kserve-v0.16.0
```

### Cleanup (run before/after tests)

```bash
helm uninstall kserve-llmisvc-crd -n kserve 2>/dev/null
helm uninstall kserve-crd -n kserve 2>/dev/null
kubectl delete crd clusterstoragecontainers.serving.kserve.io 2>/dev/null
kubectl delete ns kserve 2>/dev/null
```

### Test 1: Install v0.16.0, create CSC resource, upgrade to fixed chart — CRD and CSC should be preserved

```bash
# Install v0.16.0 (no lookup guard, CRD rendered directly)
helm install kserve-crd /tmp/kserve-v0.16.0/charts/kserve-crd \
  -n kserve --create-namespace

# Verify: CRD exists, owned by kserve-crd
kubectl get crd clusterstoragecontainers.serving.kserve.io
kubectl get crd clusterstoragecontainers.serving.kserve.io \
  -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}'
# Expected: kserve-crd

# Create a ClusterStorageContainer resource (simulates kserve-resources install)
kubectl apply -f - <<'EOF'
apiVersion: serving.kserve.io/v1alpha1
kind: ClusterStorageContainer
metadata:
  name: default
spec:
  container:
    name: storage-initializer
    image: kserve/storage-initializer:v0.16.0
    resources:
      requests:
        memory: 100Mi
  supportedUriFormats:
    - prefix: gs://
    - prefix: s3://
    - prefix: hdfs://
EOF

# Verify: CSC resource exists
kubectl get clusterstoragecontainers
# Expected: "default" resource listed

# Upgrade to the fixed local chart(0.18)
helm upgrade kserve-crd /tmp/kserve-src/charts/kserve-crd -n kserve

# Verify: CRD and CSC both still exist after upgrade
kubectl get crd clusterstoragecontainers.serving.kserve.io
kubectl get crd clusterstoragecontainers.serving.kserve.io \
  -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}'
kubectl get clusterstoragecontainers
# Expected: CRD exists (owner kserve-crd), CSC "default" still present
```

### Test 2: Install kserve-llmisvc-crd — shared CRD should be skipped

```bash
# Install kserve-llmisvc-crd (shares the same ClusterStorageContainer CRD)
helm install kserve-llmisvc-crd /tmp/kserve-src/charts/kserve-llmisvc-crd \
  -n kserve

# Verify: CRD owner unchanged
kubectl get crd clusterstoragecontainers.serving.kserve.io \
  -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}'
# Expected: kserve-crd (unchanged — llmisvc-crd skipped rendering)
```

### Test 3: Upgrade kserve-llmisvc-crd — CRD and CSC must NOT be deleted (core bug regression)

```bash
helm upgrade kserve-llmisvc-crd /tmp/kserve-src/charts/kserve-llmisvc-crd \
  -n kserve

# Verify: CRD still exists, owner unchanged, CSC resource survives
kubectl get crd clusterstoragecontainers.serving.kserve.io
kubectl get crd clusterstoragecontainers.serving.kserve.io \
  -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}'
kubectl get clusterstoragecontainers
# Expected: CRD exists, owner kserve-crd, CSC "default" still present
```

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note

```
