### PR TITLE
fix(llmisvc): allow scheduler creation when workloads are rolling

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -181,11 +181,18 @@ func (r *LLMISVCReconciler) reconcileSchedulerDeployment(ctx context.Context, ll
 	// Defer EPP spec updates until all workload pods have finished rolling out.
 	// The EPP is on the critical path for every response chunk; restarting it mid-stream
 	// truncates in-flight streaming responses on the client side.
+	// Only defer if the scheduler deployment already exists — never block initial creation,
+	// as that would create a circular dependency (workloads wait for scheduler, scheduler
+	// waits for workloads).
 	if rolling, err := r.isWorkloadRolling(ctx, llmSvc); err != nil {
 		return err
 	} else if rolling {
-		logger.Info("Workload rollout in progress, deferring EPP deployment update")
-		return r.propagateSchedulerDeploymentStatus(ctx, scheduler, llmSvc.MarkSchedulerWorkloadReady, llmSvc.MarkSchedulerWorkloadNotReady)
+		curr := &appsv1.Deployment{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(scheduler), curr); err == nil {
+			logger.Info("Workload rollout in progress, deferring EPP deployment update")
+			return r.propagateSchedulerDeploymentStatus(ctx, scheduler, llmSvc.MarkSchedulerWorkloadReady, llmSvc.MarkSchedulerWorkloadNotReady)
+		}
+		logger.Info("Workload rollout in progress but scheduler deployment does not exist yet, proceeding with creation")
 	}
 	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, scheduler, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
 		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", scheduler.GetNamespace(), scheduler.GetName(), err)


### PR DESCRIPTION
**What this PR does / why we need it**:

The `isWorkloadRolling` guard introduced in #5602 defers EPP deployment updates while workload pods are mid-rollout to prevent dropping in-flight streaming responses. However, it also blocks the scheduler's initial creation on new LLMInferenceService resources, creating a circular dependency where the scheduler is never created.

When a new LLMInferenceService is created, the workload deployments are immediately marked `Available=False` (pods still booting). If the scheduler reconcile runs after this condition is set, `isWorkloadRolling` returns `true` and the scheduler creation is permanently skipped. `propagateSchedulerDeploymentStatus` retries and fails with "Deployment not found" because the scheduler was never created in the first place.

The fix: only defer when the scheduler deployment already exists. If it doesn't exist, there's no running EPP to protect from a restart, so proceed with creation.

Fixes a regression introduced in #5602.