### PR TITLE
fix(ci): failing e2e tests fix

### DIFF
--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -61,6 +61,9 @@ if [[ $ENABLE_LLMISVC == "false" || $ENABLE_KSERVE_WITH_LLMISVC == "true" ]]; th
     export USE_LOCAL_CHARTS=true
     export INSTALL_RUNTIMES=true
     ${REPO_ROOT}/hack/setup/infra/manage.kserve-helm.sh
+
+    kubectl patch clusterservingruntime kserve-huggingfaceserver --type=json \
+      --patch-file config/overlays/test/clusterresources/huggingfaceserver-tokio-patch.yaml
     kustomize build config/overlays/test/s3-local-backend | kubectl apply --server-side --force-conflicts -f -
   else
     export SET_KSERVE_VERSION=${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Fixes CI e2e tests failing. env var: `HF_HUB_DISABLE_XET: 1` was added in `huggingfaceserver-tokio-patch.yaml` to be applied in e2e tests. But for helm installations it was not getting applied and hence they were failing. Added step to manually apply it in test-setup

**Feature/Issue validation/testing**:
CI should pass


**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note

```
