### PR TITLE
feat(logger): prefer X-Request-Id over Ce-Id for request ID

### DIFF
--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -207,8 +207,15 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// getOrCreateID resolves the request ID used to correlate the logged request
+// and response events. It prefers the dedicated X-Request-Id header, falling
+// back to Ce-Id for backward compatibility, and generates a UUID when neither
+// is present.
 func getOrCreateID(r *http.Request) string {
-	id := r.Header.Get(CloudEventsIdHeader)
+	id := r.Header.Get(RequestIdHeader)
+	if id == "" {
+		id = r.Header.Get(CloudEventsIdHeader)
+	}
 	if id == "" {
 		id = guuid.New().String()
 	}

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	guuid "github.com/google/uuid"
 	"github.com/onsi/gomega"
 	pkglogging "knative.dev/pkg/logging"
 
@@ -439,4 +440,54 @@ func TestLoggerCloudEventTimestamps(t *testing.T) {
 	// Response occurrence time should be >= request occurrence time
 	g.Expect(resTimestamps.ceTime.After(reqTimestamps.ceTime) ||
 		resTimestamps.ceTime.Equal(reqTimestamps.ceTime)).To(gomega.BeTrue())
+}
+
+func TestGetOrCreateID(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	scenarios := map[string]struct {
+		headers    map[string]string
+		expectedID string
+	}{
+		"PrefersRequestIdHeader": {
+			headers: map[string]string{
+				RequestIdHeader:     "my-trace-123",
+				CloudEventsIdHeader: "cloud-event-id",
+			},
+			expectedID: "my-trace-123",
+		},
+		"UsesRequestIdHeader": {
+			headers: map[string]string{
+				RequestIdHeader: "my-trace-123",
+			},
+			expectedID: "my-trace-123",
+		},
+		"FallsBackToCloudEventsIdHeader": {
+			headers: map[string]string{
+				CloudEventsIdHeader: "cloud-event-id",
+			},
+			expectedID: "cloud-event-id",
+		},
+		"GeneratesIDWhenNoHeaders": {
+			headers:    map[string]string{},
+			expectedID: "",
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "http://a", nil)
+			for k, v := range scenario.headers {
+				r.Header.Set(k, v)
+			}
+			id := getOrCreateID(r)
+			if scenario.expectedID != "" {
+				g.Expect(id).To(gomega.Equal(scenario.expectedID))
+			} else {
+				// A UUID should be generated when no ID headers are present
+				_, err := guuid.Parse(id)
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+		})
+	}
 }

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -40,7 +40,6 @@ const (
 	CEInferenceResponse = "org.kubeflow.serving.inference.response"
 
 	// cloud events extension attributes have to be lowercase alphanumeric
-	// TODO: ideally request id would have its own header but make do with ce-id for now
 	InferenceServiceAttr = "inferenceservicename"
 	NamespaceAttr        = "namespace"
 	ComponentAttr        = "component"
@@ -51,7 +50,12 @@ const (
 	RecordedTimeAttr = "recordedtime"
 
 	LoggerWorkerQueueSize = 100
-	CloudEventsIdHeader   = "Ce-Id"
+	// RequestIdHeader is the dedicated request ID header used to correlate
+	// logged request/response events with access logs and traces. It takes
+	// precedence over CloudEventsIdHeader, which is kept as a fallback for
+	// backward compatibility.
+	RequestIdHeader     = "X-Request-Id"
+	CloudEventsIdHeader = "Ce-Id"
 )
 
 // A buffered channel that we can send work requests on.


### PR DESCRIPTION
**What this PR does / why we need it**:

The logger resolves the inference request ID from the `Ce-Id` header (`getOrCreateID` in `pkg/logger/handler.go`), which is the CloudEvents *event* identifier and belongs to the messaging layer, not inference request tracking. The code acknowledged this with a TODO in `pkg/logger/worker.go`:

```go
// TODO: ideally request id would have its own header but make do with ce-id for now
```

Consequences of the current behaviour:
- A client-supplied `X-Request-Id` (the conventional request tracking header, injected automatically by Istio/Envoy and already used for request tracking by the Python model server in `python/kserve/kserve/model.py`) is ignored entirely — payload log events get a random UUID, so they cannot be correlated with access logs, traces, or the model server's own logs.
- An incoming `Ce-Id` (e.g. when the InferenceService is invoked from a CloudEvents pipeline) is silently adopted as the inference request ID and reused as the emitted events' own IDs.

This PR resolves the request ID with the precedence suggested in #5591: **`X-Request-Id` → `Ce-Id` (backward compatibility) → generated UUID**, and removes the stale TODO.

**Which issue(s) this PR fixes**:
Fixes #5591

**Feature/Issue validation/testing**:

- [x] Unit test: new table-driven `TestGetOrCreateID` in `pkg/logger/handler_test.go` covering all four scenarios (prefers `X-Request-Id` over `Ce-Id`, uses `X-Request-Id` alone, falls back to `Ce-Id`, generates a UUID when neither is present). `go test ./pkg/logger/...` and `./pkg/agent/...` pass; `golangci-lint run ./pkg/logger/...` reports 0 issues.
- [x] Verified end-to-end on a kind cluster: deployed a logger-enabled sklearn InferenceService with an event-display sink and sent three predictions (plain, with `X-Request-Id: my-trace-123`, with `Ce-Id: someone-elses-event-id`).

Before (stock agent):

| Request | CloudEvent `id` received by sink |
|---|---|
| plain | random UUID |
| `X-Request-Id: my-trace-123` | random UUID — header ignored |
| `Ce-Id: someone-elses-event-id` | `someone-elses-event-id` |

After (patched agent):

```
  type: org.kubeflow.serving.inference.request
  id: 066ce481-dbe5-4e2b-92bc-5890c8fb347d      <- plain: generated UUID (unchanged)
  type: org.kubeflow.serving.inference.request
  id: my-trace-123                              <- X-Request-Id now honoured
  type: org.kubeflow.serving.inference.request
  id: someone-elses-event-id                    <- Ce-Id fallback preserved
```

(each request event's matching response event carries the same id)

**Special notes for reviewer**:

The issue also suggests eventually deprecating `Ce-Id` as a request ID source; this PR intentionally keeps it as a fallback so existing CloudEvents-based callers are unaffected. Happy to adjust the precedence or follow up on deprecation if preferred.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
The inference logger now uses the X-Request-Id header as the request ID for logged request/response events, falling back to Ce-Id for backward compatibility, and generating a UUID when neither is present.
```