### PR TITLE
fix: template hardcoded namespace in LLMInferenceService CRD chart

### DIFF
--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceserviceconfigs.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-decode-template
-  namespace: kserve
+  namespace: {{ .Release.Namespace }}
 spec:
   annotations:
     serving.kserve.io/model-based-routing-enabled: "true"
@@ -303,7 +303,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-decode-worker-data-parallel
-  namespace: kserve
+  namespace: {{ .Release.Namespace }}
 spec:
   annotations:
     serving.kserve.io/model-based-routing-enabled: "true"
@@ -887,7 +887,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-prefill-template
-  namespace: kserve
+  namespace: {{ .Release.Namespace }}
 spec:
   prefill:
     annotations:
@@ -1130,7 +1130,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-prefill-worker-data-parallel
-  namespace: kserve
+  namespace: {{ .Release.Namespace }}
 spec:
   prefill:
     annotations:
@@ -1653,7 +1653,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-router-route
-  namespace: kserve
+  namespace: {{ .Release.Namespace }}
 spec:
   router:
     route:
@@ -1845,7 +1845,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-scheduler
-  namespace: kserve
+  namespace: {{ .Release.Namespace }}
 spec:
   router:
     scheduler:
@@ -2018,7 +2018,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-template
-  namespace: kserve
+  namespace: {{ .Release.Namespace }}
 spec:
   annotations:
     serving.kserve.io/model-based-routing-enabled: "true"
@@ -2260,7 +2260,7 @@ apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-worker-data-parallel
-  namespace: kserve
+  namespace: {{ .Release.Namespace }}
 spec:
   annotations:
     serving.kserve.io/model-based-routing-enabled: "true"


### PR DESCRIPTION
## Summary

The `cert-manager.io/inject-ca-from` annotation and `webhook.clientConfig.service.namespace` in the `kserve-llmisvc-crd` chart were hardcoded to the `kserve` namespace, preventing the chart from being deployed in environments using a different namespace.

The same issue existed in `charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml`, where all `LLMInferenceServiceConfig` resource `metadata.namespace` fields were hardcoded to `kserve`.

## Changes

- `charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml`: Templated `cert-manager.io/inject-ca-from` annotation and `webhook.clientConfig.service.namespace` with `{{ .Release.Namespace }}`
- `charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml`: Templated all `metadata.namespace` values with `{{ .Release.Namespace }}`

This is consistent with how namespace is handled in the `kserve-llmisvc-resources` chart.

## Testing

- `git diff` shows only the intended 10 replacements (2 in CRD template, 8 in resources.yaml)
- All occurrences of the hardcoded `kserve` namespace in these files have been replaced

Fixes #5325