### PR TITLE
feat(llmisvc): add v1/messages HTTPRoute to support Anthropic Messages API

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -1819,6 +1819,53 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/messages
+            name: v1-messages-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            matches:
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages/
+            name: v1-messages-model-routing
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/config/llmisvcconfig/config-llm-router-route.yaml
+++ b/config/llmisvcconfig/config-llm-router-route.yaml
@@ -1,6 +1,6 @@
 # HTTPRoute template for LLMInferenceService routing.
 #
-# Each endpoint (completions, chat/completions, responses) is split into two
+# Each endpoint (completions, chat/completions, responses, messages) is split into two
 # rules because Gateway API requires exactly one PathPrefix match per rule
 # when using URLRewrite with replacePrefixMatch:
 #

--- a/config/llmisvcconfig/config-llm-router-route.yaml
+++ b/config/llmisvcconfig/config-llm-router-route.yaml
@@ -175,6 +175,54 @@ spec:
               timeouts:
                 backendRequest: 0s
                 request: 0s
+            - name: v1-messages-path
+              backendRefs:
+                - group: inference.networking.k8s.io
+                  kind: InferencePool
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
+                      /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/messages
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /v1/messages
+              timeouts:
+                backendRequest: 0s
+                request: 0s
+            - name: v1-messages-model-routing
+              backendRefs:
+                - group: inference.networking.k8s.io
+                  kind: InferencePool
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: Exact
+                    value: /v1/messages
+                  headers:
+                    - type: Exact
+                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
+                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
+                - path:
+                    type: Exact
+                    value: /v1/messages/
+                  headers:
+                    - type: Exact
+                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
+                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
+              timeouts:
+                backendRequest: 0s
+                request: 0s
             # Catch-all rules route to the workload Service directly (bypassing
             # InferencePool) for endpoints not handled by the scheduler, such as
             # /v1/models, /health, or custom paths exposed by the runtime.

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4381,6 +4381,53 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/messages
+            name: v1-messages-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            matches:
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages/
+            name: v1-messages-model-routing
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -3967,6 +3967,53 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/messages
+            name: v1-messages-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            matches:
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages/
+            name: v1-messages-model-routing
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_lora_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_lora_test.go
@@ -193,6 +193,30 @@ func TestExpandLoRAAdapterMatches(t *testing.T) {
 			},
 		},
 		{
+			name: "expands messages model-routing matches for each adapter",
+			rules: []gwapiv1.HTTPRouteRule{
+				ruleWithMatches(
+					exactPathWithHeaderMatch("/v1/messages", "publishers/ns/models/base-model"),
+					exactPathWithHeaderMatch("/v1/messages/", "publishers/ns/models/base-model"),
+				),
+			},
+			namespace:  "ns",
+			adapters:   adapters,
+			headerName: headerName,
+			wantFn: func(t *testing.T, rules []gwapiv1.HTTPRouteRule) {
+				// 2 base matches + 2 matches × 2 adapters = 6 total
+				assert.Len(t, rules[0].Matches, 6)
+				assert.Equal(t, "publishers/ns/models/adapter-a", rules[0].Matches[2].Headers[0].Value)
+				assert.Equal(t, "/v1/messages", *rules[0].Matches[2].Path.Value)
+				assert.Equal(t, "publishers/ns/models/adapter-b", rules[0].Matches[3].Headers[0].Value)
+				assert.Equal(t, "/v1/messages", *rules[0].Matches[3].Path.Value)
+				assert.Equal(t, "publishers/ns/models/adapter-a", rules[0].Matches[4].Headers[0].Value)
+				assert.Equal(t, "/v1/messages/", *rules[0].Matches[4].Path.Value)
+				assert.Equal(t, "publishers/ns/models/adapter-b", rules[0].Matches[5].Headers[0].Value)
+				assert.Equal(t, "/v1/messages/", *rules[0].Matches[5].Path.Value)
+			},
+		},
+		{
 			name: "uses correct namespace in header value",
 			rules: []gwapiv1.HTTPRouteRule{
 				ruleWithMatches(

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_model_routing_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_model_routing_test.go
@@ -85,6 +85,7 @@ func TestStripModelBasedRoutingRules(t *testing.T) {
 				{Matches: []gwapiv1.HTTPRouteMatch{
 					modelMatch("/v1/completions", "publishers/ns/models/m1"),
 					modelMatch("/v1/chat/completions", "publishers/ns/models/m1"),
+					modelMatch("/v1/messages", "publishers/ns/models/m1"),
 				}},
 			},
 			headerName: hdr,
@@ -111,6 +112,24 @@ func TestStripModelBasedRoutingRules(t *testing.T) {
 				{Matches: []gwapiv1.HTTPRouteMatch{
 					pathOnlyMatch("/ns/name/v1/completions"),
 					modelMatch("/v1/completions", "publishers/ns/models/m1"),
+				}},
+			},
+			headerName: hdr,
+			wantFn: func(t *testing.T, rules []gwapiv1.HTTPRouteRule) {
+				assert.Len(t, rules, 1)
+				assert.Len(t, rules[0].Matches, 1)
+				assert.Nil(t, rules[0].Matches[0].Headers)
+			},
+		},
+		{
+			name: "strips messages model-routing rule alongside other endpoints",
+			rules: []gwapiv1.HTTPRouteRule{
+				{Matches: []gwapiv1.HTTPRouteMatch{
+					pathOnlyMatch("/ns/name/v1/messages"),
+				}},
+				{Matches: []gwapiv1.HTTPRouteMatch{
+					modelMatch("/v1/messages", "publishers/ns/models/m1"),
+					modelMatch("/v1/messages/", "publishers/ns/models/m1"),
 				}},
 			},
 			headerName: hdr,

--- a/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
@@ -144,8 +144,8 @@ var _ = Describe("Model Based Routing", func() {
 				g.Expect(&routes[0]).To(HaveHeaderMatch(headerName, "publishers/"+testNs.Name+"/models/facebook/opt-125m"))
 
 				rules := routes[0].Spec.Rules
-				g.Expect(countModelRoutingRules(rules)).To(BeNumerically(">=", 4),
-					"should have at least 4 model-routing rules")
+				g.Expect(countModelRoutingRules(rules)).To(BeNumerically(">=", 5),
+					"should have at least 5 model-routing rules")
 			}).WithContext(ctx).Should(Succeed())
 
 			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
@@ -253,7 +253,7 @@ var _ = Describe("Model Based Routing", func() {
 				g.Expect(&routes[0]).To(HaveHeaderMatch(headerName, "publishers/"+testNs.Name+"/models/facebook/opt-125m"))
 
 				rules := routes[0].Spec.Rules
-				g.Expect(countModelRoutingRules(rules)).To(BeNumerically(">=", 4),
+				g.Expect(countModelRoutingRules(rules)).To(BeNumerically(">=", 5),
 					"forced mode should keep model-routing rules despite Gateway opt-out")
 			}).WithContext(ctx).Should(Succeed())
 

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
@@ -180,6 +180,10 @@ func TestDiscoverURLs(t *testing.T) {
 					WithBackendRefs(BackendRefInferencePool("pool")),
 				),
 				WithHTTPRule(
+					Matches(PathPrefixMatch("/ns/name/v1/messages")),
+					WithBackendRefs(BackendRefInferencePool("pool")),
+				),
+				WithHTTPRule(
 					Matches(PathPrefixMatch("/ns/name")),
 					WithBackendRefs(BackendRefService("svc")),
 				),
@@ -206,6 +210,10 @@ func TestDiscoverURLs(t *testing.T) {
 					Matches(PathPrefixMatch("/ns/name/v1/chat/completions")),
 					WithBackendRefs(BackendRefInferencePool("pool")),
 				),
+				WithHTTPRule(
+					Matches(PathPrefixMatch("/ns/name/v1/messages")),
+					WithBackendRefs(BackendRefInferencePool("pool")),
+				),
 			),
 			gateways: []*gwapiv1.Gateway{
 				Gateway("no-svc-gateway",
@@ -214,7 +222,7 @@ func TestDiscoverURLs(t *testing.T) {
 					WithAddresses("203.0.113.1"),
 				),
 			},
-			assert: expectURLs("http://203.0.113.1/ns/name/v1/completions"),
+			assert: expectURLs("http://203.0.113.1/ns/name/v1/messages"),
 		},
 		{
 			name: "multi-rule path extraction - Service with default Kind (nil)",
@@ -378,6 +386,10 @@ func TestDiscoverURLs(t *testing.T) {
 				),
 				WithHTTPRule(
 					Matches(PathPrefixMatch("/ns/name/v1/chat/completions")),
+					WithBackendRefs(BackendRefInferencePool("pool")),
+				),
+				WithHTTPRule(
+					Matches(PathPrefixMatch("/ns/name/v1/messages")),
 					WithBackendRefs(BackendRefInferencePool("pool")),
 				),
 				WithHTTPRule(

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -242,7 +242,6 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
     }
 
 
-
 @pytest.mark.llminferenceservice
 @pytest.mark.asyncio(loop_scope="session")
 @pytest.mark.parametrize(

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -242,6 +242,15 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
     }
 
 
+def messages_payload(test_case: TestCase) -> Dict[str, Any]:
+    """Payload formatter for the /v1/messages endpoint (Anthropic Messages API)."""
+    return {
+        "model": test_case.model_name,
+        "messages": [{"role": "user", "content": test_case.prompt}],
+        "max_tokens": test_case.max_tokens,
+    }
+
+
 @pytest.mark.llminferenceservice
 @pytest.mark.asyncio(loop_scope="session")
 @pytest.mark.parametrize(
@@ -484,6 +493,21 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 pytest.mark.cluster_single_node,
                 pytest.mark.llmd_simulator,
             ],
+        ),
+        # Messages endpoint coverage (Anthropic Messages API)
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-single-cpu",
+                    "model-fb-opt-125m",
+                ],
+                endpoint="/v1/messages",
+                prompt="KServe is a",
+                payload_formatter=messages_payload,
+                response_assertion=create_response_assertion(with_field="content"),
+            ),
+            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
         ),
         pytest.param(
             TestCase(

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -242,14 +242,6 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
     }
 
 
-def messages_payload(test_case: TestCase) -> Dict[str, Any]:
-    """Payload formatter for the /v1/messages endpoint (Anthropic Messages API)."""
-    return {
-        "model": test_case.model_name,
-        "messages": [{"role": "user", "content": test_case.prompt}],
-        "max_tokens": test_case.max_tokens,
-    }
-
 
 @pytest.mark.llminferenceservice
 @pytest.mark.asyncio(loop_scope="session")
@@ -493,21 +485,6 @@ def messages_payload(test_case: TestCase) -> Dict[str, Any]:
                 pytest.mark.cluster_single_node,
                 pytest.mark.llmd_simulator,
             ],
