### PR TITLE
fix: preserve storageUri during webhook defaulting

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -229,6 +229,13 @@ func disableAutomountServiceAccountToken(isvc *InferenceService) {
 }
 
 func (isvc *InferenceService) setPredictorModelDefaults() {
+	// Guard: assign*Runtime() overwrites Model with the legacy spec, which may lack storageUri.
+	var existingStorageURI *string
+	if isvc.Spec.Predictor.Model != nil && isvc.Spec.Predictor.Model.StorageURI != nil {
+		uri := *isvc.Spec.Predictor.Model.StorageURI
+		existingStorageURI = &uri
+	}
+
 	switch {
 	case isvc.Spec.Predictor.SKLearn != nil:
 		isvc.assignSKLearnRuntime()
@@ -262,6 +269,11 @@ func (isvc *InferenceService) setPredictorModelDefaults() {
 	}
 
 	if isvc.Spec.Predictor.Model != nil {
+		// Restore storageUri if it was lost during legacy-to-Model conversion.
+		if existingStorageURI != nil && isvc.Spec.Predictor.Model.StorageURI == nil {
+			isvc.Spec.Predictor.Model.StorageURI = existingStorageURI
+		}
+
 		// Set 'v2' as default protocol version for triton server
 		if isvc.Spec.Predictor.Model.ProtocolVersion == nil &&
 			isvc.Spec.Predictor.Model.ModelFormat.Name == constants.SupportedModelTriton {

--- a/pkg/apis/serving/v1beta1/inference_service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults_test.go
@@ -1766,3 +1766,146 @@ func TestDefaultInferenceServiceWithLocalModelNamespaceCache(t *testing.T) {
 	g.Expect(isvc.Labels).To(gomega.HaveKeyWithValue(constants.LocalModelLabel, "test-ns-cache"))
 	g.Expect(isvc.Labels).To(gomega.HaveKeyWithValue(constants.LocalModelNamespaceLabel, "default"))
 }
+
+func TestStorageUriPreservedDuringDefaults(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	deployConfig := &DeployConfig{
+		DefaultDeploymentMode: string(constants.Knative),
+	}
+
+	ociStorageUri := "oci://quay.io/example/model:latest"
+	s3StorageUri := "s3://bucket/model"
+
+	scenarios := map[string]struct {
+		isvc               InferenceService
+		expectedStorageURI string
+	}{
+		"Model-only predictor preserves storageUri": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "model-only",
+					Namespace: "default",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String(ociStorageUri),
+							},
+						},
+					},
+				},
+			},
+			expectedStorageURI: ociStorageUri,
+		},
+		"SKLearn legacy without storageUri does not strip Model storageUri": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sklearn-dual",
+					Namespace: "default",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						SKLearn: &SKLearnSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{},
+						},
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String(ociStorageUri),
+							},
+						},
+						PodSpec: PodSpec{
+							ImagePullSecrets: []corev1.LocalObjectReference{
+								{Name: "some-secret"},
+							},
+						},
+					},
+				},
+			},
+			expectedStorageURI: ociStorageUri,
+		},
+		"Tensorflow legacy without storageUri does not strip Model storageUri": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tf-dual",
+					Namespace: "default",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{},
+						},
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "tensorflow"},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String(s3StorageUri),
+							},
+						},
+					},
+				},
+			},
+			expectedStorageURI: s3StorageUri,
+		},
+		"XGBoost legacy without storageUri does not strip Model storageUri": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "xgb-dual",
+					Namespace: "default",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						XGBoost: &XGBoostSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{},
+						},
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "xgboost"},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String(ociStorageUri),
+							},
+						},
+					},
+				},
+			},
+			expectedStorageURI: ociStorageUri,
+		},
+		"Legacy spec with own storageUri takes precedence over Model storageUri": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "legacy-wins",
+					Namespace: "default",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						SKLearn: &SKLearnSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String(s3StorageUri),
+							},
+						},
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{Name: "sklearn"},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String(ociStorageUri),
+							},
+						},
+					},
+				},
+			},
+			expectedStorageURI: s3StorageUri,
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			isvc := scenario.isvc.DeepCopy()
+			isvc.DefaultInferenceService(nil, deployConfig, nil, nil, nil)
+
+			g.Expect(isvc.Spec.Predictor.Model).NotTo(gomega.BeNil(), "Model spec should be set after defaulting")
+			g.Expect(isvc.Spec.Predictor.Model.StorageURI).NotTo(gomega.BeNil(), "StorageURI should not be nil after defaulting")
+			g.Expect(*isvc.Spec.Predictor.Model.StorageURI).To(gomega.Equal(scenario.expectedStorageURI),
+				"StorageURI should be preserved regardless of imagePullSecrets changes")
+		})
+	}
+}

