### PR TITLE
deps(llmisvc): upgrade llm-d components to v0.8.0 release

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -246,7 +246,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -584,7 +584,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -1909,7 +1909,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0-rc.2
       pool:
         spec:
           endpointPickerRef:
@@ -1948,7 +1948,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -1911,7 +1911,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.9.0-rc.2
+        app.kubernetes.io/version: 0.9.0
       pool:
         spec:
           endpointPickerRef:

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -233,6 +233,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
       - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
@@ -571,6 +572,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
       - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -168,7 +168,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -246,7 +246,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -502,7 +502,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -584,7 +584,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -834,7 +834,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -1060,7 +1060,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1336,7 +1336,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1606,7 +1606,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1909,7 +1909,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.8.0
       pool:
         spec:
           endpointPickerRef:
@@ -1948,7 +1948,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -2012,7 +2012,7 @@ spec:
         - env:
           - name: TOKENIZERS_DIR
             value: /mnt/models
-          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:vllm-v0.19.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -2249,7 +2249,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2536,7 +2536,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2806,7 +2806,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -233,7 +233,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
-      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
       - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
@@ -571,7 +571,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
-      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
       - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -229,7 +229,7 @@ spec:
     initContainers:
       - name: llm-d-routing-sidecar
         imagePullPolicy: IfNotPresent
-        image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+        image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
         restartPolicy: Always
         ports:
           - containerPort: 8000

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -268,7 +268,7 @@ spec:
           - "--vllm-port=8001"
           - "--kv-connector=nixlv2"
           - "--enable-ssrf-protection=true"
-          - "--pool-group=inference.networking.x-k8s.io"
+          - "--inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}"
           - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--decoder-use-tls=true{{- end }}'

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -268,6 +268,7 @@ spec:
           - "--vllm-port=8001"
           - "--kv-connector=nixlv2"
           - "--enable-ssrf-protection=true"
+          - "--pool-group=inference.networking.x-k8s.io"
           - "--inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}"
           - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -7,7 +7,7 @@ spec:
     serving.kserve.io/model-based-routing-enabled: "true"
   template:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -229,7 +229,7 @@ spec:
     initContainers:
       - name: llm-d-routing-sidecar
         imagePullPolicy: IfNotPresent
-        image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+        image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
         restartPolicy: Always
         ports:
           - containerPort: 8000

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -9,7 +9,7 @@ spec:
     initContainers:
       - name: llm-d-routing-sidecar
         imagePullPolicy: IfNotPresent
-        image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+        image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
         restartPolicy: Always
         ports:
           - containerPort: 8000

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -49,7 +49,7 @@ spec:
           - "--vllm-port=8001"
           - "--kv-connector=nixlv2"
           - "--enable-ssrf-protection=true"
-          - "--pool-group=inference.networking.x-k8s.io"
+          - "--inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}"
           - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--decoder-use-tls=true{{- end }}'

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -49,6 +49,7 @@ spec:
           - "--vllm-port=8001"
           - "--kv-connector=nixlv2"
           - "--enable-ssrf-protection=true"
+          - "--pool-group=inference.networking.x-k8s.io"
           - "--inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}"
           - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -9,7 +9,7 @@ spec:
     initContainers:
       - name: llm-d-routing-sidecar
         imagePullPolicy: IfNotPresent
-        image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+        image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
         restartPolicy: Always
         ports:
           - containerPort: 8000
@@ -66,7 +66,7 @@ spec:
           - name: SSL_CERT_DIR
             value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -338,7 +338,7 @@ spec:
           secretName: "{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}"
   worker:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -8,7 +8,7 @@ spec:
       serving.kserve.io/model-based-routing-enabled: "true"
     template:
       containers:
-        - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
           imagePullPolicy: IfNotPresent
           name: main
           ports:

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -8,7 +8,7 @@ spec:
       serving.kserve.io/model-based-routing-enabled: "true"
     template:
       containers:
-        - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
           imagePullPolicy: IfNotPresent
           name: main
           ports:
@@ -280,7 +280,7 @@ spec:
             secretName: "{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}"
     worker:
       containers:
-        - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
           imagePullPolicy: IfNotPresent
           name: main
           ports:

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -23,7 +23,7 @@ spec:
           targetPorts:
             - number: 8000
       annotations:
-        "app.kubernetes.io/version": "0.8.0"
+        "app.kubernetes.io/version": "0.9.0-rc.2"
       template:
         containers:
           - name: main
@@ -46,7 +46,7 @@ spec:
               - containerPort: 5557
                 name: zmq
                 protocol: TCP
-            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
+            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 3

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -23,7 +23,7 @@ spec:
           targetPorts:
             - number: 8000
       annotations:
