### PR TITLE
fix(e2e): replace removed VLLM_USE_V1 with VLLM_ENABLE_V1_MULTIPROCESSING

### DIFF
--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -62,7 +62,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                     "env": [
                         {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
-                        {"name": "VLLM_USE_V1", "value": "0"},
+                        {"name": "VLLM_ENABLE_V1_MULTIPROCESSING", "value": "0"},
                         *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                     ],
                     "resources": {
@@ -83,7 +83,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                     "env": [
                         {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
-                        {"name": "VLLM_USE_V1", "value": "0"},
+                        {"name": "VLLM_ENABLE_V1_MULTIPROCESSING", "value": "0"},
                         *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                     ],
                     "resources": {
@@ -117,7 +117,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                         "env": [
                             {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                             {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
-                            {"name": "VLLM_USE_V1", "value": "0"},
+                            {"name": "VLLM_ENABLE_V1_MULTIPROCESSING", "value": "0"},
                             *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                         ],
                         "resources": {
@@ -393,7 +393,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                     ],
                     "env": [
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
-                        {"name": "VLLM_USE_V1", "value": "0"},
+                        {"name": "VLLM_ENABLE_V1_MULTIPROCESSING", "value": "0"},
                         *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                     ],
                     "resources": {
@@ -418,7 +418,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                     ],
                     "env": [
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
-                        {"name": "VLLM_USE_V1", "value": "0"},
+                        {"name": "VLLM_ENABLE_V1_MULTIPROCESSING", "value": "0"},
                         *UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
                     ],
                     "resources": {

--- a/test/e2e/modelcache/test_localmodelcache.py
+++ b/test/e2e/modelcache/test_localmodelcache.py
@@ -123,7 +123,7 @@ async def test_vllm_modelcache():
                     value="1",
                 ),
                 client.V1EnvVar(
-                    name="VLLM_USE_V1",
+                    name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
             ],

--- a/test/e2e/predictor/test_huggingface_vllm_cpu.py
+++ b/test/e2e/predictor/test_huggingface_vllm_cpu.py
@@ -63,7 +63,7 @@ def test_huggingface_vllm_cpu_openai_chat_completions():
                     value="1",
                 ),
                 client.V1EnvVar(
-                    name="VLLM_USE_V1",
+                    name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
             ],
@@ -122,7 +122,7 @@ def test_huggingface_vllm_cpu_text_completion_streaming():
                     value="1",
                 ),
                 client.V1EnvVar(
-                    name="VLLM_USE_V1",
+                    name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
             ],
@@ -183,7 +183,7 @@ def test_huggingface_vllm_cpu_openai_completions():
                     value="1",
                 ),
                 client.V1EnvVar(
-                    name="VLLM_USE_V1",
+                    name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
             ],
@@ -241,7 +241,7 @@ def test_huggingface_vllm_openai_chat_completions_streaming():
                     value="1",
                 ),
                 client.V1EnvVar(
-                    name="VLLM_USE_V1",
+                    name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
             ],
@@ -305,7 +305,7 @@ def test_huggingface_vllm_cpu_rerank():
                     value="1",
                 ),
                 client.V1EnvVar(
-                    name="VLLM_USE_V1",
+                    name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
             ],


### PR DESCRIPTION
## Summary
- `VLLM_USE_V1` was removed in vLLM v0.11.1 (Nov 2025) as part of V0 engine deprecation
- With vLLM 0.20.0, the env var is silently ignored (`WARNING: Unknown vLLM environment variable detected: VLLM_USE_V1`), so V1's multiproc executor runs and crashes on resource-constrained CI runners with `RuntimeError: Engine core initialization failed`
- Replace with `VLLM_ENABLE_V1_MULTIPROCESSING=0` to disable worker process spawning and run in-process instead

The vLLM CPU tests are failing consistently (though not always all 3) across multiple unrelated PRs due to this issue.

## Test plan
- [ ] `test-huggingface-server-vllm (kustomize)` passes in CI
- [ ] Verify no remaining references to `VLLM_USE_V1` in test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)