### PR TITLE
fix(llmisvc): filter HTTPRoute parent status by gateway name

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -811,20 +811,47 @@ func isBackendSupported(route *gwapiv1.HTTPRoute) metav1.ConditionStatus {
 		return metav1.ConditionUnknown
 	}
 
-	// Check the first parent's status (TODO: filter to our specific gateway)
-	if len(route.Status.Parents) > 0 {
-		parent := route.Status.Parents[0]
+	parents := route.Status.Parents
+	if len(parents) == 0 {
+		return metav1.ConditionUnknown
+	}
+
+	hasInvalidKind := false
+	for _, parent := range parents {
+		if !routeParentStatusMatchesSpec(route, parent) {
+			continue
+		}
+
 		cond := meta.FindStatusCondition(parent.Conditions, string(gwapiv1.RouteConditionResolvedRefs))
 		if cond == nil {
-			return metav1.ConditionUnknown
+			continue
 		}
 		if cond.Status == metav1.ConditionFalse && cond.Reason == string(gwapiv1.RouteReasonInvalidKind) {
-			return metav1.ConditionFalse
+			hasInvalidKind = true
+			continue
 		}
 		return metav1.ConditionTrue
 	}
 
+	if hasInvalidKind {
+		return metav1.ConditionFalse
+	}
+
 	return metav1.ConditionUnknown
+}
+
+func routeParentStatusMatchesSpec(route *gwapiv1.HTTPRoute, parent gwapiv1.RouteParentStatus) bool {
+	if len(route.Spec.ParentRefs) == 0 {
+		return true
+	}
+
+	defaultNS := gwapiv1.Namespace(route.Namespace)
+	for _, specRef := range route.Spec.ParentRefs {
+		if parentRefMatches(specRef, parent.ParentRef, defaultNS) {
+			return true
+		}
+	}
+	return false
 }
 
 func isHTTPRouteUsingInferencePool(route *gwapiv1.HTTPRoute, group string) bool {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_migration_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_migration_test.go
@@ -166,6 +166,25 @@ func TestIsInferencePoolSupportedWithMultipleParents(t *testing.T) {
 			expected: metav1.ConditionFalse,
 		},
 		{
+			name: "route ignores status for a different Gateway parent",
+			route: HTTPRoute("test-route",
+				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+				WithHTTPRule(
+					WithBackendRefs(BackendRefInferencePool("my-pool")),
+				),
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayRef("other-gateway", RefInNamespace("test-ns")),
+					GatewayAPIControllerStatusInvalidKind,
+				),
+				WithHTTPRouteMultipleControllerStatus(
+					GatewayRef("test-gateway", RefInNamespace("test-ns")),
+					GatewayAPIControllerStatus,
+				),
+			),
+			expected: metav1.ConditionTrue,
+		},
+		{
 			name: "route with only Kuadrant controller (no ResolvedRefs condition) returns Unknown",
 			route: HTTPRoute("test-route",
 				InNamespace[*gwapiv1.HTTPRoute]("test-ns"),


### PR DESCRIPTION
**What this PR does / why we need it**:

`isBackendSupported` in `router_discovery.go` read `route.Status.Parents[0]` without checking whether that parent corresponds to the gateway managing this route. If multiple gateways report status on the same HTTPRoute, an unrelated gateway reporting `ResolvedRefs=False/InvalidKind` could incorrectly trigger an InferencePool migration.

This PR filters `route.Status.Parents` using a `routeParentStatusMatchesSpec` helper that matches each entry's `ParentRef` against the route's `Spec.ParentRefs` before reading conditions.

**Which issue(s) this PR fixes**:
Fixes #5582 

**Feature/Issue validation/testing**:
- [x] `TestIsInferencePoolBackendSupported` — added regression case where an unrelated gateway appears first in `status.parents` with `InvalidKind`; verifies the correct gateway's status is used
- Full integration tests require envtest; local etcd binary unavailable, covered by CI

**Special notes for your reviewer**:

Closes the TODO in `router_discovery.go`:
```go
// Check the first parent's status (TODO: filter to our specific gateway)
```

The new `routeParentStatusMatchesSpec` helper uses the existing Gateway API defaulting-aware `parentRefMatches` function already present in the codebase.

**Checklist**:
- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?