### PR TITLE
feat(llmisvc): add PVC storage e2e tests for LLMInferenceService

### DIFF
--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -55,6 +55,4 @@ def pytest_configure(config):
         "markers", "model_routing: mark test as a model-based routing test"
     )
     config.addinivalue_line("markers", "lora: mark test as a LoRA adapter test")
-    config.addinivalue_line(
-        "markers", "pvc_storage: mark test as a PVC storage test"
-    )
+    config.addinivalue_line("markers", "pvc_storage: mark test as a PVC storage test")

--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -55,3 +55,6 @@ def pytest_configure(config):
         "markers", "model_routing: mark test as a model-based routing test"
     )
     config.addinivalue_line("markers", "lora: mark test as a LoRA adapter test")
+    config.addinivalue_line(
+        "markers", "pvc_storage: mark test as a PVC storage test"
+    )

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1666,9 +1666,7 @@ def create_model_download_job(
             namespace=namespace,
             body=job,
         )
-        logger.info(
-            f"Created model download Job {job_name} in namespace {namespace}"
-        )
+        logger.info(f"Created model download Job {job_name} in namespace {namespace}")
     except client.rest.ApiException as e:
         if e.status == 409:
             logger.info(

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1616,7 +1616,9 @@ def _s3_env_from_secret(namespace):
         )
     except client.rest.ApiException as e:
         if e.status == 404:
-            logger.info(f"S3 credentials secret {S3_CREDENTIALS_SECRET} not found, skipping")
+            logger.info(
+                f"S3 credentials secret {S3_CREDENTIALS_SECRET} not found, skipping"
+            )
             return [], []
         raise
 
@@ -1624,8 +1626,14 @@ def _s3_env_from_secret(namespace):
     env = []
     endpoint = annotations.get("serving.kserve.io/s3-endpoint", "")
     if endpoint:
-        scheme = "https" if annotations.get("serving.kserve.io/s3-usehttps", "1") != "0" else "http"
-        env.append(client.V1EnvVar(name="AWS_ENDPOINT_URL", value=f"{scheme}://{endpoint}"))
+        scheme = (
+            "https"
+            if annotations.get("serving.kserve.io/s3-usehttps", "1") != "0"
+            else "http"
+        )
+        env.append(
+            client.V1EnvVar(name="AWS_ENDPOINT_URL", value=f"{scheme}://{endpoint}")
+        )
     use_https = annotations.get("serving.kserve.io/s3-usehttps")
     if use_https is not None:
         env.append(client.V1EnvVar(name="S3_USE_HTTPS", value=use_https))

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -15,6 +15,7 @@
 import hashlib
 import os
 import re
