### PR TITLE
refactor(llmisvc): convert extendControllerSetup to receiver method

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -377,7 +377,7 @@ func (r *LLMISVCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueOnLLMInferenceServicePods),
 			builder.WithPredicates(PodStatusPredicate()))
 
-	if err := extendControllerSetup(r, mgr, b); err != nil {
+	if err := r.extendControllerSetup(mgr, b); err != nil {
 		return fmt.Errorf("failed to extend controller setup: %w", err)
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/controller_setup_default.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_setup_default.go
@@ -25,6 +25,6 @@ import (
 
 // extendControllerSetup is a hook for distribution-specific controller setup such as
 // registering additional API schemes or adding ownership watches for platform-specific resources.
-func extendControllerSetup(_ *LLMISVCReconciler, _ manager.Manager, _ *builder.Builder) error {
+func (r *LLMISVCReconciler) extendControllerSetup(_ manager.Manager, _ *builder.Builder) error {
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The `extendControllerSetup` distribution hook accepts `*LLMISVCReconciler` as its first argument, which is the Go convention for a receiver. This converts it from a standalone function to a receiver method, making the relationship to the reconciler explicit.

Follows the same pattern as #5616 which converted the `localmodelnode` hooks (`enhanceDownloadJob`, `ensureModelRootFolderExistsAndIsWritable`) to receiver methods.

**Which issue(s) this PR fixes**:

N/A - signature alignment for distribution hook support.

**Feature/Issue validation/testing**:

- [x] `go build ./pkg/controller/v1alpha2/llmisvc/...` compiles
- [x] `go test ./pkg/controller/v1alpha2/llmisvc/...` - tests pass

**Special notes for your reviewer**:

This is a no-op change - the default implementation ignores all parameters. The receiver method form enables distribution-specific builds to provide implementations that naturally access the reconciler without threading it as an argument.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```