### PR TITLE
feat(llmisvc): bubble up HPA/KEDA scaling status to service conditions

### DIFF
--- a/pkg/apis/serving/v1alpha2/llm_inference_service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_lifecycle.go
@@ -32,6 +32,8 @@ const (
 	WorkerWorkloadReady        apis.ConditionType = "WorkerWorkloadReady"
 	PrefillWorkloadReady       apis.ConditionType = "PrefillWorkloadReady"
 	PrefillWorkerWorkloadReady apis.ConditionType = "PrefillWorkerWorkloadReady"
+	ScalingReady               apis.ConditionType = "ScalingReady"
+	PrefillScalingReady        apis.ConditionType = "PrefillScalingReady"
 )
 
 const (
@@ -105,12 +107,46 @@ func (in *LLMInferenceService) MarkPrefillWorkerWorkloadUnset() {
 	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(PrefillWorkerWorkloadReady)
 }
 
+func (in *LLMInferenceService) MarkScalingReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(ScalingReady)
+}
+
+func (in *LLMInferenceService) MarkScalingNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(ScalingReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkScalingUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(ScalingReady)
+}
+
+func (in *LLMInferenceService) MarkPrefillScalingReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(PrefillScalingReady)
+}
+
+func (in *LLMInferenceService) MarkPrefillScalingNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(PrefillScalingReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkPrefillScalingUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(PrefillScalingReady)
+}
+
+// DetermineWorkloadReadiness rolls up sub-conditions into the top-level WorkloadsReady
+// condition. Any sub-condition that is False blocks overall readiness.
+//
+// ScalingReady and PrefillScalingReady are included in the rollup because a misconfigured
+// autoscaler (e.g. broken metrics pipeline) should surface as a service-level issue.
+// When scaling is not configured, the controller calls MarkScalingUnset / MarkPrefillScalingUnset
+// which clears the condition entirely — GetCondition returns nil, and nil entries are
+// skipped by the loop below. This means unconfigured scaling never blocks readiness.
 func (in *LLMInferenceService) DetermineWorkloadReadiness() {
 	subConditions := []*apis.Condition{
 		in.GetStatus().GetCondition(MainWorkloadReady),
 		in.GetStatus().GetCondition(WorkerWorkloadReady),
 		in.GetStatus().GetCondition(PrefillWorkloadReady),
 		in.GetStatus().GetCondition(PrefillWorkerWorkloadReady),
+		in.GetStatus().GetCondition(ScalingReady),
+		in.GetStatus().GetCondition(PrefillScalingReady),
 	}
 
 	for _, cond := range subConditions {

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types_func_test.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types_func_test.go
@@ -19,8 +19,10 @@ package v1alpha2
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 )
@@ -499,4 +501,109 @@ func TestIsUsingLLMInferenceServiceConfigInNamespace(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestLLMISVC() *LLMInferenceService {
+	svc := &LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+		Status: LLMInferenceServiceStatus{
+			Status: duckv1.Status{},
+		},
+	}
+	svc.GetConditionSet().Manage(svc.GetStatus()).InitializeConditions()
+	return svc
+}
+
+func getConditionStatus(svc *LLMInferenceService, ct apis.ConditionType) string {
+	cond := svc.GetStatus().GetCondition(ct)
+	if cond == nil {
+		return "nil"
+	}
+	return string(cond.Status)
+}
+
+func TestDetermineWorkloadReadiness_ScalingConditions(t *testing.T) {
+	t.Run("ScalingReady=False blocks WorkloadsReady", func(t *testing.T) {
+		svc := newTestLLMISVC()
+		svc.MarkMainWorkloadReady()
+		svc.MarkScalingNotReady("FailedGetExternalMetric", "metric not found")
+
+		svc.DetermineWorkloadReadiness()
+
+		assert.Equal(t, "False", getConditionStatus(svc, WorkloadReady))
+		cond := svc.GetStatus().GetCondition(WorkloadReady)
+		assert.Equal(t, "FailedGetExternalMetric", cond.Reason)
+	})
+
+	t.Run("PrefillScalingReady=False blocks WorkloadsReady", func(t *testing.T) {
+		svc := newTestLLMISVC()
+		svc.MarkMainWorkloadReady()
+		svc.MarkScalingReady()
+		svc.MarkPrefillScalingNotReady("TriggerError", "prometheus query failed")
+
+		svc.DetermineWorkloadReadiness()
+
+		assert.Equal(t, "False", getConditionStatus(svc, WorkloadReady))
+		cond := svc.GetStatus().GetCondition(WorkloadReady)
+		assert.Equal(t, "TriggerError", cond.Reason)
+	})
+
+	t.Run("all conditions ready including scaling -> WorkloadsReady=True", func(t *testing.T) {
+		svc := newTestLLMISVC()
+		svc.MarkMainWorkloadReady()
+		svc.MarkScalingReady()
+
+		svc.DetermineWorkloadReadiness()
+
+		assert.Equal(t, "True", getConditionStatus(svc, WorkloadReady))
+	})
+
+	t.Run("absent ScalingReady does not block WorkloadsReady", func(t *testing.T) {
+		svc := newTestLLMISVC()
+		svc.MarkMainWorkloadReady()
+
+		svc.DetermineWorkloadReadiness()
+
+		assert.Equal(t, "True", getConditionStatus(svc, WorkloadReady))
+	})
+
+	t.Run("absent PrefillScalingReady does not block WorkloadsReady", func(t *testing.T) {
+		svc := newTestLLMISVC()
+		svc.MarkMainWorkloadReady()
+		svc.MarkScalingReady()
+
+		svc.DetermineWorkloadReadiness()
+
+		assert.Equal(t, "True", getConditionStatus(svc, WorkloadReady))
+	})
+
+	t.Run("MarkScalingUnset clears the condition", func(t *testing.T) {
+		svc := newTestLLMISVC()
+		svc.MarkScalingNotReady("test", "msg")
+		assert.Equal(t, "False", getConditionStatus(svc, ScalingReady))
+
+		svc.MarkScalingUnset()
+		assert.Equal(t, "nil", getConditionStatus(svc, ScalingReady))
+	})
+
+	t.Run("MarkPrefillScalingUnset clears the condition", func(t *testing.T) {
+		svc := newTestLLMISVC()
+		svc.MarkPrefillScalingNotReady("test", "msg")
+		assert.Equal(t, "False", getConditionStatus(svc, PrefillScalingReady))
+
+		svc.MarkPrefillScalingUnset()
+		assert.Equal(t, "nil", getConditionStatus(svc, PrefillScalingReady))
+	})
+
+	t.Run("MainWorkloadReady=False takes priority over ScalingReady=False", func(t *testing.T) {
+		svc := newTestLLMISVC()
+		svc.MarkMainWorkloadNotReady("DeploymentUnavailable", "pods crashing")
+		svc.MarkScalingNotReady("FailedGetExternalMetric", "metric not found")
+
+		svc.DetermineWorkloadReadiness()
+
+		assert.Equal(t, "False", getConditionStatus(svc, WorkloadReady))
+		cond := svc.GetStatus().GetCondition(WorkloadReady)
+		assert.Equal(t, "DeploymentUnavailable", cond.Reason, "MainWorkloadReady comes first in order")
+	})
 }

--- a/pkg/controller/v1alpha2/llmisvc/scaling.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling.go
@@ -26,6 +26,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -267,6 +268,10 @@ func (r *LLMISVCReconciler) propagateScalingStatus(ctx context.Context, llmSvc *
 func (r *LLMISVCReconciler) propagateHPAStatus(ctx context.Context, expected *autoscalingv2.HorizontalPodAutoscaler, ready func(), notReady func(reason, messageFormat string, messageA ...interface{})) error {
 	curr := &autoscalingv2.HorizontalPodAutoscaler{}
 	if err := r.Get(ctx, client.ObjectKeyFromObject(expected), curr); err != nil {
+		if apierrors.IsNotFound(err) {
+			notReady("HPAProgressing", "HPA not yet visible in cache")
+			return nil
+		}
 		return fmt.Errorf("failed to get current HPA %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
 	}
 
@@ -313,6 +318,10 @@ func (r *LLMISVCReconciler) propagateHPAStatus(ctx context.Context, expected *au
 func (r *LLMISVCReconciler) propagateScaledObjectStatus(ctx context.Context, expected *kedav1alpha1.ScaledObject, ready func(), notReady func(reason, messageFormat string, messageA ...interface{})) error {
 	curr := &kedav1alpha1.ScaledObject{}
 	if err := r.Get(ctx, client.ObjectKeyFromObject(expected), curr); err != nil {
+		if apierrors.IsNotFound(err) {
+			notReady("ScaledObjectProgressing", "ScaledObject not yet visible in cache")
+			return nil
+		}
 		return fmt.Errorf("failed to get current ScaledObject %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/scaling.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling.go
@@ -264,7 +264,7 @@ func (r *LLMISVCReconciler) propagateScalingStatus(ctx context.Context, llmSvc *
 
 // propagateHPAStatus reads the live HPA status and maps its conditions to a ScalingReady
 // condition on the LLMInferenceService. AbleToScale=False or ScalingActive=False means the
-// metrics pipeline is broken; ScalingLimited is informational (scaling works but is capped).
+// metrics pipeline is broken and sets ScalingReady=False.
 func (r *LLMISVCReconciler) propagateHPAStatus(ctx context.Context, expected *autoscalingv2.HorizontalPodAutoscaler, ready func(), notReady func(reason, messageFormat string, messageA ...interface{})) error {
 	curr := &autoscalingv2.HorizontalPodAutoscaler{}
 	if err := r.Get(ctx, client.ObjectKeyFromObject(expected), curr); err != nil {
@@ -279,25 +279,11 @@ func (r *LLMISVCReconciler) propagateHPAStatus(ctx context.Context, expected *au
 
 	for _, cond := range curr.Status.Conditions {
 		switch cond.Type {
-		case autoscalingv2.AbleToScale:
+		case autoscalingv2.AbleToScale, autoscalingv2.ScalingActive:
 			foundAny = true
 			if cond.Status == corev1.ConditionFalse {
 				notReady(cond.Reason, cond.Message)
 				return nil
-			}
-		case autoscalingv2.ScalingActive:
-			foundAny = true
-			if cond.Status == corev1.ConditionFalse {
-				notReady(cond.Reason, cond.Message)
-				return nil
-			}
-		case autoscalingv2.ScalingLimited:
-			// ScalingLimited=True is informational: the HPA is functioning but capped at
-			// min or max replicas. This is not a failure — scaling is still healthy — so we
-			// emit an event rather than marking ScalingReady=False. The event is visible via
-			// `kubectl describe llminferenceservice` in the Events section.
-			if cond.Status == corev1.ConditionTrue {
-				r.Eventf(expected, corev1.EventTypeNormal, "ScalingLimited", "HPA is at scaling limit: %s", cond.Message)
 			}
 		}
 	}
@@ -313,8 +299,7 @@ func (r *LLMISVCReconciler) propagateHPAStatus(ctx context.Context, expected *au
 
 // propagateScaledObjectStatus reads the live KEDA ScaledObject status and maps its conditions
 // to a ScalingReady condition on the LLMInferenceService. Ready=False means a trigger/config
-// issue; Paused=True means scaling is paused; Fallback=True is a soft warning (scaling degraded
-// but still operating).
+// issue and sets ScalingReady=False.
 func (r *LLMISVCReconciler) propagateScaledObjectStatus(ctx context.Context, expected *kedav1alpha1.ScaledObject, ready func(), notReady func(reason, messageFormat string, messageA ...interface{})) error {
 	curr := &kedav1alpha1.ScaledObject{}
 	if err := r.Get(ctx, client.ObjectKeyFromObject(expected), curr); err != nil {
@@ -331,12 +316,6 @@ func (r *LLMISVCReconciler) propagateScaledObjectStatus(ctx context.Context, exp
 		return nil
 	}
 
-	pausedCond := conditions.GetPausedCondition()
-	if pausedCond.Status == metav1.ConditionTrue {
-		notReady(pausedCond.Reason, pausedCond.Message)
-		return nil
-	}
-
 	readyCond := conditions.GetReadyCondition()
 	if readyCond.Status == metav1.ConditionFalse {
 		notReady(readyCond.Reason, readyCond.Message)
@@ -346,12 +325,6 @@ func (r *LLMISVCReconciler) propagateScaledObjectStatus(ctx context.Context, exp
 	if readyCond.Status != metav1.ConditionTrue {
 		notReady("ScaledObjectProgressing", "ScaledObject is not yet ready")
 		return nil
-	}
-
-	fallbackCond := conditions.GetFallbackCondition()
-	if fallbackCond.Status == metav1.ConditionTrue {
-		r.Eventf(expected, corev1.EventTypeWarning, "ScaledObjectFallback",
-			"ScaledObject is using fallback replicas: %s", fallbackCond.Message)
 	}
 
 	ready()

--- a/pkg/controller/v1alpha2/llmisvc/scaling.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling.go
@@ -24,11 +24,13 @@ import (
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	wvav1alpha1 "github.com/llm-d/llm-d-workload-variant-autoscaler/api/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -54,58 +56,81 @@ func (r *LLMISVCReconciler) reconcileScaling(ctx context.Context, llmSvc *v1alph
 	logger := log.FromContext(ctx).WithName("reconcileScaling")
 	ctx = log.IntoContext(ctx, logger)
 
-	if err := r.reconcileMainWorkloadScaling(ctx, llmSvc, config); err != nil {
+	if err := r.reconcileWorkloadScaling(ctx, llmSvc, config, mainWorkloadScalingParams(llmSvc)); err != nil {
 		return fmt.Errorf("failed to reconcile main workload scaling: %w", err)
 	}
 
-	if err := r.reconcilePrefillWorkloadScaling(ctx, llmSvc, config); err != nil {
+	if err := r.reconcileWorkloadScaling(ctx, llmSvc, config, prefillWorkloadScalingParams(llmSvc)); err != nil {
 		return fmt.Errorf("failed to reconcile prefill workload scaling: %w", err)
 	}
 
 	return nil
 }
 
-// reconcileMainWorkloadScaling handles scaling for the main (decode) workload.
-func (r *LLMISVCReconciler) reconcileMainWorkloadScaling(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
-	scaleTargetRef := mainScaleTargetRef(llmSvc)
-	vaName := mainVAName(llmSvc)
-	scaling := llmSvc.Spec.Scaling
-
-	if err := r.reconcileVA(ctx, llmSvc, scaling, scaleTargetRef, vaName, llmSvc.Spec.Labels); err != nil {
-		return fmt.Errorf("failed to reconcile main VA: %w", err)
-	}
-
-	if err := r.reconcileActuator(ctx, llmSvc, scaling, config, scaleTargetRef, vaName, mainHPAName(llmSvc), mainScaledObjectName(llmSvc)); err != nil {
-		return fmt.Errorf("failed to reconcile main actuator: %w", err)
-	}
-
-	return nil
+// workloadScalingParams captures the per-workload differences between main and prefill
+// scaling so that reconcileWorkloadScaling can handle both without duplication.
+type workloadScalingParams struct {
+	name             string
+	scaling          *v1alpha2.ScalingSpec
+	scaleTargetRef   autoscalingv2.CrossVersionObjectReference
+	vaName           string
+	hpaName          string
+	scaledObjectName string
+	workloadLabels   map[string]string
+	markReady        func()
+	markNotReady     func(reason, messageFormat string, messageA ...interface{})
+	markUnset        func()
 }
 
-// reconcilePrefillWorkloadScaling handles scaling for the prefill workload in disaggregated deployments.
-func (r *LLMISVCReconciler) reconcilePrefillWorkloadScaling(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
+func mainWorkloadScalingParams(llmSvc *v1alpha2.LLMInferenceService) workloadScalingParams {
+	return workloadScalingParams{
+		name:             "main",
+		scaling:          llmSvc.Spec.Scaling,
+		scaleTargetRef:   mainScaleTargetRef(llmSvc),
+		vaName:           mainVAName(llmSvc),
+		hpaName:          mainHPAName(llmSvc),
+		scaledObjectName: mainScaledObjectName(llmSvc),
+		workloadLabels:   llmSvc.Spec.Labels,
+		markReady:        llmSvc.MarkScalingReady,
+		markNotReady:     llmSvc.MarkScalingNotReady,
+		markUnset:        llmSvc.MarkScalingUnset,
+	}
+}
+
+func prefillWorkloadScalingParams(llmSvc *v1alpha2.LLMInferenceService) workloadScalingParams {
 	var scaling *v1alpha2.ScalingSpec
+	var labels map[string]string
 	if llmSvc.Spec.Prefill != nil {
 		scaling = llmSvc.Spec.Prefill.Scaling
+		labels = llmSvc.Spec.Prefill.Labels
+	}
+	return workloadScalingParams{
+		name:             "prefill",
+		scaling:          scaling,
+		scaleTargetRef:   prefillScaleTargetRef(llmSvc),
+		vaName:           prefillVAName(llmSvc),
+		hpaName:          prefillHPAName(llmSvc),
+		scaledObjectName: prefillScaledObjectName(llmSvc),
+		workloadLabels:   labels,
+		markReady:        llmSvc.MarkPrefillScalingReady,
+		markNotReady:     llmSvc.MarkPrefillScalingNotReady,
+		markUnset:        llmSvc.MarkPrefillScalingUnset,
+	}
+}
+
+// reconcileWorkloadScaling reconciles all scaling resources (VA, actuator) and propagates
+// status for a single workload (main or prefill). The workloadScalingParams struct captures
+// all per-workload differences so this method does not need to know which workload it is handling.
+func (r *LLMISVCReconciler) reconcileWorkloadScaling(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config, p workloadScalingParams) error {
+	if err := r.reconcileVA(ctx, llmSvc, p.scaling, p.scaleTargetRef, p.vaName, p.workloadLabels); err != nil {
+		return fmt.Errorf("failed to reconcile %s VA: %w", p.name, err)
 	}
 
-	scaleTargetRef := prefillScaleTargetRef(llmSvc)
-	vaName := prefillVAName(llmSvc)
-
-	var prefillLabels map[string]string
-	if llmSvc.Spec.Prefill != nil {
-		prefillLabels = llmSvc.Spec.Prefill.Labels
+	if err := r.reconcileActuator(ctx, llmSvc, p.scaling, config, p.scaleTargetRef, p.vaName, p.hpaName, p.scaledObjectName); err != nil {
+		return fmt.Errorf("failed to reconcile %s actuator: %w", p.name, err)
 	}
 
-	if err := r.reconcileVA(ctx, llmSvc, scaling, scaleTargetRef, vaName, prefillLabels); err != nil {
-		return fmt.Errorf("failed to reconcile prefill VA: %w", err)
-	}
-
-	if err := r.reconcileActuator(ctx, llmSvc, scaling, config, scaleTargetRef, vaName, prefillHPAName(llmSvc), prefillScaledObjectName(llmSvc)); err != nil {
-		return fmt.Errorf("failed to reconcile prefill actuator: %w", err)
-	}
-
-	return nil
+	return r.propagateScalingStatus(ctx, llmSvc, p.scaling, p.hpaName, p.scaledObjectName, p.markReady, p.markNotReady, p.markUnset)
 }
 
 // reconcileHPA creates or updates an HPA for the workload, or deletes it when not needed.
@@ -200,6 +225,128 @@ func (r *LLMISVCReconciler) reconcileActuator(ctx context.Context, llmSvc *v1alp
 	}
 
 	return r.reconcileHPA(ctx, llmSvc, scaling, isStopped, scaleTargetRef, vaName, hpaName)
+}
+
+// propagateScalingStatus determines which actuator is active and propagates its status.
+// When no scaling is configured (or the service is stopped), the condition is cleared.
+func (r *LLMISVCReconciler) propagateScalingStatus(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, scaling *v1alpha2.ScalingSpec, hpaName, scaledObjectName string, ready func(), notReady func(reason, messageFormat string, messageA ...interface{}), unset func()) error {
+	isStopped := utils.GetForceStopRuntime(llmSvc)
+
+	if scaling == nil || scaling.WVA == nil || isStopped {
+		unset()
+		return nil
+	}
+
+	if scaling.WVA.HPA != nil {
+		expected := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hpaName,
+				Namespace: llmSvc.GetNamespace(),
+			},
+		}
+		return r.propagateHPAStatus(ctx, expected, ready, notReady)
+	}
+
+	if scaling.WVA.KEDA != nil {
+		expected := &kedav1alpha1.ScaledObject{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      scaledObjectName,
+				Namespace: llmSvc.GetNamespace(),
+			},
+		}
+		return r.propagateScaledObjectStatus(ctx, expected, ready, notReady)
+	}
+
+	unset()
+	return nil
+}
+
+// propagateHPAStatus reads the live HPA status and maps its conditions to a ScalingReady
+// condition on the LLMInferenceService. AbleToScale=False or ScalingActive=False means the
+// metrics pipeline is broken; ScalingLimited is informational (scaling works but is capped).
+func (r *LLMISVCReconciler) propagateHPAStatus(ctx context.Context, expected *autoscalingv2.HorizontalPodAutoscaler, ready func(), notReady func(reason, messageFormat string, messageA ...interface{})) error {
+	curr := &autoscalingv2.HorizontalPodAutoscaler{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(expected), curr); err != nil {
+		return fmt.Errorf("failed to get current HPA %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
+	}
+
+	foundAny := false
+
+	for _, cond := range curr.Status.Conditions {
+		switch cond.Type {
+		case autoscalingv2.AbleToScale:
+			foundAny = true
+			if cond.Status == corev1.ConditionFalse {
+				notReady(cond.Reason, cond.Message)
+				return nil
+			}
+		case autoscalingv2.ScalingActive:
+			foundAny = true
+			if cond.Status == corev1.ConditionFalse {
+				notReady(cond.Reason, cond.Message)
+				return nil
+			}
+		case autoscalingv2.ScalingLimited:
+			// ScalingLimited=True is informational: the HPA is functioning but capped at
+			// min or max replicas. This is not a failure — scaling is still healthy — so we
+			// emit an event rather than marking ScalingReady=False. The event is visible via
+			// `kubectl describe llminferenceservice` in the Events section.
+			if cond.Status == corev1.ConditionTrue {
+				r.Eventf(expected, corev1.EventTypeNormal, "ScalingLimited", "HPA is at scaling limit: %s", cond.Message)
+			}
+		}
+	}
+
+	if !foundAny {
+		notReady("HPAProgressing", "HPA conditions not yet available")
+		return nil
+	}
+
+	ready()
+	return nil
+}
+
+// propagateScaledObjectStatus reads the live KEDA ScaledObject status and maps its conditions
+// to a ScalingReady condition on the LLMInferenceService. Ready=False means a trigger/config
+// issue; Paused=True means scaling is paused; Fallback=True is a soft warning (scaling degraded
+// but still operating).
+func (r *LLMISVCReconciler) propagateScaledObjectStatus(ctx context.Context, expected *kedav1alpha1.ScaledObject, ready func(), notReady func(reason, messageFormat string, messageA ...interface{})) error {
+	curr := &kedav1alpha1.ScaledObject{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(expected), curr); err != nil {
+		return fmt.Errorf("failed to get current ScaledObject %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
+	}
+
+	conditions := curr.Status.Conditions
+	if conditions == nil || !conditions.AreInitialized() {
+		notReady("ScaledObjectProgressing", "ScaledObject conditions not yet available")
+		return nil
+	}
+
+	pausedCond := conditions.GetPausedCondition()
+	if pausedCond.Status == metav1.ConditionTrue {
+		notReady(pausedCond.Reason, pausedCond.Message)
+		return nil
+	}
+
+	readyCond := conditions.GetReadyCondition()
+	if readyCond.Status == metav1.ConditionFalse {
+		notReady(readyCond.Reason, readyCond.Message)
+		return nil
+	}
+
+	if readyCond.Status != metav1.ConditionTrue {
+		notReady("ScaledObjectProgressing", "ScaledObject is not yet ready")
+		return nil
+	}
+
+	fallbackCond := conditions.GetFallbackCondition()
+	if fallbackCond.Status == metav1.ConditionTrue {
+		r.Eventf(expected, corev1.EventTypeWarning, "ScaledObjectFallback",
+			"ScaledObject is using fallback replicas: %s", fallbackCond.Message)
+	}
+
+	ready()
+	return nil
 }
 
 // validateAutoscalingConfig checks that the WVAAutoscalingConfig is valid for use with KEDA.

--- a/pkg/controller/v1alpha2/llmisvc/scaling_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling_int_test.go
@@ -1059,4 +1059,454 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})
+
+	Context("ScalingReady condition propagation", func() {
+		It("should set ScalingReady=False (progressing) when HPA has no status conditions", func(ctx SpecContext) {
+			svcName := "test-hpa-cond-prog"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(HPAScaling(1, 5)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil(), "ScalingReady condition should exist")
+				g.Expect(scalingCond.IsFalse()).To(BeTrue(), "ScalingReady should be False when HPA has no conditions")
+				g.Expect(scalingCond.Reason).To(Equal("HPAProgressing"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should set ScalingReady=True when HPA reports healthy conditions", func(ctx SpecContext) {
+			svcName := "test-hpa-cond-ready"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(HPAScaling(1, 5)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			hpaKey := types.NamespacedName{Name: kmeta.ChildName(svcName, "-kserve-hpa"), Namespace: testNs.Name}
+
+			// Wait for HPA to be created
+			Eventually(func(g Gomega, ctx context.Context) {
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+				g.Expect(envTest.Get(ctx, hpaKey, hpa)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Simulate the HPA controller setting healthy conditions
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+				if err := envTest.Get(ctx, hpaKey, hpa); err != nil {
+					return err
+				}
+				hpa.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionTrue, Reason: "ReadyForNewScale"},
+					{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionTrue, Reason: "ValidMetricFound"},
+				}
+				return envTest.Status().Update(ctx, hpa)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil(), "ScalingReady condition should exist")
+				g.Expect(scalingCond.IsTrue()).To(BeTrue(), "ScalingReady should be True when HPA is healthy")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should set ScalingReady=False when HPA ScalingActive is False", func(ctx SpecContext) {
+			svcName := "test-hpa-cond-fail"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(HPAScaling(1, 5)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			hpaKey := types.NamespacedName{Name: kmeta.ChildName(svcName, "-kserve-hpa"), Namespace: testNs.Name}
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+				g.Expect(envTest.Get(ctx, hpaKey, hpa)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Simulate broken metrics pipeline
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+				if err := envTest.Get(ctx, hpaKey, hpa); err != nil {
+					return err
+				}
+				hpa.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionTrue, Reason: "ReadyForNewScale"},
+					{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetExternalMetric", Message: "metric wva_desired_replicas not found"},
+				}
+				return envTest.Status().Update(ctx, hpa)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil(), "ScalingReady condition should exist")
+				g.Expect(scalingCond.IsFalse()).To(BeTrue(), "ScalingReady should be False when metrics are broken")
+				g.Expect(scalingCond.Reason).To(Equal("FailedGetExternalMetric"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should clear ScalingReady when scaling is removed", func(ctx SpecContext) {
+			svcName := "test-scaling-clear"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(HPAScaling(1, 5)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// Wait for ScalingReady to appear
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status.GetCondition(v1alpha2.ScalingReady)).ToNot(BeNil())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Remove scaling
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					llmSvc.Spec.Scaling = nil
+					llmSvc.Spec.Replicas = ptr.To(int32(1))
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Verify ScalingReady condition is cleared
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status.GetCondition(v1alpha2.ScalingReady)).To(BeNil(),
+					"ScalingReady condition should be cleared when scaling is removed")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should not have ScalingReady when no scaling is configured", func(ctx SpecContext) {
+			svcName := "test-no-scaling-cond"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// Wait for the controller to reconcile (WorkloadsReady should appear)
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status.GetCondition(v1alpha2.WorkloadReady)).ToNot(BeNil())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Verify ScalingReady is absent
+			Consistently(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status.GetCondition(v1alpha2.ScalingReady)).To(BeNil(),
+					"ScalingReady should be absent when no scaling is configured")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should set ScalingReady=False when KEDA ScaledObject is not yet ready", func(ctx SpecContext) {
+			svcName := "test-keda-cond-prog"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(KEDAScaling(1, 5)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil(), "ScalingReady condition should exist")
+				g.Expect(scalingCond.IsFalse()).To(BeTrue(), "ScalingReady should be False when ScaledObject has no conditions")
+				g.Expect(scalingCond.Reason).To(Equal("ScaledObjectProgressing"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should set ScalingReady=True when KEDA ScaledObject reports Ready", func(ctx SpecContext) {
+			svcName := "test-keda-cond-ok"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(KEDAScaling(1, 5)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			soKey := types.NamespacedName{Name: kmeta.ChildName(svcName, "-kserve-keda"), Namespace: testNs.Name}
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				so := &kedav1alpha1.ScaledObject{}
+				g.Expect(envTest.Get(ctx, soKey, so)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Simulate KEDA setting ready conditions
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				so := &kedav1alpha1.ScaledObject{}
+				if err := envTest.Get(ctx, soKey, so); err != nil {
+					return err
+				}
+				so.Status.Conditions = kedav1alpha1.Conditions{
+					{Type: kedav1alpha1.ConditionReady, Status: "True", Reason: "ScaledObjectReady"},
+					{Type: kedav1alpha1.ConditionActive, Status: "True"},
+					{Type: kedav1alpha1.ConditionFallback, Status: "False"},
+					{Type: kedav1alpha1.ConditionPaused, Status: "False"},
+				}
+				return envTest.Status().Update(ctx, so)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil(), "ScalingReady condition should exist")
+				g.Expect(scalingCond.IsTrue()).To(BeTrue(), "ScalingReady should be True when ScaledObject is ready")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should transition ScalingReady from True to False when HPA degrades", func(ctx SpecContext) {
+			svcName := "test-hpa-true-false"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(HPAScaling(1, 5)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			hpaKey := types.NamespacedName{Name: kmeta.ChildName(svcName, "-kserve-hpa"), Namespace: testNs.Name}
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+				g.Expect(envTest.Get(ctx, hpaKey, hpa)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Phase 1: set HPA to healthy
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+				if err := envTest.Get(ctx, hpaKey, hpa); err != nil {
+					return err
+				}
+				hpa.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionTrue, Reason: "ReadyForNewScale"},
+					{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionTrue, Reason: "ValidMetricFound"},
+				}
+				return envTest.Status().Update(ctx, hpa)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil())
+				g.Expect(scalingCond.IsTrue()).To(BeTrue(), "ScalingReady should be True initially")
+			}).WithContext(ctx).Should(Succeed())
+
+			// Phase 2: degrade HPA (metrics break)
+			errRetry = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+				if err := envTest.Get(ctx, hpaKey, hpa); err != nil {
+					return err
+				}
+				hpa.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionTrue, Reason: "ReadyForNewScale"},
+					{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetExternalMetric", Message: "metric wva_desired_replicas not found"},
+				}
+				return envTest.Status().Update(ctx, hpa)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil(), "ScalingReady condition should still exist")
+				g.Expect(scalingCond.IsFalse()).To(BeTrue(), "ScalingReady should flip to False after HPA degrades")
+				g.Expect(scalingCond.Reason).To(Equal("FailedGetExternalMetric"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should transition ScalingReady from True to False when KEDA ScaledObject degrades", func(ctx SpecContext) {
+			svcName := "test-keda-true-false"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(KEDAScaling(1, 5)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			soKey := types.NamespacedName{Name: kmeta.ChildName(svcName, "-kserve-keda"), Namespace: testNs.Name}
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				so := &kedav1alpha1.ScaledObject{}
+				g.Expect(envTest.Get(ctx, soKey, so)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Phase 1: set ScaledObject to ready
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				so := &kedav1alpha1.ScaledObject{}
+				if err := envTest.Get(ctx, soKey, so); err != nil {
+					return err
+				}
+				so.Status.Conditions = kedav1alpha1.Conditions{
+					{Type: kedav1alpha1.ConditionReady, Status: "True", Reason: "ScaledObjectReady"},
+					{Type: kedav1alpha1.ConditionActive, Status: "True"},
+					{Type: kedav1alpha1.ConditionFallback, Status: "False"},
+					{Type: kedav1alpha1.ConditionPaused, Status: "False"},
+				}
+				return envTest.Status().Update(ctx, so)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil())
+				g.Expect(scalingCond.IsTrue()).To(BeTrue(), "ScalingReady should be True initially")
+			}).WithContext(ctx).Should(Succeed())
+
+			// Phase 2: degrade ScaledObject (trigger error)
+			errRetry = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				so := &kedav1alpha1.ScaledObject{}
+				if err := envTest.Get(ctx, soKey, so); err != nil {
+					return err
+				}
+				so.Status.Conditions = kedav1alpha1.Conditions{
+					{Type: kedav1alpha1.ConditionReady, Status: "False", Reason: "TriggerError", Message: "prometheus query failed"},
+					{Type: kedav1alpha1.ConditionActive, Status: "False"},
+					{Type: kedav1alpha1.ConditionFallback, Status: "False"},
+					{Type: kedav1alpha1.ConditionPaused, Status: "False"},
+				}
+				return envTest.Status().Update(ctx, so)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil(), "ScalingReady condition should still exist")
+				g.Expect(scalingCond.IsFalse()).To(BeTrue(), "ScalingReady should flip to False after ScaledObject degrades")
+				g.Expect(scalingCond.Reason).To(Equal("TriggerError"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should set PrefillScalingReady when prefill scaling is configured", func(ctx SpecContext) {
+			svcName := "test-prefill-scale"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(HPAScaling(1, 5)),
+				WithPrefillScaling(HPAScaling(1, 3)),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				scalingCond := current.Status.GetCondition(v1alpha2.ScalingReady)
+				g.Expect(scalingCond).ToNot(BeNil(), "ScalingReady should exist for decode workload")
+
+				prefillScalingCond := current.Status.GetCondition(v1alpha2.PrefillScalingReady)
+				g.Expect(prefillScalingCond).ToNot(BeNil(), "PrefillScalingReady should exist for prefill workload")
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
 })

--- a/pkg/controller/v1alpha2/llmisvc/scaling_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package llmisvc
 
 import (
+	"context"
 	"testing"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -27,8 +28,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -989,4 +993,275 @@ func TestScaleTargetRefHelpers(t *testing.T) {
 		assert.Equal(t, "Deployment", ref.Kind)
 		assert.Equal(t, prefillDeploymentName(svc), ref.Name)
 	})
+}
+
+func newReconcilerWithHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) *LLMISVCReconciler {
+	scheme := runtime.NewScheme()
+	_ = autoscalingv2.AddToScheme(scheme)
+	cb := fake.NewClientBuilder().WithScheme(scheme)
+	if hpa != nil {
+		cb = cb.WithObjects(hpa)
+	}
+	return &LLMISVCReconciler{
+		Client:        cb.Build(),
+		EventRecorder: record.NewFakeRecorder(10),
+	}
+}
+
+func newReconcilerWithScaledObject(so *kedav1alpha1.ScaledObject) *LLMISVCReconciler {
+	scheme := runtime.NewScheme()
+	_ = kedav1alpha1.AddToScheme(scheme)
+	cb := fake.NewClientBuilder().WithScheme(scheme)
+	if so != nil {
+		cb = cb.WithObjects(so)
+	}
+	return &LLMISVCReconciler{
+		Client:        cb.Build(),
+		EventRecorder: record.NewFakeRecorder(10),
+	}
+}
+
+func TestPropagateHPAStatus(t *testing.T) {
+	expectedHPAObj := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-hpa", Namespace: "test-ns"},
+	}
+
+	tests := []struct {
+		name         string
+		hpa          *autoscalingv2.HorizontalPodAutoscaler
+		wantReady    bool
+		wantNotReady bool
+		wantReason   string
+		wantErr      bool
+	}{
+		{
+			name: "AbleToScale=True and ScalingActive=True -> ready",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hpa", Namespace: "test-ns"},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+					Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+						{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionTrue},
+						{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			wantReady: true,
+		},
+		{
+			name: "AbleToScale=False -> not ready with reason",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hpa", Namespace: "test-ns"},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+					Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+						{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionFalse, Reason: "FailedGetScale", Message: "cannot get scale"},
+						{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			wantNotReady: true,
+			wantReason:   "FailedGetScale",
+		},
+		{
+			name: "ScalingActive=False -> not ready with reason",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hpa", Namespace: "test-ns"},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+					Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+						{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionTrue},
+						{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetExternalMetric", Message: "metric not found"},
+					},
+				},
+			},
+			wantNotReady: true,
+			wantReason:   "FailedGetExternalMetric",
+		},
+		{
+			name: "no conditions yet -> not ready HPAProgressing",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hpa", Namespace: "test-ns"},
+			},
+			wantNotReady: true,
+			wantReason:   "HPAProgressing",
+		},
+		{
+			name: "ScalingLimited=True with healthy conditions -> ready",
+			hpa: &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hpa", Namespace: "test-ns"},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+					Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+						{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionTrue},
+						{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionTrue},
+						{Type: autoscalingv2.ScalingLimited, Status: corev1.ConditionTrue, Message: "at max replicas"},
+					},
+				},
+			},
+			wantReady: true,
+		},
+		{
+			name:    "HPA not found -> error",
+			hpa:     nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newReconcilerWithHPA(tt.hpa)
+			var readyCalled, notReadyCalled bool
+			var notReadyReason string
+
+			err := r.propagateHPAStatus(context.Background(), expectedHPAObj,
+				func() { readyCalled = true },
+				func(reason, msg string, a ...interface{}) {
+					notReadyCalled = true
+					notReadyReason = reason
+				},
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, readyCalled, "ready callback")
+			assert.Equal(t, tt.wantNotReady, notReadyCalled, "notReady callback")
+			if tt.wantReason != "" {
+				assert.Equal(t, tt.wantReason, notReadyReason)
+			}
+		})
+	}
+}
+
+func TestPropagateScaledObjectStatus(t *testing.T) {
+	expectedSO := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-so", Namespace: "test-ns"},
+	}
+
+	tests := []struct {
+		name         string
+		so           *kedav1alpha1.ScaledObject
+		wantReady    bool
+		wantNotReady bool
+		wantReason   string
+		wantErr      bool
+	}{
+		{
+			name: "Ready=True -> ready",
+			so: &kedav1alpha1.ScaledObject{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-so", Namespace: "test-ns"},
+				Status: kedav1alpha1.ScaledObjectStatus{
+					Conditions: kedav1alpha1.Conditions{
+						{Type: kedav1alpha1.ConditionReady, Status: metav1.ConditionTrue},
+						{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionTrue},
+						{Type: kedav1alpha1.ConditionFallback, Status: metav1.ConditionFalse},
+						{Type: kedav1alpha1.ConditionPaused, Status: metav1.ConditionFalse},
+					},
+				},
+			},
+			wantReady: true,
+		},
+		{
+			name: "Ready=False -> not ready with reason",
+			so: &kedav1alpha1.ScaledObject{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-so", Namespace: "test-ns"},
+				Status: kedav1alpha1.ScaledObjectStatus{
+					Conditions: kedav1alpha1.Conditions{
+						{Type: kedav1alpha1.ConditionReady, Status: metav1.ConditionFalse, Reason: "TriggerError", Message: "prometheus query failed"},
+						{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionFalse},
+						{Type: kedav1alpha1.ConditionFallback, Status: metav1.ConditionFalse},
+						{Type: kedav1alpha1.ConditionPaused, Status: metav1.ConditionFalse},
+					},
+				},
+			},
+			wantNotReady: true,
+			wantReason:   "TriggerError",
+		},
+		{
+			name: "Ready=Unknown -> not ready ScaledObjectProgressing",
+			so: &kedav1alpha1.ScaledObject{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-so", Namespace: "test-ns"},
+				Status: kedav1alpha1.ScaledObjectStatus{
+					Conditions: kedav1alpha1.Conditions{
+						{Type: kedav1alpha1.ConditionReady, Status: metav1.ConditionUnknown},
+						{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionUnknown},
+						{Type: kedav1alpha1.ConditionFallback, Status: metav1.ConditionUnknown},
+						{Type: kedav1alpha1.ConditionPaused, Status: metav1.ConditionUnknown},
+					},
+				},
+			},
+			wantNotReady: true,
+			wantReason:   "ScaledObjectProgressing",
+		},
+		{
+			name: "Paused=True -> not ready",
+			so: &kedav1alpha1.ScaledObject{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-so", Namespace: "test-ns"},
+				Status: kedav1alpha1.ScaledObjectStatus{
+					Conditions: kedav1alpha1.Conditions{
+						{Type: kedav1alpha1.ConditionReady, Status: metav1.ConditionTrue},
+						{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionTrue},
+						{Type: kedav1alpha1.ConditionFallback, Status: metav1.ConditionFalse},
+						{Type: kedav1alpha1.ConditionPaused, Status: metav1.ConditionTrue, Reason: "ScaledObjectPaused", Message: "ScaledObject is paused"},
+					},
+				},
+			},
+			wantNotReady: true,
+			wantReason:   "ScaledObjectPaused",
+		},
+		{
+			name: "Fallback=True with Ready=True -> ready (soft warning)",
+			so: &kedav1alpha1.ScaledObject{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-so", Namespace: "test-ns"},
+				Status: kedav1alpha1.ScaledObjectStatus{
+					Conditions: kedav1alpha1.Conditions{
+						{Type: kedav1alpha1.ConditionReady, Status: metav1.ConditionTrue},
+						{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionTrue},
+						{Type: kedav1alpha1.ConditionFallback, Status: metav1.ConditionTrue, Message: "using fallback replicas"},
+						{Type: kedav1alpha1.ConditionPaused, Status: metav1.ConditionFalse},
+					},
+				},
+			},
+			wantReady: true,
+		},
+		{
+			name: "no conditions (nil) -> not ready ScaledObjectProgressing",
+			so: &kedav1alpha1.ScaledObject{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-so", Namespace: "test-ns"},
+			},
+			wantNotReady: true,
+			wantReason:   "ScaledObjectProgressing",
+		},
+		{
+			name:    "ScaledObject not found -> error",
+			so:      nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newReconcilerWithScaledObject(tt.so)
+			var readyCalled, notReadyCalled bool
+			var notReadyReason string
+
+			err := r.propagateScaledObjectStatus(context.Background(), expectedSO,
+				func() { readyCalled = true },
+				func(reason, msg string, a ...interface{}) {
+					notReadyCalled = true
+					notReadyReason = reason
+				},
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, readyCalled, "ready callback")
+			assert.Equal(t, tt.wantNotReady, notReadyCalled, "notReady callback")
+			if tt.wantReason != "" {
+				assert.Equal(t, tt.wantReason, notReadyReason)
+			}
+		})
+	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/scaling_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling_test.go
@@ -1194,7 +1194,7 @@ func TestPropagateScaledObjectStatus(t *testing.T) {
 			wantReason:   "ScaledObjectProgressing",
 		},
 		{
-			name: "Paused=True -> not ready",
+			name: "Paused=True with Ready=True -> ready (pause not surfaced yet)",
 			so: &kedav1alpha1.ScaledObject{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-so", Namespace: "test-ns"},
 				Status: kedav1alpha1.ScaledObjectStatus{
@@ -1206,8 +1206,7 @@ func TestPropagateScaledObjectStatus(t *testing.T) {
 					},
 				},
 			},
-			wantNotReady: true,
-			wantReason:   "ScaledObjectPaused",
+			wantReady: true,
 		},
 		{
 			name: "Fallback=True with Ready=True -> ready (soft warning)",

--- a/pkg/controller/v1alpha2/llmisvc/scaling_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling_test.go
@@ -1098,9 +1098,10 @@ func TestPropagateHPAStatus(t *testing.T) {
 			wantReady: true,
 		},
 		{
-			name:    "HPA not found -> error",
-			hpa:     nil,
-			wantErr: true,
+			name:         "HPA not found -> not ready HPAProgressing (cache lag)",
+			hpa:          nil,
+			wantNotReady: true,
+			wantReason:   "HPAProgressing",
 		},
 	}
 
@@ -1232,9 +1233,10 @@ func TestPropagateScaledObjectStatus(t *testing.T) {
 			wantReason:   "ScaledObjectProgressing",
 		},
 		{
-			name:    "ScaledObject not found -> error",
-			so:      nil,
-			wantErr: true,
+			name:         "ScaledObject not found -> not ready ScaledObjectProgressing (cache lag)",
+			so:           nil,
+			wantNotReady: true,
+			wantReason:   "ScaledObjectProgressing",
 		},
 	}
 

--- a/test/e2e/llmisvc/test_llm_autoscaling.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling.py
@@ -1190,3 +1190,219 @@ def test_llm_autoscaling_update_keda(test_case: TestCase):
         )
     finally:
         _cleanup(kserve_client, test_case)
+
+
+# ---------------------------------------------------------------------------
+# ScalingReady condition propagation tests
+# ---------------------------------------------------------------------------
+
+
+def _get_llmisvc_condition(api, name, namespace, condition_type):
+    """Get a specific condition from LLMInferenceService status."""
+    resource = api.get_namespaced_custom_object(
+        constants.KSERVE_GROUP,
+        "v1alpha2",
+        namespace,
+        KSERVE_PLURAL_LLMINFERENCESERVICE,
+        name,
+    )
+    conditions = resource.get("status", {}).get("conditions", [])
+    for cond in conditions:
+        if cond.get("type") == condition_type:
+            return cond
+    return None
+
+
+def _wait_for_condition(api, name, namespace, condition_type, timeout=180, interval=5):
+    """Wait for a condition to appear on LLMInferenceService status.
+    Returns the condition dict or None if not found within timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        cond = _get_llmisvc_condition(api, name, namespace, condition_type)
+        if cond is not None:
+            return cond
+        time.sleep(interval)
+    return None
+
+
+@pytest.mark.llminferenceservice
+@pytest.mark.autoscaling
+@pytest.mark.autoscaling_status
+@pytest.mark.skipif(
+    os.environ.get("SCALING_E2E", "false").lower() not in ("true", "1"),
+    reason="Scaling e2e tests require SCALING_E2E=true and a cluster with HPA/KEDA infrastructure",
+)
+class TestScalingStatus:
+    """Tests for ScalingReady condition propagation.
+
+    These tests create a minimal LLMInferenceService with HPA scaling configured
+    and verify that the ScalingReady condition appears in the service status.
+
+    Since the HPA controller in a real cluster will attempt to fetch external
+    metrics (wva_desired_replicas), the ScalingReady condition may be False
+    (e.g. FailedGetExternalMetric) if WVA is not actually publishing metrics.
+    The test verifies that the *condition exists*, not that it's True --
+    that proves the status propagation pipeline works end-to-end.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        inject_k8s_proxy()
+        self.api = client.CustomObjectsApi()
+        self.namespace = KSERVE_TEST_NAMESPACE
+
+    def test_scaling_ready_condition_appears_with_hpa(self):
+        """ScalingReady condition should appear when HPA scaling is configured."""
+        svc_name = "e2e-scale-hpa-cond"
+
+        llm_body = {
+            "apiVersion": "serving.kserve.io/v1alpha2",
+            "kind": "LLMInferenceService",
+            "metadata": {"name": svc_name, "namespace": self.namespace},
+            "spec": {
+                "model": {"uri": "hf://facebook/opt-125m"},
+                "scaling": {
+                    "minReplicas": 1,
+                    "maxReplicas": 2,
+                    "wva": {
+                        "hpa": {},
+                    },
+                },
+            },
+        }
+
+        try:
+            self.api.create_namespaced_custom_object(
+                constants.KSERVE_GROUP,
+                "v1alpha2",
+                self.namespace,
+                KSERVE_PLURAL_LLMINFERENCESERVICE,
+                llm_body,
+            )
+
+            cond = _wait_for_condition(
+                self.api, svc_name, self.namespace, "ScalingReady", timeout=180
+            )
+            assert cond is not None, (
+                "ScalingReady condition should appear when HPA scaling is configured. "
+                "Check that the controller is running and HPA was created."
+            )
+            logger.info(
+                "ScalingReady condition: status=%s, reason=%s",
+                cond.get("status"),
+                cond.get("reason", "N/A"),
+            )
+
+        finally:
+            try:
+                self.api.delete_namespaced_custom_object(
+                    constants.KSERVE_GROUP,
+                    "v1alpha2",
+                    self.namespace,
+                    KSERVE_PLURAL_LLMINFERENCESERVICE,
+                    svc_name,
+                )
+            except client.rest.ApiException:
+                pass
+
+    def test_scaling_ready_condition_appears_with_keda(self):
+        """ScalingReady condition should appear when KEDA scaling is configured."""
+        svc_name = "e2e-scale-keda-cond"
+
+        llm_body = {
+            "apiVersion": "serving.kserve.io/v1alpha2",
+            "kind": "LLMInferenceService",
+            "metadata": {"name": svc_name, "namespace": self.namespace},
+            "spec": {
+                "model": {"uri": "hf://facebook/opt-125m"},
+                "scaling": {
+                    "minReplicas": 1,
+                    "maxReplicas": 2,
+                    "wva": {
+                        "keda": {},
+                    },
+                },
+            },
+        }
+
+        try:
+            self.api.create_namespaced_custom_object(
+                constants.KSERVE_GROUP,
+                "v1alpha2",
+                self.namespace,
+                KSERVE_PLURAL_LLMINFERENCESERVICE,
+                llm_body,
+            )
+
+            cond = _wait_for_condition(
+                self.api, svc_name, self.namespace, "ScalingReady", timeout=180
+            )
+            assert cond is not None, (
+                "ScalingReady condition should appear when KEDA scaling is configured. "
+                "Check that the controller is running and ScaledObject was created."
+            )
+            logger.info(
+                "ScalingReady condition: status=%s, reason=%s",
+                cond.get("status"),
+                cond.get("reason", "N/A"),
+            )
+
+        finally:
+            try:
+                self.api.delete_namespaced_custom_object(
+                    constants.KSERVE_GROUP,
+                    "v1alpha2",
+                    self.namespace,
+                    KSERVE_PLURAL_LLMINFERENCESERVICE,
+                    svc_name,
+                )
+            except client.rest.ApiException:
+                pass
+
+    def test_scaling_ready_absent_without_scaling(self):
+        """ScalingReady condition should be absent when no scaling is configured."""
+        svc_name = "e2e-no-scale-cond"
+
+        llm_body = {
+            "apiVersion": "serving.kserve.io/v1alpha2",
+            "kind": "LLMInferenceService",
+            "metadata": {"name": svc_name, "namespace": self.namespace},
+            "spec": {
+                "model": {"uri": "hf://facebook/opt-125m"},
+            },
+        }
+
+        try:
+            self.api.create_namespaced_custom_object(
+                constants.KSERVE_GROUP,
+                "v1alpha2",
+                self.namespace,
+                KSERVE_PLURAL_LLMINFERENCESERVICE,
+                llm_body,
+            )
+
+            workloads_cond = _wait_for_condition(
+                self.api, svc_name, self.namespace, "WorkloadsReady", timeout=120
+            )
+            assert workloads_cond is not None, (
+                "WorkloadsReady should exist after controller reconciles"
+            )
+
+            scaling_cond = _get_llmisvc_condition(
+                self.api, svc_name, self.namespace, "ScalingReady"
+            )
+            assert scaling_cond is None, (
+                "ScalingReady should be absent when no scaling is configured"
+            )
+
+        finally:
+            try:
+                self.api.delete_namespaced_custom_object(
+                    constants.KSERVE_GROUP,
+                    "v1alpha2",
+                    self.namespace,
+                    KSERVE_PLURAL_LLMINFERENCESERVICE,
+                    svc_name,
+                )
+            except client.rest.ApiException:
+                pass

--- a/test/e2e/llmisvc/test_llm_autoscaling.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling.py
@@ -420,6 +420,48 @@ def assert_lws_replicas(service_name, min_replicas, namespace=KSERVE_TEST_NAMESP
     wait_for(_check, timeout=60, interval=5.0)
 
 
+# --- ScalingReady condition helpers ---
+
+
+def _get_llmisvc_condition(name, namespace, condition_type):
+    """Get a specific condition from LLMInferenceService status."""
+    api = client.CustomObjectsApi()
+    resource = api.get_namespaced_custom_object(
+        constants.KSERVE_GROUP,
+        "v1alpha2",
+        namespace,
+        KSERVE_PLURAL_LLMINFERENCESERVICE,
+        name,
+    )
+    conditions = resource.get("status", {}).get("conditions", [])
+    for cond in conditions:
+        if cond.get("type") == condition_type:
+            return cond
+    return None
+
+
+def assert_scaling_ready_condition(service_name, namespace=KSERVE_TEST_NAMESPACE):
+    """Verify the ScalingReady condition is present and True."""
+
+    def _check():
+        cond = _get_llmisvc_condition(service_name, namespace, "ScalingReady")
+        assert cond is not None, f"ScalingReady condition not found on {service_name}"
+        assert cond.get("status") == "True", (
+            f"ScalingReady status is {cond.get('status')} "
+            f"(reason={cond.get('reason')}), expected True"
+        )
+
+    wait_for(_check, timeout=180, interval=5.0)
+
+
+def assert_scaling_ready_absent(service_name, namespace=KSERVE_TEST_NAMESPACE):
+    """Verify the ScalingReady condition is absent from the LLMInferenceService."""
+    cond = _get_llmisvc_condition(service_name, namespace, "ScalingReady")
+    assert cond is None, (
+        f"ScalingReady condition should be absent on {service_name}, got: {cond}"
+    )
+
+
 # --- Common test lifecycle ---
 
 
@@ -507,6 +549,7 @@ def test_llm_autoscaling_hpa_deployment(test_case: TestCase):
         assert_wva_metric_exists(service_name)
         wait_for_pod_count(service_name, min_count=2, timeout=300)
         assert_hpa_active(service_name)
+        assert_scaling_ready_condition(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -571,6 +614,7 @@ def test_llm_autoscaling_keda_deployment(test_case: TestCase):
         assert_wva_metric_exists(service_name)
         wait_for_pod_count(service_name, min_count=2, timeout=300)
         assert_scaled_object_active(service_name)
+        assert_scaling_ready_condition(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -629,6 +673,7 @@ def test_llm_autoscaling_hpa_lws(test_case: TestCase):
         wait_for_pod_count(service_name, min_count=2, timeout=300)
         assert_hpa_active(service_name)
         assert_lws_replicas(service_name, min_replicas=1)
+        assert_scaling_ready_condition(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -687,6 +732,7 @@ def test_llm_autoscaling_keda_lws(test_case: TestCase):
         wait_for_pod_count(service_name, min_count=2, timeout=300)
         assert_scaled_object_active(service_name)
         assert_lws_replicas(service_name, min_replicas=1)
+        assert_scaling_ready_condition(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -736,6 +782,7 @@ def test_llm_autoscaling_prefill_hpa(test_case: TestCase):
 
         assert_scaling_resources_exist(service_name, actuator="hpa", prefill=False)
         assert_scaling_resources_exist(service_name, actuator="hpa", prefill=True)
+        assert_scaling_ready_condition(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -785,6 +832,7 @@ def test_llm_autoscaling_prefill_keda(test_case: TestCase):
 
         assert_scaling_resources_exist(service_name, actuator="keda", prefill=False)
         assert_scaling_resources_exist(service_name, actuator="keda", prefill=True)
+        assert_scaling_ready_condition(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -831,10 +879,9 @@ def test_llm_autoscaling_cleanup_hpa(test_case: TestCase):
     try:
         _create_and_wait(kserve_client, test_case)
         assert_scaling_resources_exist(service_name, actuator="hpa")
+        assert_scaling_ready_condition(service_name)
 
         # Remove the scaling baseRef; keep only non-scaling refs.
-        # Scaling comes from a LLMInferenceServiceConfig, so patching inline
-        # spec.scaling=null won't override it — we must remove the baseRef.
         base_refs = test_case.llm_service.spec["baseRefs"]
         non_scaling_refs = [ref for ref in base_refs if "scaling" not in ref["name"]]
         patch_llmisvc(
@@ -849,6 +896,7 @@ def test_llm_autoscaling_cleanup_hpa(test_case: TestCase):
         )
 
         assert_scaling_resources_deleted(service_name, actuator="hpa")
+        assert_scaling_ready_absent(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -895,6 +943,7 @@ def test_llm_autoscaling_cleanup_keda(test_case: TestCase):
     try:
         _create_and_wait(kserve_client, test_case)
         assert_scaling_resources_exist(service_name, actuator="keda")
+        assert_scaling_ready_condition(service_name)
 
         base_refs = test_case.llm_service.spec["baseRefs"]
         non_scaling_refs = [ref for ref in base_refs if "scaling" not in ref["name"]]
@@ -910,6 +959,7 @@ def test_llm_autoscaling_cleanup_keda(test_case: TestCase):
         )
 
         assert_scaling_resources_deleted(service_name, actuator="keda")
+        assert_scaling_ready_absent(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -956,6 +1006,7 @@ def test_llm_autoscaling_stop_hpa(test_case: TestCase):
     try:
         _create_and_wait(kserve_client, test_case)
         assert_scaling_resources_exist(service_name, actuator="hpa")
+        assert_scaling_ready_condition(service_name)
 
         patch_llmisvc(
             kserve_client,
@@ -970,6 +1021,7 @@ def test_llm_autoscaling_stop_hpa(test_case: TestCase):
         )
 
         assert_scaling_resources_deleted(service_name, actuator="hpa")
+        assert_scaling_ready_absent(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -1016,6 +1068,7 @@ def test_llm_autoscaling_stop_keda(test_case: TestCase):
     try:
         _create_and_wait(kserve_client, test_case)
         assert_scaling_resources_exist(service_name, actuator="keda")
+        assert_scaling_ready_condition(service_name)
 
         patch_llmisvc(
             kserve_client,
@@ -1030,6 +1083,7 @@ def test_llm_autoscaling_stop_keda(test_case: TestCase):
         )
 
         assert_scaling_resources_deleted(service_name, actuator="keda")
+        assert_scaling_ready_absent(service_name)
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -1190,219 +1244,3 @@ def test_llm_autoscaling_update_keda(test_case: TestCase):
         )
     finally:
         _cleanup(kserve_client, test_case)
-
-
-# ---------------------------------------------------------------------------
-# ScalingReady condition propagation tests
-# ---------------------------------------------------------------------------
-
-
-def _get_llmisvc_condition(api, name, namespace, condition_type):
-    """Get a specific condition from LLMInferenceService status."""
-    resource = api.get_namespaced_custom_object(
-        constants.KSERVE_GROUP,
-        "v1alpha2",
-        namespace,
-        KSERVE_PLURAL_LLMINFERENCESERVICE,
-        name,
-    )
-    conditions = resource.get("status", {}).get("conditions", [])
-    for cond in conditions:
-        if cond.get("type") == condition_type:
-            return cond
-    return None
-
-
-def _wait_for_condition(api, name, namespace, condition_type, timeout=180, interval=5):
-    """Wait for a condition to appear on LLMInferenceService status.
-    Returns the condition dict or None if not found within timeout."""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        cond = _get_llmisvc_condition(api, name, namespace, condition_type)
-        if cond is not None:
-            return cond
-        time.sleep(interval)
-    return None
-
-
-@pytest.mark.llminferenceservice
-@pytest.mark.autoscaling
-@pytest.mark.autoscaling_status
-@pytest.mark.skipif(
-    os.environ.get("SCALING_E2E", "false").lower() not in ("true", "1"),
-    reason="Scaling e2e tests require SCALING_E2E=true and a cluster with HPA/KEDA infrastructure",
-)
-class TestScalingStatus:
-    """Tests for ScalingReady condition propagation.
-
-    These tests create a minimal LLMInferenceService with HPA scaling configured
-    and verify that the ScalingReady condition appears in the service status.
-
-    Since the HPA controller in a real cluster will attempt to fetch external
-    metrics (wva_desired_replicas), the ScalingReady condition may be False
-    (e.g. FailedGetExternalMetric) if WVA is not actually publishing metrics.
-    The test verifies that the *condition exists*, not that it's True --
-    that proves the status propagation pipeline works end-to-end.
-    """
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        inject_k8s_proxy()
-        self.api = client.CustomObjectsApi()
-        self.namespace = KSERVE_TEST_NAMESPACE
-
-    def test_scaling_ready_condition_appears_with_hpa(self):
-        """ScalingReady condition should appear when HPA scaling is configured."""
-        svc_name = "e2e-scale-hpa-cond"
-
-        llm_body = {
-            "apiVersion": "serving.kserve.io/v1alpha2",
-            "kind": "LLMInferenceService",
-            "metadata": {"name": svc_name, "namespace": self.namespace},
-            "spec": {
-                "model": {"uri": "hf://facebook/opt-125m"},
-                "scaling": {
-                    "minReplicas": 1,
-                    "maxReplicas": 2,
-                    "wva": {
-                        "hpa": {},
-                    },
-                },
-            },
-        }
-
-        try:
-            self.api.create_namespaced_custom_object(
-                constants.KSERVE_GROUP,
-                "v1alpha2",
-                self.namespace,
-                KSERVE_PLURAL_LLMINFERENCESERVICE,
-                llm_body,
-            )
-
-            cond = _wait_for_condition(
-                self.api, svc_name, self.namespace, "ScalingReady", timeout=180
-            )
-            assert cond is not None, (
-                "ScalingReady condition should appear when HPA scaling is configured. "
-                "Check that the controller is running and HPA was created."
-            )
-            logger.info(
-                "ScalingReady condition: status=%s, reason=%s",
-                cond.get("status"),
-                cond.get("reason", "N/A"),
-            )
-
-        finally:
-            try:
-                self.api.delete_namespaced_custom_object(
-                    constants.KSERVE_GROUP,
-                    "v1alpha2",
-                    self.namespace,
-                    KSERVE_PLURAL_LLMINFERENCESERVICE,
-                    svc_name,
-                )
-            except client.rest.ApiException:
-                pass
-
-    def test_scaling_ready_condition_appears_with_keda(self):
-        """ScalingReady condition should appear when KEDA scaling is configured."""
-        svc_name = "e2e-scale-keda-cond"
-
-        llm_body = {
-            "apiVersion": "serving.kserve.io/v1alpha2",
-            "kind": "LLMInferenceService",
-            "metadata": {"name": svc_name, "namespace": self.namespace},
-            "spec": {
-                "model": {"uri": "hf://facebook/opt-125m"},
-                "scaling": {
-                    "minReplicas": 1,
-                    "maxReplicas": 2,
-                    "wva": {
-                        "keda": {},
-                    },
-                },
-            },
-        }
-
-        try:
-            self.api.create_namespaced_custom_object(
-                constants.KSERVE_GROUP,
-                "v1alpha2",
-                self.namespace,
-                KSERVE_PLURAL_LLMINFERENCESERVICE,
-                llm_body,
-            )
-
-            cond = _wait_for_condition(
-                self.api, svc_name, self.namespace, "ScalingReady", timeout=180
-            )
-            assert cond is not None, (
-                "ScalingReady condition should appear when KEDA scaling is configured. "
-                "Check that the controller is running and ScaledObject was created."
-            )
-            logger.info(
-                "ScalingReady condition: status=%s, reason=%s",
-                cond.get("status"),
-                cond.get("reason", "N/A"),
-            )
-
-        finally:
-            try:
-                self.api.delete_namespaced_custom_object(
-                    constants.KSERVE_GROUP,
-                    "v1alpha2",
-                    self.namespace,
-                    KSERVE_PLURAL_LLMINFERENCESERVICE,
-                    svc_name,
-                )
-            except client.rest.ApiException:
-                pass
-
-    def test_scaling_ready_absent_without_scaling(self):
-        """ScalingReady condition should be absent when no scaling is configured."""
-        svc_name = "e2e-no-scale-cond"
-
-        llm_body = {
-            "apiVersion": "serving.kserve.io/v1alpha2",
-            "kind": "LLMInferenceService",
-            "metadata": {"name": svc_name, "namespace": self.namespace},
-            "spec": {
-                "model": {"uri": "hf://facebook/opt-125m"},
-            },
-        }
-
-        try:
-            self.api.create_namespaced_custom_object(
-                constants.KSERVE_GROUP,
-                "v1alpha2",
-                self.namespace,
-                KSERVE_PLURAL_LLMINFERENCESERVICE,
-                llm_body,
-            )
-
-            workloads_cond = _wait_for_condition(
-                self.api, svc_name, self.namespace, "WorkloadsReady", timeout=120
-            )
-            assert workloads_cond is not None, (
-                "WorkloadsReady should exist after controller reconciles"
-            )
-
-            scaling_cond = _get_llmisvc_condition(
-                self.api, svc_name, self.namespace, "ScalingReady"
-            )
-            assert scaling_cond is None, (
-                "ScalingReady should be absent when no scaling is configured"
-            )
-
-        finally:
-            try:
-                self.api.delete_namespaced_custom_object(
-                    constants.KSERVE_GROUP,
-                    "v1alpha2",
-                    self.namespace,
-                    KSERVE_PLURAL_LLMINFERENCESERVICE,
-                    svc_name,
-                )
-            except client.rest.ApiException:
-                pass

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -23,7 +23,6 @@ markers =
     llminferenceservice: e2e tests for llm inference service controller
     autoscaling_hpa: e2e tests for HPA-based autoscaling
     autoscaling_keda: e2e tests for KEDA-based autoscaling
-    autoscaling_status: e2e tests for scaling status condition propagation
     conversion: e2e tests for llm inference service api version conversion
     cluster_cpu: test targeting cluster with CPU
     cluster_amd: test targeting cluster with AMD

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -23,6 +23,7 @@ markers =
     llminferenceservice: e2e tests for llm inference service controller
     autoscaling_hpa: e2e tests for HPA-based autoscaling
     autoscaling_keda: e2e tests for KEDA-based autoscaling
+    autoscaling_status: e2e tests for scaling status condition propagation
     conversion: e2e tests for llm inference service api version conversion
     cluster_cpu: test targeting cluster with CPU
     cluster_amd: test targeting cluster with AMD


### PR DESCRIPTION
## What

Surfaces the health of autoscaling resources (HPA or KEDA ScaledObject) directly in the LLMInferenceService status via two new conditions: `ScalingReady` and `PrefillScalingReady`.

Closes #5530

## Why

Users currently have to inspect child HPA/ScaledObject resources separately to diagnose scaling issues. This change propagates autoscaler health into the parent CR so `kubectl get`/`describe` shows the full picture.

## Changes

* **New conditions**: `ScalingReady`, `PrefillScalingReady` with marker methods and rollup into `WorkloadsReady` via `DetermineWorkloadReadiness()`
* **Status propagation**: `propagateHPAStatus()` maps AbleToScale/ScalingActive; `propagateScaledObjectStatus()` maps Ready
* **Refactor**: Deduplicated main/prefill scaling into shared `reconcileWorkloadScaling()` via `workloadScalingParams`

## Follow-ups

* Informational states like ScalingLimited (HPA), Fallback (KEDA), and Paused (KEDA) are intentionally not surfaced in this PR. These are better suited as non-terminal status conditions rather than events and will be addressed separately.