### PR TITLE
feat(llmisvc): make creation of GIE CRDs optional

### DIFF
--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -58,6 +58,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.inferenceservice.resources.limits.memory | string | `"2Gi"` |  |
 | kserve.inferenceservice.resources.requests.cpu | string | `"1"` |  |
 | kserve.inferenceservice.resources.requests.memory | string | `"2Gi"` |  |
+| kserve.llmisvc.installGIECRDs | bool | `true` | Whether to install Gateway API Inference Extension (GIE) CRDs. Set to false if already managed by another release. |
 | kserve.llmisvc.controller.affinity | object | `{}` |  |
 | kserve.llmisvc.controller.annotations | object | `{}` |  |
 | kserve.llmisvc.controller.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |

--- a/charts/kserve-llmisvc-resources/templates/_resources.tpl
+++ b/charts/kserve-llmisvc-resources/templates/_resources.tpl
@@ -10,6 +10,7 @@ Parameters (dict):
   - patchGlob: string - Glob pattern for patch files (e.g., "files/kserve/*-patch.yaml")
   - certName: string - The cert name portion after namespace (e.g., "serving-cert", "llmisvc-serving-cert")
   - context: . - The root context for accessing .Release, .Files, etc.
+  - excludeCRDNames: list (optional) - List of CRD metadata.name values to exclude from output
 
 Example usage:
 {{- include "kserve-common.renderMultiResourceWithPatches" (dict
@@ -78,10 +79,21 @@ Example usage:
   {{- end -}}
 {{- end -}}
 
-{{- /* 7. Output all merged resources */ -}}
+{{- /* 6.1. Build set of CRD names to exclude (optional) */ -}}
+{{- $excludeSet := dict -}}
+{{- if .excludeCRDNames -}}
+  {{- range .excludeCRDNames -}}
+    {{- $excludeKey := printf "CustomResourceDefinition/%s" . -}}
+    {{- $_ := set $excludeSet $excludeKey true -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* 7. Output all merged resources, skipping excluded CRDs */ -}}
 {{- range $key := keys $baseMap | sortAlpha }}
+{{- if not (hasKey $excludeSet $key) }}
 {{- $resource := index $baseMap $key }}
 ---
 {{ toYaml $resource }}
+{{ end -}}
 {{ end -}}
 {{- end -}}

--- a/charts/kserve-llmisvc-resources/templates/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/templates/llmisvc/resources.yaml
@@ -1,5 +1,19 @@
+{{- $gieCRDNames := list
+  "inferencemodelrewrites.inference.networking.x-k8s.io"
+  "inferenceobjectives.inference.networking.x-k8s.io"
+  "inferencepoolimports.inference.networking.x-k8s.io"
+  "inferencepools.inference.networking.k8s.io"
+  "inferencepools.inference.networking.x-k8s.io"
+-}}
+{{- $ctx := dict "exclude" (list) -}}
+{{- if hasKey .Values.kserve.llmisvc "installGIECRDs" -}}
+  {{- if not .Values.kserve.llmisvc.installGIECRDs -}}
+    {{- $_ := set $ctx "exclude" $gieCRDNames -}}
+  {{- end -}}
+{{- end -}}
 {{- include "kserve-common.renderMultiResourceWithPatches" (dict
   "baseFile" "files/llmisvc/resources.yaml"
   "patchGlob" "files/llmisvc/*-patch.yaml"
   "certName" "llmisvc-serving-cert"
+  "excludeCRDNames" (get $ctx "exclude")
   "context" .) -}}

--- a/charts/kserve-llmisvc-resources/values.schema.json
+++ b/charts/kserve-llmisvc-resources/values.schema.json
@@ -21,6 +21,11 @@
                 "llmisvc": {
                     "type": "object",
                     "properties": {
+                        "installGIECRDs": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Whether to install Gateway API Inference Extension (GIE) CRDs. Set to false if already managed by another release."
+                        },
                         "controller": {
                             "type": "object",
                             "properties": {

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -106,6 +106,11 @@ kserve:
     scaleUpStabilizationWindowSeconds: '0'
     scaleDownStabilizationWindowSeconds: '300'
   llmisvc:
+    # -- Whether to install the Gateway API Inference Extension (GIE) CRDs
+    # (InferencePool, InferenceObjective, InferenceModelRewrite, InferencePoolImport).
+    # Set to false if these CRDs are already managed by another Helm release
+    # (e.g., a standalone gateway-api-inference-extension installation).
+    installGIECRDs: true
     controller:
       image: kserve/llmisvc-controller
       tag: ''


### PR DESCRIPTION
## What this PR does / why we need it

Adds a `kserve.llmisvc.installGIECRDs` boolean value (defaults to `true`) to the `kserve-llmisvc-resources` Helm chart, making the five Gateway API Inference Extension (GIE) CRDs opt-out.

Today `templates/llmisvc/resources.yaml` renders the GIE CRDs unconditionally. When another component (standalone `gateway-api-inference-extension` release, an operator bundle, etc.) already owns those CRDs, `helm install` fails with an ownership annotation error.

Setting `kserve.llmisvc.installGIECRDs: false` skips the five CRDs while still rendering all controller resources.

## Which issue(s) this PR fixes

Fixes #5543

## Does this PR introduce a user-facing change?

Yes. New Helm value `kserve.llmisvc.installGIECRDs` (default `true`).

## How Has This Been Tested?

Verified with `helm template` across three scenarios:

- Default (no flag): 5 GIE CRDs rendered, all controller resources present
- installGIECRDs=true: 5 GIE CRDs rendered, all controller resources present
- installGIECRDs=false: 0 GIE CRDs rendered, all controller resources still present
