### PR TITLE
test(e2e): added http/https download test cases for multi-model serving

### DIFF
--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -44,6 +44,14 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
             "v2",
             "gs://seldon-models/sklearn/mms/lr_model",
         ),
+        (
+            "v1",
+            "https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib",
+        ),
+        (
+            "v2",
+            "https://storage.googleapis.com/seldon-models/sklearn/mms/lr_model/model.joblib",
+        ),
     ],
 )
 @pytest.mark.mms
@@ -164,6 +172,14 @@ async def test_mms_sklearn_kserve(
         (
             "v2",
             "gs://seldon-models/xgboost/mms/iris",
+        ),
+        (
+            "v1",
+            "https://storage.googleapis.com/kfserving-examples/models/xgboost/1.5/model/model.bst",
+        ),
+        (
+            "v2",
+            "https://storage.googleapis.com/seldon-models/xgboost/mms/iris/model.bst",
         ),
     ],
 )

--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -34,37 +34,50 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 
 
 @pytest.mark.parametrize(
-    "protocol_version,storage_uri",
+    "protocol_version,storage_uri,storage_type",
     [
         (
             "v1",
+            # GCS directory URI: storage-initializer downloads all files under the prefix recursively
             "gs://kfserving-examples/models/sklearn/1.0/model",
+            "gcs",
         ),
         (
             "v2",
+            # GCS directory URI: storage-initializer downloads all files under the prefix recursively
             "gs://seldon-models/sklearn/mms/lr_model",
+            "gcs",
         ),
         (
             "v1",
+            # HTTPS single-file URI: storage-initializer fetches one file via HTTP GET.
+            # Both GCS and HTTPS cases result in the same model layout inside the container.
             "https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib",
+            "https",
         ),
         (
             "v2",
+            # HTTPS single-file URI: storage-initializer fetches one file via HTTP GET.
+            # Both GCS and HTTPS cases result in the same model layout inside the container.
             "https://storage.googleapis.com/seldon-models/sklearn/mms/lr_model/model.joblib",
+            "https",
         ),
     ],
-    ids=["v1-gcs", "v2-gcs", "v1-http", "v2-http"],
+    ids=["v1-gcs", "v2-gcs", "v1-https", "v2-https"],
 )
 @pytest.mark.mms
 @pytest.mark.asyncio(scope="session")
 async def test_mms_sklearn_kserve(
     protocol_version: str,
     storage_uri: str,
+    storage_type: str,
     rest_v1_client,
     rest_v2_client,
     network_layer,
 ):
-    service_name = f"isvc-sklearn-mms-{protocol_version}"
+    # Include storage_type in the service name to avoid resource name collisions
+    # when multiple parametrized cases share the same protocol_version.
+    service_name = f"isvc-sklearn-mms-{protocol_version}-{storage_type}"
     # Define an inference service
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -164,37 +177,50 @@ async def test_mms_sklearn_kserve(
 
 
 @pytest.mark.parametrize(
-    "protocol_version,storage_uri",
+    "protocol_version,storage_uri,storage_type",
     [
         (
             "v1",
+            # GCS directory URI: storage-initializer downloads all files under the prefix recursively
             "gs://kfserving-examples/models/xgboost/1.5/model",
+            "gcs",
         ),
         (
             "v2",
+            # GCS directory URI: storage-initializer downloads all files under the prefix recursively
             "gs://seldon-models/xgboost/mms/iris",
+            "gcs",
         ),
         (
             "v1",
+            # HTTPS single-file URI: storage-initializer fetches one file via HTTP GET.
+            # Both GCS and HTTPS cases result in the same model layout inside the container.
             "https://storage.googleapis.com/kfserving-examples/models/xgboost/1.5/model/model.bst",
+            "https",
         ),
         (
             "v2",
+            # HTTPS single-file URI: storage-initializer fetches one file via HTTP GET.
+            # Both GCS and HTTPS cases result in the same model layout inside the container.
             "https://storage.googleapis.com/seldon-models/xgboost/mms/iris/model.bst",
+            "https",
         ),
     ],
-    ids=["v1-gcs", "v2-gcs", "v1-http", "v2-http"],
+    ids=["v1-gcs", "v2-gcs", "v1-https", "v2-https"],
 )
 @pytest.mark.mms
 @pytest.mark.asyncio(scope="session")
 async def test_mms_xgboost_kserve(
     protocol_version: str,
     storage_uri: str,
+    storage_type: str,
     rest_v1_client,
     rest_v2_client,
     network_layer,
 ):
-    service_name = f"isvc-xgboost-mms-{protocol_version}"
+    # Include storage_type in the service name to avoid resource name collisions
+    # when multiple parametrized cases share the same protocol_version.
+    service_name = f"isvc-xgboost-mms-{protocol_version}-{storage_type}"
     # Define an inference service
     predictor = V1beta1PredictorSpec(
         min_replicas=1,

--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -53,6 +53,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
             "https://storage.googleapis.com/seldon-models/sklearn/mms/lr_model/model.joblib",
         ),
     ],
