### PR TITLE
feat(llmisvc): align default P/D config with llm-d optimized baseline

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -483,6 +483,10 @@ schedulingProfiles:
 			Expect(configText).To(ContainSubstring("disagg-profile-handler"))
 			Expect(configText).To(ContainSubstring("name: prefill"))
 			Expect(configText).To(ContainSubstring("name: decode"))
+			// Upstream optimized P/D baseline: prefill adds kv-cache-utilization-scorer,
+			// decode swaps queue-scorer for active-request-scorer.
+			Expect(configText).To(ContainSubstring("kv-cache-utilization-scorer"))
+			Expect(configText).To(ContainSubstring("active-request-scorer"))
 		})
 	})
 

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -489,7 +489,15 @@ func schedulerConfigText(llmSvc *v1alpha2.LLMInferenceService) string {
 
 	switch {
 	case llmSvc.Spec.Prefill != nil:
-		// Always do P/D by default (threshold 0)
+		// Always do P/D by default (threshold 0).
+		// Profiles follow the llm-d optimized P/D baseline:
+		//   prefill - prefix-cache + queue + kv-cache-utilization scorers
+		//   decode  - active-request + prefix-cache scorers (active request count
+		//             is a better signal than queue depth for ongoing generation).
+		// kv-cache-utilization-scorer and active-request-scorer are declared in the
+		// top-level plugins list so the profiles' pluginRefs resolve; queue-scorer
+		// stays declared because the prefill profile still references it.
+		// lora-affinity-scorer is injected into both profiles when LoRA adapters exist.
 		var loraPlugin, loraProfileEntry string
 		if llmSvc.Spec.Model.LoRA != nil && len(llmSvc.Spec.Model.LoRA.Adapters) > 0 {
 			loraPlugin = fmt.Sprintf("- type: %s\n", loraAffinityScorerPlugin)
@@ -503,6 +511,8 @@ plugins:
 - type: prefill-filter
 - type: decode-filter
 - type: queue-scorer
+- type: kv-cache-utilization-scorer
+- type: active-request-scorer
 - type: prefix-cache-scorer
 - type: max-score-picker
 - type: always-disagg-pd-decider
@@ -514,15 +524,17 @@ plugins:
 - name: prefill
   plugins:
   - pluginRef: prefill-filter
-%s  - pluginRef: queue-scorer
-    weight: 2
-  - pluginRef: prefix-cache-scorer
+%s  - pluginRef: prefix-cache-scorer
     weight: 3
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: kv-cache-utilization-scorer
+    weight: 2
   - pluginRef: max-score-picker
 - name: decode
   plugins:
   - pluginRef: decode-filter
-%s  - pluginRef: queue-scorer
+%s  - pluginRef: active-request-scorer
     weight: 2
   - pluginRef: prefix-cache-scorer
     weight: 3

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -464,6 +464,97 @@ func TestFilterArgs(t *testing.T) {
 	}
 }
 
+// pluginRefWeight is an ordered (pluginRef, weight) pair from a scheduling
+// profile. Weight is 0 when unset; the P/D baseline only uses weights 2 and 3,
+// so 0 unambiguously means "no weight".
+type pluginRefWeight struct {
+	Ref    string
+	Weight int
+}
+
+// pluginTypeSet returns the set of top-level plugin "type" values in a parsed
+// EndpointPickerConfig.
+func pluginTypeSet(cfg map[string]interface{}) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, p := range cfg["plugins"].([]interface{}) {
+		out[p.(map[string]interface{})["type"].(string)] = struct{}{}
+	}
+	return out
+}
+
+// profilePluginRefs returns the ordered pluginRef/weight pairs for the named
+// scheduling profile. Numbers are decoded as float64 by sigs.k8s.io/yaml.
+// found is false when no profile with that name exists.
+func profilePluginRefs(cfg map[string]interface{}, name string) (refs []pluginRefWeight, found bool) {
+	for _, p := range cfg["schedulingProfiles"].([]interface{}) {
+		pm := p.(map[string]interface{})
+		if pm["name"] != name {
+			continue
+		}
+		for _, r := range pm["plugins"].([]interface{}) {
+			rm := r.(map[string]interface{})
+			rw := pluginRefWeight{Ref: rm["pluginRef"].(string)}
+			if w, ok := rm["weight"]; ok {
+				rw.Weight = int(w.(float64))
+			}
+			refs = append(refs, rw)
+		}
+		return refs, true
+	}
+	return nil, false
+}
+
+// TestSchedulerConfigTextPD asserts the default prefill/decode (P/D) scheduling
+// profiles match the upstream llm-d optimized baseline: prefill gains
+// kv-cache-utilization-scorer, decode swaps queue-scorer for active-request-scorer.
+func TestSchedulerConfigTextPD(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// A non-nil Prefill selects the P/D branch of schedulerConfigText.
+	svc := &v1alpha2.LLMInferenceService{
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Prefill: &v1alpha2.WorkloadSpec{},
+		},
+	}
+
+	var cfg map[string]interface{}
+	g.Expect(yaml.Unmarshal([]byte(schedulerConfigText(svc)), &cfg)).To(Succeed())
+
+	// Every profile pluginRef must be declared in the top-level plugins list. The
+	// two new scorers are added there; queue-scorer stays (prefill still uses it).
+	g.Expect(pluginTypeSet(cfg)).To(SatisfyAll(
+		HaveKey("kv-cache-utilization-scorer"),
+		HaveKey("active-request-scorer"),
+		HaveKey("queue-scorer"),
+		HaveKey("prefix-cache-scorer"),
+		HaveKey("prefill-filter"),
+		HaveKey("decode-filter"),
+		HaveKey("max-score-picker"),
+	))
+
+	// Prefill profile: prefix-cache(3) + queue(2) + kv-cache-utilization(2).
+	prefill, found := profilePluginRefs(cfg, "prefill")
+	g.Expect(found).To(BeTrue(), "prefill profile should exist")
+	g.Expect(prefill).To(Equal([]pluginRefWeight{
+		{Ref: "prefill-filter"},
+		{Ref: "prefix-cache-scorer", Weight: 3},
+		{Ref: "queue-scorer", Weight: 2},
+		{Ref: "kv-cache-utilization-scorer", Weight: 2},
+		{Ref: "max-score-picker"},
+	}))
+
+	// Decode profile: active-request(2) replaces queue-scorer; prefix-cache(3).
+	// The exact match also guarantees queue-scorer is no longer referenced here.
+	decode, found := profilePluginRefs(cfg, "decode")
+	g.Expect(found).To(BeTrue(), "decode profile should exist")
+	g.Expect(decode).To(Equal([]pluginRefWeight{
+		{Ref: "decode-filter"},
+		{Ref: "active-request-scorer", Weight: 2},
+		{Ref: "prefix-cache-scorer", Weight: 3},
+		{Ref: "max-score-picker"},
+	}))
+}
+
 func TestWithRenamePlugin(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the default EndpointPicker (EPP) scheduling config that the llmisvc controller generates for prefill/decode (P/D) topology, aligning it with the llm-d optimized baseline. When `spec.prefill` is set, the controller emits a P/D config via `--config-text`; this PR brings that default in line with the optimized routing baseline:

- Prefill profile: adds `kv-cache-utilization-scorer` (weight 2) alongside the existing prefix-cache and queue scorers.
- Decode profile: replaces `queue-scorer` with `active-request-scorer` (weight 2). For decode pods doing ongoing token generation, active request count is a better load signal than queue depth.

Both scorers are also declared in the top-level `plugins:` list so the profile `pluginRef`s resolve (every `pluginRef` must reference a declared plugin). `queue-scorer` remains declared because the prefill profile still uses it. The change is pure embedded YAML, so it is air-gap safe (no external network or file dependencies), and both plugin names are registered in the default scheduler image (`llm-d-inference-scheduler:v0.7.1`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [x] Unit: new `TestSchedulerConfigTextPD` parses the generated YAML and asserts the exact prefill and decode profiles (pluginRefs + weights) and the top-level plugin declarations.
- [x] Regression: existing scheduler unit tests pass, including the v0.6 to v0.7 migration tests, confirming the new scorers survive `schedulerTransform`.
- [x] Integration: extended "should use prefill/decode scheduler config when prefill is configured" to assert the rendered `--config-text` contains `kv-cache-utilization-scorer` and `active-request-scorer` after the controller reconciles the scheduler Deployment.
- [x] `make precommit` passes with a clean working tree (vet, lint, generate, manifests, helm sync, verify steps).

- Logs

```
$ go test ./pkg/controller/v1alpha2/llmisvc/ -run TestSchedulerConfigTextPD -v
=== RUN   TestSchedulerConfigTextPD
--- PASS: TestSchedulerConfigTextPD (0.00s)
PASS
ok  github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc
```

This PR does not change any image versions.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Align the default prefill/decode (P/D) scheduler config with the llm-d optimized baseline: the prefill profile adds kv-cache-utilization-scorer and the decode profile uses active-request-scorer in place of queue-scorer.
```
