### PR TITLE
fix(helm): template namespace in kserve-llmisvc-crd chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,8 +245,9 @@ manifests: controller-gen kustomize yq
 	rm charts/kserve-localmodel-crd-minimal/templates/kustomization.yaml
 
 	# Copy minimal llmisvc crd (with conversion webhook patches applied via kustomize)
-	$(KUSTOMIZE) build config/crd/minimal/llmisvc | $(YQ) 'select(.metadata.name == "llminferenceservices.serving.kserve.io")' > charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
-	$(KUSTOMIZE) build config/crd/minimal/llmisvc | $(YQ) 'select(.metadata.name == "llminferenceserviceconfigs.serving.kserve.io")' > charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+	# Hardcoded "kserve" namespace is replaced with Helm template variable so the chart works in any namespace
+	$(KUSTOMIZE) build config/crd/minimal/llmisvc | $(YQ) 'select(.metadata.name == "llminferenceservices.serving.kserve.io")' | sed 's|inject-ca-from: kserve/llmisvc-serving-cert|inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert|g' | sed 's|namespace: kserve$$|namespace: {{ .Release.Namespace }}|g' > charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
+	$(KUSTOMIZE) build config/crd/minimal/llmisvc | $(YQ) 'select(.metadata.name == "llminferenceserviceconfigs.serving.kserve.io")' | sed 's|inject-ca-from: kserve/llmisvc-serving-cert|inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert|g' | sed 's|namespace: kserve$$|namespace: {{ .Release.Namespace }}|g' > charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
 	
     # Copy Test inferenceconfig configmap to test overlay
 	cp config/configmap/inferenceservice.yaml config/overlays/test/configmap/inferenceservice.yaml

--- a/Makefile
+++ b/Makefile
@@ -217,8 +217,9 @@ manifests: controller-gen kustomize yq
 	rm charts/kserve-localmodel-crd/templates/kustomization.yaml
 	
 	# Copy llmisvc crd (with conversion webhook patches applied via kustomize)
-	$(KUSTOMIZE) build config/crd/full/llmisvc | $(YQ) 'select(.metadata.name == "llminferenceservices.serving.kserve.io")' > charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
-	$(KUSTOMIZE) build config/crd/full/llmisvc | $(YQ) 'select(.metadata.name == "llminferenceserviceconfigs.serving.kserve.io")' > charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+	# Hardcoded "kserve" namespace is replaced with Helm template variable so the chart works in any namespace
+	$(KUSTOMIZE) build config/crd/full/llmisvc | $(YQ) 'select(.metadata.name == "llminferenceservices.serving.kserve.io")' | sed 's|inject-ca-from: kserve/llmisvc-serving-cert|inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert|g' | sed 's|namespace: kserve$$|namespace: {{ .Release.Namespace }}|g' > charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
+	$(KUSTOMIZE) build config/crd/full/llmisvc | $(YQ) 'select(.metadata.name == "llminferenceserviceconfigs.serving.kserve.io")' | sed 's|inject-ca-from: kserve/llmisvc-serving-cert|inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert|g' | sed 's|namespace: kserve$$|namespace: {{ .Release.Namespace }}|g' > charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
 	
 	# Copy the WVA VariantAutoscaling CRD for envtest
 	$(KUSTOMIZE) build https://github.com/llm-d/llm-d-workload-variant-autoscaler.git/config/crd?ref=$(WVA_VERSION) > test/crds/wva_variantautoscalings.yaml

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceserviceconfigs.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceservices.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceserviceconfigs.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceservices.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kserve-llmisvc-crd` and `kserve-llmisvc-crd-minimal` Helm charts had the namespace hardcoded as `kserve` in two places for both `LLMInferenceService` and `LLMInferenceServiceConfig` CRDs:

- `cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert` annotation
- `webhook.clientConfig.service.namespace: kserve`

This prevented both charts from being deployed correctly in environments using a different namespace. The `kserve-llmisvc-resources` chart already handled this correctly via namespace replacement — this PR applies the same fix to both CRD charts.

**Which issue(s) this PR fixes**:
Fixes #5325

**Feature/Issue validation/testing**:

- [x] `helm lint charts/kserve-llmisvc-crd` passes
- [x] `helm lint charts/kserve-llmisvc-crd-minimal` passes
- [x] `helm template test-release charts/kserve-llmisvc-crd --namespace my-custom-ns` correctly renders `cert-manager.io/inject-ca-from: my-custom-ns/llmisvc-serving-cert` and `namespace: my-custom-ns`
- [x] `bash hack/setup/scripts/lint-helm.sh` — all 10 charts pass
- [x] `bash hack/setup/scripts/verify-helm-helpers.sh` — helper consistency verified

**Special notes for your reviewer**:

The Makefile generation steps that build the CRD templates from kustomize have also been updated with `sed` post-processing for both charts, so the fixes are preserved across future `make generate-chart-manifests` runs. Without this, the template edits would be overwritten on regeneration.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix hardcoded namespace in kserve-llmisvc-crd and kserve-llmisvc-crd-minimal Helm charts; cert-manager annotation and webhook clientConfig now use .Release.Namespace for flexible deployment to any namespace.
```