### PR TITLE
feat(llmisvc): migrate non-zero threshold to prefix-based-pd-decider

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"path"
 	"slices"
 	"sort"
@@ -996,8 +997,25 @@ func WithRenamePlugin(oldType, newType string) mutateSchedulerConfigFunc {
 }
 
 // WithMigrateDisaggProfileParams migrates the disagg-profile-handler (formerly
-// pd-profile-handler) from the old flat deciderPluginName parameter to the new
-// deciders map structure introduced in llm-d-inference-scheduler v0.7.0.
+// pd-profile-handler) from the old flat deciderPluginName/threshold parameters
+// to the new deciders map structure introduced in llm-d-inference-scheduler v0.7.0.
+//
+// Migration paths:
+//
+//	Path A: deciderPluginName present → use that name in the deciders map, strip threshold.
+//	Path B: threshold == 0, no deciderPluginName → always-disagg-pd-decider.
+//	Path C: threshold > 0, no deciderPluginName → prefix-based-pd-decider with nonCachedTokens.
+//
+// Path C conversion rationale (threshold → nonCachedTokens):
+// In v0.6, `threshold` was the number of **non-cached characters** in the user input
+// that determined whether to disaggregate:
+//
+//	if (1.0 - hitPercentagePrefix) * len(userInput) < threshold { /* skip prefill */ }
+//
+// In v0.7, the prefix-based-pd-decider uses `nonCachedTokens` (in **tokens**, not chars).
+// The conversion uses ceil(threshold / 4) based on the empirical ~4:1 character-to-token
+// ratio for English text. Note: the original v0.6 threshold was never properly tuned
+// (per upstream feedback), so the converted value should be reviewed for each workload.
 func WithMigrateDisaggProfileParams(ctx context.Context, u *unstructured.Unstructured) error {
 	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 	if err != nil || !found {
@@ -1008,7 +1026,11 @@ func WithMigrateDisaggProfileParams(ctx context.Context, u *unstructured.Unstruc
 		return nil
 	}
 
-	needDeciderPluginEntry := false
+	type deciderPluginEntry struct {
+		pluginType string
+		params     map[string]interface{}
+	}
+	var deciderPluginsToInject []deciderPluginEntry
 
 	for _, plugin := range plugins {
 		pluginMap, ok := plugin.(map[string]interface{})
@@ -1044,42 +1066,95 @@ func WithMigrateDisaggProfileParams(ctx context.Context, u *unstructured.Unstruc
 			continue
 		}
 
-		// Path B: threshold:0 (no deciderPluginName) → always-disagg-pd-decider.
-		// threshold:0 means "always disaggregate", which maps directly to the
-		// always-disagg-pd-decider plugin.
 		thresholdVal, thresholdFound, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "threshold")
 		if !thresholdFound {
 			continue
 		}
-		if fmt.Sprintf("%v", thresholdVal) != "0" {
-			continue
+
+		if fmt.Sprintf("%v", thresholdVal) == "0" {
+			// Path B: threshold == 0 → always-disagg-pd-decider.
+			log.FromContext(ctx).Info("Migrating threshold:0 to always-disagg-pd-decider for disagg-profile-handler")
+			deciders := map[string]interface{}{
+				"prefill": "always-disagg-pd-decider",
+			}
+			if err := unstructured.SetNestedField(pluginMap, deciders, "parameters", "deciders"); err != nil {
+				return err
+			}
+			unstructured.RemoveNestedField(pluginMap, "parameters", "threshold")
+			deciderPluginsToInject = append(deciderPluginsToInject, deciderPluginEntry{pluginType: "always-disagg-pd-decider"})
+		} else {
+			// Path C: threshold > 0 → prefix-based-pd-decider with nonCachedTokens.
+			nonCachedTokens := thresholdToNonCachedTokens(thresholdVal)
+			log.FromContext(ctx).Info(
+				"Migrating non-zero threshold to prefix-based-pd-decider: "+
+					"nonCachedTokens = ceil(threshold/4) is an approximation based on ~4:1 char-to-token ratio; "+
+					"the original v0.6 threshold was never properly tuned — review nonCachedTokens for your workload",
+				"threshold", thresholdVal,
+				"nonCachedTokens", nonCachedTokens,
+			)
+			deciders := map[string]interface{}{
+				"prefill": "prefix-based-pd-decider",
+			}
+			if err := unstructured.SetNestedField(pluginMap, deciders, "parameters", "deciders"); err != nil {
+				return err
+			}
+			unstructured.RemoveNestedField(pluginMap, "parameters", "threshold")
+			deciderPluginsToInject = append(deciderPluginsToInject, deciderPluginEntry{
+				pluginType: "prefix-based-pd-decider",
+				params:     map[string]interface{}{"nonCachedTokens": nonCachedTokens},
+			})
 		}
-		log.FromContext(ctx).Info("Migrating threshold:0 to always-disagg-pd-decider for disagg-profile-handler")
-		deciders := map[string]interface{}{
-			"prefill": "always-disagg-pd-decider",
-		}
-		if err := unstructured.SetNestedField(pluginMap, deciders, "parameters", "deciders"); err != nil {
-			return err
-		}
-		unstructured.RemoveNestedField(pluginMap, "parameters", "threshold")
-		needDeciderPluginEntry = true
 	}
 
-	// Ensure the always-disagg-pd-decider plugin entry exists in the top-level
-	// plugins list when we migrated threshold:0 (the decider must be declared).
-	if needDeciderPluginEntry {
+	// Ensure each decider plugin entry exists in the top-level plugins list.
+	for _, d := range deciderPluginsToInject {
+		alreadyExists := false
 		for _, p := range plugins {
-			if pm, ok := p.(map[string]interface{}); ok && pm["type"] == "always-disagg-pd-decider" {
-				return nil
+			if pm, ok := p.(map[string]interface{}); ok && pm["type"] == d.pluginType {
+				alreadyExists = true
+				break
 			}
 		}
-		plugins = append(plugins, map[string]interface{}{"type": "always-disagg-pd-decider"})
+		if !alreadyExists {
+			entry := map[string]interface{}{"type": d.pluginType}
+			if d.params != nil {
+				entry["parameters"] = d.params
+			}
+			plugins = append(plugins, entry)
+		}
+	}
+
+	if len(deciderPluginsToInject) > 0 {
 		if err := unstructured.SetNestedSlice(u.Object, plugins, "plugins"); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// thresholdToNonCachedTokens converts a v0.6 threshold (non-cached characters)
+// to the v0.7 nonCachedTokens value (tokens) using ceil(threshold / 4).
+// The 4:1 ratio is the empirical average for English text. The threshold may
+// be deserialized from YAML as int64 or float64, so both are handled.
+func thresholdToNonCachedTokens(val interface{}) int64 {
+	var f float64
+	switch v := val.(type) {
+	case float64:
+		f = v
+	case int64:
+		f = float64(v)
+	default:
+		// Best-effort parse for unexpected types (e.g. string from JSON).
+		if _, err := fmt.Sscanf(fmt.Sprintf("%v", val), "%f", &f); err != nil {
+			return 1
+		}
+	}
+	tokens := int64(math.Ceil(f / 4.0))
+	if tokens < 1 {
+		tokens = 1
+	}
+	return tokens
 }
 
 // WithRemoveHashBlockSize removes the deprecated hashBlockSize field from
@@ -1163,7 +1238,8 @@ func hasDeprecatedMetricFlags(d *appsv1.Deployment) bool {
 //  1. extractDeprecatedMetricFlags  – strip 5 CLI flags hard-rejected by GIE v1.4.0
 //  2. withMigrateDisaggHeadersHandler – rename prefill-header-handler → disagg-headers-handler
 //  3. withMigrateDisaggProfileHandler – rename pd-profile-handler → disagg-profile-handler,
-//     migrate deciderPluginName/threshold to deciders map (skipped for non-zero threshold)
+//     migrate deciderPluginName/threshold to deciders map (threshold:0 → always-disagg-pd-decider,
+//     threshold>0 → prefix-based-pd-decider with nonCachedTokens = ceil(threshold/4))
 //  4. WithRemoveHashBlockSize – drop deprecated hashBlockSize from all plugins
 //  5. withCoreMetricsExtractorPlugin – inject core-metrics-extractor with extracted flag values
 func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
@@ -1213,17 +1289,12 @@ func withMigrateDisaggHeadersHandler(ctx context.Context, u *unstructured.Unstru
 
 // withMigrateDisaggProfileHandler renames the pd-profile-handler plugin to
 // disagg-profile-handler and migrates its parameters from the flat
-// deciderPluginName to the new deciders map (v0.7.0 rename + restructure).
+// deciderPluginName/threshold to the new deciders map (v0.7.0 rename + restructure).
 //
-// If the profile handler has a non-zero threshold value, the entire migration
-// is skipped (no rename, no param change) because there is no clean v0.7
-// equivalent for arbitrary threshold values. The v0.7 binary still accepts
-// the old pd-profile-handler + threshold as a deprecated alias.
+// All threshold values are now migrated:
+//   - threshold: 0 → always-disagg-pd-decider
+//   - threshold > 0 → prefix-based-pd-decider with nonCachedTokens = ceil(threshold/4)
 func withMigrateDisaggProfileHandler(ctx context.Context, u *unstructured.Unstructured) error {
-	if hasNonZeroThreshold(u) {
-		log.FromContext(ctx).Info("Skipping disagg-profile-handler migration: non-zero threshold has no v0.7 equivalent")
-		return nil
-	}
 	for _, fn := range []mutateSchedulerConfigFunc{
 		WithRenamePlugin("pd-profile-handler", "disagg-profile-handler"),
 		WithMigrateDisaggProfileParams,
@@ -1233,44 +1304,6 @@ func withMigrateDisaggProfileHandler(ctx context.Context, u *unstructured.Unstru
 		}
 	}
 	return nil
-}
-
-// hasNonZeroThreshold returns true if the EndpointPickerConfig contains a
-// profile handler plugin with a non-zero threshold and no deciders map.
-// Such configs have no clean v0.7 equivalent; the v0.7 binary still accepts
-// them as deprecated, so we leave them untouched to avoid partial migrations.
-func hasNonZeroThreshold(u *unstructured.Unstructured) bool {
-	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
-	if err != nil || !found {
-		return false
-	}
-	plugins, ok := val.([]interface{})
-	if !ok {
-		return false
-	}
-	for _, plugin := range plugins {
-		pluginMap, ok := plugin.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		pluginType, _ := pluginMap["type"].(string)
-		if pluginType != "disagg-profile-handler" && pluginType != "pd-profile-handler" {
-			continue
-		}
-		// Already migrated to deciders map -- not a legacy threshold config.
-		if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "deciders"); exists {
-			return false
-		}
-		thresholdVal, thresholdFound, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "threshold")
-		if !thresholdFound {
-			return false
-		}
-		// threshold:0 is semantically "always disaggregate" and can be migrated.
-		if fmt.Sprintf("%v", thresholdVal) != "0" {
-			return true
-		}
-	}
-	return false
 }
 
 // extractDeprecatedMetricFlags strips the 5 metric CLI flags that GIE v1.4.0

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1031,8 +1031,9 @@ func WithMigrateDisaggProfileParams(ctx context.Context, u *unstructured.Unstruc
 		params     map[string]interface{}
 	}
 	var deciderPluginsToInject []deciderPluginEntry
+	handlerIdx := -1 // index of the first handler; deciders must be declared before it
 
-	for _, plugin := range plugins {
+	for i, plugin := range plugins {
 		pluginMap, ok := plugin.(map[string]interface{})
 		if !ok {
 			continue
@@ -1040,6 +1041,9 @@ func WithMigrateDisaggProfileParams(ctx context.Context, u *unstructured.Unstruc
 		pluginType, _ := pluginMap["type"].(string)
 		if pluginType != "disagg-profile-handler" && pluginType != "pd-profile-handler" {
 			continue
+		}
+		if handlerIdx == -1 {
+			handlerIdx = i
 		}
 
 		// Already migrated -- nothing to do.
@@ -1107,6 +1111,10 @@ func WithMigrateDisaggProfileParams(ctx context.Context, u *unstructured.Unstruc
 	}
 
 	// Ensure each decider plugin entry exists in the top-level plugins list.
+	// Deciders must appear before the handler that references them because the
+	// GIE loader registers plugins in list order; the handler will fail with
+	// "plugin not found" if its decider has not been registered yet.
+	inserted := 0
 	for _, d := range deciderPluginsToInject {
 		alreadyExists := false
 		for _, p := range plugins {
@@ -1120,7 +1128,11 @@ func WithMigrateDisaggProfileParams(ctx context.Context, u *unstructured.Unstruc
 			if d.params != nil {
 				entry["parameters"] = d.params
 			}
-			plugins = append(plugins, entry)
+			idx := handlerIdx + inserted
+			plugins = append(plugins, nil)
+			copy(plugins[idx+1:], plugins[idx:])
+			plugins[idx] = entry
+			inserted++
 		}
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -18,6 +18,7 @@ package llmisvc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -401,6 +402,71 @@ schedulingProfiles:
 	}
 }
 
+// validateDeciderOrder checks the GIE loader ordering invariant: every plugin
+// referenced in a handler's "deciders" map must appear earlier in the plugins
+// list. The GIE loader registers plugins in list order, so a handler that
+// references a decider declared later will fail with "plugin not found".
+func validateDeciderOrder(g Gomega, obj map[string]interface{}) {
+	val, ok := obj["plugins"]
+	if !ok {
+		return
+	}
+	plugins, ok := val.([]interface{})
+	if !ok {
+		return
+	}
+
+	typeIndex := map[string]int{}
+	for i, p := range plugins {
+		pm, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, ok := pm["type"].(string); ok {
+			typeIndex[t] = i
+		}
+	}
+
+	for i, p := range plugins {
+		pm, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pluginType, _ := pm["type"].(string)
+		params, ok := pm["parameters"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		deciders, ok := params["deciders"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for role, ref := range deciders {
+			refName, ok := ref.(string)
+			if !ok {
+				continue
+			}
+			refIdx, exists := typeIndex[refName]
+			if !exists {
+				// Decider not in the plugins list — may be externally
+				// declared (e.g. Path A where the user manages it).
+				continue
+			}
+			g.Expect(refIdx).To(BeNumerically("<", i),
+				fmt.Sprintf("%s at index %d references decider %q (role %s) at index %d — decider must appear before handler",
+					pluginType, i, refName, role, refIdx))
+		}
+	}
+}
+
+// validateDeciderOrderFromYAML is a convenience wrapper that unmarshals a
+// config-text YAML string and then runs validateDeciderOrder on the result.
+func validateDeciderOrderFromYAML(g Gomega, configText string) {
+	var obj map[string]interface{}
+	g.Expect(yaml.Unmarshal([]byte(configText), &obj)).To(Succeed())
+	validateDeciderOrder(g, obj)
+}
+
 func TestWithMigrateDisaggProfileParams(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -490,18 +556,19 @@ plugins:
 			name: "migrates threshold 0 when decider plugin already exists",
 			configYAML: `
 plugins:
+- type: always-disagg-pd-decider
 - type: pd-profile-handler
   parameters:
     threshold: 0
-- type: always-disagg-pd-decider
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(plugins).To(HaveLen(2))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
+				params := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
 				g.Expect(params).NotTo(HaveKey("threshold"))
 				deciders := params["deciders"].(map[string]interface{})
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
-				g.Expect(plugins).To(HaveLen(2))
 			},
 		},
 		{
@@ -588,20 +655,21 @@ plugins:
 			name: "non-zero threshold idempotent when prefix-based-pd-decider already exists",
 			configYAML: `
 plugins:
-- type: pd-profile-handler
-  parameters:
-    threshold: 100
 - type: prefix-based-pd-decider
   parameters:
     nonCachedTokens: 50
+- type: pd-profile-handler
+  parameters:
+    threshold: 100
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(plugins).To(HaveLen(2))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("prefix-based-pd-decider"))
+				params := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
 				g.Expect(params).NotTo(HaveKey("threshold"))
 				deciders := params["deciders"].(map[string]interface{})
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
-				g.Expect(plugins).To(HaveLen(2))
 			},
 		},
 		{
@@ -655,6 +723,7 @@ plugins:
 			u := unstructured.Unstructured{Object: obj}
 			g.Expect(WithMigrateDisaggProfileParams(context.Background(), &u)).To(Succeed())
 			tt.validate(g, u.Object)
+			validateDeciderOrder(g, u.Object)
 		})
 	}
 }
@@ -736,20 +805,21 @@ plugins:
 			name: "handles threshold 0 when decider plugin already present",
 			configYAML: `
 plugins:
+- type: always-disagg-pd-decider
 - type: pd-profile-handler
   parameters:
     threshold: 0
-- type: always-disagg-pd-decider
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				pluginMap := plugins[0].(map[string]interface{})
+				g.Expect(plugins).To(HaveLen(2))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
+				pluginMap := plugins[1].(map[string]interface{})
 				g.Expect(pluginMap["type"]).To(Equal("disagg-profile-handler"))
 				params := pluginMap["parameters"].(map[string]interface{})
 				g.Expect(params).NotTo(HaveKey("threshold"))
 				deciders := params["deciders"].(map[string]interface{})
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
-				g.Expect(plugins).To(HaveLen(2))
 			},
 		},
 		{
@@ -782,6 +852,7 @@ plugins:
 			u := unstructured.Unstructured{Object: obj}
 			g.Expect(withMigrateDisaggProfileHandler(context.Background(), &u)).To(Succeed())
 			tt.validate(g, u.Object)
+			validateDeciderOrder(g, u.Object)
 		})
 	}
 }
@@ -1131,6 +1202,7 @@ plugins:
 
 			configText := d.Spec.Template.Spec.Containers[0].Args[1]
 			tt.validateConfig(g, configText)
+			validateDeciderOrderFromYAML(g, configText)
 		})
 	}
 }
@@ -1291,6 +1363,7 @@ schedulingProfiles:
 			for i, a := range resultArgs {
 				if a == "--config-text" && i+1 < len(resultArgs) {
 					tt.validateConfig(g, resultArgs[i+1])
+					validateDeciderOrderFromYAML(g, resultArgs[i+1])
 				}
 			}
 			tt.validateArgs(g, resultArgs)
@@ -1372,6 +1445,9 @@ schedulingProfiles:
 	g.Expect(configText).To(ContainSubstring("decode-filter"))
 	g.Expect(configText).To(ContainSubstring("queue-scorer"))
 	g.Expect(configText).To(ContainSubstring("max-score-picker"))
+
+	// Decider ordering invariant
+	validateDeciderOrderFromYAML(g, configText)
 }
 
 func TestExtractDeprecatedMetricFlags(t *testing.T) {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -478,12 +478,12 @@ plugins:
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(plugins).To(HaveLen(3))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
+				params := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
 				g.Expect(params).NotTo(HaveKey("threshold"))
 				deciders := params["deciders"].(map[string]interface{})
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
-				g.Expect(plugins).To(HaveLen(3))
-				g.Expect(plugins[2].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
 			},
 		},
 		{
@@ -533,15 +533,15 @@ plugins:
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
-				g.Expect(params).NotTo(HaveKey("threshold"))
-				deciders := params["deciders"].(map[string]interface{})
-				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
 				g.Expect(plugins).To(HaveLen(3))
-				deciderPlugin := plugins[2].(map[string]interface{})
+				deciderPlugin := plugins[0].(map[string]interface{})
 				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
 				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
 				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(25)))
+				params := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
 			},
 		},
 		{
@@ -554,14 +554,14 @@ plugins:
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
-				g.Expect(params).NotTo(HaveKey("threshold"))
-				deciders := params["deciders"].(map[string]interface{})
-				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
-				deciderPlugin := plugins[1].(map[string]interface{})
+				deciderPlugin := plugins[0].(map[string]interface{})
 				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
 				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
 				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(2)))
+				params := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
 			},
 		},
 		{
@@ -574,13 +574,14 @@ plugins:
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				deciderPlugin := plugins[0].(map[string]interface{})
+				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
+				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
+				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(1)))
+				params := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
 				g.Expect(params).NotTo(HaveKey("threshold"))
 				deciders := params["deciders"].(map[string]interface{})
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
-				deciderPlugin := plugins[1].(map[string]interface{})
-				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
-				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(1)))
 			},
 		},
 		{
@@ -601,6 +602,47 @@ plugins:
 				deciders := params["deciders"].(map[string]interface{})
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
 				g.Expect(plugins).To(HaveLen(2))
+			},
+		},
+		{
+			name: "decider inserted before handler not after - load order matters",
+			configYAML: `
+plugins:
+- type: queue-scorer
+- type: pd-profile-handler
+  parameters:
+    threshold: 100
+- type: prefill-filter
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(4))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+				deciderPlugin := plugins[1].(map[string]interface{})
+				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
+				handlerPlugin := plugins[2].(map[string]interface{})
+				g.Expect(handlerPlugin["type"]).To(Equal("pd-profile-handler"))
+				g.Expect(plugins[3].(map[string]interface{})["type"]).To(Equal("prefill-filter"))
+			},
+		},
+		{
+			name: "always-disagg decider inserted before handler not after",
+			configYAML: `
+plugins:
+- type: queue-scorer
+- type: pd-profile-handler
+  parameters:
+    threshold: 0
+- type: prefill-filter
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(4))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+				g.Expect(plugins[1].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
+				handlerPlugin := plugins[2].(map[string]interface{})
+				g.Expect(handlerPlugin["type"]).To(Equal("pd-profile-handler"))
+				g.Expect(plugins[3].(map[string]interface{})["type"]).To(Equal("prefill-filter"))
 			},
 		},
 	}
@@ -656,17 +698,17 @@ plugins:
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				pluginMap := plugins[0].(map[string]interface{})
+				g.Expect(plugins).To(HaveLen(2))
+				deciderPlugin := plugins[0].(map[string]interface{})
+				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
+				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
+				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(1)))
+				pluginMap := plugins[1].(map[string]interface{})
 				g.Expect(pluginMap["type"]).To(Equal("disagg-profile-handler"))
 				params := pluginMap["parameters"].(map[string]interface{})
 				g.Expect(params).NotTo(HaveKey("threshold"))
 				deciders := params["deciders"].(map[string]interface{})
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
-				g.Expect(plugins).To(HaveLen(2))
-				deciderPlugin := plugins[1].(map[string]interface{})
-				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
-				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
-				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(1)))
 			},
 		},
 		{
@@ -680,14 +722,14 @@ plugins:
 `,
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				pluginMap := plugins[0].(map[string]interface{})
+				g.Expect(plugins).To(HaveLen(3))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
+				pluginMap := plugins[1].(map[string]interface{})
 				g.Expect(pluginMap["type"]).To(Equal("disagg-profile-handler"))
 				params := pluginMap["parameters"].(map[string]interface{})
 				g.Expect(params).NotTo(HaveKey("threshold"))
 				deciders := params["deciders"].(map[string]interface{})
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
-				g.Expect(plugins).To(HaveLen(3))
-				g.Expect(plugins[2].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
 			},
 		},
 		{

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -522,6 +522,87 @@ plugins:
 				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
 			},
 		},
+		{
+			name: "migrates non-zero threshold 100 to prefix-based-pd-decider",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 100
+- type: prefill-filter
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
+				g.Expect(plugins).To(HaveLen(3))
+				deciderPlugin := plugins[2].(map[string]interface{})
+				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
+				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
+				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(25)))
+			},
+		},
+		{
+			name: "migrates non-zero threshold 5 to prefix-based-pd-decider with ceil",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 5
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
+				deciderPlugin := plugins[1].(map[string]interface{})
+				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
+				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
+				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(2)))
+			},
+		},
+		{
+			name: "migrates non-zero threshold 1 to prefix-based-pd-decider minimum 1 token",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 1
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
+				deciderPlugin := plugins[1].(map[string]interface{})
+				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
+				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(1)))
+			},
+		},
+		{
+			name: "non-zero threshold idempotent when prefix-based-pd-decider already exists",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 100
+- type: prefix-based-pd-decider
+  parameters:
+    nonCachedTokens: 50
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
+				g.Expect(plugins).To(HaveLen(2))
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -536,91 +617,25 @@ plugins:
 	}
 }
 
