### PR TITLE
feat: add latency predictor sidecar injection via plugin detection

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -2076,6 +2076,192 @@ spec:
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
+  name: kserve-config-llm-scheduler-latency-predictor
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      template:
+        containers:
+        - env:
+          - name: PREDICTION_SERVER_URL
+            value: http://localhost:8001
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MAX_SAMPLE_SIZE
+            value: "10000"
+          - name: LATENCY_MAX_CONCURRENT_DISPATCHES
+            value: "36"
+          - name: LATENCY_COALESCE_WINDOW_MS
+            value: "1"
+          name: main
+        - env:
+          - name: LATENCY_RETRAINING_INTERVAL_SEC
+            value: "10"
+          - name: LATENCY_MIN_SAMPLES_FOR_RETRAIN
+            value: "100"
+          - name: LATENCY_TTFT_MODEL_PATH
+            value: /models/ttft.joblib
+          - name: LATENCY_TPOT_MODEL_PATH
+            value: /models/tpot.joblib
+          - name: LATENCY_TTFT_SCALER_PATH
+            value: /models/ttft_scaler.joblib
+          - name: LATENCY_TPOT_SCALER_PATH
+            value: /models/tpot_scaler.joblib
+          - name: LATENCY_TTFT_GATED_MODEL_PATH
+            value: /models/ttft_gated.joblib
+          - name: LATENCY_TPOT_GATED_MODEL_PATH
+            value: /models/tpot_gated.joblib
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET
+            value: "500"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: registry.k8s.io/gateway-api-inference-extension/latency-training-server:v1.5.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          name: training-server
+          ports:
+          - containerPort: 8000
+            name: training-port
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 4000m
+              memory: 8Gi
+            requests:
+              cpu: 2000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz
+              port: 8000
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /models
+            name: training-server-storage
+          - mountPath: /tmp
+            name: training-server-tmp
+        - env:
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: PREDICT_HOST
+            value: 0.0.0.0
+          - name: PREDICT_PORT
+            value: "8001"
+          - name: LOCAL_TTFT_MODEL_PATH
+            value: /server_models/ttft.joblib
+          - name: LOCAL_TPOT_MODEL_PATH
+            value: /server_models/tpot.joblib
+          - name: LOCAL_TTFT_SCALER_PATH
+            value: /server_models/ttft_scaler.joblib
+          - name: LOCAL_TPOT_SCALER_PATH
+            value: /server_models/tpot_scaler.joblib
+          - name: LOCAL_TTFT_GATED_MODEL_PATH
+            value: /server_models/ttft_gated.joblib
+          - name: LOCAL_TPOT_GATED_MODEL_PATH
+            value: /server_models/tpot_gated.joblib
+          - name: UVICORN_WORKERS
+            value: "28"
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MODEL_SYNC_INTERVAL_SEC
+            value: "30"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: registry.k8s.io/gateway-api-inference-extension/latency-prediction-server:v1.5.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          name: prediction-server
+          ports:
+          - containerPort: 8001
+            name: predict-port
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 28000m
+              memory: 8Gi
+            requests:
+              cpu: 8000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /readyz
+              port: 8001
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /server_models
+            name: prediction-server-storage
+          - mountPath: /tmp
+            name: prediction-server-tmp
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - emptyDir:
+            sizeLimit: 20Gi
+          name: training-server-storage
+        - emptyDir:
+            sizeLimit: 10Gi
+          name: prediction-server-storage
+        - emptyDir: {}
+          name: training-server-tmp
+        - emptyDir: {}
+          name: prediction-server-tmp
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
   name: kserve-config-llm-template
   namespace: kserve
 spec:

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -2118,7 +2118,7 @@ spec:
             value: "500"
           - name: LATENCY_OBJECTIVE_TYPE
             value: mean
