### PR TITLE
feat(ci): cache opt-125m in SeaweedFS

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -226,6 +226,8 @@ jobs:
       - name: Run LLMInferenceService E2E tests
         id: llmisvc-e2e-tests
         timeout-minutes: 90
+        env:
+          OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
         run: |
           # Run only CPU tests for now using pytest markers (cluster_)
           # Available GPU vendors: amd, nvidia, intel
@@ -327,6 +329,8 @@ jobs:
       - name: Run HPA autoscaling E2E tests
         id: autoscaling-hpa-tests
         timeout-minutes: 60
+        env:
+          OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
         run: |
           export PYTEST_MAXFAIL=2
           ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_hpa and cluster_cpu" 0 "envoy-gateway"
@@ -427,6 +431,8 @@ jobs:
       - name: Run KEDA autoscaling E2E tests
         id: autoscaling-keda-tests
         timeout-minutes: 60
+        env:
+          OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
         run: |
           export PYTEST_MAXFAIL=2
           ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_keda and cluster_cpu" 0 "envoy-gateway"

--- a/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
@@ -3,8 +3,29 @@ kind: Job
 metadata:
   name: s3-init
 spec:
+  activeDeadlineSeconds: 600
   template:
     spec:
+      initContainers:
+      - name: download-hf-model
+        image: kserve/storage-initializer:latest
+        command:
+        - python3
+        - -c
+        - |
+          from huggingface_hub import snapshot_download
+          snapshot_download(
+            "facebook/opt-125m",
+            local_dir="/shared/facebook/opt-125m",
+            ignore_patterns=["*.msgpack", "*.h5", "flax_model*", "tf_model*", "rust_model*"],
+          )
+          print("Model download complete")
+        env:
+        - name: HF_HUB_DISABLE_PROGRESS_BARS
+          value: "1"
+        volumeMounts:
+        - name: model-cache
+          mountPath: /shared
       containers:
       - name: s3-init
         image: docker.io/amazon/aws-cli:2.33.11@sha256:88ea087837da1b31a3afeeb4538888244a3087a867ddb1909848643fcc4b324e
@@ -14,8 +35,9 @@ spec:
         - |
           aws s3 mb s3://logger-output || true
           aws s3 mb s3://example-models || true
-          curl -L https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib -o sklearn-model.joblib
-          aws s3 cp sklearn-model.joblib s3://example-models/sklearn/model.joblib  --no-verify-ssl
+          curl -L https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib -o /tmp/sklearn-model.joblib
+          aws s3 cp /tmp/sklearn-model.joblib s3://example-models/sklearn/model.joblib --no-verify-ssl
+          aws s3 sync /shared/facebook/opt-125m s3://example-models/facebook/opt-125m/ --no-verify-ssl
         env:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
@@ -31,5 +53,11 @@ spec:
           value: "us-east-1"
         - name: AWS_ENDPOINT_URL_S3
           value: "http://s3-service.kserve:8333"
+        volumeMounts:
+        - name: model-cache
+          mountPath: /shared
+      volumes:
+      - name: model-cache
+        emptyDir: {}
       restartPolicy: Never
   backoffLimit: 3

--- a/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
@@ -3,26 +3,21 @@ kind: Job
 metadata:
   name: s3-init
 spec:
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 900
   template:
     spec:
       initContainers:
       - name: download-hf-model
         image: kserve/storage-initializer:latest
-        command:
-        - python3
-        - -c
-        - |
-          from huggingface_hub import snapshot_download
-          snapshot_download(
-            "facebook/opt-125m",
-            local_dir="/shared/facebook/opt-125m",
-            ignore_patterns=["*.msgpack", "*.h5", "flax_model*", "tf_model*", "rust_model*"],
-          )
-          print("Model download complete")
+        imagePullPolicy: IfNotPresent
+        args:
+        - "hf://facebook/opt-125m"
+        - "/shared/facebook/opt-125m"
         env:
         - name: HF_HUB_DISABLE_PROGRESS_BARS
           value: "1"
+        - name: STORAGE_IGNORE_PATTERNS
+          value: "*.msgpack,*.h5,flax_model*,tf_model*,rust_model*"
         volumeMounts:
         - name: model-cache
           mountPath: /shared

--- a/config/overlays/test/s3-local-backend/seaweedfs-s3-creds-secret.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-s3-creds-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: seaweedfs-s3-creds
+  annotations:
+    serving.kserve.io/s3-endpoint: "s3-service.kserve:8333"
+    serving.kserve.io/s3-usehttps: "0"
+    serving.kserve.io/s3-verifyssl: "0"
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: s3admin
+  AWS_SECRET_ACCESS_KEY: s3admin123

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -34,6 +34,8 @@ KSERVE_TEST_NAMESPACE = "kserve-ci-e2e-test"
 SCHEDULER_CONFIGMAP_NAME = "scheduler-config-e2e"
 SCHEDULER_CONFIGMAP_KEY = "epp"
 