-        "app.kubernetes.io/version": "0.9.0-rc.2"
+        "app.kubernetes.io/version": "0.9.0"
       template:
         containers:
           - name: main

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -23,7 +23,7 @@ spec:
           targetPorts:
             - number: 8000
       annotations:
-        "app.kubernetes.io/version": "0.7.0"
+        "app.kubernetes.io/version": "0.8.0"
       template:
         containers:
           - name: main
@@ -46,7 +46,7 @@ spec:
               - containerPort: 5557
                 name: zmq
                 protocol: TCP
-            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 3
@@ -111,7 +111,7 @@ spec:
               - containerPort: 8082
                 name: health
                 protocol: TCP
-            image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+            image: ghcr.io/llm-d/llm-d-uds-tokenizer:vllm-v0.19.1
             imagePullPolicy: IfNotPresent
             workingDir: /mnt/models
             env:

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -7,7 +7,7 @@ spec:
     serving.kserve.io/model-based-routing-enabled: "true"
   template:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -7,7 +7,7 @@ spec:
     serving.kserve.io/model-based-routing-enabled: "true"
   template:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -279,7 +279,7 @@ spec:
           secretName: "{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}"
   worker:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_default.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_default.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     containers:
       # Override image version and command from base config
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         name: main
         command: ["/bin/sh", "-c"]
         args:
@@ -38,7 +38,7 @@ spec:
         containers:
           - name: main
             # Override scheduler image version
-            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
             # Override args to enable secure serving
             args:
               - --pool-name

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_default.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_default.yaml
@@ -38,7 +38,7 @@ spec:
         containers:
           - name: main
             # Override scheduler image version
-            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
+            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
             # Override args to enable secure serving
             args:
               - --pool-name

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_pd_disagg.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_pd_disagg.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     containers:
       - name: main
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         env:
           # Enable RDMA for KV cache transfer
           - name: KSERVE_INFER_ROCE
@@ -57,7 +57,7 @@ spec:
     template:
       containers:
         - name: main
-          image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+          image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
           env:
             - name: KSERVE_INFER_ROCE
               value: "false"

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
@@ -103,7 +103,7 @@ spec:
             emptyDir: {}
         containers:
           - name: main
-            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
+            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
             ports:
               - containerPort: 5557
                 name: zmq

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   template:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         name: main
         command: ["/bin/sh", "-c"]
         args:
@@ -103,7 +103,7 @@ spec:
             emptyDir: {}
         containers:
           - name: main
-            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
             ports:
               - containerPort: 5557
                 name: zmq

--- a/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
+++ b/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     containers:
       - name: main
-        image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
+        image: ghcr.io/llm-d/llm-d-rocm:v0.7.0
         resources:
           limits:
             cpu: '4'

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2731,7 +2731,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2809,7 +2809,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -3065,7 +3065,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -3147,7 +3147,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -3397,7 +3397,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -3623,7 +3623,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3899,7 +3899,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4169,7 +4169,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4472,7 +4472,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.8.0
       pool:
         spec:
           endpointPickerRef:
@@ -4511,7 +4511,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -4575,7 +4575,7 @@ spec:
         - env:
           - name: TOKENIZERS_DIR
             value: /mnt/models
-          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:vllm-v0.19.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -4812,7 +4812,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -5099,7 +5099,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -5369,7 +5369,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2796,7 +2796,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
-      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
       - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
@@ -3134,7 +3134,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
-      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
       - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2809,7 +2809,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -3147,7 +3147,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -4472,7 +4472,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0-rc.2
       pool:
         spec:
           endpointPickerRef:
@@ -4511,7 +4511,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4474,7 +4474,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.9.0-rc.2
+        app.kubernetes.io/version: 0.9.0
       pool:
         spec:
           endpointPickerRef:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2796,6 +2796,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
       - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
@@ -3134,6 +3135,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
       - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2382,6 +2382,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
       - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
@@ -2720,6 +2721,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
       - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2395,7 +2395,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2733,7 +2733,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -4058,7 +4058,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.8.0
+        app.kubernetes.io/version: 0.9.0-rc.2
       pool:
         spec:
           endpointPickerRef:
@@ -4097,7 +4097,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2382,7 +2382,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
-      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
       - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
@@ -2720,7 +2720,7 @@ spec:
       - --vllm-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
-      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
         end }}'
       - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2317,7 +2317,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2395,7 +2395,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2651,7 +2651,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2733,7 +2733,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2983,7 +2983,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -3209,7 +3209,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3485,7 +3485,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3755,7 +3755,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4058,7 +4058,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.8.0
       pool:
         spec:
           endpointPickerRef:
