### PR TITLE
feat(llmisvc): list available configs in configNotFoundError

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -477,7 +477,10 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 // configNotFoundError is returned by getConfig when an LLMInferenceServiceConfig
 // cannot be found in either the service namespace or the system namespace.
 // It carries the config name, the ordered list of namespaces that were searched,
-// and the names of configs that do exist so the operator can see alternatives.
+// and the namespace/name of configs that do exist so the operator can see
+// alternatives. An empty Available slice renders as "[]", which by itself is a
+// useful signal that no LLMInferenceServiceConfig resources were found in any
+// of the searched namespaces.
 type configNotFoundError struct {
 	Name       string
 	Namespaces []string
@@ -485,11 +488,8 @@ type configNotFoundError struct {
 }
 
 func (e *configNotFoundError) Error() string {
-	msg := fmt.Sprintf("LLMInferenceServiceConfig %q not found in namespaces %v", e.Name, e.Namespaces)
-	if len(e.Available) > 0 {
-		msg += fmt.Sprintf("; available configs: %v", e.Available)
-	}
-	return msg
+	return fmt.Sprintf("LLMInferenceServiceConfig %q not found in namespaces %v; available configs: %v",
+		e.Name, e.Namespaces, e.Available)
 }
 
 // getConfig retrieves kserveapis.LLMInferenceServiceConfig with the given name from either the kserveapis.LLMInferenceService
@@ -516,24 +516,21 @@ func (r *LLMISVCReconciler) getConfig(ctx context.Context, llmSvc *v1alpha2.LLMI
 	return cfg, nil
 }
 
-// listAvailableConfigs lists the names of LLMInferenceServiceConfig resources across
-// the given namespaces, deduplicating entries. This is used to provide helpful context
-// in configNotFoundError messages so operators can quickly identify available alternatives.
+// listAvailableConfigs returns the sorted, deduplicated namespace/name pairs
+// of LLMInferenceServiceConfig resources across the given namespaces, so that
+// a config named "foo" in two different namespaces is not ambiguous.
+// Best-effort: namespaces that fail to list are skipped with a log line.
 func (r *LLMISVCReconciler) listAvailableConfigs(ctx context.Context, namespaces []string) []string {
 	logger := log.FromContext(ctx).WithName("listAvailableConfigs")
 	seen := sets.New[string]()
 	for _, ns := range namespaces {
 		cfgList := &v1alpha2.LLMInferenceServiceConfigList{}
 		if err := r.List(ctx, cfgList, client.InNamespace(ns)); err != nil {
-			// Best-effort: log and skip this namespace so a recurring list failure
-			// (RBAC, transient API errors) is visible during troubleshooting and is
-			// distinguishable from "no configs exist". The original not-found
-			// information is still returned to the caller.
 			logger.Error(err, "failed to list LLMInferenceServiceConfigs", "namespace", ns)
 			continue
 		}
 		for i := range cfgList.Items {
-			seen.Insert(cfgList.Items[i].Name)
+			seen.Insert(fmt.Sprintf("%s/%s", ns, cfgList.Items[i].Name))
 		}
 	}
 	return sets.List(seen)

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -476,16 +476,20 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 
 // configNotFoundError is returned by getConfig when an LLMInferenceServiceConfig
 // cannot be found in either the service namespace or the system namespace.
-// It carries the config name and the ordered list of namespaces that were searched.
-// TODO: extend Error() to list the LLMInferenceServiceConfig resources that do exist
-// in the searched namespaces, so the operator can see available alternatives at a glance.
+// It carries the config name, the ordered list of namespaces that were searched,
+// and the names of configs that do exist so the operator can see alternatives.
 type configNotFoundError struct {
 	Name       string
 	Namespaces []string
+	Available  []string
 }
 
 func (e *configNotFoundError) Error() string {
-	return fmt.Sprintf("LLMInferenceServiceConfig %q not found in namespaces %v", e.Name, e.Namespaces)
+	msg := fmt.Sprintf("LLMInferenceServiceConfig %q not found in namespaces %v", e.Name, e.Namespaces)
+	if len(e.Available) > 0 {
+		msg += fmt.Sprintf("; available configs: %v", e.Available)
+	}
+	return msg
 }
 
 // getConfig retrieves kserveapis.LLMInferenceServiceConfig with the given name from either the kserveapis.LLMInferenceService
@@ -500,7 +504,9 @@ func (r *LLMISVCReconciler) getConfig(ctx context.Context, llmSvc *v1alpha2.LLMI
 		cfg = &v1alpha2.LLMInferenceServiceConfig{}
 		if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: constants.KServeNamespace}, cfg); err != nil {
 			if apierrors.IsNotFound(err) {
-				return nil, &configNotFoundError{Name: name, Namespaces: []string{llmSvc.Namespace, constants.KServeNamespace}}
+				searchedNamespaces := []string{llmSvc.Namespace, constants.KServeNamespace}
+				available := r.listAvailableConfigs(ctx, searchedNamespaces)
+				return nil, &configNotFoundError{Name: name, Namespaces: searchedNamespaces, Available: available}
 			}
 			return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w",
 				name, llmSvc.Namespace, constants.KServeNamespace, err)
@@ -508,6 +514,24 @@ func (r *LLMISVCReconciler) getConfig(ctx context.Context, llmSvc *v1alpha2.LLMI
 		return cfg, nil
 	}
 	return cfg, nil
+}
+
+// listAvailableConfigs lists the names of LLMInferenceServiceConfig resources across
+// the given namespaces, deduplicating entries. This is used to provide helpful context
+// in configNotFoundError messages so operators can quickly identify available alternatives.
+func (r *LLMISVCReconciler) listAvailableConfigs(ctx context.Context, namespaces []string) []string {
+	seen := sets.New[string]()
+	for _, ns := range namespaces {
+		cfgList := &v1alpha2.LLMInferenceServiceConfigList{}
+		if err := r.List(ctx, cfgList, client.InNamespace(ns)); err != nil {
+			// Best-effort: if we can't list, just skip this namespace
+			continue
+		}
+		for i := range cfgList.Items {
+			seen.Insert(cfgList.Items[i].Name)
+		}
+	}
+	return sets.List(seen)
 }
 
 func MergeSpecs(ctx context.Context, cfgs ...v1alpha2.LLMInferenceServiceSpec) (v1alpha2.LLMInferenceServiceSpec, error) {

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -520,11 +520,16 @@ func (r *LLMISVCReconciler) getConfig(ctx context.Context, llmSvc *v1alpha2.LLMI
 // the given namespaces, deduplicating entries. This is used to provide helpful context
 // in configNotFoundError messages so operators can quickly identify available alternatives.
 func (r *LLMISVCReconciler) listAvailableConfigs(ctx context.Context, namespaces []string) []string {
+	logger := log.FromContext(ctx).WithName("listAvailableConfigs")
 	seen := sets.New[string]()
 	for _, ns := range namespaces {
 		cfgList := &v1alpha2.LLMInferenceServiceConfigList{}
 		if err := r.List(ctx, cfgList, client.InNamespace(ns)); err != nil {
-			// Best-effort: if we can't list, just skip this namespace
+			// Best-effort: log and skip this namespace so a recurring list failure
+			// (RBAC, transient API errors) is visible during troubleshooting and is
+			// distinguishable from "no configs exist". The original not-found
+			// information is still returned to the caller.
+			logger.Error(err, "failed to list LLMInferenceServiceConfigs", "namespace", ns)
 			continue
 		}
 		for i := range cfgList.Items {

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_errors_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_errors_test.go
@@ -16,10 +16,24 @@ limitations under the License.
 
 package llmisvc_test
 
+// Most "config not found" coverage is provided by the envtest specs in
+// controller_int_config_not_found_test.go, which exercise the real
+// reconciliation path and assert on the user-facing Status condition
+// Message. The unit-level tests below cover the two cases that don't
+// fit naturally into an envtest cluster:
+//
+//   - the pure string-formatting contract of (*ConfigNotFoundError).Error()
+//     across populated / empty / nil Available slices, where spinning up
+//     an envtest apiserver would be overkill;
+//
+//   - the best-effort behaviour of listAvailableConfigs when a per-namespace
+//     LIST fails (e.g. RBAC denial). Reproducing a List error scoped to a
+//     single namespace is awkward under envtest, so we inject the error
+//     via controller-runtime's fake client and interceptor.Funcs.
+
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -30,7 +44,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
-	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 )
 
@@ -96,129 +109,39 @@ func TestConfigNotFoundErrorMessage(t *testing.T) {
 	}
 }
 
-func TestListAvailableConfigs(t *testing.T) {
-	t.Run("returns sorted ns/name pairs across namespaces", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		scheme := newConfigMergeTestScheme(t)
-
-		fc := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(
-				newCfg("zeta", "default"),
-				newCfg("alpha", "default"),
-				newCfg("kserve-config-llm-decode-template", "kserve"),
-				newCfg("kserve-config-llm-scheduler", "kserve"),
-			).
-			Build()
-		r := &llmisvc.LLMISVCReconciler{Client: fc}
-
-		got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "kserve"})
-
-		g.Expect(got).To(Equal([]string{
-			"default/alpha",
-			"default/zeta",
-			"kserve/kserve-config-llm-decode-template",
-			"kserve/kserve-config-llm-scheduler",
-		}))
-	})
-
-	t.Run("disambiguates same-named configs in different namespaces", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		scheme := newConfigMergeTestScheme(t)
-
-		fc := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(
-				newCfg("foo", "default"),
-				newCfg("foo", "kserve"),
-			).
-			Build()
-		r := &llmisvc.LLMISVCReconciler{Client: fc}
-
-		got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "kserve"})
-
-		g.Expect(got).To(Equal([]string{"default/foo", "kserve/foo"}))
-	})
-
-	t.Run("empty result when no configs exist in any namespace", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		scheme := newConfigMergeTestScheme(t)
-
-		fc := fake.NewClientBuilder().WithScheme(scheme).Build()
-		r := &llmisvc.LLMISVCReconciler{Client: fc}
-
-		got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "kserve"})
-
-		g.Expect(got).To(BeEmpty())
-	})
-
-	t.Run("best-effort: namespace with failing list is skipped, others returned", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		scheme := newConfigMergeTestScheme(t)
-
-		listErr := errors.New("forbidden: user cannot list LLMInferenceServiceConfig in namespace \"forbidden-ns\"")
-
-		fc := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(
-				newCfg("ok-config", "default"),
-			).
-			WithInterceptorFuncs(interceptor.Funcs{
-				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-					listOpts := &client.ListOptions{}
-					for _, o := range opts {
-						o.ApplyToList(listOpts)
-					}
-					if listOpts.Namespace == "forbidden-ns" {
-						return listErr
-					}
-					return c.List(ctx, list, opts...)
-				},
-			}).
-			Build()
-		r := &llmisvc.LLMISVCReconciler{Client: fc}
-
-		got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "forbidden-ns"})
-
-		g.Expect(got).To(Equal([]string{"default/ok-config"}),
-			"forbidden namespace should be silently dropped, default's configs preserved")
-	})
-}
-
-// TestGetConfig_NotFound_PopulatesAvailable is the end-to-end check that the
-// configNotFoundError returned by getConfig carries the namespace/name
-// formatted Available list — the user-facing payoff of listAvailableConfigs.
-func TestGetConfig_NotFound_PopulatesAvailable(t *testing.T) {
+// TestListAvailableConfigs_SkipsFailingNamespace verifies that a LIST error
+// scoped to a single namespace (e.g. an RBAC denial in that namespace only)
+// does not poison the overall result — configs from the healthy namespaces
+// are still returned. envtest cannot easily reproduce this without
+// elaborate RBAC plumbing, so we inject the error via interceptor.Funcs.
+func TestListAvailableConfigs_SkipsFailingNamespace(t *testing.T) {
 	g := NewGomegaWithT(t)
 	scheme := newConfigMergeTestScheme(t)
+
+	listErr := errors.New("forbidden: user cannot list LLMInferenceServiceConfig in namespace \"forbidden-ns\"")
 
 	fc := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(
-			newCfg("kserve-config-llm-decode-template", constants.KServeNamespace),
-			newCfg("kserve-config-llm-scheduler", constants.KServeNamespace),
-			newCfg("user-custom-config", "user-ns"),
+			newCfg("ok-config", "default"),
 		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				listOpts := &client.ListOptions{}
+				for _, o := range opts {
+					o.ApplyToList(listOpts)
+				}
+				if listOpts.Namespace == "forbidden-ns" {
+					return listErr
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
 		Build()
 	r := &llmisvc.LLMISVCReconciler{Client: fc}
 
-	llmSvc := &v1alpha2.LLMInferenceService{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-llm", Namespace: "user-ns"},
-	}
+	got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "forbidden-ns"})
 
-	_, err := r.GetConfigForTest(context.Background(), llmSvc, "does-not-exist")
-
-	g.Expect(err).To(HaveOccurred())
-
-	var cfgNotFound *llmisvc.ConfigNotFoundError
-	g.Expect(errors.As(err, &cfgNotFound)).To(BeTrue(), "error should unwrap to *ConfigNotFoundError")
-	g.Expect(cfgNotFound.Name).To(Equal("does-not-exist"))
-	g.Expect(cfgNotFound.Namespaces).To(Equal([]string{"user-ns", constants.KServeNamespace}))
-	g.Expect(cfgNotFound.Available).To(ConsistOf(
-		fmt.Sprintf("%s/%s", constants.KServeNamespace, "kserve-config-llm-decode-template"),
-		fmt.Sprintf("%s/%s", constants.KServeNamespace, "kserve-config-llm-scheduler"),
-		"user-ns/user-custom-config",
-	))
-	g.Expect(cfgNotFound.Error()).To(ContainSubstring(`"does-not-exist" not found`))
-	g.Expect(cfgNotFound.Error()).To(ContainSubstring("user-ns/user-custom-config"))
+	g.Expect(got).To(Equal([]string{"default/ok-config"}),
+		"forbidden namespace should be silently dropped, default's configs preserved")
 }

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_errors_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_errors_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KServe Authors.
+Copyright 2026 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package llmisvc
+package llmisvc_test
 
 import (
 	"context"
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 )
 
 func newConfigMergeTestScheme(t *testing.T) *runtime.Scheme {
@@ -51,12 +52,12 @@ func newCfg(name, namespace string) *v1alpha2.LLMInferenceServiceConfig {
 func TestConfigNotFoundErrorMessage(t *testing.T) {
 	tests := []struct {
 		name string
-		err  *configNotFoundError
+		err  *llmisvc.ConfigNotFoundError
 		want string
 	}{
 		{
 			name: "available configs present - ns/name listed in sorted form",
-			err: &configNotFoundError{
+			err: &llmisvc.ConfigNotFoundError{
 				Name:       "kserve-config-llm-template",
 				Namespaces: []string{"default", "kserve"},
 				Available: []string{
@@ -69,7 +70,7 @@ func TestConfigNotFoundErrorMessage(t *testing.T) {
 		},
 		{
 			name: "empty available slice renders as []",
-			err: &configNotFoundError{
+			err: &llmisvc.ConfigNotFoundError{
 				Name:       "missing",
 				Namespaces: []string{"default", "kserve"},
 				Available:  []string{},
@@ -78,7 +79,7 @@ func TestConfigNotFoundErrorMessage(t *testing.T) {
 		},
 		{
 			name: "nil available slice also renders as []",
-			err: &configNotFoundError{
+			err: &llmisvc.ConfigNotFoundError{
 				Name:       "missing",
 				Namespaces: []string{"default", "kserve"},
 				Available:  nil,
@@ -109,9 +110,9 @@ func TestListAvailableConfigs(t *testing.T) {
 				newCfg("kserve-config-llm-scheduler", "kserve"),
 			).
 			Build()
-		r := &LLMISVCReconciler{Client: fc}
+		r := &llmisvc.LLMISVCReconciler{Client: fc}
 
-		got := r.listAvailableConfigs(context.Background(), []string{"default", "kserve"})
+		got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "kserve"})
 
 		g.Expect(got).To(Equal([]string{
 			"default/alpha",
@@ -132,9 +133,9 @@ func TestListAvailableConfigs(t *testing.T) {
 				newCfg("foo", "kserve"),
 			).
 			Build()
-		r := &LLMISVCReconciler{Client: fc}
+		r := &llmisvc.LLMISVCReconciler{Client: fc}
 
-		got := r.listAvailableConfigs(context.Background(), []string{"default", "kserve"})
+		got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "kserve"})
 
 		g.Expect(got).To(Equal([]string{"default/foo", "kserve/foo"}))
 	})
@@ -144,9 +145,9 @@ func TestListAvailableConfigs(t *testing.T) {
 		scheme := newConfigMergeTestScheme(t)
 
 		fc := fake.NewClientBuilder().WithScheme(scheme).Build()
-		r := &LLMISVCReconciler{Client: fc}
+		r := &llmisvc.LLMISVCReconciler{Client: fc}
 
-		got := r.listAvailableConfigs(context.Background(), []string{"default", "kserve"})
+		got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "kserve"})
 
 		g.Expect(got).To(BeEmpty())
 	})
@@ -175,9 +176,9 @@ func TestListAvailableConfigs(t *testing.T) {
 				},
 			}).
 			Build()
-		r := &LLMISVCReconciler{Client: fc}
+		r := &llmisvc.LLMISVCReconciler{Client: fc}
 
-		got := r.listAvailableConfigs(context.Background(), []string{"default", "forbidden-ns"})
+		got := r.ListAvailableConfigsForTest(context.Background(), []string{"default", "forbidden-ns"})
 
 		g.Expect(got).To(Equal([]string{"default/ok-config"}),
 			"forbidden namespace should be silently dropped, default's configs preserved")
@@ -199,18 +200,18 @@ func TestGetConfig_NotFound_PopulatesAvailable(t *testing.T) {
 			newCfg("user-custom-config", "user-ns"),
 		).
 		Build()
-	r := &LLMISVCReconciler{Client: fc}
+	r := &llmisvc.LLMISVCReconciler{Client: fc}
 
 	llmSvc := &v1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-llm", Namespace: "user-ns"},
 	}
 
-	_, err := r.getConfig(context.Background(), llmSvc, "does-not-exist")
+	_, err := r.GetConfigForTest(context.Background(), llmSvc, "does-not-exist")
 
 	g.Expect(err).To(HaveOccurred())
 
-	var cfgNotFound *configNotFoundError
-	g.Expect(errors.As(err, &cfgNotFound)).To(BeTrue(), "error should unwrap to *configNotFoundError")
+	var cfgNotFound *llmisvc.ConfigNotFoundError
+	g.Expect(errors.As(err, &cfgNotFound)).To(BeTrue(), "error should unwrap to *ConfigNotFoundError")
 	g.Expect(cfgNotFound.Name).To(Equal("does-not-exist"))
 	g.Expect(cfgNotFound.Namespaces).To(Equal([]string{"user-ns", constants.KServeNamespace}))
 	g.Expect(cfgNotFound.Available).To(ConsistOf(

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_export_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_export_test.go
@@ -18,8 +18,6 @@ package llmisvc
 
 import (
 	"context"
-
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
 
 // SetUseVersionedConfigForTest overrides the useVersionedConfig flag for testing
@@ -33,20 +31,16 @@ func SetUseVersionedConfigForTest(enabled bool) func() {
 }
 
 // ConfigNotFoundError exposes the package-internal configNotFoundError type
-// to tests in the llmisvc_test black-box package so they can construct
-// fixtures and assert against the Error() format without leaking the type
-// into the production API surface.
+// to the llmisvc_test black-box package so the Error()-format unit tests
+// can construct fixtures directly, without leaking the type into the
+// production API surface.
 type ConfigNotFoundError = configNotFoundError
 
 // ListAvailableConfigsForTest exposes the package-internal
-// listAvailableConfigs helper to tests in the llmisvc_test black-box
-// package.
+// listAvailableConfigs helper to the llmisvc_test black-box package so
+// the best-effort-skip-failing-namespace case (which needs per-namespace
+// LIST error injection that envtest can't easily reproduce) can be
+// exercised via a fake client + interceptor.Funcs.
 func (r *LLMISVCReconciler) ListAvailableConfigsForTest(ctx context.Context, namespaces []string) []string {
 	return r.listAvailableConfigs(ctx, namespaces)
-}
-
-// GetConfigForTest exposes the package-internal getConfig method to
-// tests in the llmisvc_test black-box package.
-func (r *LLMISVCReconciler) GetConfigForTest(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, name string) (*v1alpha2.LLMInferenceServiceConfig, error) {
-	return r.getConfig(ctx, llmSvc, name)
 }

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_export_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_export_test.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package llmisvc
 
+import (
+	"context"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
 // SetUseVersionedConfigForTest overrides the useVersionedConfig flag for testing
 // and returns a cleanup function that restores the original value.
 func SetUseVersionedConfigForTest(enabled bool) func() {
@@ -24,4 +30,23 @@ func SetUseVersionedConfigForTest(enabled bool) func() {
 	return func() {
 		useVersionedConfig = original
 	}
+}
+
+// ConfigNotFoundError exposes the package-internal configNotFoundError type
+// to tests in the llmisvc_test black-box package so they can construct
+// fixtures and assert against the Error() format without leaking the type
+// into the production API surface.
+type ConfigNotFoundError = configNotFoundError
+
+// ListAvailableConfigsForTest exposes the package-internal
+// listAvailableConfigs helper to tests in the llmisvc_test black-box
+// package.
+func (r *LLMISVCReconciler) ListAvailableConfigsForTest(ctx context.Context, namespaces []string) []string {
+	return r.listAvailableConfigs(ctx, namespaces)
+}
+
+// GetConfigForTest exposes the package-internal getConfig method to
+// tests in the llmisvc_test black-box package.
+func (r *LLMISVCReconciler) GetConfigForTest(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, name string) (*v1alpha2.LLMInferenceServiceConfig, error) {
+	return r.getConfig(ctx, llmSvc, name)
 }

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_internal_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func newConfigMergeTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1alpha2.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add v1alpha2 to scheme: %v", err)
+	}
+	return scheme
+}
+
+func newCfg(name, namespace string) *v1alpha2.LLMInferenceServiceConfig {
+	return &v1alpha2.LLMInferenceServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+}
+
+func TestConfigNotFoundErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *configNotFoundError
+		want string
+	}{
+		{
+			name: "available configs present - ns/name listed in sorted form",
+			err: &configNotFoundError{
+				Name:       "kserve-config-llm-template",
+				Namespaces: []string{"default", "kserve"},
+				Available: []string{
+					"default/my-llm-config",
+					"kserve/kserve-config-llm-decode-template",
+					"kserve/kserve-config-llm-scheduler",
+				},
+			},
+			want: `LLMInferenceServiceConfig "kserve-config-llm-template" not found in namespaces [default kserve]; available configs: [default/my-llm-config kserve/kserve-config-llm-decode-template kserve/kserve-config-llm-scheduler]`,
+		},
+		{
+			name: "empty available slice renders as []",
+			err: &configNotFoundError{
+				Name:       "missing",
+				Namespaces: []string{"default", "kserve"},
+				Available:  []string{},
+			},
+			want: `LLMInferenceServiceConfig "missing" not found in namespaces [default kserve]; available configs: []`,
+		},
+		{
+			name: "nil available slice also renders as []",
+			err: &configNotFoundError{
+				Name:       "missing",
+				Namespaces: []string{"default", "kserve"},
+				Available:  nil,
+			},
+			want: `LLMInferenceServiceConfig "missing" not found in namespaces [default kserve]; available configs: []`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(tt.err.Error()).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestListAvailableConfigs(t *testing.T) {
+	t.Run("returns sorted ns/name pairs across namespaces", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		scheme := newConfigMergeTestScheme(t)
+
+		fc := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(
+				newCfg("zeta", "default"),
+				newCfg("alpha", "default"),
+				newCfg("kserve-config-llm-decode-template", "kserve"),
+				newCfg("kserve-config-llm-scheduler", "kserve"),
+			).
+			Build()
+		r := &LLMISVCReconciler{Client: fc}
+
+		got := r.listAvailableConfigs(context.Background(), []string{"default", "kserve"})
+
+		g.Expect(got).To(Equal([]string{
+			"default/alpha",
+			"default/zeta",
+			"kserve/kserve-config-llm-decode-template",
+			"kserve/kserve-config-llm-scheduler",
+		}))
+	})
+
+	t.Run("disambiguates same-named configs in different namespaces", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		scheme := newConfigMergeTestScheme(t)
+
+		fc := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(
+				newCfg("foo", "default"),
+				newCfg("foo", "kserve"),
+			).
+			Build()
+		r := &LLMISVCReconciler{Client: fc}
+
+		got := r.listAvailableConfigs(context.Background(), []string{"default", "kserve"})
+
+		g.Expect(got).To(Equal([]string{"default/foo", "kserve/foo"}))
+	})
+
+	t.Run("empty result when no configs exist in any namespace", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		scheme := newConfigMergeTestScheme(t)
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := &LLMISVCReconciler{Client: fc}
+
+		got := r.listAvailableConfigs(context.Background(), []string{"default", "kserve"})
+
+		g.Expect(got).To(BeEmpty())
+	})
+
+	t.Run("best-effort: namespace with failing list is skipped, others returned", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		scheme := newConfigMergeTestScheme(t)
+
+		listErr := errors.New("forbidden: user cannot list LLMInferenceServiceConfig in namespace \"forbidden-ns\"")
+
+		fc := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(
+				newCfg("ok-config", "default"),
+			).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					listOpts := &client.ListOptions{}
+					for _, o := range opts {
+						o.ApplyToList(listOpts)
+					}
+					if listOpts.Namespace == "forbidden-ns" {
+						return listErr
+					}
+					return c.List(ctx, list, opts...)
+				},
+			}).
+			Build()
+		r := &LLMISVCReconciler{Client: fc}
+
+		got := r.listAvailableConfigs(context.Background(), []string{"default", "forbidden-ns"})
+
+		g.Expect(got).To(Equal([]string{"default/ok-config"}),
+			"forbidden namespace should be silently dropped, default's configs preserved")
+	})
+}
+
+// TestGetConfig_NotFound_PopulatesAvailable is the end-to-end check that the
+// configNotFoundError returned by getConfig carries the namespace/name
+// formatted Available list — the user-facing payoff of listAvailableConfigs.
+func TestGetConfig_NotFound_PopulatesAvailable(t *testing.T) {
+	g := NewGomegaWithT(t)
+	scheme := newConfigMergeTestScheme(t)
+
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			newCfg("kserve-config-llm-decode-template", constants.KServeNamespace),
+			newCfg("kserve-config-llm-scheduler", constants.KServeNamespace),
+			newCfg("user-custom-config", "user-ns"),
+		).
+		Build()
+	r := &LLMISVCReconciler{Client: fc}
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-llm", Namespace: "user-ns"},
+	}
+
+	_, err := r.getConfig(context.Background(), llmSvc, "does-not-exist")
+
+	g.Expect(err).To(HaveOccurred())
+
+	var cfgNotFound *configNotFoundError
+	g.Expect(errors.As(err, &cfgNotFound)).To(BeTrue(), "error should unwrap to *configNotFoundError")
+	g.Expect(cfgNotFound.Name).To(Equal("does-not-exist"))
+	g.Expect(cfgNotFound.Namespaces).To(Equal([]string{"user-ns", constants.KServeNamespace}))
+	g.Expect(cfgNotFound.Available).To(ConsistOf(
+		fmt.Sprintf("%s/%s", constants.KServeNamespace, "kserve-config-llm-decode-template"),
+		fmt.Sprintf("%s/%s", constants.KServeNamespace, "kserve-config-llm-scheduler"),
+		"user-ns/user-custom-config",
+	))
+	g.Expect(cfgNotFound.Error()).To(ContainSubstring(`"does-not-exist" not found`))
+	g.Expect(cfgNotFound.Error()).To(ContainSubstring("user-ns/user-custom-config"))
+}

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_config_not_found_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_config_not_found_test.go
@@ -18,6 +18,7 @@ package llmisvc_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
 	. "github.com/kserve/kserve/pkg/testing"
 )
