### PR TITLE
fix(llmisvc): use `model-server-protocol-metrics` 

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -55,7 +55,7 @@ const (
 
 	precisePrefixCacheScorerPlugin = "precise-prefix-cache-scorer"
 	prefixCacheScorerPlugin        = "prefix-cache-scorer"
-	coreMetricsExtractorPlugin     = "core-metrics-extractor"
+	coreMetricsExtractorPlugin     = "model-server-protocol-metrics"
 	udsTokenizerBaseModelName      = "base"
 	udsTokenizerSocketFile         = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
 )

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -829,7 +829,7 @@ plugins:
 			name: "skips when plugin already exists",
 			configYAML: `
 plugins:
-- type: core-metrics-extractor
+- type: model-server-protocol-metrics
   parameters:
     defaultEngine: vllm
 `,
@@ -1134,8 +1134,8 @@ schedulingProfiles:
 				// Pre-existing migrations applied
 				g.Expect(configText).To(ContainSubstring("blockSizeTokens"))
 
-				// CLI flag values moved to core-metrics-extractor plugin
-				g.Expect(configText).To(ContainSubstring("core-metrics-extractor"))
+				// CLI flag values moved to model-server-protocol-metrics plugin
+				g.Expect(configText).To(ContainSubstring("model-server-protocol-metrics"))
 				g.Expect(configText).To(ContainSubstring("vllm:num_requests_waiting"))
 				g.Expect(configText).To(ContainSubstring("vllm:num_requests_running"))
 				g.Expect(configText).To(ContainSubstring("vllm:kv_cache_usage_perc"))
@@ -1171,8 +1171,8 @@ schedulingProfiles:
 				g.Expect(configText).To(ContainSubstring("deciderPluginName"))
 				g.Expect(configText).To(ContainSubstring("hashBlockSize"))
 
-				// No core-metrics-extractor injected
-				g.Expect(configText).NotTo(ContainSubstring("core-metrics-extractor"))
+				// No model-server-protocol-metrics injected
+				g.Expect(configText).NotTo(ContainSubstring("model-server-protocol-metrics"))
 
 				// Pre-existing migrations still applied (unconditional)
 				g.Expect(configText).To(ContainSubstring("blockSizeTokens"))
