### PR TITLE
feat(llmisvc): auto-enable lora-affinity-scorer for LoRA adapters

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -56,6 +56,7 @@ const (
 
 	precisePrefixCacheScorerPlugin = "precise-prefix-cache-scorer"
 	prefixCacheScorerPlugin        = "prefix-cache-scorer"
+	loraAffinityScorerPlugin       = "lora-affinity-scorer"
 	coreMetricsExtractorPlugin     = "model-server-protocol-metrics"
 	udsTokenizerBaseModelName      = "base"
 	udsTokenizerSocketFile         = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
@@ -453,6 +454,10 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 			}
 		}
 
+		if err := mutateSchedulerConfig(ctx, d, withLoraAffinityScorer(llmSvc.Spec.Model.LoRA != nil && len(llmSvc.Spec.Model.LoRA.Adapters) > 0)); err != nil {
+			return d, fmt.Errorf("failed to inject lora-affinity-scorer into scheduler config: %w", err)
+		}
+
 		// v0.7.0 migrations: version-gated (>= 0.7.0) because the v0.6 binary
 		// does not recognize the new plugin names. The v0.7 binary deprecates
 		// the old names but still accepts them.
@@ -836,6 +841,73 @@ func WithUdsTokenizerConfig(_ context.Context, u *unstructured.Unstructured) err
 	}
 
 	return nil
