### PR TITLE
fix(charts): use nested if instead for some edge cases

### DIFF
--- a/charts/_common/_utils.tpl
+++ b/charts/_common/_utils.tpl
@@ -28,8 +28,10 @@ Example:
       {{- $canMergeByName := false -}}
       {{- if gt (len $value) 0 -}}
         {{- $firstElem := index $value 0 -}}
-        {{- if and (kindIs "map" $firstElem) (hasKey $firstElem "name") -}}
-          {{- $canMergeByName = true -}}
+        {{- if kindIs "map" $firstElem -}}
+          {{- if hasKey $firstElem "name" -}}
+            {{- $canMergeByName = true -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
       {{- if $canMergeByName -}}

--- a/charts/kserve-llmisvc-resources/templates/_utils.tpl
+++ b/charts/kserve-llmisvc-resources/templates/_utils.tpl
@@ -28,8 +28,10 @@ Example:
       {{- $canMergeByName := false -}}
       {{- if gt (len $value) 0 -}}
         {{- $firstElem := index $value 0 -}}
-        {{- if and (kindIs "map" $firstElem) (hasKey $firstElem "name") -}}
-          {{- $canMergeByName = true -}}
+        {{- if kindIs "map" $firstElem -}}
+          {{- if hasKey $firstElem "name" -}}
+            {{- $canMergeByName = true -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
       {{- if $canMergeByName -}}

--- a/charts/kserve-localmodel-resources/templates/_utils.tpl
+++ b/charts/kserve-localmodel-resources/templates/_utils.tpl
@@ -28,8 +28,10 @@ Example:
       {{- $canMergeByName := false -}}
       {{- if gt (len $value) 0 -}}
         {{- $firstElem := index $value 0 -}}
-        {{- if and (kindIs "map" $firstElem) (hasKey $firstElem "name") -}}
-          {{- $canMergeByName = true -}}
+        {{- if kindIs "map" $firstElem -}}
+          {{- if hasKey $firstElem "name" -}}
+            {{- $canMergeByName = true -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
       {{- if $canMergeByName -}}

--- a/charts/kserve-resources/templates/_utils.tpl
+++ b/charts/kserve-resources/templates/_utils.tpl
@@ -28,8 +28,10 @@ Example:
       {{- $canMergeByName := false -}}
       {{- if gt (len $value) 0 -}}
         {{- $firstElem := index $value 0 -}}
-        {{- if and (kindIs "map" $firstElem) (hasKey $firstElem "name") -}}
-          {{- $canMergeByName = true -}}
+        {{- if kindIs "map" $firstElem -}}
+          {{- if hasKey $firstElem "name" -}}
+            {{- $canMergeByName = true -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
       {{- if $canMergeByName -}}

--- a/charts/kserve-runtime-configs/templates/_utils.tpl
+++ b/charts/kserve-runtime-configs/templates/_utils.tpl
@@ -28,8 +28,10 @@ Example:
       {{- $canMergeByName := false -}}
       {{- if gt (len $value) 0 -}}
         {{- $firstElem := index $value 0 -}}
-        {{- if and (kindIs "map" $firstElem) (hasKey $firstElem "name") -}}
-          {{- $canMergeByName = true -}}
+        {{- if kindIs "map" $firstElem -}}
+          {{- if hasKey $firstElem "name" -}}
+            {{- $canMergeByName = true -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
       {{- if $canMergeByName -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace `and (kindIs "map" $firstElem) (hasKey $firstElem "name")` with nested `if` blocks so hasKey is never called on non-map types like string arrays (args, command). Go template `and` evaluates all arguments before short-circuiting in some Helm versions, causing crash on string slices.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5505


**Feature/Issue validation/testing**:
Tested locally based on upgrade doc.

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note

```
