### PR TITLE
fix: make storage initializer imagePullPolicy configurable

### DIFF
--- a/charts/kserve-llmisvc-resources/files/common/storagecontainer.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/storagecontainer.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   container:
     image: kserve/storage-initializer:latest
-    imagePullPolicy: IfNotPresent
     name: storage-initializer
     resources:
       limits:

--- a/charts/kserve-resources/files/common/storagecontainer.yaml
+++ b/charts/kserve-resources/files/common/storagecontainer.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   container:
     image: kserve/storage-initializer:latest
-    imagePullPolicy: IfNotPresent
     name: storage-initializer
     resources:
       limits:

--- a/config/storagecontainers/default.yaml
+++ b/config/storagecontainers/default.yaml
@@ -6,7 +6,6 @@ spec:
   container:
     name: storage-initializer
     image: default-storage-initilizer:replace
-    imagePullPolicy: IfNotPresent
     resources:
       requests:
         memory: 100Mi

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -39479,7 +39479,6 @@ metadata:
 spec:
   container:
     image: kserve/storage-initializer:latest
-    imagePullPolicy: IfNotPresent
     name: storage-initializer
     resources:
       limits:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -39065,7 +39065,6 @@ metadata:
 spec:
   container:
     image: kserve/storage-initializer:latest
-    imagePullPolicy: IfNotPresent
     name: storage-initializer
     resources:
       limits:

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -5546,3 +5546,79 @@ func TestMergeContainerSpecs_EnvHandling(t *testing.T) {
 		})
 	}
 }
+
+// TestCustomStorageContainerImagePullPolicyPropagation is a regression test for
+// kserve/kserve#834. It verifies that a ClusterStorageContainer's
+// container.imagePullPolicy reaches the final storage initializer init
+// container after mergeContainerSpecs runs. Cluster admins on clusters that
+// require imagePullPolicy=Always (e.g. via the AlwaysPullImages admission
+// plugin or a PodSecurityPolicy) rely on this path to declaratively configure
+// the storage initializer without overriding the configmap default.
+//
+// The reciprocal case (an unset value on the CSC must not clobber an existing
+// value on the init container) is implicitly covered by strategic merge patch
+// semantics: corev1.Container.ImagePullPolicy has json:"omitempty", so a zero
+// value is omitted from the patch and never overrides the target.
+func TestCustomStorageContainerImagePullPolicyPropagation(t *testing.T) {
+	scenarios := map[string]corev1.PullPolicy{
+		"Always":       corev1.PullAlways,
+		"IfNotPresent": corev1.PullIfNotPresent,
+		"Never":        corev1.PullNever,
+	}
+
+	for name, policy := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			customStorageContainer := &v1alpha1.StorageContainerSpec{
+				Container: corev1.Container{
+					Name:            "storage-initializer",
+					Image:           "custom/storage-initializer:v1",
+					ImagePullPolicy: policy,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+						},
+					},
+				},
+				SupportsMultiModelDownload: ptr.Bool(true),
+			}
+
+			podSpec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  constants.InferenceServiceContainerName,
+						Image: "test-image",
+						Env: []corev1.EnvVar{
+							{Name: constants.CustomSpecStorageUriEnvVarKey, Value: "placeholder"},
+						},
+					},
+				},
+			}
+
+			params := &StorageInitializerParams{
+				Namespace: "default",
+				StorageURIs: []v1beta1.StorageUri{
+					{Uri: "s3://bucket/model", MountPath: "/mnt/models"},
+				},
+				IsReadOnly:           false,
+				IsLegacyURI:          false,
+				PodSpec:              podSpec,
+				CredentialBuilder:    credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{Data: map[string]string{}}),
+				Client:               c,
+				Config:               storageInitializerConfig,
+				IsvcAnnotations:      map[string]string{},
+				StorageContainerSpec: customStorageContainer,
+			}
+
+			err := CommonStorageInitialization(t.Context(), params)
+			require.NoError(t, err)
+			require.Len(t, podSpec.InitContainers, 1, "exactly one storage initializer init container should be injected")
+			assert.Equal(t, policy, podSpec.InitContainers[0].ImagePullPolicy,
+				"ClusterStorageContainer.container.imagePullPolicy must propagate to the final init container")
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The storage initializer init container is created without an explicit `imagePullPolicy`, so kube-apiserver applies the standard default — `Always` for the `:latest` tag, `IfNotPresent` for any versioned tag. On clusters that enforce `imagePullPolicy=Always` via the `AlwaysPullImages` admission plugin or a PodSecurityPolicy, pods using a versioned storage initializer image are rejected at admission time with:

```
spec.initContainers[0].imagePullPolicy: Unsupported value: "IfNotPresent": supported values: "Always"
```

This PR exposes an `imagePullPolicy` field on `StorageInitializerConfig` (and the corresponding `kserve.storage.imagePullPolicy` Helm value) so cluster admins can opt into a specific policy. The pattern mirrors the existing `RouterConfig.ImagePullPolicy` used by the inference graph router.

The field is **strictly opt-in**: leaving it empty preserves the previous behavior (kube-apiserver defaults), so no existing install is affected.

**Which issue(s) this PR fixes**:
Fixes #834

**Feature/Issue validation/testing**:

- [x] Added `TestCreateInitContainerWithConfigImagePullPolicy` in `pkg/utils/storage_test.go` covering the empty (default), `Always`, `IfNotPresent`, and `Never` cases.
- [x] `go build ./...` and `go vet ./pkg/types/... ./pkg/utils/...` clean.
- [x] `go test ./pkg/utils/...` passes locally.

```
=== RUN   TestCreateInitContainerWithConfigImagePullPolicy
=== RUN   TestCreateInitContainerWithConfigImagePullPolicy/Unset_preserves_Kubernetes_default_behavior
=== RUN   TestCreateInitContainerWithConfigImagePullPolicy/Always_is_propagated_to_the_init_container
=== RUN   TestCreateInitContainerWithConfigImagePullPolicy/IfNotPresent_is_propagated_to_the_init_container
=== RUN   TestCreateInitContainerWithConfigImagePullPolicy/Never_is_propagated_to_the_init_container
--- PASS: TestCreateInitContainerWithConfigImagePullPolicy (0.00s)
PASS
ok  	github.com/kserve/kserve/pkg/utils
```

**Special notes for your reviewer**:

Files touched fall into three buckets:

- **Code**: `pkg/types/config.go`, `pkg/utils/storage.go`, `pkg/utils/storage_test.go`.
- **ConfigMap source**: `config/configmap/inferenceservice.yaml` — documents the new field with an empty default.
- **Helm**: `charts/_common/common-sections.yaml` and `charts/_common/common-patches/configmap-patch.yaml` are the sources of truth; the three generated `values.yaml` files and the two generated chart-local `configmap.yaml` / `configmap-patch.yaml` files were updated to match what `hack/setup/scripts/generate_chart_manifests.sh` would regenerate. (I don't have `kustomize`/`yq` installed locally, so the regen wasn't re-run — happy to do so if a reviewer prefers.)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas? (Doc comments on the new field in `StorageInitializerConfig` and on the Helm value.)
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? — happy to follow up with a website PR if a reviewer thinks this warrants one; field is self-documenting in the configmap.

**Release note**:
```release-note
Add `imagePullPolicy` field to the `storageInitializer` configmap entry (and the `kserve.storage.imagePullPolicy` Helm value) so cluster admins can pin the storage initializer init container's pull policy. Required on clusters that enforce `imagePullPolicy=Always` via the `AlwaysPullImages` admission plugin or a PodSecurityPolicy when using a versioned storage initializer image. Defaults to empty, preserving existing behavior.
```