+OPT_125M_MODEL_URI = os.environ.get("OPT_125M_MODEL_URI", "hf://facebook/opt-125m")
+
 # Vanilla Kubernetes rejects runAsNonRoot-only containers when the image does not declare a USER.
 # Keep the templates OpenShift-safe and use an explicit non-root UID only in upstream CI test overrides.
 UPSTREAM_K8S_NON_ROOT_SECURITY_CONTEXT = {
@@ -145,7 +147,7 @@ LLMINFERENCESERVICE_CONFIGS = {
         },
     },
     "model-fb-opt-125m": {
-        "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+        "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
     },
     "model-qwen2.5-0.5b": {
         "model": {
@@ -161,7 +163,7 @@ LLMINFERENCESERVICE_CONFIGS = {
     },
     "model-fb-opt-125m-with-lora-hf": {
         "model": {
-            "uri": "hf://facebook/opt-125m",
+            "uri": OPT_125M_MODEL_URI,
             "name": "facebook/opt-125m",
             "lora": {
                 "adapters": [
@@ -175,7 +177,7 @@ LLMINFERENCESERVICE_CONFIGS = {
     },
     "model-fb-opt-125m-with-multiple-lora": {
         "model": {
-            "uri": "hf://facebook/opt-125m",
+            "uri": OPT_125M_MODEL_URI,
             "name": "facebook/opt-125m",
             "lora": {
                 "adapters": [
@@ -911,7 +913,7 @@ LLMINFERENCESERVICE_CONFIGS = {
     },
     "workload-llmd-simulator": {
         "replicas": 1,
-        "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+        "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
         "storageInitializer": {"enabled": False},
         "template": {
             "containers": [
@@ -937,7 +939,7 @@ LLMINFERENCESERVICE_CONFIGS = {
         },
     },
     "workload-llmd-simulator-no-replicas": {
-        "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+        "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
         "storageInitializer": {"enabled": False},
         "template": {
             "containers": [
@@ -963,7 +965,7 @@ LLMINFERENCESERVICE_CONFIGS = {
         },
     },
     "workload-llmd-simulator-lws": {
-        "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+        "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
         "parallelism": {
             "data": 2,
             "dataLocal": 1,
@@ -1017,7 +1019,7 @@ LLMINFERENCESERVICE_CONFIGS = {
         },
     },
     "workload-llmd-simulator-pd": {
-        "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+        "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
         "storageInitializer": {"enabled": False},
         "template": {
             "containers": [
@@ -1169,7 +1171,7 @@ LLMINFERENCESERVICE_CONFIGS = {
     },
     "workload-llmd-simulator-kvcache": {
         "replicas": 2,
-        "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+        "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
         # Important: storage initializer is required for precise-prefix-scorer
         "template": {
             "containers": [

--- a/test/e2e/llmisvc/test_llm_inference_service_conversion.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_conversion.py
@@ -32,6 +32,7 @@ from .fixtures import (
     inject_k8s_proxy,
     KSERVE_TEST_NAMESPACE,
     KSERVE_PLURAL_LLMINFERENCESERVICECONFIG,
+    OPT_125M_MODEL_URI,
     UPSTREAM_K8S_NON_ROOT_SECURITY_CONTEXT,
     UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
 )
@@ -225,7 +226,7 @@ class TestLLMInferenceServiceConversion:
                 "namespace": self.namespace,
             },
             "spec": {
-                "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+                "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
                 "router": {"route": {}},
                 "template": {
                     "containers": [
@@ -316,7 +317,7 @@ class TestLLMInferenceServiceConversion:
                 "namespace": self.namespace,
             },
             "spec": {
-                "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+                "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
                 "router": {"route": {}},
                 "template": {
                     "containers": [
@@ -413,7 +414,7 @@ class TestLLMInferenceServiceConversion:
             },
             "spec": {
                 "model": {
-                    "uri": "hf://facebook/opt-125m",
+                    "uri": OPT_125M_MODEL_URI,
                     "name": "facebook/opt-125m",
                     "criticality": "Critical",  # v1alpha1-specific field
                 },
@@ -451,7 +452,7 @@ class TestLLMInferenceServiceConversion:
             },
             "spec": {
                 "model": {
-                    "uri": "hf://facebook/opt-125m",
+                    "uri": OPT_125M_MODEL_URI,
                     "name": "facebook/opt-125m",
                     "criticality": "Critical",
                 },
@@ -736,7 +737,7 @@ class TestLLMInferenceServiceConversion:
             },
             "spec": {
                 "model": {
-                    "uri": "hf://facebook/opt-125m",
+                    "uri": OPT_125M_MODEL_URI,
                     "name": "test-model",
                 },
                 "replicas": 1,

--- a/test/e2e/llmisvc/test_pod_watch.py
+++ b/test/e2e/llmisvc/test_pod_watch.py
@@ -35,6 +35,7 @@ from kserve import KServeClient, V1alpha1LLMInferenceService, constants
 
 from .fixtures import (
     KSERVE_TEST_NAMESPACE,
+    OPT_125M_MODEL_URI,
     UPSTREAM_K8S_NON_ROOT_SECURITY_CONTEXT,
     UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
     inject_k8s_proxy,
@@ -323,7 +324,7 @@ async def test_event_storm_prevention_init_container_isolation():
     LLMISVC to be MODIFIED (resourceVersion change).
 
     Test flow:
-    1. Creates a "primary" LLMISVC with a valid model (hf://facebook/opt-125m)
+    1. Creates a "primary" LLMISVC with a valid model (facebook/opt-125m)
     2. Waits for the primary LLMISVC to become ready
     3. Records baseline resourceVersion
     4. Creates a "secondary" LLMISVC with invalid S3 credentials that will fail
@@ -355,7 +356,7 @@ async def test_event_storm_prevention_init_container_isolation():
             kserve_client,
             model_config_name,
             KSERVE_TEST_NAMESPACE,
-            {"model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"}},
+            {"model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"}},
         )
 
         create_llmisvc_config(

--- a/test/e2e/llmisvc/test_storage_version_migration.py
+++ b/test/e2e/llmisvc/test_storage_version_migration.py
@@ -36,6 +36,7 @@ from .fixtures import (
     inject_k8s_proxy,
     KSERVE_TEST_NAMESPACE,
     KSERVE_PLURAL_LLMINFERENCESERVICECONFIG,
+    OPT_125M_MODEL_URI,
 )
 from .logging import logger
 
@@ -131,7 +132,7 @@ class TestStorageVersionMigration:
                 "namespace": self.namespace,
             },
             "spec": {
-                "model": {"uri": "hf://facebook/opt-125m", "name": "facebook/opt-125m"},
+                "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
                 "router": {"route": {}},
                 "template": {
                     "containers": [

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -86,7 +86,7 @@ if [[ $ENABLE_LLMISVC == "false" || $ENABLE_KSERVE_WITH_LLMISVC == "true" ]]; th
   echo "Add testing models to s3 storage ..."
   sed "s|kserve/storage-initializer:latest|${KO_DOCKER_REPO:-kserve}/${STORAGE_INIT_IMG:-storage-initializer}:${TAG:-latest}|g" \
     config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml | kubectl apply -n kserve -f -
-  if ! kubectl wait --for=condition=complete --timeout=300s job/s3-init -n kserve; then
+  if ! kubectl wait --for=condition=complete --timeout=900s job/s3-init -n kserve; then
     echo "S3 init job failed. Pod status and logs:"
     kubectl get pods -l job-name=s3-init -n kserve
     kubectl logs -l job-name=s3-init -n kserve --all-containers --tail=50 || true
@@ -129,7 +129,7 @@ else
   echo "Pre-caching opt-125m model in SeaweedFS ..."
   sed "s|kserve/storage-initializer:latest|${KO_DOCKER_REPO:-kserve}/${STORAGE_INIT_IMG:-storage-initializer}:${TAG:-latest}|g" \
     "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml" | kubectl apply -n kserve -f -
-  if ! kubectl wait --for=condition=complete --timeout=300s job/s3-init -n kserve; then
+  if ! kubectl wait --for=condition=complete --timeout=900s job/s3-init -n kserve; then
     echo "S3 init job failed. Pod status and logs:"
     kubectl get pods -l job-name=s3-init -n kserve
     kubectl logs -l job-name=s3-init -n kserve --all-containers --tail=50 || true

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -84,11 +84,22 @@ if [[ $ENABLE_LLMISVC == "false" || $ENABLE_KSERVE_WITH_LLMISVC == "true" ]]; th
   kubectl rollout status deployment/seaweedfs -n kserve --timeout=120s
 
   echo "Add testing models to s3 storage ..."
-  kubectl apply -f config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml -n kserve
-  kubectl wait --for=condition=complete --timeout=90s job/s3-init -n kserve
+  sed "s|kserve/storage-initializer:latest|${KO_DOCKER_REPO:-kserve}/${STORAGE_INIT_IMG:-storage-initializer}:${TAG:-latest}|g" \
+    config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml | kubectl apply -n kserve -f -
+  if ! kubectl wait --for=condition=complete --timeout=300s job/s3-init -n kserve; then
+    echo "S3 init job failed. Pod status and logs:"
+    kubectl get pods -l job-name=s3-init -n kserve
+    kubectl logs -l job-name=s3-init -n kserve --all-containers --tail=50 || true
+    exit 1
+  fi
 
   echo "Add storageSpec testing secrets ..."
   kubectl apply -f config/overlays/test/s3-local-backend/storage-config-secret.yaml -n kserve-ci-e2e-test
+
+  echo "Configuring S3 credentials for model downloads ..."
+  kubectl apply -f config/overlays/test/s3-local-backend/seaweedfs-s3-creds-secret.yaml -n kserve-ci-e2e-test
+  kubectl patch serviceaccount default -n kserve-ci-e2e-test \
+    --type=merge -p='{"secrets": [{"name": "seaweedfs-s3-creds"}]}'
 else
   if [[ $INSTALL_METHOD == "helm" ]]; then
     export SET_KSERVE_VERSION=${TAG}
@@ -105,6 +116,30 @@ else
     export ENABLE_KSERVE=false
     ${REPO_ROOT}/hack/setup/infra/manage.kserve-kustomize.sh
   fi
+
+  echo "Deploying SeaweedFS for LLMISVC model caching ..."
+  kubectl apply -f "${REPO_ROOT}/config/overlays/test/s3-local-backend/mlpipeline-s3-artifact-secret.yaml" -n kserve
+  kubectl apply -f "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-deployment.yaml" -n kserve
+  sed "s/namespace: seaweedfs/namespace: kserve/" \
+    "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-service.yaml" | kubectl apply -n kserve -f -
+
+  echo "Waiting for seaweedfs to be ready ..."
+  kubectl rollout status deployment/seaweedfs -n kserve --timeout=120s
+
+  echo "Pre-caching opt-125m model in SeaweedFS ..."
+  sed "s|kserve/storage-initializer:latest|${KO_DOCKER_REPO:-kserve}/${STORAGE_INIT_IMG:-storage-initializer}:${TAG:-latest}|g" \
+    "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml" | kubectl apply -n kserve -f -
+  if ! kubectl wait --for=condition=complete --timeout=300s job/s3-init -n kserve; then
+    echo "S3 init job failed. Pod status and logs:"
+    kubectl get pods -l job-name=s3-init -n kserve
+    kubectl logs -l job-name=s3-init -n kserve --all-containers --tail=50 || true
+    exit 1
+  fi
+
+  echo "Configuring S3 credentials in test namespace ..."
+  kubectl apply -f "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-s3-creds-secret.yaml" -n kserve-ci-e2e-test
+  kubectl patch serviceaccount default -n kserve-ci-e2e-test \
+    --type=merge -p='{"secrets": [{"name": "seaweedfs-s3-creds"}]}'
 fi
 
 ENABLE_KEDA="${ENABLE_KEDA:-false}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Pre-cache facebook/opt-125m in SeaweedFS during E2E cluster setup to
eliminate HuggingFace downloads that cause ~15 min timeouts and
intermittent rate-limit failures in LLMISVC CI.

Changes:
- Add storage-initializer initContainer to the SeaweedFS init job that
  downloads opt-125m from HuggingFace and syncs it to S3
- Add `activeDeadlineSeconds: 600` to the init job to prevent orphaned
  jobs when network operations hang
- Deploy SeaweedFS in the LLMISVC-only CI path (previously only deployed
  in the KServe+LLMISVC path)
- Parametrize `hf://facebook/opt-125m` in test fixtures via
  `OPT_125M_MODEL_URI` env var (defaults to `hf://`, set to `s3://` in
  the LLMISVC workflow)
- Add S3 credentials secret for storage-initializer authentication

**Which issue(s) this PR fixes**:


**Feature/Issue validation/testing**:

- [ ] LLMISVC E2E tests pass using `s3://example-models/facebook/opt-125m`
- [ ] KServe E2E tests pass (init job completes with additional opt-125m download)
- [ ] SeaweedFS deploys and init job completes within 300s timeout
- [ ] `activeDeadlineSeconds` is set on the init job

**Special notes for your reviewer**:

- The `kserve/storage-initializer:latest` image ref in the init job YAML
  is substituted to the CI-built tag via `sed` in `setup-kserve.sh`
- LoRA adapter URIs (`hf://edbeeching/opt-125m-lora`) are intentionally
  left as `hf://` since they're small (~2MB)
- `OPT_125M_MODEL_URI` defaults to `hf://facebook/opt-125m` so local
  dev/test without SeaweedFS continues to work

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```