@@ -4097,7 +4097,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -4161,7 +4161,7 @@ spec:
         - env:
           - name: TOKENIZERS_DIR
             value: /mnt/models
-          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:vllm-v0.19.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -4398,7 +4398,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -4685,7 +4685,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -4955,7 +4955,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -4060,7 +4060,7 @@ spec:
   router:
     scheduler:
       annotations:
-        app.kubernetes.io/version: 0.9.0-rc.2
+        app.kubernetes.io/version: 0.9.0
       pool:
         spec:
           endpointPickerRef:

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -30,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/utils/ptr"
@@ -557,6 +558,10 @@ type templateGlobalConfig struct {
 	// shared-gateway deployments (e.g. "X-Gateway-Model-Name"). Exposed here so
 	// that HTTPRoute templates can reference it via {{ .GlobalConfig.ModelBasedRoutingHeaderName }}.
 	ModelBasedRoutingHeaderName string
+
+	// InferencePoolNamespacedName represents the inference pool namespaced reference in the format "<namespace>/<name>",
+	// or simply `<name>`.
+	InferencePoolNamespacedName string
 }
 
 // ReplaceVariables processes the configuration as a Go template to substitute
@@ -576,6 +581,14 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 			EnableTLS:                   reconcilerConfig.EnableTLS,
 			ModelBasedRoutingHeaderName: reconcilerConfig.ModelBasedRoutingHeaderName,
 		}
