### PR TITLE
docs: clarify llmisvc gateway portability and add examples

### DIFF
--- a/charts/_common/kserve-llmisvc-resources-specific.yaml
+++ b/charts/_common/kserve-llmisvc-resources-specific.yaml
@@ -78,23 +78,3 @@ kserve:
       terminationGracePeriodSeconds: 10
   controller:
     deploymentMode: Knative
-    gateway:
-      domain: example.com
-      additionalIngressDomains: []
-      domainTemplate: '{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}'
-      pathTemplate: ''
-      urlScheme: http
-      disableIstioVirtualHost: false
-      disableIngressCreation: false
-      disableHTTPRouteTimeout: false
-      localGateway:
-        gateway: knative-serving/knative-local-gateway
-        gatewayService: knative-local-gateway.istio-system.svc.cluster.local
-        knativeGatewayService: ''
-      ingressGateway:
-        enableGatewayApi: false
-        kserveGateway: kserve/kserve-ingress-gateway
-        createGateway: false
-        gateway: knative-serving/knative-ingress-gateway
-        className: istio
-        gatewayClassName: envoy

--- a/charts/_common/kserve-llmisvc-resources-specific.yaml
+++ b/charts/_common/kserve-llmisvc-resources-specific.yaml
@@ -97,4 +97,4 @@ kserve:
         createGateway: false
         gateway: knative-serving/knative-ingress-gateway
         className: istio
-
+        gatewayApiClassName: envoy

--- a/charts/_common/kserve-llmisvc-resources-specific.yaml
+++ b/charts/_common/kserve-llmisvc-resources-specific.yaml
@@ -97,4 +97,4 @@ kserve:
         createGateway: false
         gateway: knative-serving/knative-ingress-gateway
         className: istio
-        gatewayApiClassName: envoy
+        gatewayClassName: envoy

--- a/charts/_common/kserve-resources-specific.yaml
+++ b/charts/_common/kserve-resources-specific.yaml
@@ -57,6 +57,7 @@ kserve:
         createGateway: false
         gateway: knative-serving/knative-ingress-gateway
         className: istio
+        gatewayApiClassName: envoy
     nodeSelector: {}
     tolerations: []
     topologySpreadConstraints: []
@@ -74,4 +75,3 @@ kserve:
         memory: 300Mi
     knativeAddressableResolver:
       enabled: false
-

--- a/charts/_common/kserve-resources-specific.yaml
+++ b/charts/_common/kserve-resources-specific.yaml
@@ -57,7 +57,7 @@ kserve:
         createGateway: false
         gateway: knative-serving/knative-ingress-gateway
         className: istio
-        gatewayApiClassName: envoy
+        gatewayClassName: envoy
     nodeSelector: {}
     tolerations: []
     topologySpreadConstraints: []

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -43,7 +43,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.controller.gateway.domain | string | `"example.com"` |  |
 | kserve.controller.gateway.domainTemplate | string | `"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"` |  |
 | kserve.controller.gateway.ingressGateway.className | string | `"istio"` |  |
-| kserve.controller.gateway.ingressGateway.gatewayApiClassName | string | `"envoy"` |  |
+| kserve.controller.gateway.ingressGateway.gatewayClassName | string | `"envoy"` |  |
 | kserve.controller.gateway.ingressGateway.createGateway | bool | `false` |  |
 | kserve.controller.gateway.ingressGateway.enableGatewayApi | bool | `false` |  |
 | kserve.controller.gateway.ingressGateway.gateway | string | `"knative-serving/knative-ingress-gateway"` |  |

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -43,6 +43,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.controller.gateway.domain | string | `"example.com"` |  |
 | kserve.controller.gateway.domainTemplate | string | `"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"` |  |
 | kserve.controller.gateway.ingressGateway.className | string | `"istio"` |  |
+| kserve.controller.gateway.ingressGateway.gatewayApiClassName | string | `"envoy"` |  |
 | kserve.controller.gateway.ingressGateway.createGateway | bool | `false` |  |
 | kserve.controller.gateway.ingressGateway.enableGatewayApi | bool | `false` |  |
 | kserve.controller.gateway.ingressGateway.gateway | string | `"knative-serving/knative-ingress-gateway"` |  |

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -36,23 +36,6 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.autoscaler.scaleUpStabilizationWindowSeconds | string | `"0"` |  |
 | kserve.certManager.enabled | string | `""` |  |
 | kserve.controller.deploymentMode | string | `"Knative"` |  |
-| kserve.controller.gateway.additionalIngressDomains | list | `[]` |  |
-| kserve.controller.gateway.disableHTTPRouteTimeout | bool | `false` |  |
-| kserve.controller.gateway.disableIngressCreation | bool | `false` |  |
-| kserve.controller.gateway.disableIstioVirtualHost | bool | `false` |  |
-| kserve.controller.gateway.domain | string | `"example.com"` |  |
-| kserve.controller.gateway.domainTemplate | string | `"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"` |  |
-| kserve.controller.gateway.ingressGateway.className | string | `"istio"` |  |
-| kserve.controller.gateway.ingressGateway.gatewayClassName | string | `"envoy"` |  |
-| kserve.controller.gateway.ingressGateway.createGateway | bool | `false` |  |
-| kserve.controller.gateway.ingressGateway.enableGatewayApi | bool | `false` |  |
-| kserve.controller.gateway.ingressGateway.gateway | string | `"knative-serving/knative-ingress-gateway"` |  |
-| kserve.controller.gateway.ingressGateway.kserveGateway | string | `"kserve/kserve-ingress-gateway"` |  |
-| kserve.controller.gateway.localGateway.gateway | string | `"knative-serving/knative-local-gateway"` |  |
-| kserve.controller.gateway.localGateway.gatewayService | string | `"knative-local-gateway.istio-system.svc.cluster.local"` |  |
-| kserve.controller.gateway.localGateway.knativeGatewayService | string | `""` |  |
-| kserve.controller.gateway.pathTemplate | string | `""` |  |
-| kserve.controller.gateway.urlScheme | string | `"http"` |  |
 | kserve.createSharedResources | bool | `true` |  |
 | kserve.inferenceServiceConfig.enabled | string | `""` |  |
 | kserve.inferenceservice.resources.limits.cpu | string | `"1"` |  |

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -201,6 +201,6 @@ kserve:
         createGateway: false
         gateway: knative-serving/knative-ingress-gateway
         className: istio
