### PR TITLE
refactor(llmisvc): pass reconciler to extendControllerSetup hook

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -377,7 +377,7 @@ func (r *LLMISVCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueOnLLMInferenceServicePods),
 			builder.WithPredicates(PodStatusPredicate()))
 
-	if err := extendControllerSetup(mgr, b); err != nil {
+	if err := extendControllerSetup(r, mgr, b); err != nil {
 		return fmt.Errorf("failed to extend controller setup: %w", err)
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/controller_setup_default.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_setup_default.go
@@ -25,6 +25,6 @@ import (
 
 // extendControllerSetup is a hook for distribution-specific controller setup such as
 // registering additional API schemes or adding ownership watches for platform-specific resources.
-func extendControllerSetup(_ manager.Manager, _ *builder.Builder) error {
+func extendControllerSetup(_ *LLMISVCReconciler, _ manager.Manager, _ *builder.Builder) error {
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Distribution-specific controller setup hooks may need reconciler methods while registering event handlers and watches for platform resources. Currently, `extendControllerSetup` only receives `manager.Manager` and `*builder.Builder`, which limits distro hooks to scheme registration and simple ownership watches.

Passes the reconciler as the first parameter, aligning the hook with the capabilities available to built-in watchers like `enqueueOnGatewayChange` - which use the reconciler for config resolution, base-ref merging, and paginated listing.

**Feature/Issue validation/testing**:

- [x] `go build ./...` compiles cleanly
- [x] No behavioral change - the default (upstream) hook ignores the new parameter

**Special notes for your reviewer**:

Two-line change. The upstream default stub simply adds an ignored `_` parameter. Distro companions (behind `//go:build distro`) can use the reconciler for richer event handler registration.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```