### PR TITLE
fix(storage): parse S3 boolean options consistently

### DIFF
--- a/charts/kserve-llmisvc-resources/files/common/configmap.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap.yaml
@@ -258,22 +258,26 @@ data:
               "s3Endpoint": "",
 
               # s3UseHttps controls whether to use secure https or unsecure http to download models.
-              # Allowed values are 0 and 1.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseHttps": "",
 
               # s3Region specifies the region of the bucket.
               "s3Region": "",
 
               # s3VerifySSL controls whether to verify the tls/ssl certificate.
+              # Allowed boolean values include 0/1 and false/true.
               "s3VerifySSL": "",
 
               # s3UseVirtualBucket configures whether it is a virtual bucket or not.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseVirtualBucket": "",
 
               # s3UseAccelerate configures whether to use transfer acceleration.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseAccelerate": "",
 
               # s3UseAnonymousCredential configures whether to use anonymous credentials to download the model or not.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseAnonymousCredential": "",
 
               # s3CABundleConfigMap specifies the mounted CA bundle config map name.

--- a/charts/kserve-resources/files/common/configmap.yaml
+++ b/charts/kserve-resources/files/common/configmap.yaml
@@ -258,22 +258,26 @@ data:
               "s3Endpoint": "",
 
               # s3UseHttps controls whether to use secure https or unsecure http to download models.
-              # Allowed values are 0 and 1.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseHttps": "",
 
               # s3Region specifies the region of the bucket.
               "s3Region": "",
 
               # s3VerifySSL controls whether to verify the tls/ssl certificate.
+              # Allowed boolean values include 0/1 and false/true.
               "s3VerifySSL": "",
 
               # s3UseVirtualBucket configures whether it is a virtual bucket or not.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseVirtualBucket": "",
 
               # s3UseAccelerate configures whether to use transfer acceleration.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseAccelerate": "",
 
               # s3UseAnonymousCredential configures whether to use anonymous credentials to download the model or not.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseAnonymousCredential": "",
 
               # s3CABundleConfigMap specifies the mounted CA bundle config map name.

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -262,22 +262,26 @@ data:
               "s3Endpoint": "",
 
               # s3UseHttps controls whether to use secure https or unsecure http to download models.
-              # Allowed values are 0 and 1.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseHttps": "",
 
               # s3Region specifies the region of the bucket.
               "s3Region": "",
 
               # s3VerifySSL controls whether to verify the tls/ssl certificate.
+              # Allowed boolean values include 0/1 and false/true.
               "s3VerifySSL": "",
 
               # s3UseVirtualBucket configures whether it is a virtual bucket or not.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseVirtualBucket": "",
 
               # s3UseAccelerate configures whether to use transfer acceleration.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseAccelerate": "",
 
               # s3UseAnonymousCredential configures whether to use anonymous credentials to download the model or not.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseAnonymousCredential": "",
 
               # s3CABundleConfigMap specifies the mounted CA bundle config map name.

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -262,22 +262,26 @@ data:
               "s3Endpoint": "",
 
               # s3UseHttps controls whether to use secure https or unsecure http to download models.
-              # Allowed values are 0 and 1.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseHttps": "",
 
               # s3Region specifies the region of the bucket.
               "s3Region": "",
 
               # s3VerifySSL controls whether to verify the tls/ssl certificate.
+              # Allowed boolean values include 0/1 and false/true.
               "s3VerifySSL": "",
 
               # s3UseVirtualBucket configures whether it is a virtual bucket or not.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseVirtualBucket": "",
 
               # s3UseAccelerate configures whether to use transfer acceleration.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseAccelerate": "",
 
               # s3UseAnonymousCredential configures whether to use anonymous credentials to download the model or not.