@@ -1363,7 +1363,7 @@ plugins:
 			validateConfig: func(g Gomega, args []string) {
 				for i, a := range args {
 					if a == "--configText" && i+1 < len(args) {
-						g.Expect(args[i+1]).To(ContainSubstring("core-metrics-extractor"))
+						g.Expect(args[i+1]).To(ContainSubstring("model-server-protocol-metrics"))
 						g.Expect(args[i+1]).To(ContainSubstring("vllm:num_requests_waiting"))
 						g.Expect(args[i+1]).To(ContainSubstring("vllm:kv_cache_usage_perc"))
 						return
@@ -1389,7 +1389,7 @@ plugins:
 			validateConfig: func(g Gomega, args []string) {
 				for i, a := range args {
 					if a == "--config-text" && i+1 < len(args) {
-						g.Expect(args[i+1]).To(ContainSubstring("core-metrics-extractor"))
+						g.Expect(args[i+1]).To(ContainSubstring("model-server-protocol-metrics"))
 						g.Expect(args[i+1]).To(ContainSubstring("vllm:num_requests_waiting"))
 						return
 					}
@@ -1414,7 +1414,7 @@ plugins:
 			validateConfig: func(g Gomega, args []string) {
 				for i, a := range args {
 					if a == "-config-text" && i+1 < len(args) {
-						g.Expect(args[i+1]).To(ContainSubstring("core-metrics-extractor"))
+						g.Expect(args[i+1]).To(ContainSubstring("model-server-protocol-metrics"))
 						g.Expect(args[i+1]).To(ContainSubstring("vllm:num_requests_waiting"))
 						return
 					}
@@ -1439,7 +1439,7 @@ plugins:
 			validateConfig: func(g Gomega, args []string) {
 				for i, a := range args {
 					if a == "-configText" && i+1 < len(args) {
-						g.Expect(args[i+1]).To(ContainSubstring("core-metrics-extractor"))
+						g.Expect(args[i+1]).To(ContainSubstring("model-server-protocol-metrics"))
 						g.Expect(args[i+1]).To(ContainSubstring("vllm:num_requests_waiting"))
 						return
 					}

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -802,6 +802,88 @@ LLMINFERENCESERVICE_CONFIGS = {
             },
         },
     },
+    "scheduler-with-custom-template": {
+        "router": {
+            "scheduler": {
+                "template": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "env": [
+                                {
+                                    "name": "TOKENIZER_CACHE_DIR",
+                                    "value": "/tmp/tokenizer-cache",
+                                },
+                                {
+                                    "name": "HF_HOME",
+                                    "value": "/tmp/tokenizer-cache",
+                                },
+                                {
+                                    "name": "TRANSFORMERS_CACHE",
+                                    "value": "/tmp/tokenizer-cache",
+                                },
+                                {"name": "XDG_CACHE_HOME", "value": "/tmp"},
+                            ],
+                            "args": [
+                                "--cert-path",
+                                "/var/run/kserve/tls",
+                                "--pool-group",
+                                "inference.networking.x-k8s.io",
+                                "--pool-name",
+                                "{{ ChildName .ObjectMeta.Name `-inference-pool` }}",
+                                "--pool-namespace",
+                                "{{ .ObjectMeta.Namespace }}",
+                                "--zap-encoder",
+                                "json",
+                                "--grpc-port",
+                                "9002",
+                                "--grpc-health-port",
+                                "9003",
+                                "--secure-serving",
+                                "--model-server-metrics-scheme",
+                                "https",
+                                "--kv-cache-usage-percentage-metric",
+                                "vllm:kv_cache_usage_perc",
+                                "--config-text",
+                                (
+                                    "apiVersion: inference.networking.x-k8s.io/v1alpha1\n"
+                                    "kind: EndpointPickerConfig\n"
+                                    "plugins:\n"
+                                    "- type: single-profile-handler\n"
+                                    "- type: queue-scorer\n"
+                                    "- type: active-request-scorer\n"
+                                    "- type: prefix-cache-scorer\n"
+                                    "schedulingProfiles:\n"
+                                    "- name: default\n"
+                                    "  plugins:\n"
+                                    "  - pluginRef: queue-scorer\n"
+                                    "    weight: 2\n"
+                                    "  - pluginRef: active-request-scorer\n"
+                                    "    weight: 2\n"
+                                    "  - pluginRef: prefix-cache-scorer\n"
+                                    "    weight: 3\n"
+                                ),
+                            ],
+                            "volumeMounts": [
+                                {
+                                    "name": "tokenizer-cache",
+                                    "mountPath": "/tmp/tokenizer-cache",
+                                },
+                                {
+                                    "name": "cachi2-cache",
+                                    "mountPath": "/cachi2",
+                                },
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {"name": "tokenizer-cache", "emptyDir": {}},
+                        {"name": "cachi2-cache", "emptyDir": {}},
+                    ],
+                },
+            },
+        },
+    },
     "router-with-gateway-section-name": {
         "router": {
             "gateway": {

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -384,6 +384,18 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
             ),
             marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
         ),
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-with-custom-template",
+                    "workload-llmd-simulator",
+                ],
+                prompt="KServe is a",
+                service_name="scheduler-custom-template-test",
+            ),
+            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
+        ),
         # Precise prefix KV cache routing test
         pytest.param(
             TestCase(


### PR DESCRIPTION
The scheduler migration was using the wrong plugin name for the
core metrics extractor, causing a mismatch with the actual GIE
plugin type. Also adds an e2e test with a custom scheduler template
to validate the migration path for deprecated metric flags.

transformation logic assumes core-metrics-extractor but scheduler 0.7 (GIE 1.4) expects `model-server-protocol-metrics`
https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/release-1.4/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go#L28

vs GIE 1.5 using `core-metrics-extractor` (future version)
https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/release-1.5/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go#L31

Now we get the correct args for the matching llm-d scheduler version (0.7 currently)
```yaml
  - args:
    - --cert-path
    - /var/run/kserve/tls
    - --pool-group
    - inference.networking.x-k8s.io
    - --pool-name
    - scheduler-custom-template-test-inference-pool
    - --pool-namespace
    - kserve-ci-e2e-test
    - --zap-encoder
    - json
    - --grpc-port
    - "9002"
    - --grpc-health-port
    - "9003"
    - --secure-serving
    - --model-server-metrics-scheme
    - https
    - --config-text
    - |
      apiVersion: inference.networking.x-k8s.io/v1alpha1
      kind: EndpointPickerConfig
      plugins:
      - type: single-profile-handler
      - type: queue-scorer
      - type: active-request-scorer
      - type: prefix-cache-scorer
      - name: model-server-protocol-metrics
        parameters:
          defaultEngine: vllm
          engineConfigs:
          - kvUsageSpec: vllm:kv_cache_usage_perc
            name: vllm
          engineLabelKey: inference.networking.k8s.io/engine-type
        type: model-server-protocol-metrics
      schedulingProfiles:
      - name: default
        plugins:
        - pluginRef: queue-scorer
          weight: 2
        - pluginRef: active-request-scorer
          weight: 2
        - pluginRef: prefix-cache-scorer
          weight: 3
    command:
    - /app/epp
    - --pool-name
    - scheduler-custom-template-test-inference-pool
    - --pool-namespace
    - kserve-ci-e2e-test
    - --zap-encoder
    - json
    - --grpc-port
    - "9002"
    - --grpc-health-port
    - "9003"
```