-func TestHasNonZeroThreshold(t *testing.T) {
+func TestThresholdToNonCachedTokens(t *testing.T) {
 	tests := []struct {
-		name       string
-		configYAML string
-		expected   bool
+		name     string
+		val      interface{}
+		expected int64
 	}{
-		{
-			name: "no threshold - returns false",
-			configYAML: `
-plugins:
-- type: pd-profile-handler
-  parameters:
-    deciderPluginName: always-disagg-pd-decider
-`,
-			expected: false,
-		},
-		{
-			name: "threshold 0 - returns false",
-			configYAML: `
-plugins:
-- type: pd-profile-handler
-  parameters:
-    threshold: 0
-`,
-			expected: false,
-		},
-		{
-			name: "threshold 0.5 - returns true",
-			configYAML: `
-plugins:
-- type: pd-profile-handler
-  parameters:
-    threshold: 0.5
-`,
-			expected: true,
-		},
-		{
-			name: "threshold 1 - returns true",
-			configYAML: `
-plugins:
-- type: pd-profile-handler
-  parameters:
-    threshold: 1
-`,
-			expected: true,
-		},
-		{
-			name: "deciders already present - returns false even with threshold",
-			configYAML: `
-plugins:
-- type: disagg-profile-handler
-  parameters:
-    deciders:
-      prefill: always-disagg-pd-decider
-    threshold: 0.5
-`,
-			expected: false,
-		},
-		{
-			name: "non-profile plugin with threshold - returns false",
-			configYAML: `
-plugins:
-- type: some-other-plugin
-  parameters:
-    threshold: 0.5
-`,
-			expected: false,
-		},
-		{
-			name: "no plugins - returns false",
-			configYAML: `
-schedulingProfiles:
-- name: prefill
-`,
-			expected: false,
-		},
+		{name: "int64 100", val: int64(100), expected: 25},
+		{name: "int64 5", val: int64(5), expected: 2},
+		{name: "int64 1", val: int64(1), expected: 1},
+		{name: "int64 3", val: int64(3), expected: 1},
+		{name: "float64 100.0", val: float64(100.0), expected: 25},
+		{name: "float64 0.5", val: float64(0.5), expected: 1},
+		{name: "float64 7.0", val: float64(7.0), expected: 2},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			var obj map[string]interface{}
-			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
-			u := unstructured.Unstructured{Object: obj}
-			g.Expect(hasNonZeroThreshold(&u)).To(Equal(tt.expected))
+			g.Expect(thresholdToNonCachedTokens(tt.val)).To(Equal(tt.expected))
 		})
 	}
 }