-          image: registry.k8s.io/gateway-api-inference-extension/latency-training-server:v1.5.0
+          image: ghcr.io/llm-d/llm-d-latency-predictor-training-server:v0.8.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -2194,7 +2194,7 @@ spec:
             value: "30"
           - name: LATENCY_OBJECTIVE_TYPE
             value: mean
-          image: registry.k8s.io/gateway-api-inference-extension/latency-prediction-server:v1.5.0
+          image: ghcr.io/llm-d/llm-d-latency-predictor-prediction-server:v0.8.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5

--- a/config/llmisvcconfig/config-llm-scheduler-latency-predictor.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler-latency-predictor.yaml
@@ -1,0 +1,185 @@
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-scheduler-latency-predictor
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      template:
+        containers:
+        - name: main
+          env:
+          - name: PREDICTION_SERVER_URL
+            value: http://localhost:8001
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MAX_SAMPLE_SIZE
+            value: "10000"
+          - name: LATENCY_MAX_CONCURRENT_DISPATCHES
+            value: "36"
+          - name: LATENCY_COALESCE_WINDOW_MS
+            value: "1"
+        - name: training-server
+          image: registry.k8s.io/gateway-api-inference-extension/latency-training-server:v1.5.0
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8000
+            name: training-port
+          resources:
+            requests:
+              cpu: "2000m"
+              memory: "4Gi"
+            limits:
+              cpu: "4000m"
+              memory: "8Gi"
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+          - name: LATENCY_RETRAINING_INTERVAL_SEC
+            value: "10"
+          - name: LATENCY_MIN_SAMPLES_FOR_RETRAIN
+            value: "100"
+          - name: LATENCY_TTFT_MODEL_PATH
+            value: /models/ttft.joblib
+          - name: LATENCY_TPOT_MODEL_PATH
+            value: /models/tpot.joblib
+          - name: LATENCY_TTFT_SCALER_PATH
+            value: /models/ttft_scaler.joblib
+          - name: LATENCY_TPOT_SCALER_PATH
+            value: /models/tpot_scaler.joblib
+          - name: LATENCY_TTFT_GATED_MODEL_PATH
+            value: /models/ttft_gated.joblib
+          - name: LATENCY_TPOT_GATED_MODEL_PATH
+            value: /models/tpot_gated.joblib
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET
+            value: "500"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - name: training-server-storage
+            mountPath: /models
+          - name: training-server-tmp
+            mountPath: /tmp
+        - name: prediction-server
+          image: registry.k8s.io/gateway-api-inference-extension/latency-prediction-server:v1.5.0
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8001
+            name: predict-port
+          resources:
+            requests:
+              cpu: "8000m"
+              memory: "4Gi"
+            limits:
+              cpu: "28000m"
+              memory: "8Gi"
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: 8001
+            failureThreshold: 60
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: PREDICT_HOST
+            value: 0.0.0.0
+          - name: PREDICT_PORT
+            value: "8001"
+          - name: LOCAL_TTFT_MODEL_PATH
+            value: /server_models/ttft.joblib
+          - name: LOCAL_TPOT_MODEL_PATH
+            value: /server_models/tpot.joblib
+          - name: LOCAL_TTFT_SCALER_PATH
+            value: /server_models/ttft_scaler.joblib
+          - name: LOCAL_TPOT_SCALER_PATH
+            value: /server_models/tpot_scaler.joblib
+          - name: LOCAL_TTFT_GATED_MODEL_PATH
+            value: /server_models/ttft_gated.joblib
+          - name: LOCAL_TPOT_GATED_MODEL_PATH
+            value: /server_models/tpot_gated.joblib
+          - name: UVICORN_WORKERS
+            value: "28"
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MODEL_SYNC_INTERVAL_SEC
+            value: "30"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - name: prediction-server-storage
+            mountPath: /server_models
+          - name: prediction-server-tmp
+            mountPath: /tmp
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - name: training-server-storage
+          emptyDir:
+            sizeLimit: 20Gi
+        - name: prediction-server-storage
+          emptyDir:
+            sizeLimit: 10Gi
+        - name: training-server-tmp
+          emptyDir: {}
+        - name: prediction-server-tmp
+          emptyDir: {}

