### PR TITLE
fix(test): centralize diagnostics & add to LoRA tests

### DIFF
--- a/test/e2e/llmisvc/diagnostic.py
+++ b/test/e2e/llmisvc/diagnostic.py
@@ -36,7 +36,6 @@ def llmisvc_labels(service_name: str) -> dict:
     }
 
 
-
 def strip_managed_fields(d):
     """Remove managed_fields from a K8s object dict to reduce log noise."""
     if isinstance(d, dict):
@@ -45,6 +44,7 @@ def strip_managed_fields(d):
         if isinstance(metadata, dict):
             metadata.pop("managed_fields", None)
     return d
+
 
 def print_all_events_table(
     namespace: str,

--- a/test/e2e/llmisvc/diagnostic.py
+++ b/test/e2e/llmisvc/diagnostic.py
@@ -19,7 +19,22 @@ from kubernetes import client, config, dynamic
 from kubernetes.client import api_client
 from typing import Callable, Optional
 
+import yaml
+from kserve import KServeClient, constants
+
 _log = logging.getLogger(__name__)
+
+LLMISVC_PART_OF = "llminferenceservice"
+KSERVE_PLURAL_LLMINFERENCESERVICE = "llminferenceservices"
+
+
+def llmisvc_labels(service_name: str) -> dict:
+    """Return the universal label selector for all resources owned by an LLMInferenceService."""
+    return {
+        "app.kubernetes.io/part-of": LLMISVC_PART_OF,
+        "app.kubernetes.io/name": service_name,
+    }
+
 
 
 def strip_managed_fields(d):
@@ -30,7 +45,6 @@ def strip_managed_fields(d):
         if isinstance(metadata, dict):
             metadata.pop("managed_fields", None)
     return d
-
 
 def print_all_events_table(
     namespace: str,
@@ -212,3 +226,40 @@ def _emit_container_logs(
             log("%s", logs or "(empty)")
         except Exception as e:
             log("# -- logs (%s): unavailable (%s)", label, e)
+
+
+def collect_diagnostics(
+    service_name: str,
+    namespace: str,
+    kserve_client: Optional[KServeClient] = None,
+    log: Callable = _log.info,
+):
+    """
+    Collect full diagnostics for an LLMInferenceService: CR YAML, events,
+    pod logs (init + regular containers), and all labeled child resources.
+    """
+    labels = llmisvc_labels(service_name)
+
+    log("# Diagnostics for %r in %r", service_name, namespace)
+    log("---")
+
+    if kserve_client is not None:
+        log("# LLMInferenceService %s", service_name)
+        try:
+            svc = kserve_client.api_instance.get_namespaced_custom_object(
+                constants.KSERVE_GROUP,
+                constants.KSERVE_V1ALPHA1_VERSION,
+                namespace,
+                KSERVE_PLURAL_LLMINFERENCESERVICE,
+                service_name,
+            )
+            log(yaml.safe_dump(svc, sort_keys=False))
+        except Exception as e:
+            log("# failed to dump LLMInferenceService: %s", e)
+
+    print_all_events_table(namespace, log=log)
+    collect_pod_logs(namespace, labels, log=log)
+
+    for obj in kinds_matching_by_labels(namespace, labels):
+        log("---")
+        log(yaml.safe_dump(obj.to_dict(), sort_keys=False))

--- a/test/e2e/llmisvc/test_gateway_section_name.py
+++ b/test/e2e/llmisvc/test_gateway_section_name.py
@@ -36,9 +36,9 @@ from .fixtures import (
     generate_k8s_safe_suffix,
     inject_k8s_proxy,
 )
+from .diagnostic import collect_diagnostics
 from .test_llm_inference_service import (
     KSERVE_PLURAL_LLMINFERENCESERVICE,
-    _collect_diagnostics,
     wait_for,
 )
 from .test_resources import ROUTER_GATEWAYS
@@ -211,7 +211,11 @@ def test_gateway_section_name_propagation(gateway_config_key, expected_section_n
 
     except Exception:
         if llm_service is not None:
-            _collect_diagnostics(kserve_client, llm_service)
+            collect_diagnostics(
+                service_name,
+                KSERVE_TEST_NAMESPACE,
+                kserve_client=kserve_client,
+            )
         raise
 
     finally:

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -18,18 +18,12 @@ from urllib.parse import urlparse
 import os
 import pytest
 import requests
-import yaml
 from dataclasses import dataclass, field
 from kserve import KServeClient, V1alpha1LLMInferenceService, constants
 from kubernetes import client
 from typing import Any, Callable, Dict, List, Optional
 
-from .diagnostic import (
-    collect_pod_logs,
-    kinds_matching_by_labels,
-    print_all_events_table,
-    strip_managed_fields,
-)
+from .diagnostic import collect_diagnostics
 from .fixtures import (
     KSERVE_TEST_NAMESPACE,
     create_router_resources,
@@ -820,7 +814,12 @@ def test_llm_inference_service(test_case: TestCase):  # noqa: F811
             service_name,
             e,
         )
-        _collect_diagnostics(kserve_client, test_case.llm_service)
+        collect_diagnostics(
+            service_name,
+            test_case.llm_service.metadata.namespace,
+            kserve_client=kserve_client,
+            log=logger.info,
+        )
         raise
     finally:
         maybe_delete_llmisvc(kserve_client, test_case.llm_service, test_failed)
@@ -1210,36 +1209,3 @@ def wait_for(
                 logger.info("Waiting: %s", e)
                 last_msg = msg
             time.sleep(interval)
-
-
-def _collect_diagnostics(
-    kserve_client: KServeClient,
-    llm_isvc: V1alpha1LLMInferenceService,
-    log_prefix: str = "",
-):
-    name = llm_isvc.metadata.name
-    ns = llm_isvc.metadata.namespace
-
-    labels = {
-        "app.kubernetes.io/part-of": "llminferenceservice",
-        "app.kubernetes.io/name": name,
-    }
-
-    logger.info(f"{log_prefix}🔍 # Diagnostics for %r in %r", name, ns)
-    logger.info(f"{log_prefix} ---")
-    logger.info(f"{log_prefix} # LLMInferenceService %s", name)
-    try:
-        svc = get_llmisvc(kserve_client, name, ns)
-        logger.info(yaml.safe_dump(svc, sort_keys=False))
-    except Exception as e:
-        logger.info(f"{log_prefix} # ❌ failed to dump LLMInferenceService: %s", e)
-
-    print_all_events_table(ns, log=logger.info)
-    collect_pod_logs(ns, labels, log=logger.info)
-
-    all_resources = kinds_matching_by_labels(ns, labels)
-    for obj in all_resources:
-        logger.info(f"{log_prefix} ---")
-        logger.info(
-            yaml.safe_dump(strip_managed_fields(obj.to_dict()), sort_keys=False)
-        )

--- a/test/e2e/llmisvc/test_llm_lora_adapters.py
+++ b/test/e2e/llmisvc/test_llm_lora_adapters.py
@@ -22,7 +22,7 @@ from kserve import KServeClient, V1alpha1LLMInferenceService, constants
 from kubernetes import client
 from typing import List, Optional
 
-from .diagnostic import print_all_events_table
+from .diagnostic import collect_diagnostics
 from .fixtures import (
     KSERVE_TEST_NAMESPACE,
     LLMINFERENCESERVICE_CONFIGS,
@@ -170,6 +170,13 @@ def run_lora_test(test_case: LoRATestCase):
             logger.info("✓ LoRA adapter %s inference successful", adapter_name)
 
     finally:
+        # Collect diagnostics before cleanup deletes the pods
+        collect_diagnostics(
+            service_name,
+            KSERVE_TEST_NAMESPACE,
+            kserve_client=kserve_client,
+        )
+
         # Cleanup service
         if llm_service is not None:
             try:
@@ -191,9 +198,6 @@ def run_lora_test(test_case: LoRATestCase):
                 )
             except Exception as e:
                 logger.warning(f"Config cleanup failed for {config_name}: {e}")
-
-        # Print diagnostics
-        print_all_events_table(KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.parametrize(

--- a/test/e2e/llmisvc/test_tracing.py
+++ b/test/e2e/llmisvc/test_tracing.py
@@ -19,6 +19,7 @@ import pytest
 from kserve import KServeClient
 from kubernetes import client
 
+from .diagnostic import collect_diagnostics
 from .fixtures import generate_test_id, inject_k8s_proxy
 from .logging import log_execution, logger
 from .test_llm_inference_service import (
@@ -30,7 +31,6 @@ from .test_llm_inference_service import (
     wait_for_llm_isvc_ready,
     wait_for_model_response,
     wait_for,
-    _collect_diagnostics,
 )
 
 JAEGER_NAMESPACE = os.getenv("JAEGER_NAMESPACE", "observability")
@@ -239,7 +239,11 @@ def test_tracing_spans_collected(test_case: TestCase):  # noqa: F811
     except Exception as e:
         test_failed = True
         logger.error("ERROR: Tracing test failed for %s: %s", service_name, e)
-        _collect_diagnostics(kserve_client, test_case.llm_service)
+        collect_diagnostics(
+            service_name,
+            test_case.llm_service.metadata.namespace,
+            kserve_client=kserve_client,
+        )
         raise
     finally:
         maybe_delete_llmisvc(kserve_client, test_case.llm_service, test_failed)


### PR DESCRIPTION
## Summary
- Extract shared `_collect_diagnostics()` into `test/e2e/llmisvc/diagnostic.py` to eliminate duplication across LLMInferenceService E2E tests
- Update `test_gateway_section_name.py`, `test_llm_inference_service.py`, and `test_llm_lora_adapters.py` to use the shared module
- Remove the inline `_collect_diagnostics` from `test_llm_inference_service.py`

## Test plan
- [ ] Existing llmisvc E2E tests continue to pass
- [ ] Diagnostics output is consistent across test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)