@@ -632,7 +647,7 @@ func TestWithMigrateDisaggProfileHandlerThreshold(t *testing.T) {
 		validate   func(g Gomega, obj map[string]interface{})
 	}{
 		{
-			name: "skips all migration for non-zero threshold",
+			name: "migrates non-zero threshold with rename and prefix-based-pd-decider",
 			configYAML: `
 plugins:
 - type: pd-profile-handler
@@ -642,10 +657,16 @@ plugins:
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
 				pluginMap := plugins[0].(map[string]interface{})
-				g.Expect(pluginMap["type"]).To(Equal("pd-profile-handler"))
+				g.Expect(pluginMap["type"]).To(Equal("disagg-profile-handler"))
 				params := pluginMap["parameters"].(map[string]interface{})
-				g.Expect(params).NotTo(HaveKey("deciders"))
-				g.Expect(params).To(HaveKey("threshold"))
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
+				g.Expect(plugins).To(HaveLen(2))
+				deciderPlugin := plugins[1].(map[string]interface{})
+				g.Expect(deciderPlugin["type"]).To(Equal("prefix-based-pd-decider"))
+				deciderParams := deciderPlugin["parameters"].(map[string]interface{})
+				g.Expect(deciderParams["nonCachedTokens"]).To(Equal(int64(1)))
 			},
 		},
 		{
@@ -690,7 +711,7 @@ plugins:
 			},
 		},
 		{
-			name: "handles non-zero threshold with deciderPluginName - skips all",
+			name: "migrates non-zero threshold with deciderPluginName - uses specified decider",
 			configYAML: `
 plugins:
 - type: pd-profile-handler
@@ -701,11 +722,12 @@ plugins:
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
 				pluginMap := plugins[0].(map[string]interface{})
-				g.Expect(pluginMap["type"]).To(Equal("pd-profile-handler"))
+				g.Expect(pluginMap["type"]).To(Equal("disagg-profile-handler"))
 				params := pluginMap["parameters"].(map[string]interface{})
-				g.Expect(params).To(HaveKey("deciderPluginName"))
-				g.Expect(params).To(HaveKey("threshold"))
-				g.Expect(params).NotTo(HaveKey("deciders"))
+				g.Expect(params).NotTo(HaveKey("deciderPluginName"))
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
 			},
 		},
 	}
