### PR TITLE
fix(llmisvc): gate SSL_CERT_DIR /var/run/kserve/tls prefix on EnableTLS

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -243,7 +243,7 @@ spec:
           fieldRef:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
-        value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+        value: '{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls:{{- end }}/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs'
       image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -579,7 +579,7 @@ spec:
           fieldRef:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
-        value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+        value: '{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls:{{- end }}/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs'
       image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1888,7 +1888,7 @@ spec:
             }}'
           env:
           - name: SSL_CERT_DIR
-            value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+            value: '{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls:{{- end }}/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs'
           image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -281,7 +281,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: SSL_CERT_DIR
-            value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
+            value: '{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls:{{- end }}/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs'
     terminationGracePeriodSeconds: 60
     volumes:
       - emptyDir: { }

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -64,7 +64,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: SSL_CERT_DIR
-            value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
+            value: '{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls:{{- end }}/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs'
     containers:
       - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
         imagePullPolicy: IfNotPresent

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -78,7 +78,7 @@ spec:
               - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
             env:
               - name: SSL_CERT_DIR
-                value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
+                value: '{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls:{{- end }}/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs'
             resources:
               requests:
                 cpu: 256m

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -123,8 +123,10 @@ func TestPresetFiles(t *testing.T) {
 											},
 										},
 										{
+											// kserveSystemConfig in this test has EnableTLS=false (zero value),
+											// so the conditional /var/run/kserve/tls prefix is omitted.
 											Name:  "SSL_CERT_DIR",
-											Value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs",
+											Value: "/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs",
 										},
 									},
 									Ports: []corev1.ContainerPort{


### PR DESCRIPTION
## What this PR does / why we need it

`SSL_CERT_DIR` was set unconditionally in the scheduler and routing-sidecar
container specs of three LLMInferenceServiceConfig templates, always
referencing `/var/run/kserve/tls` even when TLS is disabled via
`GlobalConfig.EnableTLS`. This is inconsistent with the surrounding TLS
args (`--secure-serving`, `--cert-path`, `--decoder-use-tls`, etc.) which
are all properly gated behind `{{ if .GlobalConfig.EnableTLS }}`.

Make the `/var/run/kserve/tls` prefix conditional on `EnableTLS` while
keeping the service-account CA and system cert directories **always**
available — those are needed regardless of user-facing TLS so the
container can still verify in-cluster connections (e.g. to the K8s API
server):

```yaml
- name: SSL_CERT_DIR
  value: '{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls:{{- end }}/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs'
```

This keeps the change minimal, valid YAML (template stays inside the
quoted string like the existing `--cert-path` pattern), and addresses
the original concern: no path to a non-existent `/var/run/kserve/tls`
when TLS is off.

## Files changed

- `config/llmisvcconfig/config-llm-scheduler.yaml` — scheduler main container
- `config/llmisvcconfig/config-llm-decode-template.yaml` — routing sidecar
- `config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml` — routing sidecar
- `charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml` — regenerated from the three sources via `bash hack/setup/scripts/generate_chart_manifests.sh` so the Helm-bundled copies stay in sync
- `pkg/controller/v1alpha2/llmisvc/config_presets_test.go` — updated the `SSL_CERT_DIR` expected value in `TestPresetFiles` to match the new conditional output (the test's `kserveSystemConfig` leaves `EnableTLS` at its zero value `false`)

## Which issue(s) this PR fixes

Fixes #5537

## Does this PR introduce a user-facing change?

No behavioral change when TLS is enabled — the rendered value is
unchanged. When TLS is disabled, `SSL_CERT_DIR` no longer references the
non-existent `/var/run/kserve/tls` directory, only the service-account
CA and system certs.

## Feature/Issue validation/testing

- All 8 `TestPresetFiles` subtests pass locally.
- `go vet`, `go build`, and `golangci-lint run` on the package are clean.
- Verified the regenerated chart file is byte-identical to running
  `bash hack/setup/scripts/generate_chart_manifests.sh` on top of the
  source changes.