-        gatewayApiClassName: envoy
+        gatewayClassName: envoy
 commonLabels: {}
 commonAnnotations: {}

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -182,25 +182,5 @@ kserve:
       terminationGracePeriodSeconds: 10
   controller:
     deploymentMode: Knative
-    gateway:
-      domain: example.com
-      additionalIngressDomains: []
-      domainTemplate: '{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}'
-      pathTemplate: ''
-      urlScheme: http
-      disableIstioVirtualHost: false
-      disableIngressCreation: false
-      disableHTTPRouteTimeout: false
-      localGateway:
-        gateway: knative-serving/knative-local-gateway
-        gatewayService: knative-local-gateway.istio-system.svc.cluster.local
-        knativeGatewayService: ''
-      ingressGateway:
-        enableGatewayApi: false
-        kserveGateway: kserve/kserve-ingress-gateway
-        createGateway: false
-        gateway: knative-serving/knative-ingress-gateway
-        className: istio
-        gatewayClassName: envoy
 commonLabels: {}
 commonAnnotations: {}

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -201,5 +201,6 @@ kserve:
         createGateway: false
         gateway: knative-serving/knative-ingress-gateway
         className: istio
+        gatewayApiClassName: envoy
 commonLabels: {}
 commonAnnotations: {}

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -36,7 +36,7 @@ $ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --v
 | kserve.controller.gateway.domain | string | `"example.com"` |  |
 | kserve.controller.gateway.domainTemplate | string | `"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"` |  |
 | kserve.controller.gateway.ingressGateway.className | string | `"istio"` |  |
-| kserve.controller.gateway.ingressGateway.gatewayApiClassName | string | `"envoy"` |  |
+| kserve.controller.gateway.ingressGateway.gatewayClassName | string | `"envoy"` |  |
 | kserve.controller.gateway.ingressGateway.createGateway | bool | `false` |  |
 | kserve.controller.gateway.ingressGateway.enableGatewayApi | bool | `false` |  |
 | kserve.controller.gateway.ingressGateway.gateway | string | `"knative-serving/knative-ingress-gateway"` |  |

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -36,6 +36,7 @@ $ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --v
 | kserve.controller.gateway.domain | string | `"example.com"` |  |
 | kserve.controller.gateway.domainTemplate | string | `"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"` |  |
 | kserve.controller.gateway.ingressGateway.className | string | `"istio"` |  |
+| kserve.controller.gateway.ingressGateway.gatewayApiClassName | string | `"envoy"` |  |
 | kserve.controller.gateway.ingressGateway.createGateway | bool | `false` |  |
 | kserve.controller.gateway.ingressGateway.enableGatewayApi | bool | `false` |  |
 | kserve.controller.gateway.ingressGateway.gateway | string | `"knative-serving/knative-ingress-gateway"` |  |

--- a/charts/kserve-resources/files/kserve/ingress_gateway-patch.yaml
+++ b/charts/kserve-resources/files/kserve/ingress_gateway-patch.yaml
@@ -4,7 +4,7 @@ kind: Gateway
 metadata:
   name: kserve-ingress-gateway
 spec:
-  gatewayClassName: envoy
+  gatewayClassName: {{ .Values.kserve.controller.gateway.ingressGateway.className }}
   listeners:
    - name: http
      port: 80

--- a/charts/kserve-resources/files/kserve/ingress_gateway-patch.yaml
+++ b/charts/kserve-resources/files/kserve/ingress_gateway-patch.yaml
@@ -4,7 +4,7 @@ kind: Gateway
 metadata:
   name: kserve-ingress-gateway
 spec:
-  gatewayClassName: {{ .Values.kserve.controller.gateway.ingressGateway.className }}
+  gatewayClassName: {{ .Values.kserve.controller.gateway.ingressGateway.gatewayApiClassName }}
   listeners:
    - name: http
      port: 80

--- a/charts/kserve-resources/files/kserve/ingress_gateway-patch.yaml
+++ b/charts/kserve-resources/files/kserve/ingress_gateway-patch.yaml
@@ -4,7 +4,7 @@ kind: Gateway
 metadata:
   name: kserve-ingress-gateway
 spec:
-  gatewayClassName: {{ .Values.kserve.controller.gateway.ingressGateway.gatewayApiClassName }}
+  gatewayClassName: {{ .Values.kserve.controller.gateway.ingressGateway.gatewayClassName }}
   listeners:
    - name: http
      port: 80

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -163,7 +163,7 @@ kserve:
         createGateway: false
         gateway: knative-serving/knative-ingress-gateway
         className: istio
-        gatewayApiClassName: envoy
+        gatewayClassName: envoy
     nodeSelector: {}
     tolerations: []
     topologySpreadConstraints: []

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -163,6 +163,7 @@ kserve:
         createGateway: false
         gateway: knative-serving/knative-ingress-gateway
         className: istio
+        gatewayApiClassName: envoy
     nodeSelector: {}
     tolerations: []
     topologySpreadConstraints: []

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -127,7 +127,7 @@ This creates `LLMInferenceServiceConfig` named `llmisvc-intelligent-inference-sc
 - vLLM server container serving `/mnt/models`
 - Router with scheduler pointing at the EPP service
 
-### 6.2 Use this config in the Inference Service
+### 5.2 Use this config in the Inference Service
 
 The Inference Service (next step) references this config via `baseRefs` (e.g. `llmisvc-intelligent-inference-scheduling`).
 

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -114,7 +114,7 @@ The Job uses [kserve-storage-initializer](https://github.com/kserve/kserve/tree/
 
 LLMInferenceServiceConfig defines the **pod and router template** (containers, volumes, scheduler, probes). The actual inference service will reference this by name.
 
-### 6.1 Default config (intelligent inference scheduling)
+### 5.1 Default config (intelligent inference scheduling)
 
 Apply the default config:
 

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -183,7 +183,7 @@ The `LLMInferenceService` created earlier already provisions the `InferencePool`
 - Agentgateway example: [gateway-agentgateway.yaml](./gateway-agentgateway.yaml)
 - Envoy AI Gateway extension: [ai-gateway-route.yaml](./ai-gateway-route.yaml)
 
-### 7.1 Gateway
+### 7.2 Gateway
 
 ```bash
 kubectl apply -f gateway.yaml -n kserve-lab
