### PR TITLE
fix(llmisvc): render conversion webhook namespace dynamically

### DIFF
--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceserviceconfigs.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceservices.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceserviceconfigs.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kserve/llmisvc-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/llmisvc-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: llminferenceservices.serving.kserve.io
 spec:
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: llmisvc-webhook-server-service
-          namespace: kserve
+          namespace: {{ .Release.Namespace }}
           path: /convert
           port: 443
       conversionReviewVersions:

--- a/config/llmisvc/kustomization.yaml
+++ b/config/llmisvc/kustomization.yaml
@@ -69,6 +69,34 @@ replacements:
     select:
       kind: ValidatingWebhookConfiguration
       name: llminferenceserviceconfig.serving.kserve.io
+  # CRD conversion webhook namespace replacement
+  - fieldPaths:
+      - spec.conversion.webhook.clientConfig.service.namespace
+    select:
+      kind: CustomResourceDefinition
+      name: llminferenceservices.serving.kserve.io
+  - fieldPaths:
+      - spec.conversion.webhook.clientConfig.service.namespace
+    select:
+      kind: CustomResourceDefinition
+      name: llminferenceserviceconfigs.serving.kserve.io
+  # CRD conversion webhook cert-manager CA injection namespace replacement
+  - fieldPaths:
+      - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+    select:
+      kind: CustomResourceDefinition
+      name: llminferenceservices.serving.kserve.io
+  - fieldPaths:
+      - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+    select:
+      kind: CustomResourceDefinition
+      name: llminferenceserviceconfigs.serving.kserve.io
 # Replace llmisvc webhook service name
 - source:
     fieldPath: metadata.name
@@ -101,6 +129,17 @@ replacements:
       kind: Certificate
       name: llmisvc-serving-cert
       namespace: kserve
+  # CRD conversion webhook service name replacement
+  - fieldPaths:
+    - spec.conversion.webhook.clientConfig.service.name
+    select:
+      kind: CustomResourceDefinition
+      name: llminferenceservices.serving.kserve.io
+  - fieldPaths:
+    - spec.conversion.webhook.clientConfig.service.name
+    select:
+      kind: CustomResourceDefinition
+      name: llminferenceserviceconfigs.serving.kserve.io
 # Replace llmisvc service account name
 - source:
     fieldPath: metadata.name


### PR DESCRIPTION


**What this PR does / why we need it**:
- Use the Helm release namespace for LLMInferenceService CRD conversion webhook service references and cert-manager CA injection annotations.
- Also add Kustomize replacements so CRD conversion webhooks follow the llmisvc controller/webhook namespace instead of remaining hardcoded to kserve.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A


**Feature/Issue validation/testing**:

- [x] Verified full llmisvc CRD Helm chart renders the webhook namespace dynamically
       ```
       helm template test charts/kserve-llmisvc-crd-minimal --namespace inference-gateway
       ```
       - Result: rendered CRD conversion webhook service namespaces and cert-manager.io/inject-ca-from annotations use inference-gateway.

**Special notes for your reviewer**:

- This PR does not change image versions.
- This fixes installs where llmisvc webhook resources are deployed outside the default kserve namespace.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
  NONE
```
