### PR TITLE
chore: add bump-version Copilot agent and release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -1,0 +1,43 @@
+name: Release
+description: Prepare a new KServe release
+labels: ["release"]
+title: "release: prepare release"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## KServe Release
+
+        After creating this issue, assign it to the **bump-version** agent to start the automated version bump.
+
+        ### What the agent will do
+        1. Validate version format (X.Y.Z or X.Y.Z-rcN)
+        2. Detect prior version from `KSERVE_VERSION` in `kserve-deps.env`
+        3. Verify the prior version tag exists
+        4. Run `make bump-version` and `make precommit`
+        5. Create a PR (to master, or release branch for Z-stream releases)
+
+        ### After the PR is merged
+        Follow the release process guide to complete the remaining steps
+        (branch/tag creation, draft release, validation, publish).
+
+        - Recommended: [RELEASE_PROCESS_v3_copilot.md](https://github.com/kserve/kserve/blob/master/release/RELEASE_PROCESS_v3_copilot.md) (Copilot-assisted)
+        - Manual: [RELEASE_PROCESS_v3.md](https://github.com/kserve/kserve/blob/master/release/RELEASE_PROCESS_v3.md)
+
+  - type: input
+    id: new_version
+    attributes:
+      label: New Version
+      description: "Version without 'v' prefix. Examples: 0.18.0-rc0, 0.18.0-rc1, 0.18.0"
+      placeholder: "0.18.0-rc0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Notes
+      description: "Any special instructions for this release"
+      placeholder: "e.g., skip uv-lock, cherry-pick specific PRs first"
+    validations:
+      required: false

--- a/.github/agents/bump-version.agent.md
+++ b/.github/agents/bump-version.agent.md
@@ -1,0 +1,124 @@
+---
+name: bump-version
+description: Automated KServe version bump. Reads target version from the issue, runs make bump-version, and creates a PR.
+---
+
+You are an automated version bump agent for KServe releases.
+When assigned to a release issue, bump all version references and create a PR.
+
+## Strict Rules
+
+### Branch Restrictions
+
+1. ONLY operate on the `copilot/*` branch that is automatically created for you
+2. NEVER create, delete, modify, push to, or force-push to any other branch
+3. NEVER touch `master`, `release-*`, or any existing branches in the repository
+4. If a step requires operating on a branch other than your own `copilot/*` branch, stop and comment on the issue
+
+### Command Restrictions
+
+5. Do NOT run `make test`, `make lint`, `make py-lint`, or any validation/build commands
+6. The ONLY make commands you may run are `make bump-version` and `make precommit`
+7. Do NOT manually edit version strings — `make bump-version` handles all file changes
+8. Use `-s` (sign-off) on commits. Do NOT use `-S` (GPG sign)
+
+## Steps
+
+### 1. Read Input from Issue
+
+Extract the version from the issue's **New Version** field.
+- Must match `X.Y.Z` or `X.Y.Z-rcN` format (no `v` prefix)
+- If invalid, comment on the issue explaining the expected format and stop
+
+### 2. Determine Target Branch
+
+Parse the version to determine the correct target branch for the PR:
+
+| Condition | Target Branch | Example |
+|-----------|---------------|---------|
+| Z > 0 and no `-rcN` suffix | `release-X.Y` | `0.17.2` → `release-0.17` |
+| Everything else (RC0, RC1+, Final with Z=0) | `master` | `0.18.0-rc0`, `0.18.0` → `master` |
+
+Verify the target branch exists in the repository. If it does not exist, comment on the issue:
+> "Target branch `{target_branch}` does not exist. Please create the branch first."
+
+Then stop.
+
+Use this target branch as both:
+- The base ref to branch from (your `copilot/*` branch must be based on this branch)
+- The PR base branch in Step 6
+
+### 3. Detect and Verify Prior Version
+
+Read the current version from `kserve-deps.env`:
+
+```bash
+PRIOR_VERSION=$(grep "KSERVE_VERSION=" kserve-deps.env | cut -d'=' -f2 | sed 's/^v//')
+```
+
+Verify the matching tag exists:
+
+```bash
+git tag -l "v${PRIOR_VERSION}"
+```
+
+If the tag does not exist, comment on the issue:
+> "Prior version v{PRIOR_VERSION} found in kserve-deps.env but tag v{PRIOR_VERSION} does not exist. Please check the repository state."
+
+Then stop.
+
+### 4. Run Version Bump
+
+```bash
+yes "" | make bump-version NEW_VERSION={VERSION} PRIOR_VERSION={PRIOR_VERSION}
+```
+
+If this fails, comment the error output on the issue and stop.
+
+### 5. Fix Formatting
+
+Run `make precommit` to fix any formatting issues introduced by the version bump:
+
+```bash
+make precommit
+```
+
+Stage any formatting changes before committing.
+
+### 6. Commit and PR
+
+- **PR base branch**: Use the base branch determined in Step 2 (`master` or `release-X.Y`)
+- Commit message: `release: prepare release v{VERSION}`
+- PR title: `release: prepare release v{VERSION}`
+- PR body:
+  ```
+  Automated version bump from v{PRIOR_VERSION} to v{VERSION}.
+
+  Triggered by #{ISSUE_NUMBER}.
+  ```
+- Labels:
+  - Always add: `release`
+  - Add `cherrypick-approved` for RC1+, RC2+, and Final (Z=0) — NOT for RC0 or Z-release
+
+  | Version type | `cherrypick-approved` |
+  |---|---|
+  | RC0 (`0.18.0-rc0`) | No |
+  | RC1+ (`0.18.0-rc1`) | Yes |
+  | Final Z=0 (`0.18.0`) | Yes |
+  | Z-release (`0.17.1`) | No |
+
+### 7. Additional Notes
+
+Before starting the version bump (Step 4), check the issue's **Additional Notes** field.
+If present, follow any special instructions that may affect the bump process
+(e.g., "skip uv-lock", "update dependency X").
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| Invalid version format | Comment on issue, stop |
+| Wrong base branch | Comment on issue with correct branch, stop |
+| Prior version tag missing | Comment on issue, stop |
+| `make bump-version` fails | Comment on issue with error output, stop |
+| `make precommit` fails | Comment on issue with error output, stop |

--- a/release/BUMP_VERSION_AGENT.md
+++ b/release/BUMP_VERSION_AGENT.md
@@ -1,0 +1,99 @@
+# Bump Version Agent
+
+Automate the version bump step of a KServe release using GitHub Copilot coding agent.
+
+Instead of running `make bump-version` locally, create a GitHub issue and let the agent handle it.
+
+---
+
+## How It Works
+
+1. Create a release issue using the **Release** issue template
+2. Fill in the **New Version** field (e.g., `X.Y.Z-rc0`, `X.Y.Z`)
+3. Assign **Copilot** to the issue
+4. The agent creates a PR with all version files updated
+
+---
+
+## Usage
+
+### Step 1: Create a Release Issue
+
+Go to **Issues → New issue → Release** and fill in the version:
+
+| Field | Example |
+|-------|---------|
+| New Version | `X.Y.Z-rc0` |
+| Additional Notes | _(optional)_ |
+
+### Step 2: Assign Copilot with the bump-version agent
+
+1. Click **Assignees** → select **Copilot**
+2. Select the **`bump-version`** agent
+3. Select the **base branch**:
+   - RC0, RC1+, Final → `master` (default)
+   - Z-release (Z > 0) → `release-X.Y`
+
+> **Important:**
+> - You must select the `bump-version` agent. If you skip this, Copilot runs without the release-specific instructions.
+> - For z-releases, you must select the release branch as the base branch. Otherwise the PR targets `master`.
+
+### Step 3: Review and Merge
+
+Review the PR, verify CI passes, then merge.
+
+---
+
+## Version Types and Target Branches
+
+| Version | Type | Target Branch | Base ref on assign | `cherrypick-approved` |
+|---------|------|---------------|--------------------|-----------------------|
+| `X.Y.0-rc0` | RC0 | `master` | _(default)_ | No |
+| `X.Y.0-rcN` (N>0) | RC1+ | `master` | _(default)_ | Yes |
+| `X.Y.0` | Final | `master` | _(default)_ | Yes |
+| `X.Y.Z` (Z>0) | Z-release | `release-X.Y` | `release-X.Y` | No |
+
+For z-releases, you **must** specify the release branch when assigning Copilot. Otherwise the PR targets `master`.
+
+---
+
+## What the Agent Does
+
+1. Validates version format (`X.Y.Z` or `X.Y.Z-rcN`)
+2. Determines the correct target branch
+3. Reads the prior version from `kserve-deps.env`
+4. Verifies the prior version tag exists
+5. Runs `make bump-version`
+6. Runs `make precommit` for formatting
+7. Creates a PR targeting the correct branch
+
+---
+
+## After the PR Is Merged
+
+Follow the remaining release steps in:
+
+- [RELEASE_PROCESS_v3.md](./RELEASE_PROCESS_v3.md) (manual)
+- [RELEASE_PROCESS_v3_copilot.md](./RELEASE_PROCESS_v3_copilot.md) (Copilot CLI)
+
+---
+
+## Agent Definition
+
+The agent logic is defined in:
+
+- [`.github/agents/bump-version.agent.md`](../.github/agents/bump-version.agent.md)
+- [`.github/ISSUE_TEMPLATE/release.yml`](../.github/ISSUE_TEMPLATE/release.yml)
+
+---
+
+## Restarting a Failed or Incorrect Run
+
+If the agent produces a wrong result or you need to retry:
+
+1. **Close** the PR that the agent created
+2. **Unassign** Copilot from the issue
+3. **Re-assign** Copilot to the issue (select `bump-version` agent again, and set the base branch for z-releases)
+
+The agent starts fresh on each assignment — it does not resume from a previous attempt.
+


### PR DESCRIPTION
**What this PR does / why we need it**:
add bump-version Copilot agent and release issue template

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note

```