--- a/config/llmisvcconfig/config-llm-scheduler-latency-predictor.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler-latency-predictor.yaml
@@ -21,7 +21,7 @@ spec:
           - name: LATENCY_COALESCE_WINDOW_MS
             value: "1"
         - name: training-server
-          image: registry.k8s.io/gateway-api-inference-extension/latency-training-server:v1.5.0
+          image: ghcr.io/llm-d/llm-d-latency-predictor-training-server:v0.8.0
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 8000
@@ -91,7 +91,7 @@ spec:
           - name: training-server-tmp
             mountPath: /tmp
         - name: prediction-server
-          image: registry.k8s.io/gateway-api-inference-extension/latency-prediction-server:v1.5.0
+          image: ghcr.io/llm-d/llm-d-latency-predictor-prediction-server:v0.8.0
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 8001

--- a/config/llmisvcconfig/kustomization.yaml
+++ b/config/llmisvcconfig/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - config-llm-prefill-worker-data-parallel.yaml
   - config-llm-router-route.yaml
   - config-llm-scheduler.yaml
+  - config-llm-scheduler-latency-predictor.yaml
   - config-llm-template.yaml
   - config-llm-tracing.yaml
   - config-llm-worker-data-parallel.yaml

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4639,6 +4639,192 @@ spec:
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
+  name: kserve-config-llm-scheduler-latency-predictor
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      template:
+        containers:
+        - env:
+          - name: PREDICTION_SERVER_URL
+            value: http://localhost:8001
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MAX_SAMPLE_SIZE
+            value: "10000"
+          - name: LATENCY_MAX_CONCURRENT_DISPATCHES
+            value: "36"
+          - name: LATENCY_COALESCE_WINDOW_MS
+            value: "1"
+          name: main
+        - env:
+          - name: LATENCY_RETRAINING_INTERVAL_SEC
+            value: "10"
+          - name: LATENCY_MIN_SAMPLES_FOR_RETRAIN
+            value: "100"
+          - name: LATENCY_TTFT_MODEL_PATH
+            value: /models/ttft.joblib
+          - name: LATENCY_TPOT_MODEL_PATH
+            value: /models/tpot.joblib
+          - name: LATENCY_TTFT_SCALER_PATH
+            value: /models/ttft_scaler.joblib
+          - name: LATENCY_TPOT_SCALER_PATH
+            value: /models/tpot_scaler.joblib
+          - name: LATENCY_TTFT_GATED_MODEL_PATH
+            value: /models/ttft_gated.joblib
+          - name: LATENCY_TPOT_GATED_MODEL_PATH
+            value: /models/tpot_gated.joblib
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET
+            value: "500"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: registry.k8s.io/gateway-api-inference-extension/latency-training-server:v1.5.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          name: training-server
+          ports:
+          - containerPort: 8000
+            name: training-port
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 4000m
+              memory: 8Gi
+            requests:
+              cpu: 2000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz
+              port: 8000
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /models
+            name: training-server-storage
+          - mountPath: /tmp
+            name: training-server-tmp
+        - env:
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: PREDICT_HOST
+            value: 0.0.0.0
+          - name: PREDICT_PORT
+            value: "8001"
+          - name: LOCAL_TTFT_MODEL_PATH
+            value: /server_models/ttft.joblib
+          - name: LOCAL_TPOT_MODEL_PATH
+            value: /server_models/tpot.joblib
+          - name: LOCAL_TTFT_SCALER_PATH
+            value: /server_models/ttft_scaler.joblib
+          - name: LOCAL_TPOT_SCALER_PATH
+            value: /server_models/tpot_scaler.joblib
+          - name: LOCAL_TTFT_GATED_MODEL_PATH
+            value: /server_models/ttft_gated.joblib
+          - name: LOCAL_TPOT_GATED_MODEL_PATH
+            value: /server_models/tpot_gated.joblib
+          - name: UVICORN_WORKERS
+            value: "28"
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MODEL_SYNC_INTERVAL_SEC
+            value: "30"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: registry.k8s.io/gateway-api-inference-extension/latency-prediction-server:v1.5.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          name: prediction-server
+          ports:
+          - containerPort: 8001
+            name: predict-port
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 28000m
+              memory: 8Gi
+            requests:
+              cpu: 8000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /readyz
+              port: 8001
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /server_models
+            name: prediction-server-storage
+          - mountPath: /tmp
+            name: prediction-server-tmp
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - emptyDir:
+            sizeLimit: 20Gi
+          name: training-server-storage
+        - emptyDir:
+            sizeLimit: 10Gi
+          name: prediction-server-storage
+        - emptyDir: {}
+          name: training-server-tmp
+        - emptyDir: {}
+          name: prediction-server-tmp
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
   name: kserve-config-llm-template
   namespace: kserve
 spec:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4681,7 +4681,7 @@ spec:
             value: "500"
           - name: LATENCY_OBJECTIVE_TYPE
             value: mean
