### PR TITLE
fix(storage): add timeout and retry to HuggingFace snapshot_download

### DIFF
--- a/python/storage/kserve_storage/kserve_storage.py
+++ b/python/storage/kserve_storage/kserve_storage.py
@@ -572,13 +572,39 @@ class Storage(object):
         revision = hash_value if hash_value else None
         repo_id = f"{repo}/{model}"
 
+        etag_timeout = int(os.environ.get("HF_HUB_ETAG_TIMEOUT", "30"))
+        max_retries = int(os.environ.get("HF_HUB_DOWNLOAD_RETRIES", "3"))
+
         try:
-            kwargs = dict(repo_id=repo_id, revision=revision, local_dir=temp_dir)
+            kwargs = dict(
+                repo_id=repo_id,
+                revision=revision,
+                local_dir=temp_dir,
+                etag_timeout=etag_timeout,
+            )
             if allow_patterns:
                 kwargs["allow_patterns"] = allow_patterns
             if ignore_patterns:
                 kwargs["ignore_patterns"] = ignore_patterns
-            snapshot_download(**kwargs)
+
+            for attempt in range(1, max_retries + 1):
+                try:
+                    snapshot_download(**kwargs)
+                    break
+                except (RepositoryNotFoundError, RevisionNotFoundError, GatedRepoError):
+                    raise
+                except Exception as e:
+                    if attempt == max_retries:
+                        raise
+                    backoff = min(2**attempt, 60)
+                    logger.warning(
+                        "HuggingFace download attempt %d/%d failed: %s. Retrying in %ds...",
+                        attempt,
+                        max_retries,
+                        e,
+                        backoff,
+                    )
+                    time.sleep(backoff)
         except (
             RepositoryNotFoundError,
             RevisionNotFoundError,

--- a/python/storage/test/test_hf_storage.py
+++ b/python/storage/test/test_hf_storage.py
@@ -32,6 +32,7 @@ def test_download_model(mock_snapshot_download):
         repo_id=f"{repo}/{model}",
         revision=revision,
         local_dir=mock.ANY,
+        etag_timeout=30,
     )
 
 
@@ -45,6 +46,7 @@ def test_download_model_with_allow_patterns(mock_snapshot_download):
         repo_id="example.com/model",
         revision=None,
         local_dir="/tmp/out",
+        etag_timeout=30,
         allow_patterns=["*.safetensors", "*.json"],
     )
 
@@ -59,6 +61,7 @@ def test_download_model_with_ignore_patterns(mock_snapshot_download):
         repo_id="example.com/model",
         revision=None,
         local_dir="/tmp/out",
+        etag_timeout=30,
         ignore_patterns=["*.bin", "*.gguf"],
     )
 
@@ -78,6 +81,7 @@ def test_download_model_with_both_patterns(mock_snapshot_download):
         repo_id="example.com/model",
         revision=None,
         local_dir="/tmp/out",
+        etag_timeout=30,
         allow_patterns=["*.json"],
         ignore_patterns=["config.json"],
     )
@@ -93,6 +97,7 @@ def test_download_model_no_patterns_omits_kwargs(mock_snapshot_download):
         repo_id="example.com/model",
         revision=None,
         local_dir="/tmp/out",
+        etag_timeout=30,
     )
 
 
@@ -127,6 +132,71 @@ def test_explicit_patterns_override_env(mock_snapshot_download):
 
     call_kwargs = mock_snapshot_download.call_args[1]
     assert call_kwargs.get("allow_patterns") == ["*.safetensors"]
+
+
+@mock.patch("huggingface_hub.snapshot_download")
+def test_custom_etag_timeout_from_env(mock_snapshot_download):
+    uri = "hf://example.com/model"
+
+    with mock.patch.dict(os.environ, {"HF_HUB_ETAG_TIMEOUT": "120"}):
+        Storage._download_hf(uri, "/tmp/out")
+
+    call_kwargs = mock_snapshot_download.call_args[1]
+    assert call_kwargs.get("etag_timeout") == 120
+
+
+@mock.patch("huggingface_hub.snapshot_download")
+@mock.patch("kserve_storage.kserve_storage.time.sleep")
+def test_retry_on_transient_failure(mock_sleep, mock_snapshot_download):
+    mock_snapshot_download.side_effect = [
+        ConnectionError("stalled"),
+        ConnectionError("stalled again"),
+        None,
+    ]
+    uri = "hf://example.com/model"
+
+    Storage._download_hf(uri, "/tmp/out")
+
+    assert mock_snapshot_download.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+@mock.patch("huggingface_hub.snapshot_download")
+@mock.patch("kserve_storage.kserve_storage.time.sleep")
+def test_retry_exhaustion_raises(mock_sleep, mock_snapshot_download):
+    mock_snapshot_download.side_effect = ConnectionError("stalled")
+    uri = "hf://example.com/model"
+
+    with pytest.raises(ConnectionError, match="stalled"):
+        Storage._download_hf(uri, "/tmp/out")
+
+    assert mock_snapshot_download.call_count == 3
+
+
+@mock.patch("huggingface_hub.snapshot_download")
+@mock.patch("kserve_storage.kserve_storage.time.sleep")
+def test_custom_retry_count_from_env(mock_sleep, mock_snapshot_download):
+    mock_snapshot_download.side_effect = ConnectionError("stalled")
+    uri = "hf://example.com/model"
+
+    with mock.patch.dict(os.environ, {"HF_HUB_DOWNLOAD_RETRIES": "5"}):
+        with pytest.raises(ConnectionError):
+            Storage._download_hf(uri, "/tmp/out")
+
+    assert mock_snapshot_download.call_count == 5
+
+
+@mock.patch("huggingface_hub.snapshot_download")
+def test_no_retry_on_repository_not_found(mock_snapshot_download):
+    from huggingface_hub.utils import RepositoryNotFoundError
+
+    mock_snapshot_download.side_effect = RepositoryNotFoundError("not found")
+    uri = "hf://example.com/model"
+
+    with pytest.raises(Exception):
+        Storage._download_hf(uri, "/tmp/out")
+
+    assert mock_snapshot_download.call_count == 1
 
 
 @mock.patch("huggingface_hub.snapshot_download")


### PR DESCRIPTION
## What

Add configurable timeout and retry logic to the HuggingFace `snapshot_download` call in the storage-initializer.

Fixes #5611

## Why

`_download_hf` calls `snapshot_download` without `etag_timeout` or retry logic. When a download stalls mid-transfer (CDN throttling, network issues, AWS SOCI behavior), the storage-initializer init container hangs indefinitely, blocking the entire pod lifecycle. Operators have no way to configure timeout behavior.

## Changes

- Pass `etag_timeout` to `snapshot_download` (configurable via `HF_HUB_ETAG_TIMEOUT` env var, default 30s)
- Wrap `snapshot_download` in a retry loop with exponential backoff (configurable via `HF_HUB_DOWNLOAD_RETRIES` env var, default 3 attempts)
- Permanent errors (`RepositoryNotFoundError`, `RevisionNotFoundError`, `GatedRepoError`) are re-raised immediately without retry
- Transient failures (network errors, timeouts, stalls) are retried with backoff capped at 60s

## Testing

- Updated all existing `test_hf_storage.py` assertions to include `etag_timeout`
- New tests: custom timeout from env var, retry on transient failure, retry exhaustion, custom retry count from env var, no retry on `RepositoryNotFoundError`
- All 16 tests pass