+		infPoolNamespacedName := types.NamespacedName{
+			Name:      (&v1alpha2.SchedulerSpec{}).InferencePoolName(llmSvc),
+			Namespace: llmSvc.GetNamespace(),
+		}
+		if llmSvcCfg.Spec.Router != nil {
+			infPoolNamespacedName.Name = llmSvcCfg.Spec.Router.Scheduler.InferencePoolName(llmSvc)
+		}
+		gc.InferencePoolNamespacedName = infPoolNamespacedName.String()
 	}
 	config := struct {
 		*v1alpha2.LLMInferenceService

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -100,7 +100,7 @@ func TestPresetFiles(t *testing.T) {
 							InitContainers: []corev1.Container{
 								{
 									Name:  "llm-d-routing-sidecar",
-									Image: "ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0",
+									Image: "ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2",
 									Command: []string{
 										"/app/pd-sidecar",
 										"--port=8000",

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -100,7 +100,7 @@ func TestPresetFiles(t *testing.T) {
 							InitContainers: []corev1.Container{
 								{
 									Name:  "llm-d-routing-sidecar",
-									Image: "ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1",
+									Image: "ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0",
 									Command: []string{
 										"/app/pd-sidecar",
 										"--port=8000",
@@ -186,7 +186,7 @@ func TestPresetFiles(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:  "main",
-									Image: "ghcr.io/llm-d/llm-d-cuda:v0.6.0",
+									Image: "ghcr.io/llm-d/llm-d-cuda:v0.7.0",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8001,
@@ -335,7 +335,7 @@ func TestPresetFiles(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:  "main",
-									Image: "ghcr.io/llm-d/llm-d-cuda:v0.6.0",
+									Image: "ghcr.io/llm-d/llm-d-cuda:v0.7.0",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8001,
@@ -464,7 +464,7 @@ func TestPresetFiles(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:  "main",
-									Image: "ghcr.io/llm-d/llm-d-cuda:v0.6.0",
+									Image: "ghcr.io/llm-d/llm-d-cuda:v0.7.0",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8000,

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -107,7 +107,6 @@ func TestPresetFiles(t *testing.T) {
 										"--vllm-port=8001",
 										"--kv-connector=nixlv2",
 										"--enable-ssrf-protection=true",
-										"--pool-group=inference.networking.x-k8s.io",
 										"--secure-proxy=false",
 										"",
 										"",

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -107,6 +107,8 @@ func TestPresetFiles(t *testing.T) {
 										"--vllm-port=8001",
 										"--kv-connector=nixlv2",
 										"--enable-ssrf-protection=true",
+										"--pool-group=inference.networking.x-k8s.io",
+										"--inference-pool=test-llm-preset-test/test-llm-preset-inference-pool",
 										"--secure-proxy=false",
 										"",
 										"",

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1528,6 +1528,172 @@ schedulingProfiles:
 		})
 	})
 
+	Context("v0.9.0 prefix-cache-scorer parameter removal", func() {
+		It("should remove all parameters except prefixMatchInfoProducerName from prefix-cache-scorer", func(ctx SpecContext) {
+			svcName := "test-llm-pcs-param-removal"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			configWithPrefixCacheParams := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 16
+    prefixMatchInfoProducerName: my-producer
+- type: queue-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(configWithPrefixCacheParams),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+				g.Expect(configText).To(ContainSubstring("prefixMatchInfoProducerName: my-producer"))
+				g.Expect(configText).NotTo(ContainSubstring("blockSizeTokens"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should remove parameters entirely when no prefixMatchInfoProducerName is present", func(ctx SpecContext) {
+			svcName := "test-llm-pcs-param-all-removed"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			configWithOnlyDeprecatedParams := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 16
+- type: queue-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(configWithOnlyDeprecatedParams),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+				g.Expect(configText).NotTo(ContainSubstring("blockSizeTokens"))
+				g.Expect(configText).NotTo(ContainSubstring("parameters"))
+				g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should not touch prefix-cache-scorer without parameters", func(ctx SpecContext) {
+			svcName := "test-llm-pcs-no-params"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			configWithNoParams := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: prefix-cache-scorer
+- type: queue-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(configWithNoParams),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+				g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
 	Context("Multi-GPU-vendor pooling via workload label propagation", func() {
 		It("should create InferencePool with default workload labels that AMD pods can match", func(ctx SpecContext) {
 			// This test verifies the multi-GPU-vendor pooling pattern:

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -156,7 +156,7 @@ schedulingProfiles:
 						Containers: []corev1.Container{
 							{
 								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1",
+								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0",
 								Args: []string{
 									"--config-text",
 									"existing-config-from-template",
@@ -904,7 +904,7 @@ schedulingProfiles:
 						Containers: []corev1.Container{
 							{
 								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1",
+								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0",
 								Args: []string{
 									"--ha-enable-leader-election",
 									"--poolName",

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -156,7 +156,7 @@ schedulingProfiles:
 						Containers: []corev1.Container{
 							{
 								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0",
+								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2",
 								Args: []string{
 									"--config-text",
 									"existing-config-from-template",
@@ -904,7 +904,7 @@ schedulingProfiles:
 						Containers: []corev1.Container{
 							{
 								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0",
+								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2",
 								Args: []string{
 									"--ha-enable-leader-election",
 									"--poolName",

--- a/pkg/controller/v1alpha2/llmisvc/sample.go
+++ b/pkg/controller/v1alpha2/llmisvc/sample.go
@@ -189,7 +189,7 @@ func LLMInferenceServiceSample() *v1alpha2.LLMInferenceService {
 						Containers: []corev1.Container{
 							{
 								Name:  "scheduler",
-								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0",
+								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2",
 								Ports: []corev1.ContainerPort{
 									{
 										ContainerPort: 9002,

--- a/pkg/controller/v1alpha2/llmisvc/sample.go
+++ b/pkg/controller/v1alpha2/llmisvc/sample.go
@@ -189,7 +189,7 @@ func LLMInferenceServiceSample() *v1alpha2.LLMInferenceService {
 						Containers: []corev1.Container{
 							{
 								Name:  "scheduler",
-								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1",
+								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0",
 								Ports: []corev1.ContainerPort{
 									{
 										ContainerPort: 9002,

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1313,8 +1313,15 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 	if v.Compare(*semver.New("0.8.0")) >= 0 {
 		opts = append(opts, withMigrateCoreMetricsExtractor)
 	}
+	if v.Compare(*semver.New("0.9.0")) >= 0 {
+		opts = append(opts, withRemovePrefixCacheScorerParametersV09)
+		opts = append(opts, withRemoveUnnecessaryTokenizer(d))
+	}
 
-	return mutateSchedulerConfig(ctx, d, opts...)
+	if err := mutateSchedulerConfig(ctx, d, opts...); err != nil {
+		return fmt.Errorf("failed to mutate config: %w", err)
+	}
+	return nil
 }
 
 // withMigrateDisaggHeadersHandler renames the prefill-header-handler plugin to
@@ -1327,6 +1334,80 @@ func withMigrateDisaggHeadersHandler(ctx context.Context, u *unstructured.Unstru
 // plugin to core-metrics-extractor (v0.8.0 rename in GIE v1.5.0).
 func withMigrateCoreMetricsExtractor(ctx context.Context, u *unstructured.Unstructured) error {
 	return WithRenamePlugin(coreMetricsExtractorPlugin, coreMetricsExtractorPluginRenamed)(ctx, u)
+}
+
+// withRemovePrefixCacheScorerParametersV09 removes all parameters from the
+// prefix-cache-scorer plugin except prefixMatchInfoProducerName.
+func withRemovePrefixCacheScorerParametersV09(ctx context.Context, u *unstructured.Unstructured) error {
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	if err != nil || !found {
+		return err
+	}
+	plugins, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, plugin := range plugins {
+		pluginMap, ok := plugin.(map[string]interface{})
+		if !ok || pluginMap["type"] != prefixCacheScorerPlugin {
+			continue
+		}
+
+		params, found, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters")
+		if !found {
+			continue
+		}
+		paramsMap, ok := params.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for key := range paramsMap {
+			if key != "prefixMatchInfoProducerName" {
+				log.FromContext(ctx).V(2).Info("Removing deprecated prefix-cache-scorer parameter", "key", key)
+				delete(paramsMap, key)
+			}
+		}
+
+		if len(paramsMap) == 0 {
+			delete(pluginMap, "parameters")
+		}
+	}
+
+	return nil
+}
+
+func withRemoveUnnecessaryTokenizer(d *appsv1.Deployment) mutateSchedulerConfigFunc {
+	return func(ctx context.Context, u *unstructured.Unstructured) error {
+		val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+		if err != nil || !found {
+			return err
+		}
+		plugins, ok := val.([]interface{})
+		if !ok {
+			return nil
+		}
+
+		hasPrecisePrefix := false
+		for _, plugin := range plugins {
+			pluginMap, ok := plugin.(map[string]interface{})
+			if ok && pluginMap["type"] == precisePrefixCacheScorerPlugin {
+				hasPrecisePrefix = true
+				break
+			}
+		}
+		if !hasPrecisePrefix {
+			for i := range d.Spec.Template.Spec.Containers {
+				if d.Spec.Template.Spec.Containers[i].Name == tokenizerContainerName {
+					d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers[:i], d.Spec.Template.Spec.Containers[i+1:]...)
+					break
+				}
+			}
+		}
+
+		return nil
+	}
 }
 
 // withMigrateDisaggProfileHandler renames the pd-profile-handler plugin to

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -55,12 +55,13 @@ import (
 const (
 	tokenizerContainerName = "tokenizer"
 
-	precisePrefixCacheScorerPlugin = "precise-prefix-cache-scorer"
-	prefixCacheScorerPlugin        = "prefix-cache-scorer"
-	loraAffinityScorerPlugin       = "lora-affinity-scorer"
-	coreMetricsExtractorPlugin     = "model-server-protocol-metrics"
-	udsTokenizerBaseModelName      = "base"
-	udsTokenizerSocketFile         = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
+	precisePrefixCacheScorerPlugin    = "precise-prefix-cache-scorer"
+	prefixCacheScorerPlugin           = "prefix-cache-scorer"
+	loraAffinityScorerPlugin          = "lora-affinity-scorer"
+	coreMetricsExtractorPlugin        = "model-server-protocol-metrics"
+	coreMetricsExtractorPluginRenamed = "core-metrics-extractor"
+	udsTokenizerBaseModelName         = "base"
+	udsTokenizerSocketFile            = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
 )
 
 // reconcileScheduler manages the scheduler component and its related resources
@@ -1269,6 +1270,8 @@ func hasDeprecatedMetricFlags(d *appsv1.Deployment) bool {
 //     threshold>0 → prefix-based-pd-decider with nonCachedTokens = ceil(threshold/4))
 //  4. WithRemoveHashBlockSize – drop deprecated hashBlockSize from all plugins
 //  5. withCoreMetricsExtractorPlugin – inject core-metrics-extractor with extracted flag values
+//  6. withMigrateCoreMetricsExtractor – rename model-server-protocol-metrics → core-metrics-extractor
+//     (v0.8.0 only, runs after injection so freshly injected plugins are also renamed)
 func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 	version, ok := d.Spec.Template.Annotations["app.kubernetes.io/version"]
 	if !ok || version == "" {
@@ -1305,6 +1308,12 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 		opts = append(opts, withCoreMetricsExtractorPlugin(extracted))
 	}
 
+	// v0.8.0 plugin rename runs AFTER injection so freshly injected plugins
+	// (using the v0.7.x name) are also renamed to the v0.8.0+ name.
+	if v.Compare(*semver.New("0.8.0")) >= 0 {
+		opts = append(opts, withMigrateCoreMetricsExtractor)
+	}
+
 	return mutateSchedulerConfig(ctx, d, opts...)
 }
 
@@ -1312,6 +1321,12 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 // disagg-headers-handler (v0.7.0 rename).
 func withMigrateDisaggHeadersHandler(ctx context.Context, u *unstructured.Unstructured) error {
 	return WithRenamePlugin("prefill-header-handler", "disagg-headers-handler")(ctx, u)
+}
+
+// withMigrateCoreMetricsExtractor renames the model-server-protocol-metrics
+// plugin to core-metrics-extractor (v0.8.0 rename in GIE v1.5.0).
+func withMigrateCoreMetricsExtractor(ctx context.Context, u *unstructured.Unstructured) error {
+	return WithRenamePlugin(coreMetricsExtractorPlugin, coreMetricsExtractorPluginRenamed)(ctx, u)
 }
 
 // withMigrateDisaggProfileHandler renames the pd-profile-handler plugin to
@@ -1404,7 +1419,7 @@ func withCoreMetricsExtractorPlugin(extracted map[string]string) mutateScheduler
 
 		for _, plugin := range plugins {
 			pluginMap, ok := plugin.(map[string]interface{})
-			if ok && pluginMap["type"] == coreMetricsExtractorPlugin {
+			if ok && (pluginMap["type"] == coreMetricsExtractorPlugin || pluginMap["type"] == coreMetricsExtractorPluginRenamed) {
 				return nil
 			}
 		}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -857,7 +857,7 @@ func WithUdsTokenizerConfig(_ context.Context, u *unstructured.Unstructured) err
 // WithMigrateTokenProcessorConfig migrates tokenProcessorConfig from inside
 // indexerConfig to the top level of the plugin parameters for the
 // precise-prefix-cache-scorer plugin. This handles the schema change in
-// llm-d-inference-scheduler v0.6.0 where tokenProcessorConfig was promoted
+// llm-d-router v0.6.0 where tokenProcessorConfig was promoted
 // from indexerConfig to a top-level plugin parameter.
 func WithMigrateTokenProcessorConfig(ctx context.Context, u *unstructured.Unstructured) error {
 	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
@@ -903,7 +903,7 @@ func WithMigrateTokenProcessorConfig(ctx context.Context, u *unstructured.Unstru
 
 // WithMigrateBlockSizeToBlockSizeTokens migrates the deprecated blockSize
 // field to blockSizeTokens in the prefix-cache-scorer plugin parameters.
-// In llm-d-inference-scheduler v0.6.0 the prefix-cache-scorer plugin renamed
+// In llm-d-router v0.6.0 the prefix-cache-scorer plugin renamed
 // blockSize (characters) to blockSizeTokens (tokens). If only blockSize is
 // set the plugin refuses to start. This migration copies blockSize to
 // blockSizeTokens when blockSizeTokens is not already present.
@@ -1014,7 +1014,7 @@ func WithRenamePlugin(oldType, newType string) mutateSchedulerConfigFunc {
 
 // WithMigrateDisaggProfileParams migrates the disagg-profile-handler (formerly
 // pd-profile-handler) from the old flat deciderPluginName/threshold parameters
-// to the new deciders map structure introduced in llm-d-inference-scheduler v0.7.0.
+// to the new deciders map structure introduced in llm-d-router v0.7.0.
 //
 // Migration paths:
 //
@@ -1186,7 +1186,7 @@ func thresholdToNonCachedTokens(val interface{}) int64 {
 }
 
 // WithRemoveHashBlockSize removes the deprecated hashBlockSize field from
-// all plugin parameters. This field was removed in llm-d-inference-scheduler v0.7.0.
+// all plugin parameters. This field was removed in llm-d-router v0.7.0.
 func WithRemoveHashBlockSize(_ context.Context, u *unstructured.Unstructured) error {
 	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 	if err != nil || !found {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1076,6 +1076,96 @@ plugins:
 	}
 }
 
+func TestWithRemovePrefixCacheScorerParametersV09(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "removes all parameters except prefixMatchInfoProducerName",
+			configYAML: `
+plugins:
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 16
+    hashBlockSize: 64
+    prefixMatchInfoProducerName: my-producer
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).To(HaveKey("prefixMatchInfoProducerName"))
+				g.Expect(params).NotTo(HaveKey("blockSizeTokens"))
+				g.Expect(params).NotTo(HaveKey("hashBlockSize"))
+			},
+		},
+		{
+			name: "removes parameters entirely when no prefixMatchInfoProducerName",
+			configYAML: `
+plugins:
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 16
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins[0].(map[string]interface{})).NotTo(HaveKey("parameters"))
+			},
+		},
+		{
+			name: "no parameters - no-op",
+			configYAML: `
+plugins:
+- type: prefix-cache-scorer
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins[0].(map[string]interface{})).NotTo(HaveKey("parameters"))
+			},
+		},
+		{
+			name: "does not affect other plugins",
+			configYAML: `
+plugins:
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 16
+- type: queue-scorer
+  parameters:
+    someParam: value
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins[0].(map[string]interface{})).NotTo(HaveKey("parameters"))
+				queueParams := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(queueParams).To(HaveKeyWithValue("someParam", "value"))
+			},
+		},
+		{
+			name: "no plugins - no-op",
+			configYAML: `
+schedulingProfiles:
+- name: default
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				g.Expect(obj).NotTo(HaveKey("plugins"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			g.Expect(withRemovePrefixCacheScorerParametersV09(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
 func TestWithCoreMetricsExtractorPlugin(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1127,6 +1127,22 @@ plugins:
 			},
 		},
 		{
+			name: "skips when renamed plugin already exists",
+			configYAML: `
+plugins:
+- type: core-metrics-extractor
+  parameters:
+    defaultEngine: vllm
+`,
+			extracted: map[string]string{
+				"kv-cache-usage-percentage-metric": "vllm:kv_cache_usage_perc",
+			},
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+			},
+		},
+		{
 			name: "skips when no values extracted",
 			configYAML: `
 plugins:
@@ -1445,6 +1461,39 @@ schedulingProfiles:
 					g.Expect(a).NotTo(ContainSubstring("kv-cache-usage-percentage-metric"))
 				}
 				// Non-metric flags preserved
+				g.Expect(args).To(ContainElement("--grpc-port"))
+				g.Expect(args).To(ContainElement("9002"))
+			},
+		},
+		{
+			name:    "v0.8.0 renames model-server-protocol-metrics to core-metrics-extractor",
+			version: "0.8.0",
+			extraArgs: []string{
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--total-running-requests-metric", "vllm:num_requests_running",
+				"--kv-cache-usage-percentage-metric", "vllm:kv_cache_usage_perc",
+				"--grpc-port", "9002",
+			},
+			validateConfig: func(g Gomega, configText string) {
+				// v0.8.0 plugin name used
+				g.Expect(configText).To(ContainSubstring("core-metrics-extractor"))
+				g.Expect(configText).NotTo(ContainSubstring("model-server-protocol-metrics"))
+
+				// Metric values present
+				g.Expect(configText).To(ContainSubstring("vllm:num_requests_waiting"))
+				g.Expect(configText).To(ContainSubstring("vllm:num_requests_running"))
+				g.Expect(configText).To(ContainSubstring("vllm:kv_cache_usage_perc"))
+
+				// v0.7 renames also applied
+				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+			},
+			validateArgs: func(g Gomega, args []string) {
+				for _, a := range args {
+					g.Expect(a).NotTo(ContainSubstring("total-queued-requests-metric"))
+					g.Expect(a).NotTo(ContainSubstring("total-running-requests-metric"))
+					g.Expect(a).NotTo(ContainSubstring("kv-cache-usage-percentage-metric"))
+				}
 				g.Expect(args).To(ContainElement("--grpc-port"))
 				g.Expect(args).To(ContainElement("9002"))
 			},

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -41,7 +41,7 @@ import (
 // These permissions are needed to discover and monitor inference pools and pods.
 var sidecarSSRFProtectionRules = []rbacv1.PolicyRule{
 	{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list", "watch"}},
-	{APIGroups: []string{"inference.networking.x-k8s.io"}, Resources: []string{"inferencepools"}, Verbs: []string{"get", "list", "watch"}},
+	{APIGroups: []string{"inference.networking.x-k8s.io", "inference.networking.k8s.io"}, Resources: []string{"inferencepools"}, Verbs: []string{"get", "list", "watch"}},
 }
 
 // reconcileWorkload manages the Deployments and Services for the LLM.

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -170,7 +170,7 @@ func GetWorkloadLabelSelector(meta metav1.ObjectMeta, _ *v1alpha2.LLMInferenceSe
 		constants.KServeComponentLabelKey:   constants.KServeComponentWorkload,
 	}
 
-	// TODO https://github.com/llm-d/llm-d-inference-scheduler/issues/220 and DP template
+	// TODO https://github.com/llm-d/llm-d-router/issues/220 and DP template
 
 	return s
 }

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -954,6 +954,8 @@ LLMINFERENCESERVICE_CONFIGS = {
                             "args": [
                                 "--cert-path",
                                 "/var/run/kserve/tls",
+                                "--pool-group",
+                                "inference.networking.x-k8s.io",
                                 "--pool-name",
                                 "{{ ChildName .ObjectMeta.Name `-inference-pool` }}",
                                 "--pool-namespace",

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -954,8 +954,6 @@ LLMINFERENCESERVICE_CONFIGS = {
                             "args": [
                                 "--cert-path",
                                 "/var/run/kserve/tls",
-                                "--pool-group",
-                                "inference.networking.x-k8s.io",
                                 "--pool-name",
                                 "{{ ChildName .ObjectMeta.Name `-inference-pool` }}",
                                 "--pool-namespace",


### PR DESCRIPTION
Closes #5595

## What

Upgrades llm-d container images to align with the llm-d v0.8.0 release. This PR was originally scoped to the [llm-d v0.7.0 coordinated release](https://github.com/llm-d/llm-d/releases/tag/v0.7.0) and later re-purposed to include llm-d-router v0.9.0-rc.2 and associated scheduler migrations.

| Component | Previous | New | Notes |
|-----------|----------|-----|-------|
| llm-d-cuda | v0.6.0 | v0.7.0 | |
| llm-d-rocm | v0.6.0 | v0.7.0 | |
| llm-d-inference-scheduler → llm-d-router-endpoint-picker | v0.7.1 | v0.9.0-rc.2 | Image renamed |
| llm-d-routing-sidecar → llm-d-router-disagg-sidecar | v0.7.1 | v0.9.0-rc.2 | Image renamed |
| llm-d-uds-tokenizer | v0.7.1 | vllm-v0.19.1 | Tag format changed to vllm-aligned |
| Scheduler version annotation | 0.7.0 | 0.9.0 | |

GIE (v1.5.0) remains unchanged — already at correct version on master. WVA upgrade is handled in a separate PR.

## Why

The llm-d v0.7.0 release brings predicted-latency scheduling GA, optimized baseline stabilization, and CUDA 13.0.2 runtime support. The llm-d-router v0.9.0-rc.2 upgrade includes image renames (the project rebranded from `llm-d-inference-scheduler` / `llm-d-routing-sidecar` to `llm-d-router-endpoint-picker` / `llm-d-router-disagg-sidecar`), SSRF protection fixes, and scheduler configuration simplifications.

## Changes

### Image upgrades and renames
- Upgrade `llm-d-cuda` and `llm-d-rocm` from v0.6.0 to v0.7.0
- Upgrade and rename `llm-d-inference-scheduler` → `llm-d-router-endpoint-picker:v0.9.0-rc.2`
- Upgrade and rename `llm-d-routing-sidecar` → `llm-d-router-disagg-sidecar:v0.9.0-rc.2`
- Upgrade `llm-d-uds-tokenizer` from v0.7.1 to vllm-v0.19.1

### Sidecar fixes (contributed by @pierDipi)
- Pass `--inference-pool` arg to disagg sidecar, required when `--enable-ssrf-protection=true` (without this, the sidecar crashes with `"--inference-pool flag or INFERENCE_POOL environment variable is required"`)
- Add `inference.networking.k8s.io` API group to sidecar RBAC rules for InferencePool v1 compatibility
- Set `--pool-group=inference.networking.x-k8s.io` pending [llm-d-router#1696](https://github.com/llm-d/llm-d-router/pull/1696)

### Scheduler configuration migrations
- **v0.8.0**: `withMigrateCoreMetricsExtractor` — rename `model-server-protocol-metrics` → `core-metrics-extractor` plugin (GIE v1.5.0 rename). Version-gated for scheduler >= 0.8.0, runs after plugin injection so freshly injected plugins are also renamed.
- **v0.9.0**: `withRemovePrefixCacheScorerParametersV09` — remove all deprecated parameters from `prefix-cache-scorer` except `prefixMatchInfoProducerName`
- **v0.9.0**: `withRemoveUnnecessaryTokenizer` — remove tokenizer sidecar container when `precise-prefix-cache-scorer` is not in use

### Template config
- Add `InferencePoolNamespacedName` to `templateGlobalConfig` so sidecar templates can reference `{{ .GlobalConfig.InferencePoolNamespacedName }}`

## Breaking Changes

- **CUDA 13.0.2**: `llm-d-cuda:v0.7.0` requires NVIDIA driver 580+ on host nodes.
- **Tokenizer tag format**: Changed from semver (`v0.7.1`) to vllm-aligned (`vllm-v0.19.1`).
- **Image renames**: `llm-d-inference-scheduler` is now `llm-d-router-endpoint-picker`; `llm-d-routing-sidecar` is now `llm-d-router-disagg-sidecar`.

## Compatibility

- The `llm-d-router-endpoint-picker` v0.9.0-rc.2 binary supports both v1 and v1alpha2 InferencePool APIs.
- No `GIE_VERSION` upgrade in install scripts is required — already at v1.5.0.
- All scheduler migrations are version-gated, ensuring both fresh deployments and upgrades from older scheduler versions receive the correct configuration.

```release-note
Upgrade llm-d components to v0.8.0 release: cuda/rocm v0.7.0, router v0.9.0-rc.2 (with image renames), tokenizer vllm-v0.19.1. Includes scheduler config migrations for v0.8.0+ and sidecar --inference-pool fix.