+}
+
+// withLoraAffinityScorer returns a mutateSchedulerConfigFunc that injects the
+// lora-affinity-scorer plugin when LoRA adapters are configured. It adds the
+// plugin to the top-level plugins list and to the default schedulingProfile so
+// requests are routed to endpoints that have the requested adapter loaded.
+// No-op when hasLoRA is false or the plugin is already present.
+//
+// Scope: only the "default" schedulingProfile is targeted. Prefill/decode
+// profiles used in P/D disaggregation are not modified; LoRA + P/D is a
+// separate concern tracked outside this function.
+//
+// Removal: once injected the scorer persists if LoRA adapters are later
+// removed, because preserveSchedulerConfig carries forward the existing
+// --config-text. The scorer is harmless when idle (no LoRA requests).
+func withLoraAffinityScorer(hasLoRA bool) mutateSchedulerConfigFunc {
+	return func(_ context.Context, u *unstructured.Unstructured) error {
+		if !hasLoRA {
+			return nil
+		}
+
+		val, _, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+		if err != nil {
+			return err
+		}
+		plugins, _ := val.([]interface{})
+
+		for _, plugin := range plugins {
+			if pm, ok := plugin.(map[string]interface{}); ok && pm["type"] == loraAffinityScorerPlugin {
+				return nil
+			}
+		}
+
+		plugins = append(plugins, map[string]interface{}{"type": loraAffinityScorerPlugin})
+		if err := unstructured.SetNestedSlice(u.Object, plugins, "plugins"); err != nil {
+			return err
+		}
+
+		profiles, found, err := unstructured.NestedFieldNoCopy(u.Object, "schedulingProfiles")
+		if err != nil || !found {
+			return err
+		}
+		profileList, ok := profiles.([]interface{})
+		if !ok {
+			return nil
+		}
+		for _, profile := range profileList {
+			profileMap, ok := profile.(map[string]interface{})
+			if !ok || profileMap["name"] != "default" {
+				continue
+			}
+			pluginRefs, _, _ := unstructured.NestedFieldNoCopy(profileMap, "plugins")
+			refs, _ := pluginRefs.([]interface{})
+			for _, ref := range refs {
+				if rm, ok := ref.(map[string]interface{}); ok && rm["pluginRef"] == loraAffinityScorerPlugin {
+					return nil
+				}
+			}
+			newRef := map[string]interface{}{"pluginRef": loraAffinityScorerPlugin, "weight": int64(4)}
+			refs = append([]interface{}{newRef}, refs...)
+			if err := unstructured.SetNestedSlice(profileMap, refs, "plugins"); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
 }
 
 // WithMigrateTokenProcessorConfig migrates tokenProcessorConfig from inside

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -32,6 +32,157 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
 
+func TestWithLoraAffinityScorer(t *testing.T) {
+	tests := []struct {
+		name       string
+		hasLoRA    bool
+		configYAML string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name:    "no LoRA - no-op",
+			hasLoRA: false,
+			configYAML: `
+plugins:
+- type: single-profile-handler
+- type: queue-scorer
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(2))
+				for _, p := range plugins {
+					g.Expect(p.(map[string]interface{})["type"]).NotTo(Equal(loraAffinityScorerPlugin))
+				}
+			},
+		},
+		{
+			name:    "with LoRA - injects plugin and default profile entry",
+			hasLoRA: true,
+			configYAML: `
+plugins:
+- type: single-profile-handler
+- type: queue-scorer
+- type: prefix-cache-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				types := make([]string, 0, len(plugins))
+				for _, p := range plugins {
+					types = append(types, p.(map[string]interface{})["type"].(string))
+				}
+				g.Expect(types).To(ContainElement(loraAffinityScorerPlugin))
+
+				profiles := obj["schedulingProfiles"].([]interface{})
+				defaultProfile := profiles[0].(map[string]interface{})
+				g.Expect(defaultProfile["name"]).To(Equal("default"))
+				refs := defaultProfile["plugins"].([]interface{})
+				g.Expect(refs[0].(map[string]interface{})["pluginRef"]).To(Equal(loraAffinityScorerPlugin))
+				g.Expect(refs[0].(map[string]interface{})["weight"]).To(Equal(int64(4)))
+			},
+		},
+		{
+			name:    "with LoRA - idempotent when plugin already present",
+			hasLoRA: true,
+			configYAML: `
+plugins:
+- type: lora-affinity-scorer
+- type: queue-scorer
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: lora-affinity-scorer
+    weight: 4
+  - pluginRef: queue-scorer
+    weight: 2
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				count := 0
+				for _, p := range plugins {
+					if p.(map[string]interface{})["type"] == loraAffinityScorerPlugin {
+						count++
+					}
+				}
+				g.Expect(count).To(Equal(1))
+			},
+		},
+		{
+			name:    "with LoRA - only injects into default profile, not others",
+			hasLoRA: true,
+			configYAML: `
+plugins:
+- type: queue-scorer
+schedulingProfiles:
+- name: prefill
+  plugins:
+  - pluginRef: queue-scorer
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				profiles := obj["schedulingProfiles"].([]interface{})
+				for _, profile := range profiles {
+					pm := profile.(map[string]interface{})
+					refs := pm["plugins"].([]interface{})
+					if pm["name"] == "default" {
+						g.Expect(refs[0].(map[string]interface{})["pluginRef"]).To(Equal(loraAffinityScorerPlugin))
+					} else {
+						for _, ref := range refs {
+							g.Expect(ref.(map[string]interface{})["pluginRef"]).NotTo(Equal(loraAffinityScorerPlugin))
+						}
+					}
+				}
+			},
+		},
+		{
+			name:    "no LoRA - no-op (hasLoRA=false)",
+			hasLoRA: false,
+			configYAML: `
+plugins:
+- type: queue-scorer
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			fn := withLoraAffinityScorer(tt.hasLoRA)
+			g.Expect(fn(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
 func TestPreserveSchedulerConfig(t *testing.T) {
 	defaultSvc := &v1alpha2.LLMInferenceService{}
 	inlineSvc := &v1alpha2.LLMInferenceService{


### PR DESCRIPTION
## Summary

- When an `LLMInferenceService` has LoRA adapters specified, the controller now automatically injects the `lora-affinity-scorer` plugin into the default llm-d-router scheduling profile — no manual scheduler config required from the platform operator
- When no LoRA adapters are configured, behavior is unchanged
- The injection is idempotent and only targets the `default` schedulingProfile

## Background

The `lora-affinity-scorer` plugin scores endpoints by whether the requested LoRA adapter is already active, waiting, or beyond capacity on each pod. When LoRA adapters are in use, this scorer should be part of the default profile to minimize adapter load latency and improve request routing efficiency.

## Implementation

The injection follows the existing `mutateSchedulerConfigFunc` pattern (same as `withCoreMetricsExtractorPlugin`, etc.): a new `withLoraAffinityScorer(hasLoRA bool)` function is applied unconditionally in `expectedSchedulerDeployment`. It:

1. No-ops when `hasLoRA` is false
2. Checks if `lora-affinity-scorer` is already present (idempotent)
3. Appends the plugin to the top-level `plugins` list
4. Prepends a `pluginRef` with `weight: 4` to the `default` schedulingProfile (higher than `prefix-cache-scorer`'s weight of 3, since adapter locality is the primary routing concern when LoRA adapters are in use)

## Test plan

- [ ] `TestWithLoraAffinityScorer`: 4 unit test cases covering no-op (no LoRA), injection (with LoRA), idempotency, and only-default-profile targeting
- [ ] All existing scheduler tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)