### PR TITLE
feat(charts): make llmisvc GIE CRD creation optional

### DIFF
--- a/charts/_common/kserve-llmisvc-resources-specific.yaml
+++ b/charts/_common/kserve-llmisvc-resources-specific.yaml
@@ -2,6 +2,7 @@ commonLabels: {}
 commonAnnotations: {}
 kserve:
   llmisvc:
+    createGIECRDs: true
     controller:
       image: kserve/llmisvc-controller
       tag: ''

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -113,6 +113,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.llmisvc.controller.terminationGracePeriodSeconds | int | `10` |  |
 | kserve.llmisvc.controller.tolerations | list | `[]` |  |
 | kserve.llmisvc.controller.topologySpreadConstraints | list | `[]` |  |
+| kserve.llmisvc.createGIECRDs | bool | `true` |  |
 | kserve.localmodel.agent.affinity | object | `{}` |  |
 | kserve.localmodel.agent.hostPath | string | `"/mnt/models"` |  |
 | kserve.localmodel.agent.image | string | `"kserve/kserve-localmodelnode-agent"` |  |

--- a/charts/kserve-llmisvc-resources/templates/_helpers.tpl
+++ b/charts/kserve-llmisvc-resources/templates/_helpers.tpl
@@ -81,3 +81,14 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
+{{/*
+Names of the GIE CRDs bundled with this chart.
+*/}}
+{{- define "llm-isvc-resources.gieCRDNames" -}}
+- inferencemodelrewrites.inference.networking.x-k8s.io
+- inferenceobjectives.inference.networking.x-k8s.io
+- inferencepoolimports.inference.networking.x-k8s.io
+- inferencepools.inference.networking.k8s.io
+- inferencepools.inference.networking.x-k8s.io
+{{- end }}
+

--- a/charts/kserve-llmisvc-resources/templates/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/templates/llmisvc/resources.yaml
@@ -1,5 +1,19 @@
-{{- include "kserve-common.renderMultiResourceWithPatches" (dict
+{{- $rendered := include "kserve-common.renderMultiResourceWithPatches" (dict
   "baseFile" "files/llmisvc/resources.yaml"
   "patchGlob" "files/llmisvc/*-patch.yaml"
   "certName" "llmisvc-serving-cert"
-  "context" .) -}}
+  "context" .) }}
+{{- if .Values.kserve.llmisvc.createGIECRDs -}}
+{{ $rendered }}
+{{- else -}}
+{{- range $doc := splitList "\n---\n" $rendered -}}
+{{- $trimmed := trim $doc -}}
+{{- if $trimmed -}}
+{{- $parsed := fromYaml $trimmed -}}
+{{- if and $parsed (ne $parsed.kind "CustomResourceDefinition") }}
+---
+{{ $trimmed }}
+{{- end -}}
+{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/kserve-llmisvc-resources/templates/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/templates/llmisvc/resources.yaml
@@ -6,14 +6,25 @@
 {{- if .Values.kserve.llmisvc.createGIECRDs -}}
 {{ $rendered }}
 {{- else -}}
+{{- $gieCRDNames := include "llm-isvc-resources.gieCRDNames" . | fromYamlArray -}}
 {{- range $doc := splitList "\n---\n" $rendered -}}
 {{- $trimmed := trim $doc -}}
 {{- if $trimmed -}}
 {{- $parsed := fromYaml $trimmed -}}
-{{- if and $parsed (ne $parsed.kind "CustomResourceDefinition") }}
+{{- $skip := false -}}
+{{- if and $parsed (eq (default "" $parsed.kind) "CustomResourceDefinition") -}}
+{{- $name := "" -}}
+{{- if $parsed.metadata -}}
+{{- $name = default "" $parsed.metadata.name -}}
+{{- end -}}
+{{- if has $name $gieCRDNames -}}
+{{- $skip = true -}}
+{{- end -}}
+{{- end -}}
+{{- if and $parsed (not $skip) }}
 ---
 {{ $trimmed }}
 {{- end -}}
 {{- end -}}
-{{- end }}
+{{- end -}}
 {{- end }}

--- a/charts/kserve-llmisvc-resources/values.schema.json
+++ b/charts/kserve-llmisvc-resources/values.schema.json
@@ -21,6 +21,11 @@
                 "llmisvc": {
                     "type": "object",
                     "properties": {
+                        "createGIECRDs": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Create the Gateway API Inference Extension (GIE) CRDs bundled with this chart. Set to false if these CRDs are managed by another component to avoid Helm release-ownership conflicts. The LLMInferenceService controller still requires the CRDs to exist on the cluster at runtime."
+                        },
                         "controller": {
                             "type": "object",
                             "properties": {

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -106,6 +106,7 @@ kserve:
     scaleUpStabilizationWindowSeconds: '0'
     scaleDownStabilizationWindowSeconds: '300'
   llmisvc:
+    createGIECRDs: true
     controller:
       image: kserve/llmisvc-controller
       tag: ''


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new Helm value `kserve.llmisvc.createGIECRDs` (default: `true`) to `kserve-llmisvc-resources` so operators can skip creating bundled Gateway API Inference Extension (GIE) CRDs when those CRDs are already managed elsewhere.

When the value is set to `false`, the chart renders all `llmisvc` resources except `CustomResourceDefinition` objects, avoiding Helm ownership conflicts in shared-cluster setups. This keeps default behavior unchanged while adding a safe opt-out path for pre-provisioned CRDs.

Also updates chart schema/docs for the new value and includes generated OpenAPI formatting-only updates.

**Which issue(s) this PR fixes**:  
- https://github.com/kserve/kserve/issues/5543

**Feature/Issue validation/testing**:

- Verified Helm values and schema include `kserve.llmisvc.createGIECRDs` with default `true`
- Verified chart template logic filters out CRDs only when `createGIECRDs=false`
- Verified default behavior still renders full resource set (including CRDs)

**Notes for the reviewer**:

- Default install behavior remains backward compatible (`createGIECRDs=true`)
- `createGIECRDs=false` is intended for environments where GIE CRDs are installed/owned by another release or platform component
- LLMISVC controller still requires these CRDs to exist at runtime; this flag only controls chart ownership/creation

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
Add `kserve.llmisvc.createGIECRDs` Helm value to optionally skip creating bundled GIE CRDs in the kserve-llmisvc-resources chart.