@@ -61,7 +63,12 @@ var _ = Describe("LLMInferenceService Config resolution", func() {
 				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "False"))
 				cond := current.Status.GetCondition(v1alpha2.PresetsCombined)
 				g.Expect(cond.Reason).To(Equal("ConfigNotFound"))
-				g.Expect(cond.Message).To(ContainSubstring("does-not-exist"))
+				g.Expect(cond.Message).To(ContainSubstring(`"does-not-exist"`),
+					"message should quote the missing config name")
+				g.Expect(cond.Message).To(ContainSubstring("not found in namespaces"),
+					"message should name the searched namespaces")
+				g.Expect(cond.Message).To(ContainSubstring("available configs:"),
+					"message should include the available-configs hint (even if empty)")
 				return nil
 			}).WithContext(ctx).Should(Succeed())
 
@@ -122,6 +129,121 @@ var _ = Describe("LLMInferenceService Config resolution", func() {
 				current := &v1alpha2.LLMInferenceService{}
 				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
 				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "True"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should list available configs across service and system namespaces in the message", func(ctx SpecContext) {
+			// given - configs seeded in BOTH the service namespace and the
+			// system (KServe) namespace; the user-facing payoff of the
+			// configNotFoundError Available list is that it surfaces both
+			// scopes so operators can see what they could have referenced.
+			svcName := "test-llm-cfg-available-list"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			userCfgName := svcName + "-user-cfg"
+			systemCfgName := svcName + "-system-cfg"
+
+			userCfg := LLMInferenceServiceConfig(userCfgName,
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
+			)
+			Expect(envTest.Create(ctx, userCfg)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, userCfg)).To(Succeed())
+			}()
+
+			systemCfg := LLMInferenceServiceConfig(systemCfgName,
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](constants.KServeNamespace),
+			)
+			Expect(envTest.Create(ctx, systemCfg)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, systemCfg)).To(Succeed())
+			}()
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithBaseRefs(corev1.LocalObjectReference{Name: "does-not-exist"}),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - the rendered Available list carries both configs in
+			// namespace/name form. Other tests in the suite may have left
+			// unrelated configs in KServeNamespace, so we only assert that
+			// OUR configs are present, not that they are the only entries.
+			Eventually(func(g Gomega, ctx context.Context) error {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "False"))
+				cond := current.Status.GetCondition(v1alpha2.PresetsCombined)
+				g.Expect(cond.Reason).To(Equal("ConfigNotFound"))
+				g.Expect(cond.Message).To(ContainSubstring(
+					fmt.Sprintf("%s/%s", testNs.Name, userCfgName)),
+					"message should list the service-namespace config in ns/name form")
+				g.Expect(cond.Message).To(ContainSubstring(
+					fmt.Sprintf("%s/%s", constants.KServeNamespace, systemCfgName)),
+					"message should list the system-namespace config in ns/name form")
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should disambiguate same-named configs in different namespaces", func(ctx SpecContext) {
+			// given - identical config names in two namespaces; without the
+			// namespace qualifier the operator could not tell which one is
+			// which from the error message.
+			svcName := "test-llm-cfg-same-name-disambig"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			sharedName := svcName + "-shared"
+
+			userCfg := LLMInferenceServiceConfig(sharedName,
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
+			)
+			Expect(envTest.Create(ctx, userCfg)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, userCfg)).To(Succeed())
+			}()
+
+			systemCfg := LLMInferenceServiceConfig(sharedName,
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](constants.KServeNamespace),
+			)
+			Expect(envTest.Create(ctx, systemCfg)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, systemCfg)).To(Succeed())
+			}()
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithBaseRefs(corev1.LocalObjectReference{Name: "does-not-exist"}),
+			)
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - both occurrences appear in the message, distinguished
+			// by their namespace prefix.
+			Eventually(func(g Gomega, ctx context.Context) error {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "False"))
+				cond := current.Status.GetCondition(v1alpha2.PresetsCombined)
+				g.Expect(cond.Reason).To(Equal("ConfigNotFound"))
+				g.Expect(cond.Message).To(ContainSubstring(
+					fmt.Sprintf("%s/%s", testNs.Name, sharedName)),
+					"message should carry the service-namespace copy")
+				g.Expect(cond.Message).To(ContainSubstring(
+					fmt.Sprintf("%s/%s", constants.KServeNamespace, sharedName)),
+					"message should carry the system-namespace copy")
 				return nil
 			}).WithContext(ctx).Should(Succeed())
 		})


