### PR TITLE
fix: prevent Value/ValueFrom conflict when merging ClusterStorageContainer

### DIFF
--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -794,10 +794,40 @@ func mergeContainerSpecs(targetContainer *corev1.Container, crdContainer *corev1
 		return err
 	}
 
-	if err := json.Unmarshal(jsonResult, targetContainer); err != nil {
+	// Unmarshal into a fresh Container rather than the existing targetContainer:
+	// json.Unmarshal does not clear struct fields absent from the JSON, so reusing
+	// the target's existing EnvVar slice elements lets stale Value/ValueFrom fields
+	// bleed into merged-in entries (issue #5516).
+	merged := corev1.Container{}
+	if err := json.Unmarshal(jsonResult, &merged); err != nil {
 		return err
 	}
 
+	// For env entries whose name is overridden by the ClusterStorageContainer, strategic
+	// merge patch performs a field-wise merge keyed on name, which can leave both
+	// Value and ValueFrom populated on a single entry — a state Kubernetes
+	// admission rejects. Reconcile by deferring to the ClusterStorageContainer's intent.
+	crdEnvByName := make(map[string]corev1.EnvVar, len(crdContainer.Env))
+	for _, e := range crdContainer.Env {
+		crdEnvByName[e.Name] = e
+	}
+	for i := range merged.Env {
+		e := &merged.Env[i]
+		if e.Value == "" || e.ValueFrom == nil {
+			continue
+		}
+		crdEntry, ok := crdEnvByName[e.Name]
+		if !ok {
+			continue
+		}
+		if crdEntry.ValueFrom != nil {
+			e.Value = ""
+		} else if crdEntry.Value != "" {
+			e.ValueFrom = nil
+		}
+	}
+
+	*targetContainer = merged
 	if targetContainer.Name == "" {
 		targetContainer.Name = containerName
 	}

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -5251,3 +5251,136 @@ func TestCommonStorageInitializationWithOciURI(t *testing.T) {
 		assert.True(t, found, "worker container should have MODEL_INIT_MODE=async env var")
 	})
 }