+              # Allowed boolean values include 0/1 and false/true.
               "s3UseAnonymousCredential": "",
 
               # s3CABundleConfigMap specifies the mounted CA bundle config map name.

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -212,16 +212,8 @@ func GetProvider(providers map[Protocol]Provider, protocol Protocol) (Provider, 
 		var err error
 
 		region, _ := os.LookupEnv(s3credential.AWSRegion)
-		useVirtualBucketString, ok := os.LookupEnv(s3credential.S3UseVirtualBucket)
-		useVirtualBucket := true
-		if ok && strings.ToLower(useVirtualBucketString) == "false" {
-			useVirtualBucket = false
-		}
-		useAccelerateString, ok := os.LookupEnv(s3credential.S3UseAccelerate)
-		useAccelerate := false
-		if ok && strings.ToLower(useAccelerateString) == "true" {
-			useAccelerate = true
-		}
+		useVirtualBucket := parseBoolEnvOrDefault(s3credential.S3UseVirtualBucket, true)
+		useAccelerate := parseBoolEnvOrDefault(s3credential.S3UseAccelerate, false)
 
 		awsConfig := aws.Config{
 			Region:           aws.String(region),
@@ -233,7 +225,7 @@ func GetProvider(providers map[Protocol]Provider, protocol Protocol) (Provider, 
 			awsConfig.Endpoint = aws.String(endpoint)
 		}
 
-		if useAnonCred, ok := os.LookupEnv(s3credential.AWSAnonymousCredential); ok && strings.ToLower(useAnonCred) == "true" {
+		if parseBoolEnvOrDefault(s3credential.AWSAnonymousCredential, false) {
 			awsConfig.Credentials = credentials.AnonymousCredentials
 		}
 
@@ -261,4 +253,20 @@ func GetProvider(providers map[Protocol]Provider, protocol Protocol) (Provider, 
 	}
 
 	return providers[protocol], nil
+}
+
+func parseBoolEnvOrDefault(envVar string, defaultValue bool) bool {
+	value, ok := os.LookupEnv(envVar)
+	if !ok {
+		return defaultValue
+	}
+	return parseBoolOrDefault(value, defaultValue)
+}
+
+func parseBoolOrDefault(value string, defaultValue bool) bool {
+	parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
 }

--- a/pkg/agent/storage/utils_test.go
+++ b/pkg/agent/storage/utils_test.go
@@ -23,9 +23,13 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	awss3 "github.com/aws/aws-sdk-go/service/s3"
 	"github.com/onsi/gomega"
 
 	"github.com/kserve/kserve/pkg/agent/mocks"
+	s3credential "github.com/kserve/kserve/pkg/credentials/s3"
 )
 
 func TestCreate(t *testing.T) {
@@ -127,5 +131,113 @@ func TestGetProvider(t *testing.T) {
 			g.Expect(err).ToNot(gomega.HaveOccurred())
 			g.Expect(provider).ShouldNot(gomega.BeNil())
 		}
+	}
+}
+
+func TestGetProviderS3ConfigParsesNumericBoolEnvs(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	t.Setenv(s3credential.S3UseVirtualBucket, "0")
+	t.Setenv(s3credential.S3UseAccelerate, "1")
+	t.Setenv(s3credential.AWSAnonymousCredential, "1")
+
+	provider, err := GetProvider(map[Protocol]Provider{}, S3)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	s3Provider, ok := provider.(*S3Provider)
+	g.Expect(ok).To(gomega.BeTrue())
+	s3Client, ok := s3Provider.Client.(*awss3.S3)
+	g.Expect(ok).To(gomega.BeTrue())
+
+	g.Expect(aws.BoolValue(s3Client.Config.S3ForcePathStyle)).To(gomega.BeTrue())
+	g.Expect(aws.BoolValue(s3Client.Config.S3UseAccelerate)).To(gomega.BeTrue())
+	g.Expect(
+		s3Client.Config.Credentials == credentials.AnonymousCredentials,
+	).To(gomega.BeTrue())
+}
+
+func TestParseBoolEnvOrDefault(t *testing.T) {
+	scenarios := map[string]struct {
+		set          bool
+		value        string
+		defaultValue bool
+		expected     bool
+	}{
+		"UnsetUsesDefaultTrue": {
+			defaultValue: true,
+			expected:     true,
+		},
+		"UnsetUsesDefaultFalse": {
+			defaultValue: false,
+			expected:     false,
+		},
+		"EmptyUsesDefault": {
+			set:          true,
+			defaultValue: true,
+			expected:     true,
+		},
+		"ZeroParsesFalse": {
+			set:          true,
+			value:        "0",
+			defaultValue: true,
+			expected:     false,
+		},
+		"OneParsesTrue": {
+			set:          true,
+			value:        "1",
+			defaultValue: false,
+			expected:     true,
+		},
+		"UpperFalseParsesFalse": {
+			set:          true,
+			value:        "FALSE",
+			defaultValue: true,
+			expected:     false,
+		},
+		"UpperTrueParsesTrue": {
+			set:          true,
+			value:        "TRUE",
+			defaultValue: false,
+			expected:     true,
+		},
+		"ShortFalseParsesFalse": {
+			set:          true,
+			value:        "f",
+			defaultValue: true,
+			expected:     false,
+		},
+		"ShortTrueParsesTrue": {
+			set:          true,
+			value:        "t",
+			defaultValue: false,
+			expected:     true,
+		},
+		"InvalidUsesDefaultTrue": {
+			set:          true,
+			value:        "invalid",
+			defaultValue: true,
+			expected:     true,
+		},
+		"InvalidUsesDefaultFalse": {
+			set:          true,
+			value:        "invalid",
+			defaultValue: false,
+			expected:     false,
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			const envVar = "KSERVE_TEST_S3_BOOL"
+			if scenario.set {
+				t.Setenv(envVar, scenario.value)
+			} else {
+				_ = os.Unsetenv(envVar)
+			}
+
+			g.Expect(
+				parseBoolEnvOrDefault(envVar, scenario.defaultValue),
+			).To(gomega.Equal(scenario.expected))
+		})
 	}
 }