@@ -204,7 +204,7 @@ With that in place, the standard `LLMInferenceService` path is:
 - `HTTPRoute` -> `InferencePool`
 - `InferencePool` / scheduler -> selected inference pod
 
-### 7.2 Envoy AI Gateway extension
+### 7.3 Envoy AI Gateway extension
 
 If you also want model-name routing for OpenAI-compatible clients, apply the Envoy-specific `AIGatewayRoute` example below. This step is optional and only applies when your gateway provider supports `AIGatewayRoute`.
 

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -189,7 +189,7 @@ The `LLMInferenceService` created earlier already provisions the `InferencePool`
 kubectl apply -f gateway.yaml -n kserve-lab
 ```
 
-[gateway.yaml](./gateway.yaml) defines a `Gateway` named `ai-gateway` with an HTTP listener on port 80. Before applying it, replace `gatewayClassName` with the GatewayClass provided by your cluster.
+[gateway.yaml](./gateway.yaml) defines a `Gateway` named `ai-gateway` with an HTTP listener on port 80 and defaults `gatewayClassName` to `envoy`. Change it only if your cluster uses a different GatewayClass.
 
 If you are using [Agentgateway's Kubernetes inference support](https://agentgateway.dev/docs/kubernetes/latest/inference/), you can apply the ready-to-use sample instead:
 

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -18,7 +18,7 @@ Meet the [LLMInferenceService minimum requirements](https://kserve.github.io/web
 - **Cert Manager**: 1.18.0+
 - **Gateway API**: 1.3.0+
 - **Gateway API Inference Extension (GIE)**: 1.2.0
-- **Gateway provider**: Envoy Gateway v1.5.0+
+- **Gateway provider**: any implementation that supports the required Gateway API and Gateway API Inference Extension resources
 - **LeaderWorkerSet**: 0.6.2+ (for multi-node deployments)
 - `kubectl` configured for your cluster, **cluster admin** permissions, **helm** v3+
 
@@ -27,7 +27,8 @@ For this guide you also need:
 - Kubernetes cluster with GPU nodes (`nvidia.com/gpu`)
 - KServe and LLM Inference Service CRDs installed (see [Kubernetes Deployment - LLMIsvc](https://kserve.github.io/website/docs/next/admin-guide/kubernetes-deployment-llmisvc))
 - [Hugging Face](https://huggingface.co/) account and token for `RedHatAI/gpt-oss-20b`
-- Optional: Envoy-based [Gateway API](https://gateway-api.sigs.k8s.io/) and AIGatewayRoute for the AI gateway
+- Optional: a [Gateway API](https://gateway-api.sigs.k8s.io/) provider for external exposure
+- Optional: Envoy AI Gateway if you want model-name routing via `AIGatewayRoute`
 - Optional: Prometheus + Grafana for metrics
 
 ---
@@ -158,9 +159,14 @@ kubectl get pods -n kserve-lab -l app.kubernetes.io/name=gpt-oss-20b
 
 ---
 
-## 7. AI Gateway and Route
+## 7. Gateway integration
 
-To expose the model behind an AI gateway and route by model name (e.g. for OpenAI-compatible clients), create a Gateway and an AIGatewayRoute.
+KServe's portable integration surface for `LLMInferenceService` routing is:
+
+- `Gateway` and `HTTPRoute` from Gateway API
+- `InferencePool` from Gateway API Inference Extension
+
+The `LLMInferenceService` created earlier already provisions the `InferencePool` and manages the `HTTPRoute` that points to it. To expose that route externally, create a `Gateway` backed by your cluster's GatewayClass.
 
 ### 7.1 Gateway
 
@@ -168,22 +174,31 @@ To expose the model behind an AI gateway and route by model name (e.g. for OpenA
 kubectl apply -f gateway.yaml -n kserve-lab
 ```
 
-[gateway.yaml](./gateway.yaml) defines an Envoy-based `Gateway` `ai-gateway` with an HTTP listener on port 80. Ensure the cluster has a Gateway controller that implements `gatewayClassName: envoy` (e.g. Envoy Gateway with AIGatewayRoute support).
+[gateway.yaml](./gateway.yaml) defines a `Gateway` named `ai-gateway` with an HTTP listener on port 80. Before applying it, replace `gatewayClassName` with the GatewayClass provided by your cluster.
 
-### 7.2 AIGatewayRoute
+With that in place, the standard `LLMInferenceService` path is:
+
+- client -> `Gateway`
+- `Gateway` -> KServe-managed `HTTPRoute`
+- `HTTPRoute` -> `InferencePool`
+- `InferencePool` / scheduler -> selected inference pod
+
+### 7.2 Envoy AI Gateway extension
+
+If you also want model-name routing for OpenAI-compatible clients, apply the Envoy-specific `AIGatewayRoute` example below. This step is optional and only applies when your gateway provider supports `AIGatewayRoute`.
 
 ```bash
 kubectl apply -f ai-gateway-route.yaml -n kserve-lab
 ```
 
-[ai-gateway-route.yaml](./ai-gateway-route.yaml) defines an `AIGatewayRoute` that:
+[ai-gateway-route.yaml](./ai-gateway-route.yaml) defines an Envoy AI Gateway `AIGatewayRoute` that:
 
 - Attaches to `ai-gateway`
 - Matches requests with header `x-ai-eg-model: RedHatAI/gpt-oss-20b`
 - Backends to the LLMInferenceService’s `InferencePool`: `gpt-oss-20b-inference-pool`
 - Optionally tracks token usage via `llmRequestCosts`
 
-Clients should send the header `x-ai-eg-model: RedHatAI/gpt-oss-20b` when calling the gateway.
+Clients should send the header `x-ai-eg-model: RedHatAI/gpt-oss-20b` when calling the gateway through Envoy AI Gateway.
 
 ---
 
@@ -215,7 +230,7 @@ Either:
 
 - Or in [kustomization.yaml](./kustomization.yaml), comment out `inference_default.yaml` and uncomment `inference_prefix_cache.yaml`, then run `kubectl apply -k . -n kserve-lab`.
 
-The Gateway and Route from step 7 still apply; they reference the same `InferencePool` name.
+The Gateway and optional Envoy AI Gateway route from step 7 still apply; they reference the same `InferencePool` name.
 
 ---
 
