### PR TITLE
fix: set limits and increase requests in llmisvc

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -1991,9 +1991,12 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
+            limits:
+              cpu: 6
+              memory: 16Gi
             requests:
-              cpu: 256m
-              memory: 500Mi
+              cpu: 1
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -86,9 +86,12 @@ spec:
               - name: SSL_CERT_DIR
                 value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
             resources:
+              limits:
+                cpu: 6
+                memory: 16Gi
               requests:
-                cpu: 256m
-                memory: 500Mi
+                cpu: 1
+                memory: 2Gi
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: FallbackToLogsOnError
             securityContext:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4594,9 +4594,12 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
+            limits:
+              cpu: 6
+              memory: 16Gi
             requests:
-              cpu: 256m
-              memory: 500Mi
+              cpu: 1
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -4180,9 +4180,12 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
+            limits:
+              cpu: 6
+              memory: 16Gi
             requests:
-              cpu: 256m
-              memory: 500Mi
+              cpu: 1
+              memory: 2Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -379,7 +379,25 @@ LLMINFERENCESERVICE_CONFIGS = {
         },
     },
     "router-managed": {
-        "router": {"scheduler": {}, "route": {}, "gateway": {}},
+        "router": {
+            "scheduler": {
+                "template": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "resources": {
+                                "requests": {
+                                    "cpu": "256m",
+                                    "memory": "500Mi",
+                                },
+                            },
+                        }
+                    ],
+                },
+            },
+            "route": {},
+            "gateway": {},
+        },
     },
     "router-no-scheduler": {
         "router": {"route": {}},
@@ -711,7 +729,21 @@ LLMINFERENCESERVICE_CONFIGS = {
     },
     "scheduler-managed": {
         "router": {
-            "scheduler": {},
+            "scheduler": {
+                "template": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "resources": {
+                                "requests": {
+                                    "cpu": "256m",
+                                    "memory": "500Mi",
+                                },
+                            },
+                        }
+                    ],
+                },
+            },
         },
     },
     "scheduler-with-inline-config": {
@@ -926,6 +958,19 @@ LLMINFERENCESERVICE_CONFIGS = {
         "router": {
             "scheduler": {
                 "replicas": 2,
+                "template": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "resources": {
+                                "requests": {
+                                    "cpu": "256m",
+                                    "memory": "500Mi",
+                                },
+                            },
+                        }
+                    ],
+                },
             },
         },
     },


### PR DESCRIPTION
## Summary
Updates the resource requests and limits configuration for the LLM scheduler, to ensure full compatibility with Kubernetes `LimitRanges`.

### Why is this change necessary?
Previously, the scheduler omitted explicit resource limits/requests or used configurations that conflicted with our cluster's `LimitRanges`. In namespaces where strict limit ranges are enforced, pods would fail to deploy with validation errors (e.g., missing mandatory limits or exceeding maximum constraints). 

### Testing

These numbers are derived from the results after running some load tests using llm-d-scheduler 0.6 with 8 backends:

#### "default" scheduling, (empty value in the scheduler field of the LLMIinferenceService object)
<img width="1646" height="469" alt="image" src="https://github.com/user-attachments/assets/2ff8bf28-ff52-434d-8f0b-045e62b10dfe" />

#### "approximate" scheduling
<details>
<summary>**View config**</summary>

```yaml
apiVersion: serving.kserve.io/v1alpha1
kind: LLMInferenceService
metadata:
  name: qwen3-0-6b-approximate
  annotations:
    security.opendatahub.io/enable-auth: "false"
spec:
  model:
    uri: "hf://dummy-org/dummy-model"
    name: Qwen/Qwen3-0.6B
  replicas: 8
  router:
    scheduler:
      config:
        inline:
          apiVersion: inference.networking.x-k8s.io/v1alpha1
          kind: EndpointPickerConfig
          plugins:
          - type: queue-scorer
          - type: kv-cache-utilization-scorer
          - type: prefix-cache-scorer
          - type: no-hit-lru-scorer
          schedulingProfiles:
          - name: default
            plugins:
            - pluginRef: queue-scorer
              weight: 2
            - pluginRef: kv-cache-utilization-scorer
              weight: 2
            - pluginRef: prefix-cache-scorer
              weight: 3
            - pluginRef: no-hit-lru-scorer
              weight: 2
    route: {}
    gateway: {}
  template:
    containers:
      - name: main
        image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.2
        command: ["/app/llm-d-inference-sim"]
        args:
          - --port
          - "8000"
          - --model
          - "{{ .Spec.Model.Name }}"
          - --mode
          - random
          - --hash-seed
          - "42"
          - --event-batch-size
          - "1"
          - --ssl-certfile
          - /var/run/kserve/tls/tls.crt
          - --ssl-keyfile
          - /var/run/kserve/tls/tls.key
          - --max-model-len
          - "131072"
        env:
        - name: POD_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        - name: POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: PYTHONHASHSEED
          value: "42"
        livenessProbe:
          httpGet:
            path: /health
            port: 8000
            scheme: HTTPS
          periodSeconds: 5
          timeoutSeconds: 30
          failureThreshold: 5
        readinessProbe:
          httpGet:
            path: /health
            port: 8000
            scheme: HTTPS
          periodSeconds: 5
          timeoutSeconds: 30
          failureThreshold: 5
        startupProbe:
          httpGet:
            path: /health
            port: 8000
            scheme: HTTPS
          periodSeconds: 10
          timeoutSeconds: 10
          failureThreshold: 10
```
</details>


<img width="1758" height="501" alt="image" src="https://github.com/user-attachments/assets/6dd08e08-f6af-410f-b025-1bf116555e6c" />

---

I also conducted more experiments using a higher number of backends, using the approximate scheduling configuration again

#### **CPU & Memory with more replicas**

| RPS | 8 Replicas | 16 Replicas | CPU Increase (%) | 24 Replicas | CPU Increase (%) | 32 Replicas | CPU Increase (%) | 40 Replicas | CPU Increase (%) |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| 20 | 0.456 | 0.684 | \+50.0% | 0.938 | \+105.7% | 1.189 | \+160.7% | 1.409 | \+209.0% |
| 40 | 0.655 | 0.895 | \+36.6% | 1.162 | \+77.4% | 1.393 | \+112.7% | 1.633 | \+149.3% |
| 60 | 0.861 | 1.081 | \+25.6% | 1.360 | \+58.0% | 1.609 | \+86.9% | 1.865 | \+116.6% |
| 80 | 1.045 | 1.285 | \+23.0% | 1.364 | \+30.5% | 1.779 | \+70.2% | 1.984 | \+89.9% |
| 100 | 1.263 | 1.506 | \+19.2% | 1.749 | \+38.5% | 2.032 | \+60.9% | 2.243 | \+77.6% |
</div>


Although the limits may be insufficient on higher load cases, it helps to establish a reasonable baseline.

/cc @pierDipi