--- a/pkg/credentials/s3/utils.go
+++ b/pkg/credentials/s3/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package s3
 
 import (
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -175,13 +176,21 @@ func getEndpointConfiguration(configuredS3Endpoint string, annotations map[strin
 	default:
 		s3UseHttps = getEnvValue(annotations, secretData, InferenceServiceS3SecretHttpsAnnotation, S3UseHttps, s3Config.S3UseHttps)
 		s3Endpoint = configuredS3Endpoint
-		if s3UseHttps == "0" {
-			s3EndpointUrl = "http://" + configuredS3Endpoint
-		} else {
+		if parseBoolOrDefault(s3UseHttps, true) {
 			// https by default.
 			s3EndpointUrl = "https://" + configuredS3Endpoint
+		} else {
+			s3EndpointUrl = "http://" + configuredS3Endpoint
 		}
 	}
 
 	return s3UseHttps, s3Endpoint, s3EndpointUrl
+}
+
+func parseBoolOrDefault(value string, defaultValue bool) bool {
+	parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
 }

--- a/pkg/credentials/s3/utils_test.go
+++ b/pkg/credentials/s3/utils_test.go
@@ -45,6 +45,66 @@ func TestBuildS3EnvVars(t *testing.T) {
 				},
 			},
 		},
+		"S3EndpointWithFalseUseHTTPS": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+				InferenceServiceS3SecretHttpsAnnotation:   "false",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "false",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://s3.aws.com",
+				},
+			},
+		},
+		"S3EndpointWithUpperTrueUseHTTPS": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+				InferenceServiceS3SecretHttpsAnnotation:   "TRUE",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "TRUE",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+			},
+		},
+		"S3EndpointWithInvalidUseHTTPSDefaultsHTTPS": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+				InferenceServiceS3SecretHttpsAnnotation:   "invalid",
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "invalid",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+			},
+		},
 		"AllAnnotations": {
 			annotations: map[string]string{
 				InferenceServiceS3SecretEndpointAnnotation:    "s3.aws.com",

--- a/python/storage/README.md
+++ b/python/storage/README.md
@@ -107,6 +107,8 @@ These are all handled by the `huggingface_hub` package, you can see all the avai
 
 ### AWS/S3 Configuration / Environments variables
 
+Boolean S3 environment variables accept `0`/`1` and `false`/`true` values.
+
 - `AWS_ENDPOINT_URL`: Custom endpoint URL for S3-compatible storage
 - `AWS_ACCESS_KEY_ID`: Access key for S3
 - `AWS_SECRET_ACCESS_KEY`: Secret access key for S3

--- a/python/storage/kserve_storage/kserve_storage.py
+++ b/python/storage/kserve_storage/kserve_storage.py
@@ -74,6 +74,26 @@ _AZURE_MAX_FILE_CONCURRENCY = int(os.getenv("AZURE_MAX_FILE_CONCURRENCY", "4"))
 _AZURE_MAX_CHUNK_CONCURRENCY = int(os.getenv("AZURE_MAX_CHUNK_CONCURRENCY", "4"))
 
 
+def _parse_bool(value: Optional[str]) -> Optional[bool]:
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if normalized in {"1", "t", "true"}:
+        return True
+    if normalized in {"0", "f", "false"}:
+        return False
+
+    return None
+
+
+def _parse_bool_or_default(value: Optional[str], default: bool) -> bool:
+    parsed = _parse_bool(value)
+    if parsed is None:
+        return default
+    return parsed
+
+
 def _should_download(
     relative_path: str,
     allow_patterns: Optional[List[str]] = None,
@@ -294,18 +314,20 @@ class Storage(object):
         )
 
         # anon environment variable defined in s3_secret.go
-        anon = "true" == os.getenv("awsAnonymousCredential", "false").lower()
+        anon = _parse_bool_or_default(os.getenv("awsAnonymousCredential"), False)
         # S3UseVirtualBucket environment variable defined in s3_secret.go
         # use virtual hosted-style URLs if enabled
-        virtual = "true" == os.getenv("S3_USER_VIRTUAL_BUCKET", "false").lower()
+        virtual_env = os.getenv("S3_USER_VIRTUAL_BUCKET")
+        virtual = _parse_bool(virtual_env)
         # S3UseAccelerate environment variable defined in s3_secret.go
         # use transfer acceleration if enabled
-        accelerate = "true" == os.getenv("S3_USE_ACCELERATE", "false").lower()
+        accelerate = _parse_bool_or_default(os.getenv("S3_USE_ACCELERATE"), False)
 
         if anon:
             c = c.merge(Config(signature_version=UNSIGNED))
-        if virtual:
-            c = c.merge(Config(s3={"addressing_style": "virtual"}))
+        if virtual is not None:
+            addressing_style = "virtual" if virtual else "path"
+            c = c.merge(Config(s3={"addressing_style": addressing_style}))
         if accelerate:
             c = c.merge(Config(s3={"use_accelerate_endpoint": accelerate}))
 
@@ -334,12 +356,10 @@ class Storage(object):
         endpoint_url = os.getenv("AWS_ENDPOINT_URL")
         if endpoint_url:
             kwargs.update({"endpoint_url": endpoint_url})
-        verify_ssl = os.getenv("S3_VERIFY_SSL")
-        if verify_ssl:
-            verify_ssl = verify_ssl.lower() not in ["0", "false"]
+        verify_ssl_env = os.getenv("S3_VERIFY_SSL")
+        verify_ssl = _parse_bool_or_default(verify_ssl_env, True)
+        if verify_ssl_env:
             kwargs.update({"verify": verify_ssl})
-        else:
-            verify_ssl = True
 
         # If verify_ssl is true, then check there is custom ca bundle cert
         # The CA bundle can be any local file in the container under the path

--- a/python/storage/test/test_s3_storage.py
+++ b/python/storage/test/test_s3_storage.py
@@ -280,6 +280,10 @@ def test_get_S3_config():
         config4 = Storage.get_S3_config()
     assert config4.signature_version == ANON_CONFIG.signature_version
 
+    with mock.patch.dict(os.environ, {"awsAnonymousCredential": "1"}):
+        config4_numeric = Storage.get_S3_config()
+    assert config4_numeric.signature_version == ANON_CONFIG.signature_version
+
     # assuming Python 3.5 or greater for joining dictionaries
     credentials_and_anon = {**AWS_TEST_CREDENTIALS, "awsAnonymousCredential": "True"}
     with mock.patch.dict(os.environ, credentials_and_anon):
@@ -288,20 +292,41 @@ def test_get_S3_config():
 
     with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "False"}, clear=True):
         config6 = Storage.get_S3_config()