@@ -251,7 +266,7 @@ Either:
 
 - Or in [kustomization.yaml](./kustomization.yaml), comment out `inference_default.yaml` and uncomment `inference_pd_disaggregation.yaml`, then run `kubectl apply -k . -n kserve-lab`.
 
-The Gateway and Route from step 7 still apply; they reference the same `InferencePool` name.
+The Gateway and optional Envoy AI Gateway route from step 7 still apply; they reference the same `InferencePool` name.
 
 ---
 
@@ -294,7 +309,8 @@ Import in Grafana: **Dashboards** → **New** → **Import** → upload the JSON
 1. `kubectl apply -f model_weights_job.yaml -n kserve-lab` → wait for completion
 1. `kubectl apply -f llmisvc_config_default.yaml -n kserve-lab`
 1. `kubectl apply -f inference_default.yaml -n kserve-lab`
-1. `kubectl apply -f gateway.yaml -n kserve-lab` and `kubectl apply -f ai-gateway-route.yaml -n kserve-lab`
+1. `kubectl apply -f gateway.yaml -n kserve-lab`
+1. (Optional, Envoy AI Gateway only) `kubectl apply -f ai-gateway-route.yaml -n kserve-lab`
 1. (Alternative) Prefix caching: `llmisvc_config_prefix_cache.yaml` then `inference_prefix_cache.yaml`
 1. (Alternative) Prefill Decode Disaggregation: `inference_pd_disaggregation.yaml`
 1. (Optional) `service_monitor.yaml` for Prometheus

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -177,7 +177,7 @@ The `LLMInferenceService` created earlier already provisions the `InferencePool`
 | Scheduler / EPP integration | Gateway API Inference Extension | Yes | Requires provider support for `InferencePool` |
 | Model-name routing | `AIGatewayRoute` | No | Envoy AI Gateway-specific extension |
 
-### 7.0.1 Gateway provider examples
+### 7.1 Gateway provider examples
 
 - Provider-neutral template: [gateway.yaml](./gateway.yaml)
 - Agentgateway example: [gateway-agentgateway.yaml](./gateway-agentgateway.yaml)

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -168,7 +168,7 @@ KServe's portable integration surface for `LLMInferenceService` routing is:
 
 The `LLMInferenceService` created earlier already provisions the `InferencePool` and manages the `HTTPRoute` that points to it. To expose that route externally, create a `Gateway` backed by your cluster's GatewayClass.
 
-### 7.0 Provider matrix
+### 7.1 Provider matrix
 
 | Capability | Standard API | Portable across providers | Notes |
 |-----------|--------------|---------------------------|-------|
@@ -177,13 +177,13 @@ The `LLMInferenceService` created earlier already provisions the `InferencePool`
 | Scheduler / EPP integration | Gateway API Inference Extension | Yes | Requires provider support for `InferencePool` |
 | Model-name routing | `AIGatewayRoute` | No | Envoy AI Gateway-specific extension |
 
-### 7.1 Gateway provider examples
+### 7.2 Gateway provider examples
 
 - Provider-neutral template: [gateway.yaml](./gateway.yaml)
 - Agentgateway example: [gateway-agentgateway.yaml](./gateway-agentgateway.yaml)
 - Envoy AI Gateway extension: [ai-gateway-route.yaml](./ai-gateway-route.yaml)
 
-### 7.2 Gateway
+### 7.3 Gateway
 
 ```bash
 kubectl apply -f gateway.yaml -n kserve-lab
@@ -204,7 +204,7 @@ With that in place, the standard `LLMInferenceService` path is:
 - `HTTPRoute` -> `InferencePool`
 - `InferencePool` / scheduler -> selected inference pod
 
-### 7.3 Envoy AI Gateway extension
+### 7.4 Envoy AI Gateway extension
 
 If you also want model-name routing for OpenAI-compatible clients, apply the Envoy-specific `AIGatewayRoute` example below. This step is optional and only applies when your gateway provider supports `AIGatewayRoute`.
 

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -337,7 +337,7 @@ Import in Grafana: **Dashboards** → **New** → **Import** → upload the JSON
 1. (Optional) `service_monitor.yaml` for Prometheus
 1. (Optional) Import Grafana dashboards
 
-Or use Kustomize from this directory for the core llmisvc resources (after fixing the HF token in the secret and choosing default vs prefix-cache inference). Apply your gateway manifest separately:
+Or use Kustomize from this directory. It applies the core llmisvc resources (after fixing the HF token in the secret and choosing default vs prefix-cache inference) and the default Envoy Gateway. To use a different gateway provider, swap `gateway.yaml` with `gateway-agentgateway.yaml` in [kustomization.yaml](./kustomization.yaml):
 
 ```bash
 kubectl apply -k docs/samples/llmisvc/e2e-gpt-oss/ -n kserve-lab

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -168,6 +168,21 @@ KServe's portable integration surface for `LLMInferenceService` routing is:
 
 The `LLMInferenceService` created earlier already provisions the `InferencePool` and manages the `HTTPRoute` that points to it. To expose that route externally, create a `Gateway` backed by your cluster's GatewayClass.
 
+### 7.0 Provider matrix
+
+| Capability | Standard API | Portable across providers | Notes |
+|-----------|--------------|---------------------------|-------|
+| External listener | `Gateway` | Yes | Choose the `gatewayClassName` for your provider |
+| LLM routing path | `HTTPRoute` -> `InferencePool` | Yes | This is the standard KServe contract |
+| Scheduler / EPP integration | Gateway API Inference Extension | Yes | Requires provider support for `InferencePool` |
+| Model-name routing | `AIGatewayRoute` | No | Envoy AI Gateway-specific extension |
+
+### 7.0.1 Gateway provider examples
+
+- Provider-neutral template: [gateway.yaml](./gateway.yaml)
+- Agentgateway example: [gateway-agentgateway.yaml](./gateway-agentgateway.yaml)
+- Envoy AI Gateway extension: [ai-gateway-route.yaml](./ai-gateway-route.yaml)
+
 ### 7.1 Gateway
 
 ```bash
@@ -175,6 +190,12 @@ kubectl apply -f gateway.yaml -n kserve-lab
 ```
 
 [gateway.yaml](./gateway.yaml) defines a `Gateway` named `ai-gateway` with an HTTP listener on port 80. Before applying it, replace `gatewayClassName` with the GatewayClass provided by your cluster.
