### PR TITLE
feat(localmodel): align enhanceDownloadJob hook signature

### DIFF
--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -209,7 +209,7 @@ func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode
 			},
 		},
 	}
-	if err := enhanceDownloadJob(job, storageKey); err != nil {
+	if err := c.enhanceDownloadJob(ctx, job, storageKey); err != nil {
 		c.Log.Error(err, "Failed to enhance download job", "name", modelInfo.ModelName)
 		return nil, err
 	}
@@ -568,7 +568,7 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		fsHelper = NewFileSystemHelper(modelsRootFolder)
 	}
 
-	folderResult, err := ensureModelRootFolderExistsAndIsWritable(ctx, c, localModelConfig)
+	folderResult, err := c.ensureModelRootFolderExistsAndIsWritable(ctx, localModelConfig)
 	if err != nil || !folderResult.Continue {
 		if folderResult != nil {
 			return folderResult.Result, err

--- a/pkg/controller/v1alpha1/localmodelnode/platform_default.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_default.go
@@ -29,10 +29,12 @@ import (
 
 const MountPath = "/mnt/models"
 
-func enhanceDownloadJob(_ *batchv1.Job, _ string) error { return nil }
+func (c *LocalModelNodeReconciler) enhanceDownloadJob(_ context.Context, _ *batchv1.Job, _ string) error {
+	return nil
+}
 
 // TODO we need a way to ensure that the local path on persistent volume is the same as the local path of the node agent DaemonSet.
-func ensureModelRootFolderExistsAndIsWritable(_ context.Context, _ *LocalModelNodeReconciler,
+func (c *LocalModelNodeReconciler) ensureModelRootFolderExistsAndIsWritable(_ context.Context,
 	_ *v1beta1.LocalModelConfig,
 ) (*ensureModelRootFolderResult, error) {
 	if err := fsHelper.ensureModelRootFolderExists(); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The default (no-op) `enhanceDownloadJob` hook in `platform_default.go` accepts only the Job and storage key (2 params), while distribution-specific implementations need `context.Context` and `*LocalModelNodeReconciler` to access the API client and propagate context for platform-specific logic (e.g. resolving security contexts, MCS levels).

This expands the default stub signature to match the contract that platform hook implementations already depend on. The `ensureModelRootFolderExistsAndIsWritable` hook already follows this pattern (accepts context + reconciler).

**Which issue(s) this PR fixes**:

N/A - signature alignment for distribution hook support.

**Feature/Issue validation/testing**:

- [x] `go build ./pkg/controller/v1alpha1/localmodelnode/...` compiles
- [x] `go test ./pkg/controller/v1alpha1/localmodelnode/...` - 4 tests pass

**Special notes for your reviewer**:

This is a no-op change - the default implementation ignores the extra parameters. The expanded signature enables platform-specific builds to provide implementations that need API client access without modifying the upstream controller code.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```