### PR TITLE
fix(llmisvc): remove duplicate yaml.Unmarshal in loadConfig test helper

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -613,10 +613,6 @@ func loadConfig(t *testing.T, data []byte, filePath string) *v1alpha2.LLMInferen
 		t.Errorf("Failed to unmarshal YAML from %s: %v", filePath, err)
 		return nil
 	}
-	if err := yaml.Unmarshal(data, config); err != nil {
-		t.Errorf("Failed to unmarshal YAML from %s: %v", filePath, err)
-		return nil
-	}
 
 	expectedGroupVersion := v1alpha2.LLMInferenceServiceConfigGVK.GroupVersion().String()
 	if config.APIVersion != expectedGroupVersion {


### PR DESCRIPTION
## What this PR does / why we need it

`loadConfig()` in `pkg/controller/v1alpha2/llmisvc/config_presets_test.go`
called `yaml.Unmarshal` twice on the same data into the same struct —
a copy-paste bug. The second call is redundant and is removed here.

> The PR was originally scoped to also gate `SSL_CERT_DIR` in
> `charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml`,
> but that file is generated from `config/llmisvcconfig/*.yaml` via
> `kustomize build` (see `hack/setup/scripts/generate_chart_manifests.sh`),
> so editing it directly is incorrect — thanks @pierDipi for catching this.
> The SSL_CERT_DIR fix is being addressed at the source in #5547; once
> that lands, `make generate-chart-manifests` will regenerate the chart
> file with the conditional automatically.

## Does this PR introduce a user-facing change?

No — test-only cleanup with no behavior change.

## Feature/Issue validation/testing

- Pure deletion of 4 lines; the first `yaml.Unmarshal` call still populates
  `config`, so all subsequent assertions in `loadConfig` are unaffected.
- Package compiles cleanly (`go vet`, `go build`, `golangci-lint run`).
