### PR TITLE
fix(llmisvc): only inject lora-affinity-scorer into default config

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -502,10 +502,6 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 			}
 		}
 
-		if err := mutateSchedulerConfig(ctx, d, withLoraAffinityScorer(llmSvc.Spec.Model.LoRA != nil && len(llmSvc.Spec.Model.LoRA.Adapters) > 0)); err != nil {
-			return d, fmt.Errorf("failed to inject lora-affinity-scorer into scheduler config: %w", err)
-		}
-
 		// v0.7.0 migrations: version-gated (>= 0.7.0) because the v0.6 binary
 		// does not recognize the new plugin names. The v0.7 binary deprecates
 		// the old names but still accepts them.
@@ -573,7 +569,12 @@ schedulingProfiles:
   - pluginRef: max-score-picker
 `
 	default:
-		return `
+		var loraPlugin, loraProfileEntry string
+		if llmSvc.Spec.Model.LoRA != nil && len(llmSvc.Spec.Model.LoRA.Adapters) > 0 {
+			loraPlugin = fmt.Sprintf("- type: %s\n", loraAffinityScorerPlugin)
+			loraProfileEntry = fmt.Sprintf("  - pluginRef: %s\n    weight: 4\n", loraAffinityScorerPlugin)
+		}
+		return fmt.Sprintf(`
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -581,15 +582,15 @@ plugins:
 - type: queue-scorer
 - type: prefix-cache-scorer
 - type: max-score-picker
-schedulingProfiles:
+%sschedulingProfiles:
 - name: default
   plugins:
-  - pluginRef: queue-scorer
+%s  - pluginRef: queue-scorer
     weight: 2
   - pluginRef: prefix-cache-scorer
     weight: 3
   - pluginRef: max-score-picker
-`
+`, loraPlugin, loraProfileEntry)
 	}
 }
 
@@ -889,73 +890,6 @@ func WithUdsTokenizerConfig(_ context.Context, u *unstructured.Unstructured) err
 	}
 
 	return nil
-}
-
-// withLoraAffinityScorer returns a mutateSchedulerConfigFunc that injects the
-// lora-affinity-scorer plugin when LoRA adapters are configured. It adds the
-// plugin to the top-level plugins list and to the default schedulingProfile so
-// requests are routed to endpoints that have the requested adapter loaded.
-// No-op when hasLoRA is false or the plugin is already present.
-//
-// Scope: only the "default" schedulingProfile is targeted. Prefill/decode
-// profiles used in P/D disaggregation are not modified; LoRA + P/D is a
-// separate concern tracked outside this function.
-//
-// Removal: once injected the scorer persists if LoRA adapters are later
-// removed, because preserveSchedulerConfig carries forward the existing
-// --config-text. The scorer is harmless when idle (no LoRA requests).
-func withLoraAffinityScorer(hasLoRA bool) mutateSchedulerConfigFunc {
-	return func(_ context.Context, u *unstructured.Unstructured) error {
-		if !hasLoRA {
-			return nil
-		}
-
-		val, _, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
-		if err != nil {
-			return err
-		}
-		plugins, _ := val.([]interface{})
-
-		for _, plugin := range plugins {
-			if pm, ok := plugin.(map[string]interface{}); ok && pm["type"] == loraAffinityScorerPlugin {
-				return nil
-			}
-		}
-
-		plugins = append(plugins, map[string]interface{}{"type": loraAffinityScorerPlugin})
-		if err := unstructured.SetNestedSlice(u.Object, plugins, "plugins"); err != nil {
-			return err
-		}
-
-		profiles, found, err := unstructured.NestedFieldNoCopy(u.Object, "schedulingProfiles")
-		if err != nil || !found {
-			return err
-		}
-		profileList, ok := profiles.([]interface{})
-		if !ok {
-			return nil
-		}
-		for _, profile := range profileList {
-			profileMap, ok := profile.(map[string]interface{})
-			if !ok || profileMap["name"] != "default" {
-				continue
-			}
-			pluginRefs, _, _ := unstructured.NestedFieldNoCopy(profileMap, "plugins")
-			refs, _ := pluginRefs.([]interface{})
-			for _, ref := range refs {
-				if rm, ok := ref.(map[string]interface{}); ok && rm["pluginRef"] == loraAffinityScorerPlugin {
-					return nil
-				}
-			}
-			newRef := map[string]interface{}{"pluginRef": loraAffinityScorerPlugin, "weight": int64(4)}
-			refs = append([]interface{}{newRef}, refs...)
-			if err := unstructured.SetNestedSlice(profileMap, refs, "plugins"); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
 }
 
 // WithMigrateTokenProcessorConfig migrates tokenProcessorConfig from inside

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -535,7 +535,12 @@ func schedulerConfigText(llmSvc *v1alpha2.LLMInferenceService) string {
 	switch {
 	case llmSvc.Spec.Prefill != nil:
 		// Always do P/D by default (threshold 0)
-		return `
+		var loraPlugin, loraProfileEntry string
+		if llmSvc.Spec.Model.LoRA != nil && len(llmSvc.Spec.Model.LoRA.Adapters) > 0 {
+			loraPlugin = fmt.Sprintf("- type: %s\n", loraAffinityScorerPlugin)
+			loraProfileEntry = fmt.Sprintf("  - pluginRef: %s\n    weight: 4\n", loraAffinityScorerPlugin)
+		}
+		return fmt.Sprintf(`
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -550,11 +555,11 @@ plugins:
   parameters:
     deciders:
       prefill: always-disagg-pd-decider
-schedulingProfiles:
+%sschedulingProfiles:
 - name: prefill
   plugins:
   - pluginRef: prefill-filter
-  - pluginRef: queue-scorer
+%s  - pluginRef: queue-scorer
     weight: 2
   - pluginRef: prefix-cache-scorer
     weight: 3
@@ -562,12 +567,12 @@ schedulingProfiles:
 - name: decode
   plugins:
   - pluginRef: decode-filter
-  - pluginRef: queue-scorer
+%s  - pluginRef: queue-scorer
     weight: 2
   - pluginRef: prefix-cache-scorer
     weight: 3
   - pluginRef: max-score-picker
-`
+`, loraPlugin, loraProfileEntry, loraProfileEntry)
 	default:
 		var loraPlugin, loraProfileEntry string
 		if llmSvc.Spec.Model.LoRA != nil && len(llmSvc.Spec.Model.LoRA.Adapters) > 0 {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -32,153 +32,80 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
 
-func TestWithLoraAffinityScorer(t *testing.T) {
+func TestSchedulerConfigTextLoRA(t *testing.T) {
+	loraAdapters := []v1alpha2.LLMModelSpec{{}}
+
 	tests := []struct {
-		name       string
-		hasLoRA    bool
-		configYAML string
-		validate   func(g Gomega, obj map[string]interface{})
+		name     string
+		llmSvc   *v1alpha2.LLMInferenceService
+		wantLoRA bool
 	}{
 		{
-			name:    "no LoRA - no-op",
-			hasLoRA: false,
-			configYAML: `
-plugins:
-- type: single-profile-handler
-- type: queue-scorer
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: queue-scorer
-    weight: 2
-`,
-			validate: func(g Gomega, obj map[string]interface{}) {
-				plugins := obj["plugins"].([]interface{})
-				g.Expect(plugins).To(HaveLen(2))
-				for _, p := range plugins {
-					g.Expect(p.(map[string]interface{})["type"]).NotTo(Equal(loraAffinityScorerPlugin))
-				}
-			},
+			name:     "no LoRA - standard default config",
+			llmSvc:   &v1alpha2.LLMInferenceService{},
+			wantLoRA: false,
 		},
 		{
-			name:    "with LoRA - injects plugin and default profile entry",
-			hasLoRA: true,
-			configYAML: `
-plugins:
-- type: single-profile-handler
-- type: queue-scorer
-- type: prefix-cache-scorer
-- type: max-score-picker
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: queue-scorer
-    weight: 2
-  - pluginRef: prefix-cache-scorer
-    weight: 3
-  - pluginRef: max-score-picker
-`,
-			validate: func(g Gomega, obj map[string]interface{}) {
-				plugins := obj["plugins"].([]interface{})
-				types := make([]string, 0, len(plugins))
-				for _, p := range plugins {
-					types = append(types, p.(map[string]interface{})["type"].(string))
-				}
-				g.Expect(types).To(ContainElement(loraAffinityScorerPlugin))
-
-				profiles := obj["schedulingProfiles"].([]interface{})
-				defaultProfile := profiles[0].(map[string]interface{})
-				g.Expect(defaultProfile["name"]).To(Equal("default"))
-				refs := defaultProfile["plugins"].([]interface{})
-				g.Expect(refs[0].(map[string]interface{})["pluginRef"]).To(Equal(loraAffinityScorerPlugin))
-				g.Expect(refs[0].(map[string]interface{})["weight"]).To(Equal(int64(4)))
+			name: "LoRA nil pointer - no scorer",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{LoRA: nil},
+				},
 			},
+			wantLoRA: false,
 		},
 		{
-			name:    "with LoRA - idempotent when plugin already present",
-			hasLoRA: true,
-			configYAML: `
-plugins:
-- type: lora-affinity-scorer
-- type: queue-scorer
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: lora-affinity-scorer
-    weight: 4
-  - pluginRef: queue-scorer
-    weight: 2
-`,
-			validate: func(g Gomega, obj map[string]interface{}) {
-				plugins := obj["plugins"].([]interface{})
-				count := 0
-				for _, p := range plugins {
-					if p.(map[string]interface{})["type"] == loraAffinityScorerPlugin {
-						count++
-					}
-				}
-				g.Expect(count).To(Equal(1))
+			name: "LoRA spec with empty adapters - no scorer",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{LoRA: &v1alpha2.LoRASpec{}},
+				},
 			},
+			wantLoRA: false,
 		},
 		{
-			name:    "with LoRA - only injects into default profile, not others",
-			hasLoRA: true,
-			configYAML: `
-plugins:
-- type: queue-scorer
-schedulingProfiles:
-- name: prefill
-  plugins:
-  - pluginRef: queue-scorer
-- name: default
-  plugins:
-  - pluginRef: queue-scorer
-    weight: 2
-`,
-			validate: func(g Gomega, obj map[string]interface{}) {
-				profiles := obj["schedulingProfiles"].([]interface{})
-				for _, profile := range profiles {
-					pm := profile.(map[string]interface{})
-					refs := pm["plugins"].([]interface{})
-					if pm["name"] == "default" {
-						g.Expect(refs[0].(map[string]interface{})["pluginRef"]).To(Equal(loraAffinityScorerPlugin))
-					} else {
-						for _, ref := range refs {
-							g.Expect(ref.(map[string]interface{})["pluginRef"]).NotTo(Equal(loraAffinityScorerPlugin))
-						}
-					}
-				}
+			name: "LoRA adapters present - scorer included",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{
+						LoRA: &v1alpha2.LoRASpec{Adapters: loraAdapters},
+					},
+				},
 			},
-		},
-		{
-			name:    "no LoRA - no-op (hasLoRA=false)",
-			hasLoRA: false,
-			configYAML: `
-plugins:
-- type: queue-scorer
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: queue-scorer
-    weight: 2
-`,
-			validate: func(g Gomega, obj map[string]interface{}) {
-				plugins := obj["plugins"].([]interface{})
-				g.Expect(plugins).To(HaveLen(1))
-				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
-			},
+			wantLoRA: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
+			text := schedulerConfigText(tt.llmSvc)
+
 			var obj map[string]interface{}
-			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
-			u := unstructured.Unstructured{Object: obj}
-			fn := withLoraAffinityScorer(tt.hasLoRA)
-			g.Expect(fn(context.Background(), &u)).To(Succeed())
-			tt.validate(g, u.Object)
+			g.Expect(yaml.Unmarshal([]byte(text), &obj)).To(Succeed())
+
+			plugins := obj["plugins"].([]interface{})
+			types := make([]string, 0, len(plugins))
+			for _, p := range plugins {
+				types = append(types, p.(map[string]interface{})["type"].(string))
+			}
+
+			profiles := obj["schedulingProfiles"].([]interface{})
+			defaultProfile := profiles[0].(map[string]interface{})
+			refs := defaultProfile["plugins"].([]interface{})
+			refNames := make([]string, 0, len(refs))
+			for _, r := range refs {
+				refNames = append(refNames, r.(map[string]interface{})["pluginRef"].(string))
+			}
+
+			if tt.wantLoRA {
+				g.Expect(types).To(ContainElement(loraAffinityScorerPlugin))
+				g.Expect(refNames[0]).To(Equal(loraAffinityScorerPlugin))
+				g.Expect(refs[0].(map[string]interface{})["weight"]).To(BeNumerically("==", 4))
+			} else {
+				g.Expect(types).NotTo(ContainElement(loraAffinityScorerPlugin))
+				g.Expect(refNames).NotTo(ContainElement(loraAffinityScorerPlugin))
+			}
 		})
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -110,6 +110,78 @@ func TestSchedulerConfigTextLoRA(t *testing.T) {
 	}
 }
 
+func TestSchedulerConfigTextPDLoRA(t *testing.T) {
+	loraAdapters := []v1alpha2.LLMModelSpec{{}}
+
+	tests := []struct {
+		name     string
+		llmSvc   *v1alpha2.LLMInferenceService
+		wantLoRA bool
+	}{
+		{
+			name: "P/D without LoRA - no scorer",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Prefill: &v1alpha2.WorkloadSpec{},
+				},
+			},
+			wantLoRA: false,
+		},
+		{
+			name: "P/D with LoRA adapters - scorer in both profiles",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Prefill: &v1alpha2.WorkloadSpec{},
+					Model: v1alpha2.LLMModelSpec{
+						LoRA: &v1alpha2.LoRASpec{Adapters: loraAdapters},
+					},
+				},
+			},
+			wantLoRA: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			text := schedulerConfigText(tt.llmSvc)
+
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(text), &obj)).To(Succeed())
+
+			plugins := obj["plugins"].([]interface{})
+			types := make([]string, 0, len(plugins))
+			for _, p := range plugins {
+				types = append(types, p.(map[string]interface{})["type"].(string))
+			}
+
+			profiles := obj["schedulingProfiles"].([]interface{})
+			g.Expect(profiles).To(HaveLen(2))
+
+			for _, profile := range profiles {
+				refs := profile.(map[string]interface{})["plugins"].([]interface{})
+				refNames := make([]string, 0, len(refs))
+				for _, r := range refs {
+					refNames = append(refNames, r.(map[string]interface{})["pluginRef"].(string))
+				}
+
+				if tt.wantLoRA {
+					g.Expect(types).To(ContainElement(loraAffinityScorerPlugin))
+					// scorer is second (after the profile's filter plugin)
+					g.Expect(refNames[1]).To(Equal(loraAffinityScorerPlugin))
+					g.Expect(refs[1].(map[string]interface{})["weight"]).To(BeNumerically("==", 4))
+				} else {
+					g.Expect(refNames).NotTo(ContainElement(loraAffinityScorerPlugin))
+				}
+			}
+
+			if !tt.wantLoRA {
+				g.Expect(types).NotTo(ContainElement(loraAffinityScorerPlugin))
+			}
+		})
+	}
+}
+
 func TestPreserveSchedulerConfig(t *testing.T) {
 	defaultSvc := &v1alpha2.LLMInferenceService{}
 	inlineSvc := &v1alpha2.LLMInferenceService{


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves the \`lora-affinity-scorer\` injection from \`mutateSchedulerConfig\` into \`schedulerConfigText\` so the scorer only appears in the auto-generated default \`EndpointPickerConfig\`, not in user-provided configs. Also extends the injection to P/D disaggregation profiles (prefill and decode), where it is equally applicable since the scorer operates on vLLM adapter metrics exposed by all pods regardless of role.

Previously (#5655) the scorer was injected via \`mutateSchedulerConfig\`, which runs on any active config — including configs provided via \`spec.router.scheduler.config.inline\`, a ConfigMap ref, or preserved from an existing deployment. This gave users no way to opt out or override the scorer placement.

Now the scorer is part of the generated default YAML only when LoRA adapters are specified (\`len(spec.model.lora.adapters) > 0\`). If the user supplies their own scheduler config through any mechanism, that config is used untouched.

**Which issue(s) this PR fixes** *(optional)*:
Follow-up to #5655 (addresses review feedback from @pierDipi)

**Feature/Issue validation/testing**:

- [x] \`TestSchedulerConfigTextLoRA\` — covers no LoRA, nil LoRA, empty adapters (no scorer), and adapters present (scorer included with weight 4 as first profile entry)
- [x] \`TestSchedulerConfigTextPDLoRA\` — covers P/D without LoRA (no scorer) and P/D with LoRA adapters (scorer in both prefill and decode profiles)
- [ ] Manual validation via e2e with LoRA adapters configured

**Special notes for your reviewer**:
\`withLoraAffinityScorer\` and its \`mutateSchedulerConfig\` call are removed entirely. The \`loraAffinityScorerPlugin\` constant is still used via \`fmt.Sprintf\` inside \`schedulerConfigText\` to avoid hardcoding the string.

**Checklist**:
- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```
Auto-enable lora-affinity-scorer in the default scheduler config when LoRA adapters are specified, including in P/D disaggregation profiles
```