### PR TITLE
feat(llmisvc): align standard default with llm-d optimized baseline

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -427,12 +427,16 @@ schedulingProfiles:
 				}, expectedDeployment)
 			}).WithContext(ctx).Should(Succeed())
 
-			// Verify default config for non-prefill mode (should contain queue-scorer, kv-cache-utilization-scorer, etc.)
+			// Verify default config for non-prefill mode. The default single-profile
+			// config follows the llm-d optimized baseline: queue-scorer,
+			// kv-cache-utilization-scorer, prefix-cache-scorer, no-hit-lru-scorer, max-score-picker.
 			configText, found := getSchedulerConfigText(expectedDeployment)
 			Expect(found).To(BeTrue(), "Expected default config in scheduler deployment")
 			// Default non-prefill config should contain these plugins
 			Expect(configText).To(ContainSubstring("queue-scorer"))
+			Expect(configText).To(ContainSubstring("kv-cache-utilization-scorer"))
 			Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+			Expect(configText).To(ContainSubstring("no-hit-lru-scorer"))
 			Expect(configText).To(ContainSubstring("max-score-picker"))
 			Expect(configText).To(ContainSubstring("name: default"))
 		})

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -529,6 +529,11 @@ plugins:
   - pluginRef: max-score-picker
 `, loraPlugin, loraProfileEntry, loraProfileEntry)
 	default:
+		// Single-profile default follows the llm-d optimized baseline:
+		// queue + kv-cache-utilization + prefix-cache + no-hit-lru scorers, plus
+		// lora-affinity-scorer injected when LoRA adapters are configured.
+		// kv-cache-utilization-scorer and no-hit-lru-scorer are declared in the
+		// top-level plugins list so the profile pluginRefs resolve.
 		var loraPlugin, loraProfileEntry string
 		if llmSvc.Spec.Model.LoRA != nil && len(llmSvc.Spec.Model.LoRA.Adapters) > 0 {
 			loraPlugin = fmt.Sprintf("- type: %s\n", loraAffinityScorerPlugin)
@@ -540,15 +545,21 @@ kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler
 - type: queue-scorer
+- type: kv-cache-utilization-scorer
 - type: prefix-cache-scorer
+- type: no-hit-lru-scorer
 - type: max-score-picker
 %sschedulingProfiles:
 - name: default
   plugins:
 %s  - pluginRef: queue-scorer
     weight: 2
+  - pluginRef: kv-cache-utilization-scorer
+    weight: 2
   - pluginRef: prefix-cache-scorer
     weight: 3
+  - pluginRef: no-hit-lru-scorer
+    weight: 2
   - pluginRef: max-score-picker
 `, loraPlugin, loraProfileEntry)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -384,6 +384,59 @@ func TestPreserveSchedulerConfig(t *testing.T) {
 	}
 }
 
+// TestSchedulerConfigTextDefault asserts the default (non-prefill, single-profile)
+// scheduler config matches the llm-d optimized baseline: queue + kv-cache-utilization +
+// prefix-cache + no-hit-lru scorers. Kept self-contained (no shared helpers) so it does
+// not collide with the P/D config test added in a separate change.
+func TestSchedulerConfigTextDefault(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// No Prefill selects the default branch of schedulerConfigText.
+	svc := &v1alpha2.LLMInferenceService{}
+
+	var cfg map[string]interface{}
+	g.Expect(yaml.Unmarshal([]byte(schedulerConfigText(svc)), &cfg)).To(Succeed())
+
+	// Every profile pluginRef must be declared in the top-level plugins list.
+	topLevel := map[string]struct{}{}
+	for _, p := range cfg["plugins"].([]interface{}) {
+		topLevel[p.(map[string]interface{})["type"].(string)] = struct{}{}
+	}
+	g.Expect(topLevel).To(SatisfyAll(
+		HaveKey("single-profile-handler"),
+		HaveKey("queue-scorer"),
+		HaveKey("kv-cache-utilization-scorer"),
+		HaveKey("prefix-cache-scorer"),
+		HaveKey("no-hit-lru-scorer"),
+		HaveKey("max-score-picker"),
+	))
+
+	// Exactly one "default" profile with the baseline pluginRef/weight sequence.
+	// sigs.k8s.io/yaml decodes numbers as float64; an absent weight is nil.
+	profiles := cfg["schedulingProfiles"].([]interface{})
+	g.Expect(profiles).To(HaveLen(1))
+	def := profiles[0].(map[string]interface{})
+	g.Expect(def["name"]).To(Equal("default"))
+
+	type refWeight struct {
+		ref    string
+		weight interface{}
+	}
+	defPlugins := def["plugins"].([]interface{})
+	got := make([]refWeight, 0, len(defPlugins))
+	for _, r := range defPlugins {
+		rm := r.(map[string]interface{})
+		got = append(got, refWeight{ref: rm["pluginRef"].(string), weight: rm["weight"]})
+	}
+	g.Expect(got).To(Equal([]refWeight{
+		{ref: "queue-scorer", weight: float64(2)},
+		{ref: "kv-cache-utilization-scorer", weight: float64(2)},
+		{ref: "prefix-cache-scorer", weight: float64(3)},
+		{ref: "no-hit-lru-scorer", weight: float64(2)},
+		{ref: "max-score-picker", weight: nil},
+	}))
+}
+
 func TestFilterArgs(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the default (non-prefill, single-profile / "standard topology") EndpointPicker config the llmisvc controller generates, aligning it with the llm-d optimized baseline. The default single scheduling profile now uses:

- `queue-scorer` (weight 2)
- `kv-cache-utilization-scorer` (weight 2)
- `prefix-cache-scorer` (weight 3)
- `no-hit-lru-scorer` (weight 2)
- `max-score-picker`

The two new scorers are declared in the top-level `plugins:` list so the profile `pluginRef`s resolve. The change is pure embedded YAML delivered via inline `--config-text` (consistent with the controller's existing default path), so it is air-gap safe; both new plugin names are registered in the default scheduler image (`llm-d-inference-scheduler:v0.7.1`). Explicit overrides via `spec.router.scheduler.config.inline`/`.ref` are resolved before the default is generated, so they continue to take precedence, and the v0.6→v0.7 config migration is unaffected (the default still flows through `schedulerTransform` and the new scorers are not touched by any rename).

Follow-up to #5662 (which updated the prefill/decode default).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [x] Unit: new `TestSchedulerConfigTextDefault` parses the generated YAML and asserts the top-level plugin declarations and the exact default-profile pluginRef/weight sequence.
- [x] Regression: existing scheduler unit tests pass, including the v0.6 to v0.7 migration tests, confirming the new scorers survive `schedulerTransform`.
- [x] Integration: extended "should use default scheduler config when no config is specified (non-prefill)" to assert the rendered `--config-text` contains `kv-cache-utilization-scorer` and `no-hit-lru-scorer`.
- [x] `make precommit` passes with a clean working tree (vet, lint, generate, manifests, helm sync, verify steps).

- Logs

```
$ go test ./pkg/controller/v1alpha2/llmisvc/ -run TestSchedulerConfigTextDefault -v
=== RUN   TestSchedulerConfigTextDefault
--- PASS: TestSchedulerConfigTextDefault (0.00s)
PASS
ok  github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc
```

This PR does not change any image versions.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Align the default (non-prefill, single-profile) scheduler config with the llm-d optimized baseline: the default profile now uses queue-scorer, kv-cache-utilization-scorer, prefix-cache-scorer, and no-hit-lru-scorer.
```