-          image: registry.k8s.io/gateway-api-inference-extension/latency-training-server:v1.5.0
+          image: ghcr.io/llm-d/llm-d-latency-predictor-training-server:v0.8.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -4757,7 +4757,7 @@ spec:
             value: "30"
           - name: LATENCY_OBJECTIVE_TYPE
             value: mean
-          image: registry.k8s.io/gateway-api-inference-extension/latency-prediction-server:v1.5.0
+          image: ghcr.io/llm-d/llm-d-latency-predictor-prediction-server:v0.8.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -4267,7 +4267,7 @@ spec:
             value: "500"
           - name: LATENCY_OBJECTIVE_TYPE
             value: mean
-          image: registry.k8s.io/gateway-api-inference-extension/latency-training-server:v1.5.0
+          image: ghcr.io/llm-d/llm-d-latency-predictor-training-server:v0.8.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -4343,7 +4343,7 @@ spec:
             value: "30"
           - name: LATENCY_OBJECTIVE_TYPE
             value: mean
-          image: registry.k8s.io/gateway-api-inference-extension/latency-prediction-server:v1.5.0
+          image: ghcr.io/llm-d/llm-d-latency-predictor-prediction-server:v0.8.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -4225,6 +4225,192 @@ spec:
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
 metadata:
+  name: kserve-config-llm-scheduler-latency-predictor
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      template:
+        containers:
+        - env:
+          - name: PREDICTION_SERVER_URL
+            value: http://localhost:8001
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MAX_SAMPLE_SIZE
+            value: "10000"
+          - name: LATENCY_MAX_CONCURRENT_DISPATCHES
+            value: "36"
+          - name: LATENCY_COALESCE_WINDOW_MS
+            value: "1"
+          name: main
+        - env:
+          - name: LATENCY_RETRAINING_INTERVAL_SEC
+            value: "10"
+          - name: LATENCY_MIN_SAMPLES_FOR_RETRAIN
+            value: "100"
+          - name: LATENCY_TTFT_MODEL_PATH
+            value: /models/ttft.joblib
+          - name: LATENCY_TPOT_MODEL_PATH
+            value: /models/tpot.joblib
+          - name: LATENCY_TTFT_SCALER_PATH
+            value: /models/ttft_scaler.joblib
+          - name: LATENCY_TPOT_SCALER_PATH
+            value: /models/tpot_scaler.joblib
+          - name: LATENCY_TTFT_GATED_MODEL_PATH
+            value: /models/ttft_gated.joblib
+          - name: LATENCY_TPOT_GATED_MODEL_PATH
+            value: /models/tpot_gated.joblib
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET
+            value: "500"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: registry.k8s.io/gateway-api-inference-extension/latency-training-server:v1.5.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          name: training-server
+          ports:
+          - containerPort: 8000
+            name: training-port
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 4000m
+              memory: 8Gi
+            requests:
+              cpu: 2000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz
+              port: 8000
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /models
+            name: training-server-storage
+          - mountPath: /tmp
+            name: training-server-tmp
+        - env:
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: PREDICT_HOST
+            value: 0.0.0.0
+          - name: PREDICT_PORT
+            value: "8001"
+          - name: LOCAL_TTFT_MODEL_PATH
+            value: /server_models/ttft.joblib
+          - name: LOCAL_TPOT_MODEL_PATH
+            value: /server_models/tpot.joblib
+          - name: LOCAL_TTFT_SCALER_PATH
+            value: /server_models/ttft_scaler.joblib
+          - name: LOCAL_TPOT_SCALER_PATH
+            value: /server_models/tpot_scaler.joblib
+          - name: LOCAL_TTFT_GATED_MODEL_PATH
+            value: /server_models/ttft_gated.joblib
+          - name: LOCAL_TPOT_GATED_MODEL_PATH
+            value: /server_models/tpot_gated.joblib
+          - name: UVICORN_WORKERS
+            value: "28"
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MODEL_SYNC_INTERVAL_SEC
+            value: "30"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: registry.k8s.io/gateway-api-inference-extension/latency-prediction-server:v1.5.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          name: prediction-server
+          ports:
+          - containerPort: 8001
+            name: predict-port
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 28000m
+              memory: 8Gi
+            requests:
+              cpu: 8000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /readyz
+              port: 8001
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /server_models
+            name: prediction-server-storage
+          - mountPath: /tmp
+            name: prediction-server-tmp
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - emptyDir:
+            sizeLimit: 20Gi
+          name: training-server-storage
+        - emptyDir:
+            sizeLimit: 10Gi
+          name: prediction-server-storage
+        - emptyDir: {}
+          name: training-server-tmp
+        - emptyDir: {}
+          name: prediction-server-tmp
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
   name: kserve-config-llm-template
   namespace: kserve
 spec:

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -61,8 +61,9 @@ const (
 	configDecodeWorkerDataParallelNameSuffix  = "config-llm-decode-worker-data-parallel"
 	configPrefillWorkerDataParallelNameSuffix = "config-llm-prefill-worker-data-parallel"
 	// Router and scheduler configurations
-	configRouterSchedulerNameSuffix = "config-llm-scheduler"
-	configRouterRouteNameSuffix     = "config-llm-router-route"
+	configRouterSchedulerNameSuffix           = "config-llm-scheduler"
+	configRouterRouteNameSuffix               = "config-llm-router-route"
+	configSchedulerLatencyPredictorNameSuffix = "config-llm-scheduler-latency-predictor"
 	// Tracing configurations
 	configTracingNameSuffix = "config-llm-tracing"
 )
