### PR TITLE
fix(ci): improve automerge error handling and bump github-script to v9

### DIFF
--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -22,7 +22,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -116,27 +116,30 @@ jobs:
                 });
                 core.info(`Merged PR #${issue.number}`);
               } catch (e) {
+                const responseData = e.response?.data;
+                const errorDetails = [
+                  `status=${e.status ?? 'unknown'}`,
+                  `message=${responseData?.message ?? e.message}`,
+                ];
+
+                if (responseData) {
+                  core.info(
+                    `PR #${issue.number} merge API response:\n${JSON.stringify(responseData, null, 2)}`
+                  );
+                }
+
+                const requiredPerms = e.response?.headers?.['x-accepted-github-permissions'];
+                if (requiredPerms) {
+                  core.info(`PR #${issue.number} required permissions: ${requiredPerms}`);
+                }
+
                 if (debugEnabled) {
-                  const errorDetails = [
-                    `status=${e.status ?? 'unknown'}`,
-                    `message=${e.response?.data?.message ?? e.message}`,
-                  ];
-                  const apiErrors = e.response?.data?.errors;
-                  const responseData = e.response?.data;
-                  const documentationUrl = e.response?.data?.documentation_url;
-                  if (responseData) {
-                    const prettyResponseData = JSON.stringify(responseData, null, 2);
-                    core.info(
-                      `PR #${issue.number} merge API response:\n${prettyResponseData}`
-                    );
-                  }
+                  const apiErrors = responseData?.errors;
                   if (apiErrors) {
                     core.info(`[debug] PR #${issue.number} API errors: ${JSON.stringify(apiErrors)}`);
                   }
-                  if (documentationUrl) {
-                    core.info(`[debug] PR #${issue.number} docs: ${documentationUrl}`);
-                  }
                 }
+
                 core.warning(`Could not merge PR #${issue.number}: ${errorDetails.join(', ')}`);
               }
             }


### PR DESCRIPTION
chore:  Upgrade actions/github-script from v8 to v9 to fix the deprecated REST
        API version warning. Fix a ReferenceError in the catch block where
        errorDetails was scoped inside the debug-only branch, and always log the
        full API response and required permissions header on merge failures.



**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:



**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