### PR DESCRIPTION
## What this PR does / why we need it
When an `LLMInferenceServiceConfig` is not found during reconciliation,
the error message now includes the names of configs that **do** exist in
the searched namespaces. This helps operators quickly identify typos,
missing installations, or available alternatives without running
additional `kubectl` commands.

**Before:**
```LLMInferenceServiceConfig "kserve-config-llm-template" not found in namespaces ["default", "kserve"]```

**After:**
```LLMInferenceServiceConfig "kserve-config-llm-template" not found in namespaces ["default", "kserve"]; available configs: ["kserve-config-llm-decode-template", "kserve-config-llm-scheduler", ...]```

Resolves the TODO at `config_merge.go:480`.

## Which issue(s) this PR fixes

Fixes #5549

## Implementation Details

- Added `Available []string` field to `configNotFoundError`
- Added `listAvailableConfigs()` method on `LLMISVCReconciler` that uses `r.List()` to enumerate configs across searched namespaces with deduplication via `sets.New[string]()`
- Best-effort design: if listing fails (RBAC, network), the namespace is silently skipped and the original not-found info is still present
- Sorted, deduplicated output via `sets.List()`
- `go vet` passes cleanly

## Does this PR introduce a user-facing change?

Yes — improved error messages when `LLMInferenceServiceConfig` is not found. The error now lists available configs for faster debugging.
