### PR TITLE
build: narrow controller-gen RBAC path for v1beta1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ verify-minimal-crd-sync:
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen kustomize yq
 	@$(CONTROLLER_GEN) $(CRD_OPTIONS) paths=./pkg/apis/serving/... output:crd:dir=config/crd/full	
-	@$(CONTROLLER_GEN) rbac:roleName=kserve-manager-role paths={./pkg/controller/v1alpha1/inferencegraph,./pkg/controller/v1alpha1/trainedmodel,./pkg/controller/v1beta1/...} output:rbac:artifacts:config=config/rbac
+	@$(CONTROLLER_GEN) rbac:roleName=kserve-manager-role paths={./pkg/controller/v1alpha1/inferencegraph,./pkg/controller/v1alpha1/trainedmodel,./pkg/controller/v1beta1/inferenceservice} output:rbac:artifacts:config=config/rbac
 	@$(CONTROLLER_GEN) rbac:roleName=kserve-llmisvc-manager-role paths=./pkg/controller/v1alpha2/llmisvc output:rbac:artifacts:config=config/rbac/llmisvc
 	@$(CONTROLLER_GEN) rbac:roleName=kserve-localmodel-manager-role paths=./pkg/controller/v1alpha1/localmodel output:rbac:artifacts:config=config/rbac/localmodel
 	@$(CONTROLLER_GEN) rbac:roleName=kserve-localmodelnode-agent-role paths=./pkg/controller/v1alpha1/localmodelnode output:rbac:artifacts:config=config/rbac/localmodelnode


### PR DESCRIPTION
**What this PR does / why we need it**:

The `manifests` target scans `./pkg/controller/v1beta1/...` (recursive glob) for `//+kubebuilder:rbac:` markers when generating the `kserve-manager-role` ClusterRole. Meanwhile `inferencegraph` and `trainedmodel` are listed as explicit package paths.

`controller-gen` recursively picks up every sub-package under `v1beta1/` . Today only `inferenceservice` has RBAC markers under `v1beta1/`. When `llmisvc` graduates from `v1alpha2` to a v1beta-level package, the glob would pull its markers into the main manager role as well which might result in too broad permission.

This narrows the path to the explicit package, consistent with how every other controller is already listed.

**Feature/Issue validation/testing**:

- [x] `make manifests` produces identical `config/rbac/role.yaml` output (only `inferenceservice` has markers)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```