@@ -962,7 +984,7 @@ func TestSchedulerTransformThreshold(t *testing.T) {
 		validateConfig func(g Gomega, configText string)
 	}{
 		{
-			name: "skips profile handler rename for non-zero threshold",
+			name: "migrates non-zero threshold in full transform",
 			configYAML: `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -979,14 +1001,17 @@ plugins:
 			validateConfig: func(g Gomega, configText string) {
 				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
 				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
-				g.Expect(configText).To(ContainSubstring("pd-profile-handler"))
-				g.Expect(configText).NotTo(ContainSubstring("disagg-profile-handler"))
-				g.Expect(configText).To(ContainSubstring("threshold"))
+				g.Expect(configText).To(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("prefix-based-pd-decider"))
+				g.Expect(configText).To(ContainSubstring("nonCachedTokens"))
+				g.Expect(configText).NotTo(ContainSubstring("threshold"))
 				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+				g.Expect(configText).To(ContainSubstring("blockSizeTokens"))
 			},
 		},
 		{
-			name: "skips profile handler for non-zero threshold with deciderPluginName",
+			name: "migrates non-zero threshold with deciderPluginName in full transform",
 			configYAML: `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -1002,10 +1027,12 @@ plugins:
 			version: "0.7.0",
 			validateConfig: func(g Gomega, configText string) {
 				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
-				g.Expect(configText).To(ContainSubstring("pd-profile-handler"))
-				g.Expect(configText).NotTo(ContainSubstring("disagg-profile-handler"))
-				g.Expect(configText).To(ContainSubstring("deciderPluginName"))
-				g.Expect(configText).To(ContainSubstring("threshold"))
+				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).To(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("deciderPluginName"))
+				g.Expect(configText).NotTo(ContainSubstring("threshold"))
+				g.Expect(configText).To(ContainSubstring("prefill: prefix-based-pd-decider"))
 				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
 			},
 		},
