### PR TITLE
fix: update SERVING_READINESS_PROBE port with co-injected sidecars

### DIFF
--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -384,12 +384,28 @@ func (ag *AgentInjector) InjectAgent(pod *corev1.Pod) error {
 			}
 		}
 	} else {
-		// Adjust USER_PORT when queueProxy is available
+		// Adjust USER_PORT and SERVING_READINESS_PROBE when queueProxy is available.
 		for i, envVar := range queueProxyEnvs {
 			if envVar.Name == "USER_PORT" {
 				klog.Infof("Adjusting USER_PORT to %s for pod %s/%s", constants.InferenceServiceDefaultAgentPortStr, pod.Namespace, pod.Name)
 				envVar.Value = constants.InferenceServiceDefaultAgentPortStr
 				queueProxyEnvs[i] = envVar // Update the environment variable in the list
+			}
+			if envVar.Name == "SERVING_READINESS_PROBE" {
+				var probe corev1.Probe
+				if err := json.Unmarshal([]byte(envVar.Value), &probe); err == nil {
+					agentPort := intstr.FromInt(constants.InferenceServiceDefaultAgentPort)
+					if probe.TCPSocket != nil {
+						probe.TCPSocket.Port = agentPort
+					} else if probe.HTTPGet != nil {
+						probe.HTTPGet.Port = agentPort
+					}
+					if updated, err := json.Marshal(probe); err == nil {
+						klog.Infof("Adjusting SERVING_READINESS_PROBE port to %s for pod %s/%s", constants.InferenceServiceDefaultAgentPortStr, pod.Namespace, pod.Name)
+						envVar.Value = string(updated)
+						queueProxyEnvs[i] = envVar
+					}
+				}
 			}
 		}
 	}

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -334,7 +334,7 @@ func TestAgentInjector(t *testing.T) {
 						},
 						{
 							Name: "queue-proxy",
-							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":9081},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 						},
 						{
 							Name:  constants.AgentContainerName,
@@ -462,7 +462,7 @@ func TestAgentInjector(t *testing.T) {
 						},
 						{
 							Name: "queue-proxy",
-							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":9081},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 						},
 						{
 							Name:  constants.AgentContainerName,
@@ -594,7 +594,7 @@ func TestAgentInjector(t *testing.T) {
 						},
 						{
 							Name: "queue-proxy",
-							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":9081},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 						},
 						{
 							Name:  constants.AgentContainerName,
@@ -745,7 +745,7 @@ func TestAgentInjector(t *testing.T) {
 						},
 						{
 							Name: "queue-proxy",
-							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":9081},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 						},
 						{
 							Name:  constants.AgentContainerName,
@@ -1073,7 +1073,7 @@ func TestAgentInjector(t *testing.T) {
 						},
 						{
 							Name: "queue-proxy",
-							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":9081},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 						},
 						{
 							Name:  constants.AgentContainerName,
@@ -1202,7 +1202,7 @@ func TestAgentInjector(t *testing.T) {
 						{
 							Name: "queue-proxy",
 							Env: []corev1.EnvVar{
-								{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"},
+								{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":9081},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"},
 								{Name: "USER_PORT", Value: constants.InferenceServiceDefaultAgentPortStr},
 							},
 						},
@@ -1488,7 +1488,7 @@ func TestAgentInjector(t *testing.T) {
 						},
 						{
 							Name: "queue-proxy",
-							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":9081},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 						},
 						{
 							Name:  constants.AgentContainerName,
@@ -1642,7 +1642,7 @@ func TestAgentInjector(t *testing.T) {
 						},
 						{
 							Name: "queue-proxy",
-							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							Env:  []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":9081},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 						},
 						{
 							Name:  constants.AgentContainerName,


### PR DESCRIPTION
**What this PR does / why we need it**:
When the agent sidecar is injected alongside queue-proxy, `USER_PORT` was correctly updated to the agent port (`9081`) but `SERVING_READINESS_PROBE` retained the original model server port (`8080`). This meant queue-proxy was probing the model server directly instead of the agent, bypassing the agent's readiness logic entirely.

This fix updates the `else` branch in `InjectAgent` to also rewrite the port inside the `SERVING_READINESS_PROBE` JSON payload (for both `tcpSocket` and `httpGet` probe types) to match the agent's port when queue-proxy is present.

**Which issue(s) this PR fixes**:
Fixes #5569

**Feature/Issue validation/testing**:

Updated the existing `QueueProxyUserPortProvided` unit test to assert that `SERVING_READINESS_PROBE` is updated to port `9081` (not just `USER_PORT`), and also updated all other test cases where queue-proxy is present in the input pod to reflect the corrected expected value.

- [x] `TestAgentInjector` — all cases pass including `QueueProxyUserPortProvided`
- [x] Full `pkg/webhook/admission/pod` test suite passes

**Special notes for your reviewer**:
`agentEnvs` is a copy of the queue-proxy env vars made before modification, so the agent container retains `SERVING_READINESS_PROBE` pointing to the model server (`8080`) — which is correct, as the agent probes the model server directly. Only the queue-proxy container's env var is updated to `9081`.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fixed queue-proxy SERVING_READINESS_PROBE not being updated to the agent port when the agent sidecar is injected alongside queue-proxy, causing queue-proxy to probe the model server directly instead of the agent.