-    assert config6.connect_timeout == DEFAULT_CONFIG.connect_timeout
+    assert config6.s3["addressing_style"] == "path"
+
+    with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "0"}, clear=True):
+        config6_numeric = Storage.get_S3_config()
+    assert config6_numeric.s3["addressing_style"] == "path"
 
     with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "True"}, clear=True):
         config7 = Storage.get_S3_config()
     assert config7.s3["addressing_style"] == VIRTUAL_CONFIG.s3["addressing_style"]
 
+    with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "1"}, clear=True):
+        config7_numeric = Storage.get_S3_config()
+    assert (
+        config7_numeric.s3["addressing_style"] == VIRTUAL_CONFIG.s3["addressing_style"]
+    )
+
     with mock.patch.dict(os.environ, {"S3_USE_ACCELERATE": "False"}, clear=True):
         config6 = Storage.get_S3_config()
     assert config6.connect_timeout == DEFAULT_CONFIG.connect_timeout
+
+    with mock.patch.dict(os.environ, {"S3_USE_ACCELERATE": "0"}, clear=True):
+        config6_numeric = Storage.get_S3_config()
+    assert config6_numeric.connect_timeout == DEFAULT_CONFIG.connect_timeout
 
     with mock.patch.dict(os.environ, {"S3_USE_ACCELERATE": "True"}):
         config7 = Storage.get_S3_config()
     assert (
         config7.s3["use_accelerate_endpoint"]
+        == USE_ACCELERATE_CONFIG.s3["use_accelerate_endpoint"]
+    )
+
+    with mock.patch.dict(os.environ, {"S3_USE_ACCELERATE": "1"}):
+        config7_numeric = Storage.get_S3_config()
+    assert (
+        config7_numeric.s3["use_accelerate_endpoint"]
         == USE_ACCELERATE_CONFIG.s3["use_accelerate_endpoint"]
     )
 