@@ -1227,6 +1254,82 @@ schedulingProfiles:
 			tt.validateArgs(g, resultArgs)
 		})
 	}
+}
+
+func TestFullMigrationPipelineNonZeroThreshold(t *testing.T) {
+	oldConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefill-header-handler
+- type: prefill-filter
+- type: decode-filter
+- type: queue-scorer
+- type: prefix-cache-scorer
+  parameters:
+    hashBlockSize: 64
+    blockSizeTokens: 16
+- type: max-score-picker
+- type: pd-profile-handler
+  parameters:
+    threshold: 100
+schedulingProfiles:
+- name: prefill
+  plugins:
+  - pluginRef: prefill-filter
+  - pluginRef: queue-scorer
+  - pluginRef: max-score-picker
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: prefix-cache-scorer
+  - pluginRef: queue-scorer
+  - pluginRef: max-score-picker
+`
+	g := NewGomegaWithT(t)
+
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"app.kubernetes.io/version": "0.7.0",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main", Args: []string{"--config-text", oldConfigYAML}},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	g.Expect(schedulerTransform(ctx, d)).To(Succeed())
+
+	configText := d.Spec.Template.Spec.Containers[0].Args[1]
+
+	// Plugin renames applied
+	g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+	g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+	g.Expect(configText).To(ContainSubstring("disagg-profile-handler"))
+	g.Expect(configText).NotTo(ContainSubstring("pd-profile-handler"))
+
+	// Non-zero threshold migrated to prefix-based-pd-decider
+	g.Expect(configText).NotTo(ContainSubstring("threshold"))
+	g.Expect(configText).To(ContainSubstring("prefix-based-pd-decider"))
+	g.Expect(configText).To(ContainSubstring("nonCachedTokens"))
+	g.Expect(configText).To(ContainSubstring("prefill: prefix-based-pd-decider"))
+
+	// Deprecated field removed
+	g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+	g.Expect(configText).To(ContainSubstring("blockSizeTokens"))
+
+	// Unchanged plugins preserved
+	g.Expect(configText).To(ContainSubstring("prefill-filter"))
+	g.Expect(configText).To(ContainSubstring("decode-filter"))
+	g.Expect(configText).To(ContainSubstring("queue-scorer"))
+	g.Expect(configText).To(ContainSubstring("max-score-picker"))
 }
 
 func TestExtractDeprecatedMetricFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #5561

Completes the v0.6 → v0.7 scheduler migration for non-zero `threshold` values in the disagg-profile-handler plugin, which were previously skipped entirely by #5433.

- `threshold: 0` → `always-disagg-pd-decider` (already implemented in #5433)
- `threshold > 0` → `prefix-based-pd-decider` with `nonCachedTokens = ceil(threshold / 4)`

The `/4` conversion is based on the ~4:1 character-to-token ratio for English text. The original v0.6 threshold (non-cached characters) was never properly tuned, so a runtime warning is logged advising users to review the converted value for their workload.

## Changes

- **Removed** `hasNonZeroThreshold` guard that skipped migration for non-zero thresholds
- **Added** Path C in `WithMigrateDisaggProfileParams` for `threshold > 0` without `deciderPluginName`
- **Added** `thresholdToNonCachedTokens` helper (handles int64/float64 from YAML, minimum 1 token)
- **Added** runtime warning log with original threshold and converted nonCachedTokens values
- **Added** code comments documenting the unit shift (chars → tokens) and conversion rationale

## Test plan

- [x] New unit tests for Path C: threshold 100 → 25, threshold 5 → 2, threshold 1 → 1
- [x] New unit test for idempotency (prefix-based-pd-decider already exists)
- [x] New `TestThresholdToNonCachedTokens` for int64/float64 edge cases
- [x] New `TestFullMigrationPipelineNonZeroThreshold` end-to-end test
- [x] Updated existing "skips all" tests to expect migration proceeds
- [x] All existing tests still pass (no regressions)