-        ),
-        # Messages endpoint coverage (Anthropic Messages API)
-        pytest.param(
-            TestCase(
-                base_refs=[
-                    "router-managed",
-                    "workload-single-cpu",
-                    "model-fb-opt-125m",
-                ],
-                endpoint="/v1/messages",
-                prompt="KServe is a",
-                payload_formatter=messages_payload,
-                response_assertion=create_response_assertion(with_field="content"),
-            ),
-            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
         ),
         pytest.param(
             TestCase(


### PR DESCRIPTION
**What this PR does / why we need it**:

Routes `/v1/messages` traffic through InferencePool in LLMInferenceService HTTPRoute configs, enabling backends that support the Anthropic Messages API to receive requests via the llm-d-router scheduler.

This is the KServe counterpart to llm-d/llm-d-router#1088, which added Anthropic Messages API parsing support to the router. Without this change, `/v1/messages` requests fall through to the catch-all rule and bypass the InferencePool, meaning they skip the scheduler entirely.

Follows the same pattern as #5291 (which added `/v1/responses`) and #5521 (which added model-based routing rules for all endpoints).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #5647.

**Feature/Issue validation/testing:**
- [x] Existing Go unit tests pass (go test ./pkg/controller/v1alpha2/llmisvc/...).
- [x] Added test case to config_merge_model_routing_test.go – verifies model-routing rules for /v1/messages are correctly stripped/kept.
- [x] Added test case to config_merge_lora_test.go – verifies LoRA adapter match expansion works for /v1/messages paths.
- [x] Added /v1/messages rules to router_discovery_test.go – verifies URL discovery handles the new path in multi-rule extraction.
- [x] Updated countModelRoutingRules >= 5 assertion in controller_model_based_routing_int_test.go to account for the additional model-routing rule.

**Special notes for your reviewer**:
This is a config-only change:

Each endpoint gets two HTTPRoute rules:
1. PathPrefix rule – matches `/{namespace}/{name}/v1/messages`, rewrites to `/v1/messages`, routes through InferencePool
2. Model-routing rule – matches exact path `/v1/messages` with the ModelBasedRoutingHeaderName header for shared-gateway deployments

**Checklist:**

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
Added unit tests for model-routing strip/keep, LoRA expansion, and route discovery. Updated integration test assertion. e2e test for /v1/messages to follow once simulator support is available.
- [x] Has code been commented, particularly in hard-to-understand areas?
Updated the header comment in config-llm-router-route.yaml to include "messages" in the endpoint list.
- [ ] Have you made corresponding changes to the documentation?
No – documentation update can follow once Anthropic Messages API support is fully e2e.

**Release note**:
```release-note
Add /v1/messages HTTPRoute rules to LLMInferenceService, enabling Anthropic Messages API requests to be routed through the InferencePool and llm-d-router scheduler.
```