### PR TITLE
ci: increase s3-init job backoff to survive transient HF outages

### DIFF
--- a/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: s3-init
 spec:
-  activeDeadlineSeconds: 900
+  activeDeadlineSeconds: 1800
   template:
     spec:
       initContainers:
@@ -55,4 +55,4 @@ spec:
       - name: model-cache
         emptyDir: {}
       restartPolicy: Never
-  backoffLimit: 3
+  backoffLimit: 5

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -86,7 +86,7 @@ if [[ $ENABLE_LLMISVC == "false" || $ENABLE_KSERVE_WITH_LLMISVC == "true" ]]; th
   echo "Add testing models to s3 storage ..."
   sed "s|kserve/storage-initializer:latest|${KO_DOCKER_REPO:-kserve}/${STORAGE_INIT_IMG:-storage-initializer}:${TAG:-latest}|g" \
     config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml | kubectl apply -n kserve -f -
-  if ! kubectl wait --for=condition=complete --timeout=900s job/s3-init -n kserve; then
+  if ! kubectl wait --for=condition=complete --timeout=1800s job/s3-init -n kserve; then
     echo "S3 init job failed. Pod status and logs:"
     kubectl get pods -l job-name=s3-init -n kserve
     kubectl logs -l job-name=s3-init -n kserve --all-containers --tail=50 || true
@@ -129,7 +129,7 @@ else
   echo "Pre-caching opt-125m model in SeaweedFS ..."
   sed "s|kserve/storage-initializer:latest|${KO_DOCKER_REPO:-kserve}/${STORAGE_INIT_IMG:-storage-initializer}:${TAG:-latest}|g" \
     "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml" | kubectl apply -n kserve -f -
-  if ! kubectl wait --for=condition=complete --timeout=900s job/s3-init -n kserve; then
+  if ! kubectl wait --for=condition=complete --timeout=1800s job/s3-init -n kserve; then
     echo "S3 init job failed. Pod status and logs:"
     kubectl get pods -l job-name=s3-init -n kserve
     kubectl logs -l job-name=s3-init -n kserve --all-containers --tail=50 || true


### PR DESCRIPTION
The s3-init Job pre-caches the facebook/opt-125m model from HuggingFace Hub into the local SeaweedFS S3 store.  When the CI runner cannot reach hf.co (transient network blip, rate-limit, etc.) each pod attempt exits immediately with Init:Error.  With backoffLimit:3 all four attempts are exhausted quickly — well within the 900 s deadline — and the setup step fails, blocking the whole llmisvc e2e workflow despite the code changes being unrelated.

Kubernetes Jobs already implement exponential backoff between retries (10 s, 20 s, 40 s, 80 s, 160 s …).  Rather than managing retries in shell, let the Job machinery handle it:

- backoffLimit: 3 -> 5  (6 pod attempts; up to ~310 s of backoff delay)
- activeDeadlineSeconds: 900 -> 1800  (gives the full backoff sequence room to complete even if each failed pod takes a few seconds)

The kubectl wait timeouts in setup-kserve.sh are raised to match.

See example in https://github.com/kserve/kserve/actions/runs/26883810633/job/79291792422?pr=5623