@@ -80,6 +81,7 @@ var (
 	configPrefillWorkerDataParallelName     = configPrefix + configPrefillWorkerDataParallelNameSuffix
 	configRouterSchedulerName               = configPrefix + configRouterSchedulerNameSuffix
 	configRouterRouteName                   = configPrefix + configRouterRouteNameSuffix
+	configSchedulerLatencyPredictorName     = configPrefix + configSchedulerLatencyPredictorNameSuffix
 	configTracingName                       = configPrefix + configTracingNameSuffix
 )
 
@@ -101,6 +103,7 @@ var WellKnownDefaultConfigs = sets.New[string](
 	configPrefillWorkerDataParallelName,
 	configRouterSchedulerName,
 	configRouterRouteName,
+	configSchedulerLatencyPredictorName,
 	configTracingName,
 )
 
@@ -206,6 +209,9 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 	refs := make([]corev1.LocalObjectReference, 0, len(llmSvc.Spec.BaseRefs))
 	if resolvedSpec.Router != nil && resolvedSpec.Router.Scheduler != nil && !resolvedSpec.Router.Scheduler.Pool.HasRef() {
 		refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configRouterSchedulerName)})
+	}
+	if hasLatencyProducerInSpec(resolvedSpec) {
+		refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configSchedulerLatencyPredictorName)})
 	}
 	if resolvedSpec.Router != nil && resolvedSpec.Router.Route != nil && !resolvedSpec.Router.Route.HTTP.HasRefs() {
 		// For the HTTP route configuration we don't use versioned defaults since this configuration depends on the
@@ -394,6 +400,14 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 		// Skip clearing if the caller needs to check which ConfigMap was referenced.
 		if !options.skipClearSchedulerConfigRef {
 			llmSvcCfg.Spec.Router.Scheduler.Config.Ref = nil
+		}
+
+		// Warn if the resolved ConfigMap contains predicted-latency-producer but the
+		// well-known config was not injected (because detection runs before Ref resolution).
+		if hasLatencyProducerInSpec(llmSvcCfg.Spec) {
+			r.Eventf(llmSvc, corev1.EventTypeWarning, "LatencyPredictorConfigRef",
+				"predicted-latency-producer plugin detected in Config.Ref ConfigMap %q; "+
+					"latency predictor sidecar injection requires Config.Inline instead of Config.Ref", cmName)
 		}
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/controller_latency_predictor_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_latency_predictor_int_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+var _ = Describe("LLMInferenceService Controller — Latency Predictor", func() {
+	Context("When predicted-latency-producer plugin is in the scheduler config", func() {
+		It("should inject training and prediction sidecar containers into the scheduler deployment", func(ctx SpecContext) {
+			svcName := "test-llm-lp-sidecars"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(`plugins:
+- type: predicted-latency-producer
+- type: latency-scorer
+- type: weighted-random-picker
+`),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				deployments := &appsv1.DeploymentList{}
+				g.Expect(envTest.Client.List(ctx, deployments, &client.ListOptions{
+					Namespace:     testNs.Name,
+					LabelSelector: labels.SelectorFromSet(llmisvc.SchedulerLabels(llmSvc)),
+				})).To(Succeed())
+				g.Expect(deployments.Items).To(HaveLen(1))
+
+				dep := deployments.Items[0]
+				containerNames := make([]string, len(dep.Spec.Template.Spec.Containers))
+				for i, c := range dep.Spec.Template.Spec.Containers {
+					containerNames[i] = c.Name
+				}
+				g.Expect(containerNames).To(ContainElement("training-server"))
+				g.Expect(containerNames).To(ContainElement("prediction-server"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("When predicted-latency-producer plugin is NOT in the scheduler config", func() {
+		It("should not inject sidecar containers", func(ctx SpecContext) {
+			svcName := "test-llm-no-lp"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(`plugins:
+- type: queue-scorer
+- type: max-score-picker
+`),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				deployments := &appsv1.DeploymentList{}
+				g.Expect(envTest.Client.List(ctx, deployments, &client.ListOptions{
+					Namespace:     testNs.Name,
+					LabelSelector: labels.SelectorFromSet(llmisvc.SchedulerLabels(llmSvc)),
+				})).To(Succeed())
+				g.Expect(deployments.Items).To(HaveLen(1))
+
+				dep := deployments.Items[0]
+				containerNames := make([]string, len(dep.Spec.Template.Spec.Containers))
+				for i, c := range dep.Spec.Template.Spec.Containers {
+					containerNames[i] = c.Name
+				}
+				g.Expect(containerNames).NotTo(ContainElement("training-server"))
+				g.Expect(containerNames).NotTo(ContainElement("prediction-server"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+})

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+const (
+	predictedLatencyProducerPlugin = "predicted-latency-producer"
+)
+
+// hasLatencyProducerInSpec checks the LLMInferenceService spec's inline config.
+// NOTE: This only checks Config.Inline, not Config.Ref (ConfigMap-based config).
+// The ConfigMap Ref is resolved later in expectedSchedulerDeployment, after
+// combineBaseRefsConfig has already run. If the plugin is specified via Ref,
+// the well-known config will not be auto-injected. This is a known limitation;
+// all llm-d guides and examples use Config.Inline.
+func hasLatencyProducerInSpec(spec v1alpha2.LLMInferenceServiceSpec) bool {
+	if spec.Router == nil || spec.Router.Scheduler == nil || spec.Router.Scheduler.Config == nil || spec.Router.Scheduler.Config.Inline == nil {
+		return false
+	}
+	u := unstructured.Unstructured{}
+	if err := yaml.Unmarshal(spec.Router.Scheduler.Config.Inline.Raw, &u.Object); err != nil {
+		return false
+	}
+	return hasPluginType(u.Object, predictedLatencyProducerPlugin)
+}
+
+func hasPluginType(obj map[string]interface{}, pluginType string) bool {
+	val, _, err := unstructured.NestedFieldNoCopy(obj, "plugins")
+	if err != nil {
+		return false
+	}
+	plugins, _ := val.([]interface{})
+	for _, plugin := range plugins {
+		if pm, ok := plugin.(map[string]interface{}); ok && pm["type"] == pluginType {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+const latencyProducerConfig = `
+plugins:
+- type: predicted-latency-producer
+- type: latency-scorer
+- type: weighted-random-picker
+`
+
+const noLatencyConfig = `
+plugins:
+- type: queue-scorer
+- type: max-score-picker
+`
+
+func TestHasLatencyProducerInSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		spec v1alpha2.LLMInferenceServiceSpec
+		want bool
+	}{
+		{
+			name: "plugin in inline config",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Config: &v1alpha2.SchedulerConfigSpec{
+							Inline: &runtime.RawExtension{Raw: []byte(latencyProducerConfig)},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no plugin",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Config: &v1alpha2.SchedulerConfigSpec{
+							Inline: &runtime.RawExtension{Raw: []byte(noLatencyConfig)},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil config",
+			spec: v1alpha2.LLMInferenceServiceSpec{},
+			want: false,
+		},
+		{
+			name: "nil inline",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Config: &v1alpha2.SchedulerConfigSpec{},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(hasLatencyProducerInSpec(tt.spec)).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Detects `predicted-latency-producer` in the EPP inline config and auto-injects a well-known `LLMInferenceServiceConfig` that provides training-server and prediction-server sidecar containers. Follows the existing well-known config pattern used by scheduler, router, prefill, and worker configs.

No CRD API changes. No hardcoded defaults in the controller.

### How it works

1. Controller detects `predicted-latency-producer` plugin in the resolved scheduler config (`combineBaseRefsConfig`)
2. Auto-injects the well-known `kserve-config-llm-scheduler-latency-predictor` config
3. The well-known config provides everything: sidecar containers, images, probes, resources, securityContext, env vars (including EPP env vars via strategic merge on `main` container), and emptyDir volumes
4. Users override any default via their own `LLMInferenceServiceConfig` and `baseRefs`

### Minimal usage

```yaml
spec:
  router:
    scheduler:
      config:
        inline: |
          plugins:
          - type: predicted-latency-producer
          - type: latency-scorer
          - type: weighted-random-picker
```

### Custom images (optional)

```yaml
spec:
  baseRefs:
  - name: my-latency-predictor-config
```

### Changes

- `config_merge.go` — detect plugin in resolved spec, auto-inject well-known config ref
- `scheduler_latency_predictor.go` — `hasLatencyProducerInSpec` and `hasPluginType` detection functions
- `charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml` — well-known `LLMInferenceServiceConfig` with sidecar containers, env vars, probes, resources, securityContext, volumes

## Test plan
- [x] 4 unit tests: plugin detection (present, absent, nil config, nil inline)
- [x] `go build ./...`, `go vet ./...` pass
- [x] Existing `TestWellKnownConfigResolver_Attach` covers versioning annotation
- [x] Existing `TestMergeSpecs` covers env var merge on containers