+    ids=["v1-gcs", "v2-gcs", "v1-http", "v2-http"],
 )
 @pytest.mark.mms
 @pytest.mark.asyncio(scope="session")
@@ -182,6 +183,7 @@ async def test_mms_sklearn_kserve(
             "https://storage.googleapis.com/seldon-models/xgboost/mms/iris/model.bst",
         ),
     ],
+    ids=["v1-gcs", "v2-gcs", "v1-http", "v2-http"],
 )
 @pytest.mark.mms
 @pytest.mark.asyncio(scope="session")

--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -99,81 +99,82 @@ async def test_mms_sklearn_kserve(
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
 
+    model_names = [
+        f"model1-sklearn-{protocol_version}-{storage_type}",
+        f"model2-sklearn-{protocol_version}-{storage_type}",
+    ]
+
     # Create an instance of inference service with isvc
     kserve_client = KServeClient(
         config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
     )
     kserve_client.create(isvc)
-    kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+    try:
+        kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    cluster_ip = get_cluster_ip()
+        cluster_ip = get_cluster_ip()
 
-    model_names = [
-        f"model1-sklearn-{protocol_version}",
-        f"model2-sklearn-{protocol_version}",
-    ]
-
-    for model_name in model_names:
-        model_spec = V1alpha1ModelSpec(
-            storage_uri=storage_uri,
-            memory="128Mi",
-            framework="sklearn",
-        )
-
-        model = V1alpha1TrainedModel(
-            api_version=constants.KSERVE_V1ALPHA1,
-            kind=constants.KSERVE_KIND_TRAINEDMODEL,
-            metadata=client.V1ObjectMeta(
-                name=model_name, namespace=KSERVE_TEST_NAMESPACE
-            ),
-            spec=V1alpha1TrainedModelSpec(
-                inference_service=service_name, model=model_spec
-            ),
-        )
-
-        # Create instances of trained models using model1 and model2
-        kserve_client.create_trained_model(model, KSERVE_TEST_NAMESPACE)
-
-        kserve_client.wait_model_ready(
-            service_name,
-            model_name,
-            isvc_namespace=KSERVE_TEST_NAMESPACE,
-            isvc_version=constants.KSERVE_V1BETA1_VERSION,
-            protocol_version=protocol_version,
-            cluster_ip=cluster_ip,
-        )
-
-    if protocol_version == "v1":
-        responses = [
-            await predict_isvc(
-                rest_v1_client,
-                service_name,
-                "./data/iris_input.json",
-                model_name=model_name,
-                network_layer=network_layer,
+        for model_name in model_names:
+            model_spec = V1alpha1ModelSpec(
+                storage_uri=storage_uri,
+                memory="128Mi",
+                framework="sklearn",
             )
-            for model_name in model_names
-        ]
-        assert responses[0]["predictions"] == [1, 1]
-        assert responses[1]["predictions"] == [1, 1]
-    elif protocol_version == "v2":
-        responses = [
-            await predict_isvc(
-                rest_v2_client,
-                service_name,
-                "./data/iris_input_v2.json",
-                model_name=model_name,
-                network_layer=network_layer,
-            )
-            for model_name in model_names
-        ]
-        assert responses[0].outputs[0].data == [1, 1]
-        assert responses[1].outputs[0].data == [1, 1]
 
-    # Clean up inference service and trained models
-    for model_name in model_names:
-        kserve_client.delete_trained_model(model_name, KSERVE_TEST_NAMESPACE)
-    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+            model = V1alpha1TrainedModel(
+                api_version=constants.KSERVE_V1ALPHA1,
+                kind=constants.KSERVE_KIND_TRAINEDMODEL,
+                metadata=client.V1ObjectMeta(
+                    name=model_name, namespace=KSERVE_TEST_NAMESPACE
+                ),
+                spec=V1alpha1TrainedModelSpec(
+                    inference_service=service_name, model=model_spec
+                ),
+            )
+
+            # Create instances of trained models using model1 and model2
+            kserve_client.create_trained_model(model, KSERVE_TEST_NAMESPACE)
+
+            kserve_client.wait_model_ready(
+                service_name,
+                model_name,
+                isvc_namespace=KSERVE_TEST_NAMESPACE,
+                isvc_version=constants.KSERVE_V1BETA1_VERSION,
+                protocol_version=protocol_version,
+                cluster_ip=cluster_ip,
+            )
+
+        if protocol_version == "v1":
+            responses = [
+                await predict_isvc(
+                    rest_v1_client,
+                    service_name,
+                    "./data/iris_input.json",
+                    model_name=model_name,
+                    network_layer=network_layer,
+                )
+                for model_name in model_names
+            ]
+            assert responses[0]["predictions"] == [1, 1]
+            assert responses[1]["predictions"] == [1, 1]
+        elif protocol_version == "v2":
+            responses = [
+                await predict_isvc(
+                    rest_v2_client,
+                    service_name,
+                    "./data/iris_input_v2.json",
+                    model_name=model_name,
+                    network_layer=network_layer,
+                )
+                for model_name in model_names
+            ]
+            assert responses[0].outputs[0].data == [1, 1]
+            assert responses[1].outputs[0].data == [1, 1]
+    finally:
+        # Clean up inference service and trained models
+        for model_name in model_names:
+            kserve_client.delete_trained_model(model_name, KSERVE_TEST_NAMESPACE)
+        kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.parametrize(
@@ -243,78 +244,80 @@ async def test_mms_xgboost_kserve(
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
 
+    model_names = [
+        f"model1-xgboost-{protocol_version}-{storage_type}",
+        f"model2-xgboost-{protocol_version}-{storage_type}",
+    ]
+
     # Create an instance of inference service with isvc
     kserve_client = KServeClient(
         config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
     )
     kserve_client.create(isvc)
-    kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+    try:
+        kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    cluster_ip = get_cluster_ip()
-    model_names = [
-        f"model1-xgboost-{protocol_version}",
-        f"model2-xgboost-{protocol_version}",
-    ]
+        cluster_ip = get_cluster_ip()
 
-    for model_name in model_names:
-        # Define trained models
-        model_spec = V1alpha1ModelSpec(
-            storage_uri=storage_uri,
-            memory="128Mi",
-            framework="xgboost",
-        )
-
-        model = V1alpha1TrainedModel(
-            api_version=constants.KSERVE_V1ALPHA1,
-            kind=constants.KSERVE_KIND_TRAINEDMODEL,
-            metadata=client.V1ObjectMeta(
-                name=model_name, namespace=KSERVE_TEST_NAMESPACE
-            ),
-            spec=V1alpha1TrainedModelSpec(
-                inference_service=service_name, model=model_spec
-            ),
-        )
-
-        # Create instances of trained models using model1 and model2
-        kserve_client.create_trained_model(model, KSERVE_TEST_NAMESPACE)
-
-        kserve_client.wait_model_ready(
-            service_name,
-            model_name,
-            isvc_namespace=KSERVE_TEST_NAMESPACE,
-            isvc_version=constants.KSERVE_V1BETA1_VERSION,
-            protocol_version=protocol_version,
-            cluster_ip=cluster_ip,
-        )
-
-    if protocol_version == "v1":
-        responses = [
-            await predict_isvc(
-                rest_v1_client,
-                service_name,
-                "./data/iris_input.json",
-                model_name=model_name,
-                network_layer=network_layer,
+        for model_name in model_names:
+            # Define trained models
+            model_spec = V1alpha1ModelSpec(
+                storage_uri=storage_uri,
+                memory="128Mi",
+                framework="xgboost",
             )
-            for model_name in model_names
-        ]
-        assert responses[0]["predictions"] == [1, 1]
-        assert responses[1]["predictions"] == [1, 1]
-    elif protocol_version == "v2":
-        responses = [
-            await predict_isvc(
-                rest_v2_client,
-                service_name,
-                "./data/iris_input_v2.json",
-                model_name=model_name,
-                network_layer=network_layer,
-            )
-            for model_name in model_names
-        ]
-        assert responses[0].outputs[0].data == [1.0, 1.0]
-        assert responses[1].outputs[0].data == [1.0, 1.0]
 
-    # Clean up inference service and trained models
-    for model_name in model_names:
-        kserve_client.delete_trained_model(model_name, KSERVE_TEST_NAMESPACE)
-    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+            model = V1alpha1TrainedModel(
+                api_version=constants.KSERVE_V1ALPHA1,
+                kind=constants.KSERVE_KIND_TRAINEDMODEL,
+                metadata=client.V1ObjectMeta(
+                    name=model_name, namespace=KSERVE_TEST_NAMESPACE
+                ),
+                spec=V1alpha1TrainedModelSpec(
+                    inference_service=service_name, model=model_spec
+                ),
+            )
+
+            # Create instances of trained models using model1 and model2
+            kserve_client.create_trained_model(model, KSERVE_TEST_NAMESPACE)
+
+            kserve_client.wait_model_ready(
+                service_name,
+                model_name,
+                isvc_namespace=KSERVE_TEST_NAMESPACE,
+                isvc_version=constants.KSERVE_V1BETA1_VERSION,
+                protocol_version=protocol_version,
+                cluster_ip=cluster_ip,
+            )
+
+        if protocol_version == "v1":
+            responses = [
+                await predict_isvc(
+                    rest_v1_client,
+                    service_name,
+                    "./data/iris_input.json",
+                    model_name=model_name,
+                    network_layer=network_layer,
+                )
+                for model_name in model_names
+            ]
+            assert responses[0]["predictions"] == [1, 1]
+            assert responses[1]["predictions"] == [1, 1]
+        elif protocol_version == "v2":
+            responses = [
+                await predict_isvc(
+                    rest_v2_client,
+                    service_name,
+                    "./data/iris_input_v2.json",
+                    model_name=model_name,
+                    network_layer=network_layer,
+                )
+                for model_name in model_names
+            ]
+            assert responses[0].outputs[0].data == [1.0, 1.0]
+            assert responses[1].outputs[0].data == [1.0, 1.0]
+    finally:
+        # Clean up inference service and trained models
+        for model_name in model_names:
+            kserve_client.delete_trained_model(model_name, KSERVE_TEST_NAMESPACE)
+        kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)


### PR DESCRIPTION
**What this PR does / why we need it**:                                                                                                            
    This PR resolves and closes issue #1576 by updating the multi-model serving E2E tests (`test_multi_model_serving.py`) to test downloading model artifacts from HTTP/HTTPS storage URIs 
  in addition to GCS.                                                                                                                                  
                                                                                                                                                       
    We added HTTPS counterparts for:                                                                                                                   
    - Sklearn `v1` and `v2` protocols under `test_mms_sklearn_kserve`.                                                                                 
    - XGBoost `v1` and `v2` protocols under `test_mms_xgboost_kserve`.                                                                                 
                                                                                                                                                       
**Which issue(s) this PR fixes**:                                                                                                                  
    Fixes #1576                                                                                                                                        
                                                                                                                                                       
**Feature/Issue validation/testing**:                                                                                                              
    - Verified all public HTTP/HTTPS model file endpoints are reachable and return `200 OK`.                                                           
    - Checked and compiled the test script file: `python3 -m py_compile test/e2e/predictor/test_multi_model_serving.py`.
    - Ran the core storage initializer HTTP/HTTPS unit tests to verify the downloader resolution behaves correctly:
      ```bash
      PYTHONPATH=python/storage pytest python/storage/test/test_storage.py -k "test_http_uri_path or test_https_uri_path"
      # Output: 23 passed, 33 deselected
  
  Special notes for your reviewer:
  Note that the HTTP/HTTPS storage URIs point directly to individual model files ( model.joblib  and  model.bst ) instead of directory paths. Since    
  HTTP/HTTPS protocol does not support native directory listing, the storage-initializer requires a specific file endpoint to download the model       
  successfully and avoid raising  No filename contained in URI  errors.
  
  Checklist:
  
  [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  [ ] Has code been commented, particularly in hard-to-understand areas?
  [ ] Have you made corresponding changes to the documentation https://github.com/kserve/website?
  
  Release note:
    test(e2e): Add HTTP/HTTPS download test cases for multi-model serving