+
+// findEnv returns the env var with the given name, or nil if not present.
+func findEnv(envs []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range envs {
+		if envs[i].Name == name {
+			return &envs[i]
+		}
+	}
+	return nil
+}
+
+// TestMergeContainerSpecs_EnvHandling is a regression test for issue #5516:
+// when the storage-initializer init container's env (typically injected from
+// the ServiceAccount's storage secret) is merged with a ClusterStorageContainer's
+// env, no resulting entry may have both `value` and `valueFrom` set — Kubernetes
+// admission rejects such pods. The merge must reconcile by env name so that
+// CRD overrides cleanly replace the conflicting field on the target.
+func TestMergeContainerSpecs_EnvHandling(t *testing.T) {
+	secretKeyRef := func(secret, key string) *corev1.EnvVarSource {
+		return &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secret},
+				Key:                  key,
+			},
+		}
+	}
+	fieldRef := func(path string) *corev1.EnvVarSource {
+		return &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: path}}
+	}
+
+	scenarios := map[string]struct {
+		targetEnv []corev1.EnvVar
+		crdEnv    []corev1.EnvVar
+		assert    func(t *testing.T, merged []corev1.EnvVar)
+	}{
+		"valueFrom overrides value on same name": {
+			targetEnv: []corev1.EnvVar{
+				{Name: "AWS_ACCESS_KEY_ID", Value: "literal-from-sa-secret"},
+				{Name: "AWS_SECRET_ACCESS_KEY", Value: "literal-from-sa-secret"},
+			},
+			crdEnv: []corev1.EnvVar{
+				{Name: "AWS_ACCESS_KEY_ID", ValueFrom: secretKeyRef("my-creds", "access-key")},
+			},
+			assert: func(t *testing.T, merged []corev1.EnvVar) {
+				overridden := findEnv(merged, "AWS_ACCESS_KEY_ID")
+				require.NotNil(t, overridden)
+				assert.Empty(t, overridden.Value, "Value must be cleared when CRD supplies ValueFrom")
+				require.NotNil(t, overridden.ValueFrom)
+				require.NotNil(t, overridden.ValueFrom.SecretKeyRef)
+				assert.Equal(t, "my-creds", overridden.ValueFrom.SecretKeyRef.Name)
+				assert.Equal(t, "access-key", overridden.ValueFrom.SecretKeyRef.Key)
+
+				preserved := findEnv(merged, "AWS_SECRET_ACCESS_KEY")
+				require.NotNil(t, preserved)
+				assert.Equal(t, "literal-from-sa-secret", preserved.Value)
+				assert.Nil(t, preserved.ValueFrom)
+			},
+		},
+		"value overrides valueFrom on same name": {
+			targetEnv: []corev1.EnvVar{
+				{Name: "AWS_ACCESS_KEY_ID", ValueFrom: secretKeyRef("sa-creds", "access-key")},
+			},
+			crdEnv: []corev1.EnvVar{
+				{Name: "AWS_ACCESS_KEY_ID", Value: "literal-override"},
+			},
+			assert: func(t *testing.T, merged []corev1.EnvVar) {
+				overridden := findEnv(merged, "AWS_ACCESS_KEY_ID")
+				require.NotNil(t, overridden)
+				assert.Equal(t, "literal-override", overridden.Value)
+				assert.Nil(t, overridden.ValueFrom, "ValueFrom must be cleared when CRD supplies a literal Value")
+			},
+		},
+		"disjoint env names with valueFrom in CRD": {
+			targetEnv: []corev1.EnvVar{
+				{Name: "AWS_ACCESS_KEY_ID", Value: "literal-from-sa-secret"},
+				{Name: "AWS_SECRET_ACCESS_KEY", Value: "literal-from-sa-secret"},
+				{Name: "S3_ENDPOINT", Value: "https://s3.example.com"},
+			},
+			crdEnv: []corev1.EnvVar{
+				{Name: "CUSTOM_SECRET", ValueFrom: secretKeyRef("custom-secret", "token")},
+				{Name: "POD_IP", ValueFrom: fieldRef("status.podIP")},
+			},
+			assert: func(t *testing.T, merged []corev1.EnvVar) {
+				for _, name := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "S3_ENDPOINT"} {
+					e := findEnv(merged, name)
+					require.NotNil(t, e, "credential env %q should be preserved after merge", name)
+					assert.NotEmpty(t, e.Value, "credential env %q should retain its literal Value", name)
+					assert.Nil(t, e.ValueFrom, "credential env %q must not have ValueFrom set", name)
+				}
+
+				customSecret := findEnv(merged, "CUSTOM_SECRET")
+				require.NotNil(t, customSecret)
+				assert.Empty(t, customSecret.Value)
+				require.NotNil(t, customSecret.ValueFrom)
+				require.NotNil(t, customSecret.ValueFrom.SecretKeyRef)
+				assert.Equal(t, "custom-secret", customSecret.ValueFrom.SecretKeyRef.Name)
+				assert.Equal(t, "token", customSecret.ValueFrom.SecretKeyRef.Key)
+
+				podIP := findEnv(merged, "POD_IP")
+				require.NotNil(t, podIP)
+				assert.Empty(t, podIP.Value)
+				require.NotNil(t, podIP.ValueFrom)
+				require.NotNil(t, podIP.ValueFrom.FieldRef)
+				assert.Equal(t, "status.podIP", podIP.ValueFrom.FieldRef.FieldPath)
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			target := &corev1.Container{
+				Name:  constants.StorageInitializerContainerName,
+				Image: "kserve/storage-initializer:latest",
+				Env:   scenario.targetEnv,
+			}
+			crd := &corev1.Container{
+				Name: "custom-storage-initializer",
+				Env:  scenario.crdEnv,
+			}
+
+			require.NoError(t, mergeContainerSpecs(target, crd))
+
+			for _, e := range target.Env {
+				if e.Value != "" && e.ValueFrom != nil {
+					t.Errorf("env %q has both Value=%q and ValueFrom set; "+
+						"Kubernetes admission will reject this", e.Name, e.Value)
+				}
+			}
+
+			scenario.assert(t, target.Env)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The problem:
When using a ClusterStorageContainer with environment variables, these can conflict when there are envs already injected into the existing `storage-initializer` initContainer.  

1. **Unmarshalling JSON of a modified object into an existing struct** - previously, the approach was to capture the container's state, perform a strategic JSON merge, and unmarshal that JSON back into the original state. However, unmarshalling into the same struct's env slices after merging unintentionally writes ClusterStorageContainer envs to the same slots that were in the original state. For example, if an env with name `AWS` was already in slot 0 set with `value`, and the CSC override added an env named 'CUSTOM' to the container set with `valueFrom`, it'd get written to slot 0 as well when unmarshalling. But since the `value` part of the overwritten entry didn't get cleared from the previous entry in JSON unmarshal, the final result would look like `'CUSTOM': {'value': 'foo', 'valueFrom': 'bar'}` when it should be `'CUSTOM': {'valueFrom': 'bar'}` to pass admission.

2. **Same-name field-wise merge.** Strategic merge patch will populate both `value` and `valueFrom` entries since they're keyed by field name. So if the ClusterStorageContainer manually overrides known envs like `AWS_ACCESS_KEY_ID` and provides them via `value` while the webhook may inject these envs via `valueFrom`, you'll get rejected by admission for that pod's spec.

This solution:
StrategicMergePatch with the CSC overrides as usual. Then, unmarshal into a fresh container struct to ensure no stale fields are left behind. Finally, reconcile environment variables to ensure there are no conflicts, favoring the values defined in the ClusterStorageContainer if there are duplicate definitions.

**Which issue(s) this PR fixes**:
Fixes #5516

**Feature/Issue validation/testing**:

Added `TestMergeContainerSpecs_EnvHandling` — a table-driven test with three subtests covering both bugs:

- [x] `valueFrom_overrides_value_on_same_name`: credential env injected as literal `Value` is correctly replaced by a CSC `valueFrom` reference on the same name; merged entry has only `valueFrom`.
- [x] `value_overrides_valueFrom_on_same_name`: symmetric case; merged entry has only `Value`.
- [x] `disjoint_env_names_with_valueFrom_in_CRD`: the originally reported scenario: CSC envs (`CUSTOM_SECRET` via `secretKeyRef`, `POD_IP` via `fieldRef`) with names disjoint from the credential envs do not bleed `Value` from target slots; all envs end up correctly populated.

Each subtest also asserts no merged env entry ends up with both `Value` and `ValueFrom` set.

```
$ go test ./pkg/webhook/admission/pod/ -run TestMergeContainerSpecs_EnvHandling -v
--- PASS: TestMergeContainerSpecs_EnvHandling (0.00s)
    --- PASS: TestMergeContainerSpecs_EnvHandling/valueFrom_overrides_value_on_same_name
    --- PASS: TestMergeContainerSpecs_EnvHandling/value_overrides_valueFrom_on_same_name
    --- PASS: TestMergeContainerSpecs_EnvHandling/disjoint_env_names_with_valueFrom_in_CRD
```

Full `pkg/webhook/admission/pod` suite passes; `go vet` and `golangci-lint` clean.

**Special notes for your reviewer**:

The two fixes are independent corrections of distinct issues (one in `json.Unmarshal` semantics, one in strategic merge semantics for same-name list entries). The unmarshal fix will help with other slice-based attributes (volumes, args, etc.) and the reconciliation phase explicitly covers the cases covered in the original issue.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website) - N/A, this is an internal bug fix that shouldn't require documentation updates.

**Release note**:
```release-note
Fix admission rejection when a ClusterStorageContainer adds environment variables via `value` or `valueFrom` and the `storage-initializer` also has envs injected from storage secrets.
```

**Backport plan**:
We originally observed this in version 0.16. Once this lands, I'll make a follow-up PR to backport to release-0.16.