### PR TITLE
feat(apis): validate pathTemplate format in IngressConfig

### DIFF
--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"text/template"
 
@@ -311,16 +312,30 @@ func NewIngressConfig(isvcConfigMap *corev1.ConfigMap) (*IngressConfig, error) {
 			return nil, errors.New("invalid ingress config - ingressGateway is required")
 		}
 		if ingressConfig.PathTemplate != "" {
-			// TODO: ensure that the generated path is valid, that is:
-			// * both Name and Namespace are used to avoid collisions
-			// * starts with a /
-			// For now simply check that this is a valid template.
-			_, err := template.New("path-template").Parse(ingressConfig.PathTemplate)
+			tmpl, err := template.New("path-template").Parse(ingressConfig.PathTemplate)
 			if err != nil {
 				return nil, fmt.Errorf("invalid ingress config, unable to parse pathTemplate: %w", err)
 			}
 			if ingressConfig.IngressDomain == "" {
 				return nil, errors.New("invalid ingress config - ingressDomain is required if pathTemplate is given")
+			}
+			// Blocking validation: check template generates valid path format
+			// Validate that the generated path starts with '/' and uses both .Name and .Namespace
+			// to avoid route collisions. Returns an error if the path is invalid.
+			var buf strings.Builder
+			testParams := struct{ Name, Namespace string }{
+				Name: "test-service", Namespace: "test-namespace",
+			}
+			if err := tmpl.Execute(&buf, testParams); err != nil {
+				return nil, fmt.Errorf("invalid pathTemplate - execution failed: %w", err)
+			}
+			// Check if path starts with /
+			if _, err := url.ParseRequestURI(buf.String()); err != nil {
+				return nil, fmt.Errorf("invalid pathTemplate - generated path %q is not a valid URI path: %w", buf.String(), err)
+			}
+			// Check if template uses Name/Namespace to avoid collisions
+			if !strings.Contains(ingressConfig.PathTemplate, "{{ .Name }}") || !strings.Contains(ingressConfig.PathTemplate, "{{ .Namespace }}") {
+				return nil, errors.New("invalid pathTemplate - must include both {{ .Name }} and {{ .Namespace }} to avoid route collisions")
 			}
 		}
 

--- a/pkg/apis/serving/v1beta1/configmap_test.go
+++ b/pkg/apis/serving/v1beta1/configmap_test.go
@@ -724,4 +724,71 @@ func TestNewIngressConfig_Validation(t *testing.T) {
 		g.Expect(cfg.IngressDomain).To(gomega.Equal("mydomain.com"))
 		g.Expect(cfg.UrlScheme).To(gomega.Equal("https"))
 	})
+
+	t.Run("pathTemplate without / should return error", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			Data: map[string]string{
+				IngressConfigKeyName: `{
+					"kserveIngressGateway": "kserve/kserve-ingress-gateway",
+					"ingressGateway": "knative-serving/knative-ingress-gateway",
+					"ingressDomain": "mydomain.com",
+					"pathTemplate": "foo/bar"
+				}`,
+			},
+		}
+		cfg, err := NewIngressConfig(cm)
+		g.Expect(err).Should(gomega.HaveOccurred())
+		g.Expect(cfg).To(gomega.BeNil())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("is not a valid URI path"))
+	})
+
+	t.Run("pathTemplate without .Name should return error", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			Data: map[string]string{
+				IngressConfigKeyName: `{
+					"kserveIngressGateway": "kserve/kserve-ingress-gateway",
+					"ingressGateway": "knative-serving/knative-ingress-gateway",
+					"ingressDomain": "mydomain.com",
+					"pathTemplate": "/{{ .Namespace }}/inference"
+				}`,
+			},
+		}
+		cfg, err := NewIngressConfig(cm)
+		g.Expect(err).Should(gomega.HaveOccurred())
+		g.Expect(cfg).To(gomega.BeNil())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("invalid pathTemplate - must include both {{ .Name }} and {{ .Namespace }} to avoid route collisions"))
+	})
+
+	t.Run("pathTemplate without .Namespace should return error", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			Data: map[string]string{
+				IngressConfigKeyName: `{
+					"kserveIngressGateway": "kserve/kserve-ingress-gateway",
+					"ingressGateway": "knative-serving/knative-ingress-gateway",
+					"ingressDomain": "mydomain.com",
+					"pathTemplate": "/{{ .Name }}/inference"
+				}`,
+			},
+		}
+		cfg, err := NewIngressConfig(cm)
+		g.Expect(err).Should(gomega.HaveOccurred())
+		g.Expect(cfg).To(gomega.BeNil())
+		g.Expect(err.Error()).To(gomega.ContainSubstring("invalid pathTemplate - must include both {{ .Name }} and {{ .Namespace }} to avoid route collisions"))
+	})
+
+	t.Run("pathTemplate valid with .Name and .Namespace starting with /", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			Data: map[string]string{
+				IngressConfigKeyName: `{
+					"kserveIngressGateway": "kserve/kserve-ingress-gateway",
+					"ingressGateway": "knative-serving/knative-ingress-gateway",
+					"ingressDomain": "mydomain.com",
+					"pathTemplate": "/{{ .Name }}/{{ .Namespace }}/inference"
+				}`,
+			},
+		}
+		cfg, err := NewIngressConfig(cm)
+		g.Expect(err).ShouldNot(gomega.HaveOccurred())
+		g.Expect(cfg).ShouldNot(gomega.BeNil())
+	})
 }


### PR DESCRIPTION
What this PR does / why we need it:
Implements the TODO in pkg/apis/serving/v1beta1/configmap.go:308 to validate that the pathTemplate ingress configuration generates a path that starts with / and uses both .Name and .Namespace to avoid route collisions. Returns an error when the template does not meet these criteria, consistent with the existing validation pattern in the function. Path without / already fails at runtime in GenerateUrlPath(), so this does not break any working configuration.

Which issue(s) this PR fixes: N/A
Feature/Issue validation/testing:

- [x] go test ./pkg/apis/serving/v1beta1/... all existing tests pass
- [x]  go test -race ./pkg/apis/serving/v1beta1/... no race conditions detected
- [x]  go vet ./pkg/apis/serving/v1beta1/... clean
- [x]  make generate && make manifests: no changes generated

Notes: 
- make precommit was attempted but failed during the Python venv setup step (ruff installation). The Go-specific checks (go vet, go test -race, make generate, make manifests) were run manually and all passed. No Python files were modified in this PR.

Checklist:
- [x]  Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x]  Has code been commented, particularly in hard-to-understand areas?
- [ ]  Have you made corresponding changes to the documentation?

```
release note:
Validate pathTemplate in IngressConfig to return an error when the generated path does not start with '/' or does not use both .Name and .Namespace to avoid collisions.
```