+import time
 
 import pytest
 from ..common.gw_api import (
@@ -35,6 +36,13 @@ SCHEDULER_CONFIGMAP_NAME = "scheduler-config-e2e"
 SCHEDULER_CONFIGMAP_KEY = "epp"
 
 OPT_125M_MODEL_URI = os.environ.get("OPT_125M_MODEL_URI", "hf://facebook/opt-125m")
+
+# PVC storage test constants
+PVC_STORAGE_NAME = "e2e-pvc-model-storage"
+STORAGE_INITIALIZER_IMAGE = os.environ.get(
+    "STORAGE_INITIALIZER_IMAGE", "kserve/storage-initializer:latest"
+)
+MODEL_DOWNLOAD_JOB_NAME = "e2e-pvc-model-download"
 
 # Vanilla Kubernetes rejects runAsNonRoot-only containers when the image does not declare a USER.
 # Keep the templates OpenShift-safe and use an explicit non-root UID only in upstream CI test overrides.
@@ -148,6 +156,9 @@ LLMINFERENCESERVICE_CONFIGS = {
     },
     "model-fb-opt-125m": {
         "model": {"uri": OPT_125M_MODEL_URI, "name": "facebook/opt-125m"},
+    },
+    "model-pvc": {
+        "model": {"uri": f"pvc://{PVC_STORAGE_NAME}", "name": "facebook/opt-125m"},
     },
     "model-qwen2.5-0.5b": {
         "model": {
@@ -1531,3 +1542,212 @@ def delete_scheduler_configmap():
     except client.rest.ApiException as e:
         if e.status != 404:  # Ignore not found
             raise
+
+
+def create_pvc(
+    pvc_name=PVC_STORAGE_NAME,
+    namespace=KSERVE_TEST_NAMESPACE,
+    storage="2Gi",
+):
+    """Create a PersistentVolumeClaim for PVC storage tests.
+
+    Uses ReadWriteOnce (universally supported) and no explicit StorageClass
+    so it works on KinD, Minikube, and OpenShift with the cluster default.
+    """
+    inject_k8s_proxy()
+    core_v1 = client.CoreV1Api()
+
+    pvc = client.V1PersistentVolumeClaim(
+        api_version="v1",
+        kind="PersistentVolumeClaim",
+        metadata=client.V1ObjectMeta(
+            name=pvc_name,
+            namespace=namespace,
+        ),
+        spec=client.V1PersistentVolumeClaimSpec(
+            access_modes=["ReadWriteOnce"],
+            resources=client.V1VolumeResourceRequirements(
+                requests={"storage": storage},
+            ),
+        ),
+    )
+
+    try:
+        core_v1.create_namespaced_persistent_volume_claim(
+            namespace=namespace,
+            body=pvc,
+        )
+        logger.info(f"Created PVC {pvc_name} in namespace {namespace}")
+    except client.rest.ApiException as e:
+        if e.status == 409:
+            logger.info(f"PVC {pvc_name} already exists in namespace {namespace}")
+        else:
+            raise
+
+
+def delete_pvc(
+    pvc_name=PVC_STORAGE_NAME,
+    namespace=KSERVE_TEST_NAMESPACE,
+):
+    """Delete a PersistentVolumeClaim."""
+    inject_k8s_proxy()
+    core_v1 = client.CoreV1Api()
+
+    try:
+        core_v1.delete_namespaced_persistent_volume_claim(
+            name=pvc_name,
+            namespace=namespace,
+        )
+        logger.info(f"Deleted PVC {pvc_name} from namespace {namespace}")
+    except client.rest.ApiException as e:
+        if e.status != 404:
+            raise
+
+
+def create_model_download_job(
+    job_name=MODEL_DOWNLOAD_JOB_NAME,
+    pvc_name=PVC_STORAGE_NAME,
+    namespace=KSERVE_TEST_NAMESPACE,
+    model_uri=None,
+):
+    """Create a Kubernetes Job to download model files into a PVC.
+
+    Uses the KServe storage-initializer image with the same args format
+    used internally by LocalModelNode. No explicit security context is set
+    so the Job works under OpenShift restricted SCCs, KinD, and Minikube.
+    """
+    if model_uri is None:
+        model_uri = OPT_125M_MODEL_URI
+
+    inject_k8s_proxy()
+    batch_v1 = client.BatchV1Api()
+
+    job = client.V1Job(
+        api_version="batch/v1",
+        kind="Job",
+        metadata=client.V1ObjectMeta(
+            name=job_name,
+            namespace=namespace,
+        ),
+        spec=client.V1JobSpec(
+            ttl_seconds_after_finished=3600,
+            backoff_limit=3,
+            template=client.V1PodTemplateSpec(
+                spec=client.V1PodSpec(
+                    restart_policy="Never",
+                    containers=[
+                        client.V1Container(
+                            name="storage-initializer",
+                            image=STORAGE_INITIALIZER_IMAGE,
+                            args=[model_uri, "/mnt/models"],
+                            volume_mounts=[
+                                client.V1VolumeMount(
+                                    name="model-storage",
+                                    mount_path="/mnt/models",
+                                ),
+                            ],
+                        ),
+                    ],
+                    volumes=[
+                        client.V1Volume(
+                            name="model-storage",
+                            persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+                                claim_name=pvc_name,
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        ),
+    )
+
+    try:
+        batch_v1.create_namespaced_job(
+            namespace=namespace,
+            body=job,
+        )
+        logger.info(
+            f"Created model download Job {job_name} in namespace {namespace}"
+        )
+    except client.rest.ApiException as e:
+        if e.status == 409:
+            logger.info(
+                f"Model download Job {job_name} already exists in namespace {namespace}"
+            )
+        else:
+            raise
+
+
+def wait_for_job_completion(
+    job_name=MODEL_DOWNLOAD_JOB_NAME,
+    namespace=KSERVE_TEST_NAMESPACE,
+    timeout=600,
+):
+    """Wait for a Kubernetes Job to complete successfully."""
+    inject_k8s_proxy()
+    batch_v1 = client.BatchV1Api()
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        job = batch_v1.read_namespaced_job(name=job_name, namespace=namespace)
+
+        if job.status.succeeded and job.status.succeeded >= 1:
+            logger.info(f"Model download Job {job_name} completed successfully")
+            return
+
+        if job.status.failed and job.status.failed >= job.spec.backoff_limit:
+            raise RuntimeError(
+                f"Model download Job {job_name} failed after {job.status.failed} attempts"
+            )
+
+        time.sleep(10)
+
+    raise TimeoutError(
+        f"Model download Job {job_name} did not complete within {timeout}s"
+    )
+
+
+def delete_model_download_job(
+    job_name=MODEL_DOWNLOAD_JOB_NAME,
+    namespace=KSERVE_TEST_NAMESPACE,
+):
+    """Delete the model download Job and its pods."""
+    inject_k8s_proxy()
+    batch_v1 = client.BatchV1Api()
+
+    try:
+        batch_v1.delete_namespaced_job(
+            name=job_name,
+            namespace=namespace,
+            body=client.V1DeleteOptions(propagation_policy="Background"),
+        )
+        logger.info(f"Deleted model download Job {job_name} from namespace {namespace}")
+    except client.rest.ApiException as e:
+        if e.status != 404:
+            raise
+
+
+def ensure_pvc_with_model():
+    """Idempotent setup: create PVC and download model if not already done.
+
+    Safe to call from multiple test cases -- skips work that is already complete.
+    """
+    inject_k8s_proxy()
+    batch_v1 = client.BatchV1Api()
+
+    create_pvc()
+
+    try:
+        job = batch_v1.read_namespaced_job(
+            name=MODEL_DOWNLOAD_JOB_NAME,
+            namespace=KSERVE_TEST_NAMESPACE,
+        )
+        if job.status.succeeded and job.status.succeeded >= 1:
+            logger.info("Model download Job already completed, skipping")
+            return
+    except client.rest.ApiException as e:
+        if e.status != 404:
+            raise
+
+    create_model_download_job()
+    wait_for_job_completion()

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -40,9 +40,11 @@ OPT_125M_MODEL_URI = os.environ.get("OPT_125M_MODEL_URI", "hf://facebook/opt-125
 # PVC storage test constants
 PVC_STORAGE_NAME = "e2e-pvc-model-storage"
 STORAGE_INITIALIZER_IMAGE = os.environ.get(
-    "STORAGE_INITIALIZER_IMAGE", "kserve/storage-initializer:latest"
+    "STORAGE_INITIALIZER_IMAGE",
+    f"kserve/storage-initializer:{os.environ.get('TAG', 'latest')}",
 )
 MODEL_DOWNLOAD_JOB_NAME = "e2e-pvc-model-download"
+S3_CREDENTIALS_SECRET = os.environ.get("S3_CREDENTIALS_SECRET", "seaweedfs-s3-creds")
 
 # Vanilla Kubernetes rejects runAsNonRoot-only containers when the image does not declare a USER.
 # Keep the templates OpenShift-safe and use an explicit non-root UID only in upstream CI test overrides.
@@ -1604,6 +1606,41 @@ def delete_pvc(
             raise
 
 
+def _s3_env_from_secret(namespace):
+    """Read the S3 credentials secret and return (env_from, env) for a container."""
+    core_v1 = client.CoreV1Api()
+    try:
+        secret = core_v1.read_namespaced_secret(
+            name=S3_CREDENTIALS_SECRET,
+            namespace=namespace,
+        )
+    except client.rest.ApiException as e:
+        if e.status == 404:
+            logger.info(f"S3 credentials secret {S3_CREDENTIALS_SECRET} not found, skipping")
+            return [], []
+        raise
+
+    annotations = secret.metadata.annotations or {}
+    env = []
+    endpoint = annotations.get("serving.kserve.io/s3-endpoint", "")
+    if endpoint:
+        scheme = "https" if annotations.get("serving.kserve.io/s3-usehttps", "1") != "0" else "http"
+        env.append(client.V1EnvVar(name="AWS_ENDPOINT_URL", value=f"{scheme}://{endpoint}"))
+    use_https = annotations.get("serving.kserve.io/s3-usehttps")
+    if use_https is not None:
+        env.append(client.V1EnvVar(name="S3_USE_HTTPS", value=use_https))
+    verify_ssl = annotations.get("serving.kserve.io/s3-verifyssl")
+    if verify_ssl is not None:
+        env.append(client.V1EnvVar(name="S3_VERIFY_SSL", value=verify_ssl))
+
+    env_from = [
+        client.V1EnvFromSource(
+            secret_ref=client.V1SecretEnvSource(name=S3_CREDENTIALS_SECRET),
+        ),
+    ]
+    return env_from, env
+
+
 def create_model_download_job(
     job_name=MODEL_DOWNLOAD_JOB_NAME,
     pvc_name=PVC_STORAGE_NAME,
@@ -1621,6 +1658,10 @@ def create_model_download_job(
 
     inject_k8s_proxy()
     batch_v1 = client.BatchV1Api()
+
+    env_from, env = [], []
+    if model_uri.startswith("s3://"):
+        env_from, env = _s3_env_from_secret(namespace)
 
     job = client.V1Job(
         api_version="batch/v1",
@@ -1640,6 +1681,8 @@ def create_model_download_job(
                             name="storage-initializer",
                             image=STORAGE_INITIALIZER_IMAGE,
                             args=[model_uri, "/mnt/models"],
+                            env=env or None,
+                            env_from=env_from or None,
                             volume_mounts=[
                                 client.V1VolumeMount(
                                     name="model-storage",

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -34,6 +34,7 @@ from .fixtures import (
     create_router_resources,
     create_scheduler_configmap,
     delete_scheduler_configmap,
+    ensure_pvc_with_model,
     generate_test_id,
     inject_k8s_proxy,
 )
@@ -691,6 +692,57 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 pytest.mark.cluster_single_node,
                 pytest.mark.model_routing,
                 pytest.mark.lora,
+            ],
+        ),
+        # PVC storage tests -- validate direct PVC volume mount with real vLLM serving
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-single-cpu",
+                    "model-pvc",
+                ],
+                prompt="KServe is a",
+                response_assertion=assert_200_with_choices,
+                before_test=[ensure_pvc_with_model],
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.pvc_storage,
+            ],
+        ),
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-pd-cpu",
+                    "model-pvc",
+                ],
+                prompt="KServe is a",
+                response_assertion=assert_200_with_choices,
+                before_test=[ensure_pvc_with_model],
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.pvc_storage,
+            ],
+        ),
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-simulated-dp-ep-cpu",
+                    "model-pvc",
+                ],
+                prompt="KServe is a",
+                before_test=[ensure_pvc_with_model],
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_multi_node,
+                pytest.mark.pvc_storage,
             ],
         ),
     ],


### PR DESCRIPTION
Add three new parametrized test cases to validate PVC-based model storage across different deployment topologies:

1. Single-node: workload-single-cpu with model loaded from PVC
2. PD disaggregation: workload-pd-cpu with shared PVC mount
3. LWS multi-worker: workload-simulated-dp-ep-cpu with PVC

The tests use real vLLM CPU serving with facebook/opt-125m downloaded into a PVC via a Kubernetes Job running the kserve storage-initializer.

The PVC setup is idempotent and cluster-agnostic (no hardcoded StorageClass, no explicit security context) so it works on KinD, Minikube, and OpenShift.
