### PR TITLE
fix(llmisvc): `config/llmisvcconfig/**` to E2E test trigger paths

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -9,6 +9,7 @@ on:
       - "pkg/controller/v1alpha2/llmisvc/**"
       - "charts/kserve-llmisvc-resources/**"
       - "config/llmisvc/**"
+      - "config/llmisvcconfig/**"
       - "config/rbac/llmisvc/**"
       - "cmd/llmisvc/**"
       - "test/e2e/llmisvc/**"


### PR DESCRIPTION
The e2e-test-llmisvc workflow was missing config/llmisvcconfig/** in its pull_request path filters, so changes to LLM inference service configuration files did not trigger the E2E tests.