--- a/test/e2e/predictor/test_webhook_defaults.py
+++ b/test/e2e/predictor/test_webhook_defaults.py
@@ -1,0 +1,234 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+
+import pytest
+from kubernetes import client
+from kubernetes.client import V1ResourceRequirements
+
+from kserve import (
+    KServeClient,
+    V1beta1InferenceService,
+    V1beta1InferenceServiceSpec,
+    V1beta1ModelFormat,
+    V1beta1ModelSpec,
+    V1beta1PredictorSpec,
+    V1beta1SKLearnSpec,
+    constants,
+)
+
+from ..common.utils import KSERVE_TEST_NAMESPACE
+
+
+kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
+
+
+def _get_storage_uri(name: str) -> str | None:
+    """Read back the storageUri from the stored InferenceService spec."""
+    isvc = kserve_client.get(name, namespace=KSERVE_TEST_NAMESPACE)
+    model = isvc.get("spec", {}).get("predictor", {}).get("model")
+    if model is None:
+        return None
+    return model.get("storageUri")
+
+
+@pytest.mark.predictor
+def test_storage_uri_preserved_with_legacy_spec_on_create():
+    """The mutating webhook must preserve model.storageUri when a legacy spec
+    (sklearn) triggers assignSKLearnRuntime() during CREATE defaulting.
+
+    This is the exact code path fixed by the storageUri preservation guard in
+    setPredictorModelDefaults().
+    """
+    service_name = "isvc-webhook-legacy-uri"
+
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+        model=V1beta1ModelSpec(
+            model_format=V1beta1ModelFormat(name="sklearn"),
+            storage_uri="oci://quay.io/example/model:latest",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+        image_pull_secrets=[
+            client.V1LocalObjectReference(name="nonexistent-secret"),
+        ],
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    try:
+        kserve_client.create(isvc)
+        assert _get_storage_uri(service_name) == "oci://quay.io/example/model:latest"
+    finally:
+        kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+
+@pytest.mark.predictor
+def test_storage_uri_preserved_on_replace():
+    """storageUri must survive a PUT/replace that changes imagePullSecrets.
+
+    This mirrors the dashboard workflow (RHOAIENG-61105): delete old OCI
+    secret, create new one, PUT the IS referencing the new secret.
+    """
+    service_name = "isvc-webhook-replace-uri"
+
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        model=V1beta1ModelSpec(
+            model_format=V1beta1ModelFormat(name="sklearn"),
+            storage_uri="oci://quay.io/example/model:latest",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+        image_pull_secrets=[
+            client.V1LocalObjectReference(name="test-secret-1"),
+        ],
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    try:
+        kserve_client.create(isvc)
+        assert _get_storage_uri(service_name) == "oci://quay.io/example/model:latest"
+
+        # GET → modify imagePullSecrets → PUT (mirrors dashboard replace)
+        # Retry on 409 Conflict since the controller may update status concurrently.
+        for _ in range(5):
+            isvc_dict = kserve_client.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
+            isvc_dict["spec"]["predictor"]["imagePullSecrets"] = [
+                {"name": "test-secret-2"}
+            ]
+            try:
+                kserve_client.api_instance.replace_namespaced_custom_object(
+                    constants.KSERVE_GROUP,
+                    constants.KSERVE_V1BETA1_VERSION,
+                    KSERVE_TEST_NAMESPACE,
+                    constants.KSERVE_PLURAL_INFERENCESERVICE,
+                    service_name,
+                    isvc_dict,
+                )
+                break
+            except client.ApiException as e:
+                if e.status == 409:
+                    time.sleep(1)
+                    continue
+                raise
+        else:
+            pytest.fail("replace failed after 5 retries due to 409 Conflict")
+
+        assert _get_storage_uri(service_name) == "oci://quay.io/example/model:latest"
+    finally:
+        kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+
+@pytest.mark.predictor
+def test_no_spurious_storage_uri_injected():
+    """When no storageUri is set, the defaulting fix must not inject one."""
+    service_name = "isvc-webhook-no-uri"
+
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    try:
+        kserve_client.create(isvc)
+        assert _get_storage_uri(service_name) is None
+    finally:
+        kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+
+@pytest.mark.predictor
+def test_legacy_storage_uri_takes_precedence():
+    """When the legacy spec has its own storageUri, it must win over the
+    model spec's storageUri after assignSKLearnRuntime() conversion."""
+    service_name = "isvc-webhook-legacy-wins"
+
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            storage_uri="s3://bucket/legacy-model",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+        model=V1beta1ModelSpec(
+            model_format=V1beta1ModelFormat(name="sklearn"),
+            storage_uri="oci://quay.io/other/model:latest",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    try:
+        kserve_client.create(isvc)
+        assert _get_storage_uri(service_name) == "s3://bucket/legacy-model"
+    finally:
+        kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_webhook_defaults.py
+++ b/test/e2e/predictor/test_webhook_defaults.py
@@ -94,11 +94,7 @@ def test_storage_uri_preserved_with_legacy_spec_on_create():
 
 @pytest.mark.predictor
 def test_storage_uri_preserved_on_replace():
-    """storageUri must survive a PUT/replace that changes imagePullSecrets.
-
-    This mirrors the dashboard workflow (RHOAIENG-61105): delete old OCI
-    secret, create new one, PUT the IS referencing the new secret.
-    """
+    """storageUri must survive a PUT/replace that changes imagePullSecrets."""
     service_name = "isvc-webhook-replace-uri"
 
     predictor = V1beta1PredictorSpec(


### PR DESCRIPTION
## Summary
- Preserve `model.storageUri` when `assign*Runtime()` overwrites the Model spec during legacy-to-Model conversion in the mutating webhook
- Add unit tests (5 scenarios) and e2e tests (4 scenarios) verifying storageUri preservation

## Root Cause

The `assign*Runtime()` methods (e.g. `assignSKLearnRuntime()`) create a **new** `ModelSpec` from the legacy spec's `PredictorExtensionSpec`, discarding any existing `model.storageUri`. This affects any workflow where both a legacy spec and a Model spec with `storageUri` coexist during webhook defaulting.

## Fix

Save `storageUri` before the legacy-to-Model conversion switch and restore it afterward if it was cleared. When the legacy spec carries its own `storageUri`, it takes precedence (the conversion copies it through).

## Test plan
- [x] Unit tests: 5 scenarios — model-only, sklearn+model, tensorflow+model, xgboost+model, legacy-wins
- [x] E2e tests: 4 scenarios exercising the real webhook pipeline
  - Legacy spec + model storageUri preserved on CREATE
  - storageUri preserved on PUT/replace (dashboard workflow)
  - No spurious storageUri injected when none set
  - Legacy storageUri takes precedence over model storageUri

🤖 Generated with [Claude Code](https://claude.com/claude-code)