+
+If you are using [Agentgateway's Kubernetes inference support](https://agentgateway.dev/docs/kubernetes/latest/inference/), you can apply the ready-to-use sample instead:
+
+```bash
+kubectl apply -f gateway-agentgateway.yaml -n kserve-lab
+```
 
 With that in place, the standard `LLMInferenceService` path is:
 
@@ -309,14 +330,14 @@ Import in Grafana: **Dashboards** → **New** → **Import** → upload the JSON
 1. `kubectl apply -f model_weights_job.yaml -n kserve-lab` → wait for completion
 1. `kubectl apply -f llmisvc_config_default.yaml -n kserve-lab`
 1. `kubectl apply -f inference_default.yaml -n kserve-lab`
-1. `kubectl apply -f gateway.yaml -n kserve-lab`
+1. `kubectl apply -f gateway.yaml -n kserve-lab` or `kubectl apply -f gateway-agentgateway.yaml -n kserve-lab`
 1. (Optional, Envoy AI Gateway only) `kubectl apply -f ai-gateway-route.yaml -n kserve-lab`
 1. (Alternative) Prefix caching: `llmisvc_config_prefix_cache.yaml` then `inference_prefix_cache.yaml`
 1. (Alternative) Prefill Decode Disaggregation: `inference_pd_disaggregation.yaml`
 1. (Optional) `service_monitor.yaml` for Prometheus
 1. (Optional) Import Grafana dashboards
 
-Or use Kustomize from this directory (after fixing the HF token in the secret and choosing default vs prefix-cache inference):
+Or use Kustomize from this directory for the core llmisvc resources (after fixing the HF token in the secret and choosing default vs prefix-cache inference). Apply your gateway manifest separately:
 
 ```bash
 kubectl apply -k docs/samples/llmisvc/e2e-gpt-oss/ -n kserve-lab

--- a/docs/samples/llmisvc/e2e-gpt-oss/gateway-agentgateway.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/gateway-agentgateway.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ai-gateway
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80

--- a/docs/samples/llmisvc/e2e-gpt-oss/gateway.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/gateway.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   # Replace this with the GatewayClass provided by your cluster.
   # The companion AIGatewayRoute example in this directory is Envoy AI Gateway-specific.
-  gatewayClassName: envoy
+  gatewayClassName: change-me
   listeners:
     - name: http
       protocol: HTTP

--- a/docs/samples/llmisvc/e2e-gpt-oss/gateway.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/gateway.yaml
@@ -4,6 +4,8 @@ kind: Gateway
 metadata:
   name: ai-gateway
 spec:
+  # Replace this with the GatewayClass provided by your cluster.
+  # The companion AIGatewayRoute example in this directory is Envoy AI Gateway-specific.
   gatewayClassName: envoy
   listeners:
     - name: http

--- a/docs/samples/llmisvc/e2e-gpt-oss/gateway.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/gateway.yaml
@@ -4,9 +4,9 @@ kind: Gateway
 metadata:
   name: ai-gateway
 spec:
-  # Replace this with the GatewayClass provided by your cluster.
-  # The companion AIGatewayRoute example in this directory is Envoy AI Gateway-specific.
-  gatewayClassName: change-me
+  # Envoy Gateway installs the "envoy" GatewayClass by default.
+  # Change this only if your cluster uses a different GatewayClass.
+  gatewayClassName: envoy
   listeners:
     - name: http
       protocol: HTTP

--- a/docs/samples/llmisvc/e2e-gpt-oss/inference_default.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/inference_default.yaml
@@ -10,7 +10,9 @@ spec:
   replicas: 2
   router:
     scheduler: { }
-    gateway: { }
+    gateway:
+      refs:
+        - name: ai-gateway
   baseRefs:
     - name: llmisvc-intelligent-inference-scheduling
   template:

--- a/docs/samples/llmisvc/e2e-gpt-oss/inference_prefix_cache.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/inference_prefix_cache.yaml
@@ -10,7 +10,9 @@ spec:
   replicas: 2
   router:
     scheduler: { }
-    gateway: { }
+    gateway:
+      refs:
+        - name: ai-gateway
   baseRefs:
     - name: llmisvc-prefix-caching
   template:

--- a/docs/samples/llmisvc/e2e-gpt-oss/kustomization.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/kustomization.yaml
@@ -13,3 +13,8 @@ resources:
   # - inference_prefix_cache.yaml
   # - inference_pd_disaggregation.yaml
   - service_monitor.yaml
+  # Uncomment one gateway for your provider:
+  # - gateway.yaml
+  # - gateway-agentgateway.yaml
+  # Envoy AI Gateway only:
+  # - ai-gateway-route.yaml

--- a/docs/samples/llmisvc/e2e-gpt-oss/kustomization.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/kustomization.yaml
@@ -13,8 +13,8 @@ resources:
   # - inference_prefix_cache.yaml
   # - inference_pd_disaggregation.yaml
   - service_monitor.yaml
-  # Uncomment one gateway for your provider:
-  # - gateway.yaml
+  # Include one gateway for your provider:
+  - gateway.yaml
   # - gateway-agentgateway.yaml
   # Envoy AI Gateway only:
   # - ai-gateway-route.yaml

--- a/docs/samples/llmisvc/e2e-gpt-oss/kustomization.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/kustomization.yaml
@@ -13,5 +13,3 @@ resources:
   # - inference_prefix_cache.yaml
   # - inference_pd_disaggregation.yaml
   - service_monitor.yaml
-  - gateway.yaml
-  - ai-gateway-route.yaml

--- a/hack/setup/infra/manage.kserve-helm.sh
+++ b/hack/setup/infra/manage.kserve-helm.sh
@@ -247,11 +247,13 @@ install() {
         fi
 
         # Enable Gateway API for KServe(ISVC) if needed
+        # Use GATEWAYCLASS_NAME if set, otherwise fall back to GATEWAY_NETWORK_LAYER
+        # This handles cases where the provider identifier and GatewayClass name differ
         if [ "${GATEWAY_NETWORK_LAYER}" != "false" ] && ! is_positive "${ENABLE_LLMISVC}"; then
-            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
+            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}, gatewayClassName=${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
-            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/infra/manage.kserve-helm.sh
+++ b/hack/setup/infra/manage.kserve-helm.sh
@@ -251,7 +251,7 @@ install() {
             log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
-            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayApiClassName=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAY_NETWORK_LAYER}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/infra/manage.kserve-helm.sh
+++ b/hack/setup/infra/manage.kserve-helm.sh
@@ -251,6 +251,7 @@ install() {
             log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayApiClassName=${GATEWAY_NETWORK_LAYER}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -1389,6 +1389,7 @@ install_kserve_helm() {
             log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayApiClassName=${GATEWAY_NETWORK_LAYER}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -1385,11 +1385,13 @@ install_kserve_helm() {
         fi
 
         # Enable Gateway API for KServe(ISVC) if needed
+        # Use GATEWAYCLASS_NAME if set, otherwise fall back to GATEWAY_NETWORK_LAYER
+        # This handles cases where the provider identifier and GatewayClass name differ
         if [ "${GATEWAY_NETWORK_LAYER}" != "false" ] && ! is_positive "${ENABLE_LLMISVC}"; then
-            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
+            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}, gatewayClassName=${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
-            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -1389,7 +1389,7 @@ install_kserve_helm() {
             log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
-            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayApiClassName=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAY_NETWORK_LAYER}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -980,6 +980,7 @@ install_kserve_helm() {
             log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayApiClassName=${GATEWAY_NETWORK_LAYER}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -976,11 +976,13 @@ install_kserve_helm() {
         fi
 
         # Enable Gateway API for KServe(ISVC) if needed
+        # Use GATEWAYCLASS_NAME if set, otherwise fall back to GATEWAY_NETWORK_LAYER
+        # This handles cases where the provider identifier and GatewayClass name differ
         if [ "${GATEWAY_NETWORK_LAYER}" != "false" ] && ! is_positive "${ENABLE_LLMISVC}"; then
-            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
+            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}, gatewayClassName=${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
-            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -980,7 +980,7 @@ install_kserve_helm() {
             log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
-            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayApiClassName=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAY_NETWORK_LAYER}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -1359,6 +1359,7 @@ install_kserve_helm() {
             log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayApiClassName=${GATEWAY_NETWORK_LAYER}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -1359,7 +1359,7 @@ install_kserve_helm() {
             log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
-            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayApiClassName=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAY_NETWORK_LAYER}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -1355,11 +1355,13 @@ install_kserve_helm() {
         fi
 
         # Enable Gateway API for KServe(ISVC) if needed
+        # Use GATEWAYCLASS_NAME if set, otherwise fall back to GATEWAY_NETWORK_LAYER
+        # This handles cases where the provider identifier and GatewayClass name differ
         if [ "${GATEWAY_NETWORK_LAYER}" != "false" ] && ! is_positive "${ENABLE_LLMISVC}"; then
-            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
+            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}, gatewayClassName=${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}"
             config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
             config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
-            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAY_NETWORK_LAYER}")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.gatewayClassName=${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}")
         fi
 
         if is_positive "${ENABLE_LOCALMODEL}"; then

--- a/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
@@ -125,3 +125,31 @@ func TestLoadConfig(t *testing.T) {
 		t.Fatal("SchedulerConfig = nil, want populated config")
 	}
 }
+
+func TestLoadConfigWithCustomGatewayName(t *testing.T) {
+	configMap := fixture.InferenceServiceCfgMap(constants.KServeNamespace)
+	configMap.Data["ingress"] = `{
+		"enableGatewayApi": true,
+		"kserveIngressGateway": "gateway-system/shared-gateway",
+		"ingressGateway": "knative-serving/knative-ingress-gateway",
+		"localGateway": "knative-serving/knative-local-gateway",
+		"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
+	}`
+
+	c := fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithObjects(configMap).
+		Build()
+
+	got, err := llmisvc.LoadConfig(t.Context(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.IngressGatewayNamespace != "gateway-system" {
+		t.Fatalf("IngressGatewayNamespace = %q, want %q", got.IngressGatewayNamespace, "gateway-system")
+	}
+	if got.IngressGatewayName != "shared-gateway" {
+		t.Fatalf("IngressGatewayName = %q, want %q", got.IngressGatewayName, "shared-gateway")
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -1378,8 +1378,22 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			}()
 
 			customGatewayName := "my-custom-gateway"
+			customGatewayClass := &gwapiv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "agentgateway",
+				},
+				Spec: gwapiv1.GatewayClassSpec{
+					ControllerName: "gateway.networking.k8s.io/gateway-controller",
+				},
+			}
+			Expect(envTest.Client.Create(ctx, customGatewayClass)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(client.IgnoreNotFound(envTest.Client.Delete(ctx, customGatewayClass))).To(Succeed())
+			})
+
 			customGateway := Gateway(customGatewayName,
 				InNamespace[*gwapiv1.Gateway](nsName),
+				WithClassName(customGatewayClass.Name),
 				WithListener(gwapiv1.HTTPProtocolType),
 				WithAddresses("203.0.113.42"),
 			)
@@ -1410,6 +1424,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					Name:      gwapiv1.ObjectName(customGatewayName),
 					Namespace: ptr.To(gwapiv1.Namespace(nsName)),
 				}))
+				g.Expect(customGateway.Spec.GatewayClassName).To(Equal(gwapiv1.ObjectName("agentgateway")))
 
 				createdRoute = &routes[0]
 				return nil

--- a/test/e2e/llmisvc/test_resources.py
+++ b/test/e2e/llmisvc/test_resources.py
@@ -16,8 +16,8 @@ import os
 
 from .fixtures import KSERVE_TEST_NAMESPACE
 
-# GatewayClass name - can be overridden via GATEWAY_CLASS_NAME env var (e.g., "istio")
-GATEWAY_CLASS_NAME = os.environ.get("GATEWAY_CLASS_NAME", "envoy")
+# GatewayClass name - prefer GATEWAYCLASS_NAME, but keep the old env var as a fallback.
+GATEWAY_CLASS_NAME = os.environ.get("GATEWAYCLASS_NAME", os.environ.get("GATEWAY_CLASS_NAME", "envoy"))
 
 ROUTER_GATEWAYS = [
     {

--- a/test/e2e/llmisvc/test_resources.py
+++ b/test/e2e/llmisvc/test_resources.py
@@ -16,8 +16,8 @@ import os
 
 from .fixtures import KSERVE_TEST_NAMESPACE
 
-# GatewayClass name - prefer GATEWAYCLASS_NAME, but keep the old env var as a fallback.
-GATEWAY_CLASS_NAME = os.environ.get("GATEWAYCLASS_NAME", os.environ.get("GATEWAY_CLASS_NAME", "envoy"))
+# GatewayClass name - can be overridden via GATEWAYCLASS_NAME env var (e.g., "istio").
+GATEWAY_CLASS_NAME = os.environ.get("GATEWAYCLASS_NAME", "envoy")
 
 ROUTER_GATEWAYS = [
     {

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -46,7 +46,7 @@ NETWORK_LAYER="${3:-istio}"
 export SKIP_DELETION_ON_FAILURE
 
 if [[ "$NETWORK_LAYER" == *"-gatewayapi"* ]]; then
-  export GATEWAY_CLASS_NAME="${GATEWAY_CLASS_NAME:-${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}}"
+  export GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
 fi
 
 echo "Parallelism requested for pytest is ${PARALLELISM}"

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -45,6 +45,10 @@ NETWORK_LAYER="${3:-istio}"
 : "${SKIP_DELETION_ON_FAILURE:=true}"
 export SKIP_DELETION_ON_FAILURE
 
+if [[ "$NETWORK_LAYER" == *"-gatewayapi"* ]]; then
+  export GATEWAY_CLASS_NAME="${GATEWAY_CLASS_NAME:-${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}}"
+fi
+
 echo "Parallelism requested for pytest is ${PARALLELISM}"
 
 MAXFAIL="${PYTEST_MAXFAIL:-5}"

--- a/test/scripts/gh-actions/setup-deps.sh
+++ b/test/scripts/gh-actions/setup-deps.sh
@@ -35,6 +35,24 @@ ENABLE_LLMISVC="${4:-false}"
 LLMISVC_AUTOSCALER="${5:-none}"
 OBSERVABILITY="${6:-none}"
 
+export_gateway_class_env() {
+  local gateway_class_name="${1:-}"
+
+  if [[ -z "${gateway_class_name}" ]]; then
+    return 0
+  fi
+
+  export GATEWAY_CLASS_NAME="${gateway_class_name}"
+  export GATEWAYCLASS_NAME="${gateway_class_name}"
+
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    {
+      echo "GATEWAY_CLASS_NAME=${gateway_class_name}"
+      echo "GATEWAYCLASS_NAME=${gateway_class_name}"
+    } >> "${GITHUB_ENV}"
+  fi
+}
+
 # Parse network layer configuration
 USES_GATEWAY_API=false
 USES_ISTIO=false
@@ -79,7 +97,7 @@ if [[ $ENABLE_LLMISVC == "false" ]]; then
   # Install Envoy Gateway
   if [[ $USES_ENVOY == true ]]; then
     export GATEWAY_NETWORK_LAYER="${NETWORK_LAYER%%-*}"
-    export GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
+    export_gateway_class_env "${GATEWAY_CLASS_NAME:-${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}}"
     ${REPO_ROOT}/hack/setup/infra/manage.envoy-gateway-helm.sh
     ${REPO_ROOT}/hack/setup/infra/gateway-api/manage.gateway-api-gwclass.sh
   fi
@@ -91,7 +109,7 @@ if [[ $ENABLE_LLMISVC == "false" ]]; then
 
   # Install KServe Gateway for Gateway API or LLM use cases
   if [[ $USES_GATEWAY_API == true ]]; then
-    export GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
+    export_gateway_class_env "${GATEWAY_CLASS_NAME:-${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}}"
     ${REPO_ROOT}/hack/setup/infra/gateway-api/manage.gateway-api-gw.sh
   fi
 

--- a/test/scripts/gh-actions/setup-deps.sh
+++ b/test/scripts/gh-actions/setup-deps.sh
@@ -42,12 +42,10 @@ export_gateway_class_env() {
     return 0
   fi
 
-  export GATEWAY_CLASS_NAME="${gateway_class_name}"
   export GATEWAYCLASS_NAME="${gateway_class_name}"
 
   if [[ -n "${GITHUB_ENV:-}" ]]; then
     {
-      echo "GATEWAY_CLASS_NAME=${gateway_class_name}"
       echo "GATEWAYCLASS_NAME=${gateway_class_name}"
     } >> "${GITHUB_ENV}"
   fi
@@ -97,7 +95,7 @@ if [[ $ENABLE_LLMISVC == "false" ]]; then
   # Install Envoy Gateway
   if [[ $USES_ENVOY == true ]]; then
     export GATEWAY_NETWORK_LAYER="${NETWORK_LAYER%%-*}"
-    export_gateway_class_env "${GATEWAY_CLASS_NAME:-${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}}"
+    export_gateway_class_env "${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
     ${REPO_ROOT}/hack/setup/infra/manage.envoy-gateway-helm.sh
     ${REPO_ROOT}/hack/setup/infra/gateway-api/manage.gateway-api-gwclass.sh
   fi
@@ -109,7 +107,7 @@ if [[ $ENABLE_LLMISVC == "false" ]]; then
 
   # Install KServe Gateway for Gateway API or LLM use cases
   if [[ $USES_GATEWAY_API == true ]]; then
-    export_gateway_class_env "${GATEWAY_CLASS_NAME:-${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}}"
+    export_gateway_class_env "${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
     ${REPO_ROOT}/hack/setup/infra/gateway-api/manage.gateway-api-gw.sh
   fi
 

--- a/test/scripts/gh-actions/setup-deps.sh
+++ b/test/scripts/gh-actions/setup-deps.sh
@@ -79,6 +79,7 @@ if [[ $ENABLE_LLMISVC == "false" ]]; then
   # Install Envoy Gateway
   if [[ $USES_ENVOY == true ]]; then
     export GATEWAY_NETWORK_LAYER="${NETWORK_LAYER%%-*}"
+    export GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
     ${REPO_ROOT}/hack/setup/infra/manage.envoy-gateway-helm.sh
     ${REPO_ROOT}/hack/setup/infra/gateway-api/manage.gateway-api-gwclass.sh
   fi
@@ -90,7 +91,7 @@ if [[ $ENABLE_LLMISVC == "false" ]]; then
 
   # Install KServe Gateway for Gateway API or LLM use cases
   if [[ $USES_GATEWAY_API == true ]]; then
-    export GATEWAYCLASS_NAME="${NETWORK_LAYER%%-*}"
+    export GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
     ${REPO_ROOT}/hack/setup/infra/gateway-api/manage.gateway-api-gw.sh
   fi
 

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -32,10 +32,14 @@ export ENABLE_LLMISVC="${ENABLE_LLMISVC:-false}"
 export ENABLE_KSERVE_WITH_LLMISVC="${ENABLE_KSERVE_WITH_LLMISVC:-false}"
 export INSTALL_METHOD="${INSTALL_METHOD:-kustomize}"
 
-# Extract gateway class name from NETWORK_LAYER (e.g., "envoy-gatewayapi" -> "envoy")
-# If NETWORK_LAYER contains "-", extract the first part; otherwise, use "false"
+# Extract the gateway provider identifier from NETWORK_LAYER (e.g. "envoy-gatewayapi" -> "envoy").
+# Tests can still override the actual GatewayClass name via GATEWAY_CLASS_NAME when needed.
 if [[ $NETWORK_LAYER == *"-gatewayapi"* ]]; then
   export GATEWAY_NETWORK_LAYER="${NETWORK_LAYER%%-*}"
+fi
+
+if [[ $NETWORK_LAYER == *"-gatewayapi"* ]]; then
+  export GATEWAY_CLASS_NAME="${GATEWAY_CLASS_NAME:-${NETWORK_LAYER%%-*}}"
 fi
 
 echo "Installing KServe using ${INSTALL_METHOD^}..."

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -42,6 +42,10 @@ if [[ $NETWORK_LAYER == *"-gatewayapi"* ]]; then
   export GATEWAY_CLASS_NAME="${GATEWAY_CLASS_NAME:-${NETWORK_LAYER%%-*}}"
 fi
 
+if [[ -n "${GATEWAY_CLASS_NAME:-}" && -n "${GITHUB_ENV:-}" ]]; then
+  echo "GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME}" >> "${GITHUB_ENV}"
+fi
+
 echo "Installing KServe using ${INSTALL_METHOD^}..."
 
 echo "Creating a namespace kserve-ci-e2e-test ..."

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -36,10 +36,7 @@ export INSTALL_METHOD="${INSTALL_METHOD:-kustomize}"
 # Tests can still override the actual GatewayClass name via GATEWAYCLASS_NAME when needed.
 if [[ $NETWORK_LAYER == *"-gatewayapi"* ]]; then
   export GATEWAY_NETWORK_LAYER="${NETWORK_LAYER%%-*}"
-fi
-
-if [[ $NETWORK_LAYER == *"-gatewayapi"* ]]; then
-  export GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
+  export GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-${GATEWAY_NETWORK_LAYER}}"
 fi
 
 if [[ -n "${GATEWAYCLASS_NAME:-}" && -n "${GITHUB_ENV:-}" ]]; then

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -33,17 +33,17 @@ export ENABLE_KSERVE_WITH_LLMISVC="${ENABLE_KSERVE_WITH_LLMISVC:-false}"
 export INSTALL_METHOD="${INSTALL_METHOD:-kustomize}"
 
 # Extract the gateway provider identifier from NETWORK_LAYER (e.g. "envoy-gatewayapi" -> "envoy").
-# Tests can still override the actual GatewayClass name via GATEWAY_CLASS_NAME when needed.
+# Tests can still override the actual GatewayClass name via GATEWAYCLASS_NAME when needed.
 if [[ $NETWORK_LAYER == *"-gatewayapi"* ]]; then
   export GATEWAY_NETWORK_LAYER="${NETWORK_LAYER%%-*}"
 fi
 
 if [[ $NETWORK_LAYER == *"-gatewayapi"* ]]; then
-  export GATEWAY_CLASS_NAME="${GATEWAY_CLASS_NAME:-${NETWORK_LAYER%%-*}}"
+  export GATEWAYCLASS_NAME="${GATEWAYCLASS_NAME:-${NETWORK_LAYER%%-*}}"
 fi
 
-if [[ -n "${GATEWAY_CLASS_NAME:-}" && -n "${GITHUB_ENV:-}" ]]; then
-  echo "GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME}" >> "${GITHUB_ENV}"
+if [[ -n "${GATEWAYCLASS_NAME:-}" && -n "${GITHUB_ENV:-}" ]]; then
+  echo "GATEWAYCLASS_NAME=${GATEWAYCLASS_NAME}" >> "${GITHUB_ENV}"
 fi
 
 echo "Installing KServe using ${INSTALL_METHOD^}..."


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the remaining Envoy-default assumptions from the LLMInferenceService gateway flow and makes the supported path clearer:

- Makes the llmisvc gateway examples provider-neutral instead of hardcoding Envoy.
- Adds an `agentgateway` example so users have a second documented GatewayClass option.
- Clarifies in the sample docs that the standard contract is `Gateway` + `HTTPRoute` + `InferencePool`, while `AIGatewayRoute` stays Envoy-specific.
- Fixes the e2e setup flow so the chosen GatewayClass is carried all the way through to the pytest environment.
- Adds test coverage for a non-Envoy GatewayClass path.

**Which issue(s) this PR fixes**:
Fixes #5518

**Feature/Issue validation/testing**:

- `bash -n test/scripts/gh-actions/setup-deps.sh test/scripts/gh-actions/setup-kserve.sh test/scripts/gh-actions/run-e2e-tests.sh`
- `pre-commit run --files docs/samples/llmisvc/e2e-gpt-oss/README.md docs/samples/llmisvc/e2e-gpt-oss/gateway.yaml docs/samples/llmisvc/e2e-gpt-oss/gateway-agentgateway.yaml docs/samples/llmisvc/e2e-gpt-oss/kustomization.yaml test/scripts/gh-actions/setup-deps.sh test/scripts/gh-actions/setup-kserve.sh test/scripts/gh-actions/run-e2e-tests.sh`
- `go test ./pkg/controller/v1alpha2/llmisvc -run 'Test(NewSchedulerConfig|LoadConfig|LoadConfigWithCustomGatewayName)$|Custom\\ Gateway\\ Reference'`

**Special notes for your reviewer**:

- This PR does not change any image versions.
- `AIGatewayRoute` remains Envoy AI Gateway-specific on purpose; the provider-neutral path is the standard Gateway API + Inference Extension flow.
- The non-Envoy example is documented with `agentgateway` and the test path now carries the selected GatewayClass through to the e2e environment.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
NONE