### PR TITLE
fix(ci): add manual debug path for prow automerge

### DIFF
--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -5,20 +5,37 @@
 name: "Prow merge on lgtm label"
 on:
   schedule:
-  - cron: "*/10 * * * *" # every 10 minutes
+    - cron: "*/10 * * * *" # every 10 minutes
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: "Enable extra automerge diagnostics"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
+            const mergeableStatesAllowed = new Set(['clean', 'unstable', 'has_hooks']);
+            const debugEnabled = context.eventName === 'workflow_dispatch' && context.payload.inputs?.debug === 'true';
+            const debug = (message) => {
+              if (debugEnabled) {
+                core.info(`[debug] ${message}`);
+              }
+            };
+
+            debug(`Triggered by ${context.eventName}`);
 
             // Load approvers from the OWNERS file
             const { data: ownersFile } = await github.rest.repos.getContent({ owner, repo, path: 'OWNERS', ref: 'master' });
@@ -37,6 +54,7 @@ jobs:
             const prs = await github.paginate(github.rest.issues.listForRepo, {
               owner, repo, state: 'open', labels: 'lgtm',
             });
+            debug(`Found ${prs.length} open issues/PRs with the lgtm label`);
 
             for (const issue of prs) {
               if (!issue.pull_request) continue;
@@ -45,6 +63,7 @@ jobs:
               const { data: reviews } = await github.rest.pulls.listReviews({
                 owner, repo, pull_number: issue.number,
               });
+              debug(`PR #${issue.number} has ${reviews.length} reviews`);
               const approvedByApprover = reviews.some(
                 r => r.state === 'APPROVED' &&
                   (r.user.login === 'github-actions[bot]' || approvers.includes(r.user.login.toLowerCase()))
@@ -55,12 +74,62 @@ jobs:
                 continue;
               }
 
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo, pull_number: issue.number,
+              });
+              debug([
+                `PR #${issue.number}`,
+                `head=${pr.head.repo?.full_name ?? 'unknown'}:${pr.head.ref}@${pr.head.sha}`,
+                `base=${pr.base.repo?.full_name ?? 'unknown'}:${pr.base.ref}`,
+                `mergeable=${pr.mergeable}`,
+                `mergeable_state=${pr.mergeable_state}`,
+                `maintainer_can_modify=${pr.maintainer_can_modify}`,
+              ].join(' | '));
+
+              let mergeablePr = pr;
+              if (mergeablePr.mergeable === null || mergeablePr.mergeable_state === 'unknown') {
+                debug(`PR #${issue.number} has unresolved mergeability, refreshing details once`);
+                const { data: refreshedPr } = await github.rest.pulls.get({
+                  owner, repo, pull_number: issue.number,
+                });
+                mergeablePr = refreshedPr;
+                debug([
+                  `PR #${issue.number} refreshed`,
+                  `mergeable=${mergeablePr.mergeable}`,
+                  `mergeable_state=${mergeablePr.mergeable_state}`,
+                ].join(' | '));
+              }
+
+              if (mergeablePr.mergeable === false) {
+                core.info(`PR #${issue.number} is not mergeable (mergeable=false, mergeable_state=${mergeablePr.mergeable_state ?? 'unknown'}), skipping`);
+                continue;
+              }
+
+              if (!mergeableStatesAllowed.has(mergeablePr.mergeable_state)) {
+                core.info(`PR #${issue.number} is not merge-ready (mergeable=${mergeablePr.mergeable}, mergeable_state=${mergeablePr.mergeable_state ?? 'unknown'}), skipping`);
+                continue;
+              }
+
               try {
                 await github.rest.pulls.merge({
                   owner, repo, pull_number: issue.number, merge_method: 'squash',
                 });
                 core.info(`Merged PR #${issue.number}`);
               } catch (e) {
-                core.warning(`Could not merge PR #${issue.number}: ${e.message}`);
+                const errorDetails = [
+                  `status=${e.status ?? 'unknown'}`,
+                  `message=${e.response?.data?.message ?? e.message}`,
+                ];
+                if (debugEnabled) {
+                  const apiErrors = e.response?.data?.errors;
+                  if (apiErrors) {
+                    core.info(`[debug] PR #${issue.number} API errors: ${JSON.stringify(apiErrors)}`);
+                  }
+                  const documentationUrl = e.response?.data?.documentation_url;
+                  if (documentationUrl) {
+                    core.info(`[debug] PR #${issue.number} docs: ${documentationUrl}`);
+                  }
+                }
+                core.warning(`Could not merge PR #${issue.number}: ${errorDetails.join(', ')}`);
               }
             }


### PR DESCRIPTION
chore:  Allow the automerge workflow to be run manually with extra diagnostics and
        skip PRs that GitHub already reports as not mergeable before attempting the
        merge API call.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