@@ -330,6 +355,28 @@ def test_get_S3_config():
     assert config9.connect_timeout == 5
     assert config9.read_timeout == 10
     assert config9.retries["max_attempts"] == 5
+
+
+def test_s3_client_kwargs_verify_ssl_bool_values():
+    scenarios = {
+        "0": False,
+        "false": False,
+        "FALSE": False,
+        "f": False,
+        "1": True,
+        "true": True,
+        "TRUE": True,
+        "t": True,
+        "invalid": True,
+    }
+    for value, expected in scenarios.items():
+        with mock.patch.dict(os.environ, {"S3_VERIFY_SSL": value}, clear=True):
+            kwargs = Storage._get_s3_client_kwargs()
+        assert kwargs["verify"] is expected
+
+    with mock.patch.dict(os.environ, {}, clear=True):
+        kwargs = Storage._get_s3_client_kwargs()
+    assert "verify" not in kwargs
 
 
 def test_update_with_storage_spec_s3(monkeypatch):


### PR DESCRIPTION
**What this PR does / why we need it**:

KServe S3 docs and examples use both numeric boolean values (`"0"` / `"1"`) and string boolean values (`"false"` / `"true"`) for S3 options.

Some runtime paths only handled one representation. In particular, `serving.kserve.io/s3-usevirtualbucket: "0"` was not treated as false by the Go agent, so S3-compatible endpoints without wildcard bucket DNS could still receive virtual-hosted-style requests such as:

`https://<bucket>.<endpoint>/...`

This PR makes S3 boolean parsing consistent across the Go agent, S3 endpoint configuration, and the Python storage helper while preserving existing defaults for unset or invalid values.

Covered options:
- `serving.kserve.io/s3-usehttps`
- `serving.kserve.io/s3-useanoncredential`
- `serving.kserve.io/s3-usevirtualbucket`
- `serving.kserve.io/s3-useaccelerate`
- `serving.kserve.io/s3-verifyssl`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Feature/Issue validation/testing**:

- [x] `PYTHONPATH=. uv run --project . --with pytest pytest test/test_s3_storage.py -q`
- [x] `PYTHONPATH=. uv run --project . --with ruff ruff format --check kserve_storage/kserve_storage.py test/test_s3_storage.py`
- [x] `PYTHONPATH=. uv run --project . --with ruff ruff check kserve_storage/kserve_storage.py test/test_s3_storage.py`
- [x] `git diff --check`
- [ ] `go test ./pkg/agent/storage ./pkg/credentials/s3` (not run locally: `go` is not installed)
- [ ] `gofmt -w pkg/agent/storage/utils.go pkg/agent/storage/utils_test.go pkg/credentials/s3/utils.go pkg/credentials/s3/utils_test.go` (not run locally: `gofmt` is not installed)

**Special notes for your reviewer**:

Unset values keep their previous defaults. Invalid values also fall back to the existing per-option defaults to avoid breaking existing deployments.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? Existing website docs already advertise `0`/`1`; this PR updates in-repo config comments to document both accepted forms.

**Release note**:
```release-note
S3 boolean configuration parsing now accepts both numeric (`0`/`1`) and string (`false`/`true`) values consistently across supported S3 options.
```
