### PR TITLE
feat(llmisvc): cache inferenceservice-config and watch for changes

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -51,6 +52,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
 	llmisvcwebhook "github.com/kserve/kserve/pkg/webhook/admission/llminferenceservice"
@@ -197,7 +199,16 @@ func main() {
 					Label: llmSvcCacheSelector,
 				},
 				&corev1.ConfigMap{}: {
-					Label: llmSvcCacheSelector,
+					Namespaces: map[string]cache.Config{
+						cache.AllNamespaces: {
+							LabelSelector: llmSvcCacheSelector,
+						},
+						constants.KServeNamespace: {
+							// Namespace-specific cache configs do not merge with AllNamespaces.
+							// Keep the system namespace scope limited to the global config read by LLMISVC.
+							FieldSelector: fields.OneTermEqualSelector("metadata.name", constants.InferenceServiceConfigMapName),
+						},
+					},
 				},
 				&appsv1.Deployment{}: {
 					Label: llmSvcCacheSelector,
@@ -234,7 +245,7 @@ func main() {
 		os.Exit(1)
 	}
 	v1alpha1ConfigValidator := &v1alpha1.LLMInferenceServiceConfigValidator{
-		ConfigValidationFunc:   createV1Alpha1ConfigValidationFunc(clientSet),
+		ConfigValidationFunc:   createV1Alpha1ConfigValidationFunc(mgr.GetAPIReader()),
 		WellKnownConfigChecker: wellKnownConfigChecker,
 	}
 	if err = v1alpha1ConfigValidator.SetupWithManager(mgr); err != nil {
@@ -242,7 +253,7 @@ func main() {
 		os.Exit(1)
 	}
 	v1alpha2ConfigValidator := &v1alpha2.LLMInferenceServiceConfigValidator{
-		ConfigValidationFunc:   createV1Alpha2ConfigValidationFunc(clientSet),
+		ConfigValidationFunc:   createV1Alpha2ConfigValidationFunc(mgr.GetAPIReader()),
 		WellKnownConfigChecker: wellKnownConfigChecker,
 	}
 	if err = v1alpha2ConfigValidator.SetupWithManager(mgr); err != nil {
@@ -370,8 +381,8 @@ func wellKnownConfigChecker(name string) bool {
 
 // validateLLMISVCConfig validates a v1alpha2 LLMInferenceServiceConfig by loading the controller
 // config and validating the template variables.
-func validateLLMISVCConfig(ctx context.Context, clientSet kubernetes.Interface, config *v1alpha2.LLMInferenceServiceConfig) error {
-	cfg, err := llmisvc.LoadConfig(ctx, clientSet)
+func validateLLMISVCConfig(ctx context.Context, reader client.Reader, config *v1alpha2.LLMInferenceServiceConfig) error {
+	cfg, err := llmisvc.LoadConfig(ctx, reader)
 	if err != nil {
 		return err
 	}
@@ -381,19 +392,19 @@ func validateLLMISVCConfig(ctx context.Context, clientSet kubernetes.Interface, 
 
 // createV1Alpha1ConfigValidationFunc creates a validation function for v1alpha1 LLMInferenceServiceConfig.
 // It converts the config to v1alpha2 and validates using the v1alpha2 llmisvc package.
-func createV1Alpha1ConfigValidationFunc(clientSet kubernetes.Interface) func(ctx context.Context, config *v1alpha1.LLMInferenceServiceConfig) error {
+func createV1Alpha1ConfigValidationFunc(reader client.Reader) func(ctx context.Context, config *v1alpha1.LLMInferenceServiceConfig) error {
 	return func(ctx context.Context, config *v1alpha1.LLMInferenceServiceConfig) error {
 		v2Config := &v1alpha2.LLMInferenceServiceConfig{}
 		if err := config.ConvertTo(v2Config); err != nil {
 			return err
 		}
-		return validateLLMISVCConfig(ctx, clientSet, v2Config)
+		return validateLLMISVCConfig(ctx, reader, v2Config)
 	}
 }
 
 // createV1Alpha2ConfigValidationFunc creates a validation function for v1alpha2 LLMInferenceServiceConfig.
-func createV1Alpha2ConfigValidationFunc(clientSet kubernetes.Interface) func(ctx context.Context, config *v1alpha2.LLMInferenceServiceConfig) error {
+func createV1Alpha2ConfigValidationFunc(reader client.Reader) func(ctx context.Context, config *v1alpha2.LLMInferenceServiceConfig) error {
 	return func(ctx context.Context, config *v1alpha2.LLMInferenceServiceConfig) error {
-		return validateLLMISVCConfig(ctx, clientSet, config)
+		return validateLLMISVCConfig(ctx, reader, config)
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/config_loader.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader.go
@@ -23,7 +23,8 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
@@ -177,15 +178,34 @@ func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *types.Storag
 	}
 }
 
-// LoadConfig loads configuration from the KServe configmap in the cluster
-// It fetches and converts the configmap into structured config objects needed by LLM services
-func LoadConfig(ctx context.Context, clientset kubernetes.Interface) (*Config, error) {
-	// Fetch the KServe configmap directly from the API server to get latest values
-	isvcConfigMap, errCfgMap := v1beta1.GetInferenceServiceConfigMap(ctx, clientset)
-	if errCfgMap != nil {
-		return nil, fmt.Errorf("failed to load InferenceServiceConfigMap: %w", errCfgMap)
+// LoadConfig loads configuration from the supplied Kubernetes object reader.
+func LoadConfig(ctx context.Context, reader client.Reader) (*Config, error) {
+	isvcConfigMap := &corev1.ConfigMap{}
+	if err := reader.Get(ctx, k8stypes.NamespacedName{
+		Namespace: constants.KServeNamespace,
+		Name:      constants.InferenceServiceConfigMapName,
+	}, isvcConfigMap); err != nil {
+		return nil, fmt.Errorf("failed to load InferenceServiceConfigMap: %w", err)
 	}
 
+	return toConfig(isvcConfigMap)
+}
+
+func (r *LLMISVCReconciler) loadConfig(ctx context.Context) (*Config, error) {
+	configMap, fallbackErr := Get(
+		ctx,
+		r.Client,
+		client.ObjectKey{Namespace: constants.KServeNamespace, Name: constants.InferenceServiceConfigMapName},
+		&corev1.ConfigMap{},
+		WithGetFallbackAPIServerConfigMap(r.Clientset),
+	)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("failed to load InferenceServiceConfigMap: %w", fallbackErr)
+	}
+	return toConfig(configMap)
+}
+
+func toConfig(isvcConfigMap *corev1.ConfigMap) (*Config, error) {
 	ingressConfig, errConvert := v1beta1.NewIngressConfig(isvcConfigMap)
 	if errConvert != nil {
 		return nil, fmt.Errorf("failed to convert InferenceServiceConfigMap to IngressConfig: %w", errConvert)

--- a/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
@@ -21,8 +21,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
 )
 
 func TestNewSchedulerConfig(t *testing.T) {
@@ -87,5 +91,37 @@ func TestNewSchedulerConfig(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	cachedConfigMap := fixture.InferenceServiceCfgMapWithUrlScheme(constants.KServeNamespace, "https")
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithObjects(cachedConfigMap).
+		Build()
+
+	got, err := llmisvc.LoadConfig(t.Context(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.UrlScheme != "https" {
+		t.Fatalf("UrlScheme = %q, want %q", got.UrlScheme, "https")
+	}
+	if got.IngressGatewayNamespace != constants.KServeNamespace {
+		t.Fatalf("IngressGatewayNamespace = %q, want %q", got.IngressGatewayNamespace, constants.KServeNamespace)
+	}
+	if got.IngressGatewayName != "kserve-ingress-gateway" {
+		t.Fatalf("IngressGatewayName = %q, want %q", got.IngressGatewayName, "kserve-ingress-gateway")
+	}
+	if got.StorageConfig == nil {
+		t.Fatal("StorageConfig = nil, want populated config")
+	}
+	if got.CredentialConfig == nil {
+		t.Fatal("CredentialConfig = nil, want populated config")
+	}
+	if got.SchedulerConfig == nil {
+		t.Fatal("SchedulerConfig = nil, want populated config")
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -18,6 +18,7 @@ package llmisvc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"k8s.io/client-go/kubernetes"
@@ -75,6 +76,48 @@ var ChildResourcesLabelSelector = metav1.LabelSelector{
 // childResourcesPredicate filters events to only those from resources owned by LLMInferenceService
 // This prevents unnecessary reconciliation triggers from unrelated resources
 var childResourcesPredicate, _ = predicate.LabelSelectorPredicate(ChildResourcesLabelSelector)
+
+var (
+	inferenceServiceConfigMapPredicate = predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isInferenceServiceConfigMap(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isInferenceServiceConfigMap(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isInferenceServiceConfigMap(e.ObjectNew) && inferenceServiceConfigChanged(e.ObjectOld, e.ObjectNew)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isInferenceServiceConfigMap(e.Object)
+		},
+	}
+	nonInferenceServiceConfigMapPredicate = predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return !isInferenceServiceConfigMap(obj)
+	})
+)
+
+func isInferenceServiceConfigMap(obj client.Object) bool {
+	return obj.GetNamespace() == constants.KServeNamespace &&
+		obj.GetName() == constants.InferenceServiceConfigMapName
+}
+
+func inferenceServiceConfigChanged(oldObj, newObj client.Object) bool {
+	oldConfigMap := oldObj.(*corev1.ConfigMap)
+	newConfigMap := newObj.(*corev1.ConfigMap)
+
+	oldConfig, oldErr := toConfig(oldConfigMap)
+	newConfig, newErr := toConfig(newConfigMap)
+	if oldErr != nil || newErr != nil {
+		ctrl.Log.WithName("LLMInferenceService").Error(
+			errors.Join(oldErr, newErr),
+			"Failed to parse inferenceservice-config, falling back to raw comparison",
+		)
+		return !equality.Semantic.DeepEqual(oldConfigMap.Data, newConfigMap.Data)
+	}
+
+	return !equality.Semantic.DeepEqual(oldConfig, newConfig)
+}
 
 // LLMInferenceServiceState describes the readiness of the LLMInferenceService.
 type LLMInferenceServiceState string
@@ -202,9 +245,8 @@ func (r *LLMISVCReconciler) reconcile(ctx context.Context, llmSvc *v1alpha2.LLMI
 	logger := log.FromContext(ctx).WithName("reconcile")
 	ctx = log.IntoContext(ctx, logger)
 
-	// Load global configuration from KServe configmap
-	// TODO(ctrl): add watch on CfgMap with predicate and cache tuning to trigger reconcile when it changes
-	config, configErr := LoadConfig(ctx, r.Clientset)
+	// Load global configuration from KServe configmap.
+	config, configErr := r.loadConfig(ctx)
 	if configErr != nil {
 		return fmt.Errorf("failed to load ingress config: %w", configErr)
 	}
@@ -329,7 +371,8 @@ func (r *LLMISVCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}, builder.WithPredicates(childResourcesPredicate)).
 		Owns(&corev1.Service{}, builder.WithPredicates(childResourcesPredicate)).
 		Owns(&autoscalingv2.HorizontalPodAutoscaler{}, builder.WithPredicates(childResourcesPredicate)).
-		Watches(&corev1.ConfigMap{}, r.enqueueOnConfigMapChange(logger)).
+		Watches(&corev1.ConfigMap{}, r.enqueueOnConfigMapChange(logger), builder.WithPredicates(nonInferenceServiceConfigMapPredicate)).
+		Watches(&corev1.ConfigMap{}, r.enqueueOnInferenceServiceConfigMapChange(logger), builder.WithPredicates(inferenceServiceConfigMapPredicate)).
 		Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueOnLLMInferenceServicePods),
 			builder.WithPredicates(PodStatusPredicate()))
@@ -381,7 +424,7 @@ func (r *LLMISVCReconciler) enqueueOnGatewayChange(logger logr.Logger) handler.E
 
 		listNamespace := corev1.NamespaceAll
 
-		cfg, err := LoadConfig(ctx, r.Clientset)
+		cfg, err := r.loadConfig(ctx)
 		if err != nil {
 			logger.Error(err, "Failed to load config")
 			return reqs
@@ -466,7 +509,7 @@ func (r *LLMISVCReconciler) enqueueOnHttpRouteChange(logger logr.Logger) handler
 
 		listNamespace := corev1.NamespaceAll
 
-		cfg, err := LoadConfig(ctx, r.Clientset)
+		cfg, err := r.loadConfig(ctx)
 		if err != nil {
 			logger.Error(err, "Failed to load config")
 			return reqs
@@ -540,7 +583,7 @@ func (r *LLMISVCReconciler) enqueueOnInferencePoolChange(logger logr.Logger) han
 		reqs := make([]reconcile.Request, 0, 2)
 		listNamespace := sub.GetNamespace()
 
-		cfg, err := LoadConfig(ctx, r.Clientset)
+		cfg, err := r.loadConfig(ctx)
 		if err != nil {
 			logger.Error(err, "Failed to load config")
 			return reqs
@@ -687,15 +730,10 @@ func (r *LLMISVCReconciler) enqueueOnConfigMapChange(logger logr.Logger) handler
 
 		listNamespace := sub.GetNamespace()
 
-		cfg, err := LoadConfig(ctx, r.Clientset)
+		cfg, err := r.loadConfig(ctx)
 		if err != nil {
 			logger.Error(err, "Failed to load config")
 			return reqs
-		}
-
-		// System namespace configs are global and can affect services in any namespace
-		if sub.Namespace == constants.KServeNamespace {
-			listNamespace = corev1.NamespaceAll
 		}
 
 		// When a ConfigMap is modified, we need to find all LLMInferenceService instances that might
@@ -724,6 +762,31 @@ func (r *LLMISVCReconciler) enqueueOnConfigMapChange(logger logr.Logger) handler
 				continue
 			}
 
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: llmSvc.Namespace,
+				Name:      llmSvc.Name,
+			}})
+		}
+
+		return reqs
+	})
+}
+
+func (r *LLMISVCReconciler) enqueueOnInferenceServiceConfigMapChange(logger logr.Logger) handler.EventHandler {
+	logger = logger.WithName("enqueueOnInferenceServiceConfigMapChange")
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
+		reqs := make([]reconcile.Request, 0)
+		if !isInferenceServiceConfigMap(object) {
+			return reqs
+		}
+
+		llmSvcList := &v1alpha2.LLMInferenceServiceList{}
+		if err := r.List(ctx, llmSvcList, &client.ListOptions{Namespace: corev1.NamespaceAll}); err != nil {
+			logger.Error(err, "Failed to list LLMInferenceService")
+			return reqs
+		}
+
+		for _, llmSvc := range llmSvcList.Items {
 			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
 				Namespace: llmSvc.Namespace,
 				Name:      llmSvc.Name,

--- a/pkg/controller/v1alpha2/llmisvc/controller_handlers_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_handlers_test.go
@@ -162,8 +162,7 @@ func TestSetRoutingPoolStatusOnlyWritesWhenRoutingExists(t *testing.T) {
 func TestRequestsForInferencePoolChangeMatchesExternalPoolRefs(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	scheme := runtime.NewScheme()
-	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
+	scheme := newControllerHandlersScheme(t)
 
 	llmSvcWithMatch := &v1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -237,8 +236,7 @@ func TestRequestsForInferencePoolChangeMatchesExternalPoolRefs(t *testing.T) {
 func TestRequestsForInferencePoolChangeIncludesRefsEvenWhenPoolIsOwned(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	scheme := runtime.NewScheme()
-	g.Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
+	scheme := newControllerHandlersScheme(t)
 
 	ownerSvc := &v1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -307,6 +305,95 @@ func TestRequestsForInferencePoolChangeIncludesRefsEvenWhenPoolIsOwned(t *testin
 			Name:      "svc-consumer",
 		},
 	}))
+}
+
+func TestRequestsForInferenceServiceConfigMapChangeEnqueuesAllServices(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	scheme := newControllerHandlersScheme(t)
+
+	first := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "first",
+			Namespace: "default",
+		},
+	}
+	second := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "second",
+			Namespace: "other",
+		},
+	}
+
+	reconciler := &LLMISVCReconciler{
+		Client: clientfake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(first, second).
+			Build(),
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.InferenceServiceConfigMapName,
+			Namespace: constants.KServeNamespace,
+		},
+	}
+
+	reqs := enqueueRequestsForObject(
+		reconciler.enqueueOnInferenceServiceConfigMapChange(logr.Discard()),
+		configMap,
+	)
+
+	g.Expect(reqs).To(ConsistOf(
+		reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "first"}},
+		reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "other", Name: "second"}},
+	))
+}
+
+func TestInferenceServiceConfigMapPredicateOnlyAcceptsConfigChanges(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	base := testInferenceServiceConfigMap()
+
+	metadataOnly := base.DeepCopy()
+	metadataOnly.Labels = map[string]string{"changed": "true"}
+	g.Expect(inferenceServiceConfigMapPredicate.Update(event.UpdateEvent{
+		ObjectOld: base,
+		ObjectNew: metadataOnly,
+	})).To(BeFalse())
+
+	unusedData := base.DeepCopy()
+	unusedData.Data["unrelated"] = "ignored"
+	g.Expect(inferenceServiceConfigMapPredicate.Update(event.UpdateEvent{
+		ObjectOld: base,
+		ObjectNew: unusedData,
+	})).To(BeFalse())
+
+	configChange := base.DeepCopy()
+	configChange.Data["ingress"] = `{
+		"enableGatewayApi": true,
+		"kserveIngressGateway": "kserve/changed-gateway",
+		"ingressGateway": "knative-serving/knative-ingress-gateway",
+		"localGateway": "knative-serving/knative-local-gateway",
+		"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
+	}`
+	g.Expect(inferenceServiceConfigMapPredicate.Update(event.UpdateEvent{
+		ObjectOld: base,
+		ObjectNew: configChange,
+	})).To(BeTrue())
+}
+
+func newControllerHandlersScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := v1alpha2.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add v1alpha2 to scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	return scheme
 }
 
 func enqueueRequestsForObject(eventHandler handler.EventHandler, object client.Object) []reconcile.Request {

--- a/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
@@ -152,6 +152,34 @@ var _ = Describe("Model Based Routing", func() {
 
 			Eventually(LLMInferenceServiceIsReady(llmSvc)).WithContext(ctx).Should(Succeed())
 		})
+
+		It("should reconcile existing services when inferenceservice-config changes", func(ctx SpecContext) {
+			DeferCleanup(restoreIngressModelBasedRoutingMode)
+
+			svcName := "test-mbr-config-update"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := createModelRoutingTestService(ctx, svcName, testNs)
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(&routes[0]).To(HaveHeaderMatch(headerName, "publishers/"+testNs.Name+"/models/facebook/opt-125m"))
+			}).WithContext(ctx).Should(Succeed())
+
+			patchIngressModelBasedRoutingMode(ctx, "disabled")
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(&routes[0]).NotTo(HaveHeaderMatch(headerName, "publishers/"+testNs.Name+"/models/facebook/opt-125m"))
+			}).WithContext(ctx).Should(Succeed())
+		})
 	})
 
 	Context("Disabled via ConfigMap", func() {

--- a/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
@@ -69,15 +69,10 @@ func SetupTestEnv(ctx context.Context) *pkgtest.Client {
 	}
 
 	webhookManifests := pkgtest.WithWebhookManifests(filepath.Join(pkgtest.ProjectRoot(), "test", "webhooks"))
-	webhooks := func(cfg *rest.Config, mgr ctrl.Manager) error {
-		clientSet, err := kubernetes.NewForConfig(cfg)
-		if err != nil {
-			return err
-		}
-
+	webhooks := func(_ *rest.Config, mgr ctrl.Manager) error {
 		// Create validation function for config template validation
 		v2ConfigValidationFunc := func(ctx context.Context, config *v1alpha2.LLMInferenceServiceConfig) error {
-			llmisvcConfig, err := llmisvc.LoadConfig(ctx, clientSet)
+			llmisvcConfig, err := llmisvc.LoadConfig(ctx, mgr.GetAPIReader())
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -309,10 +309,7 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 		return nil, nil
 	}
 
-	// TODO: LoadConfig fetches the configmap from the API server on every
-	// reconciliation. Consider caching with an informer-based watch to reduce
-	// API server pressure under high reconciliation load.
-	cfg, err := LoadConfig(ctx, r.Clientset)
+	cfg, err := r.loadConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -433,7 +433,7 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 				return d, fmt.Errorf("failed to get current scheduler deployment %s/%s: %w", d.GetNamespace(), d.GetName(), err)
 			}
 
-			config, err := LoadConfig(ctx, r.Clientset)
+			config, err := r.loadConfig(ctx)
 			if err != nil {
 				return d, fmt.Errorf("failed to load config for scheduler deployment %s/%s: %w", d.GetNamespace(), d.GetName(), err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

`LoadConfig` was calling the API server directly on every reconcile loop and in every event handler (`enqueueOnGatewayChange`, `enqueueOnHttpRouteChange`, `enqueueOnInferencePoolChange`, `enqueueOnConfigMapChange`, `updateRoutingStatus`, `expectedSchedulerDeployment`). This adds unnecessary API server pressure under high reconciliation load.



This PR switches all call sites to a cached controller-runtime client read via `r.loadConfig(ctx)`, backed by a field-selector-scoped informer cache for the `inferenceservice-config` ConfigMap.

It also adds a dedicated `Watches` entry so that changes to `inferenceservice-config` trigger reconciliation of all `LLMInferenceService` objects across namespaces.

The existing ConfigMap watch is updated with a predicate to exclude `inferenceservice-config` so the two paths do not overlap.

**Feature/Issue validation/testing**:

- [x] `TestLoadConfigFromClient` — verifies the cached client read path returns correct config
- [x] `TestRequestsForInferenceServiceConfigMapChangeEnqueuesAllServices`: verifies that a change to `inferenceservice-config` enqueues all `LLMInferenceService` objects across namespaces
- [x] Existing `TestNewSchedulerConfig` and `TestRequestsForInferencePoolChange` pass unchanged
- Full integration tests require `envtest`; local etcd binary unavailable, covered by CI

**Special notes for your reviewer**:

Closes two TODOs in the codebase:
- `router.go`: `// TODO: LoadConfig fetches the configmap from the API server on every reconciliation...`
- `controller.go`: `// TODO(ctrl): add watch on CfgMap with predicate and cache tuning to trigger reconcile when it changes`

The `enqueueOnConfigMapChange` handler previously fanned out to all namespaces when a ConfigMap in `KServeNamespace` changed. That behavior is preserved for `LLMInferenceServiceConfig` objects via the existing `enqueueOnLLMInferenceServiceConfigChange` handler. 
The `inferenceservice-config` ConfigMap now has its own dedicated handler for this fan-out.