### PR TITLE
fix(hack): resolve ShellCheck findings in shell scripts

### DIFF
--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright 2022 The KServe Authors
 #
@@ -12,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 set -e
 

--- a/hack/kserve_migration/kserve_migration.sh
+++ b/hack/kserve_migration/kserve_migration.sh
@@ -37,12 +37,11 @@ isControllerRunning() {
         fi
     done
     po_names=$(kubectl get po -n $namespace -o jsonpath='{.items[*].metadata.name}')
-    for po_name in "${prefix}-controller-manager"; do
-        if [ ! -z "${po_names##*$po_name*}" ]; then
-            log ERROR "${prefix} controller services are not installed completely."
-            exit 1;
-        fi
-    done
+    po_name="${prefix}-controller-manager"
+    if [ ! -z "${po_names##*$po_name*}" ]; then
+        log ERROR "${prefix} controller services are not installed completely."
+        exit 1;
+    fi
 }
 
 # Checks user preference on cleaning kfserving controller


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes three ShellCheck findings (SC1128, SC2066, SC2043) that the SAST shell-check pipeline flags on every build. These create noise in downstream builds where this check is run and will likely become enforced failures as SAST policies tighten.

**Feature/Issue validation/testing**:

- [x] Verified locally with ShellCheck 0.11.0 - no findings for SC1128, SC2066, SC2043

**Special notes for your reviewer**:

These are pre-existing issues in upstream scripts caught by the downstream Konflux SAST shell-check pipeline. The fixes are minimal and behavior-preserving.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```