### PR TITLE
fix(charts/kserve-localmodel-resources): remove duplicated nodeSelector

### DIFF
--- a/charts/kserve-localmodel-resources/files/resources.yaml
+++ b/charts/kserve-localmodel-resources/files/resources.yaml
@@ -372,8 +372,6 @@ spec:
         - mountPath: /mnt/models
           name: models
           readOnly: false
-      nodeSelector:
-        kserve/localmodel: worker
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/config/overlays/charts-localmodel/kustomization.yaml
+++ b/config/overlays/charts-localmodel/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../localmodels
+
+# Used by hack/setup/scripts/generate_chart_manifests.sh to build the
+# kserve-localmodel-resources chart's files/resources.yaml. The chart sets the
+# DaemonSet nodeSelector from .Values.kserve.localmodelnode.controller.nodeSelector
+# (files/daemonset-patch.yaml). The hardcoded selector must not remain in the
+# base: Helm would merge it back in, making it impossible to override or clear.
+patches:
+- target:
+    kind: DaemonSet
+    name: kserve-localmodelnode-agent
+  patch: |-
+    - op: remove
+      path: /spec/template/spec/nodeSelector

--- a/hack/setup/scripts/generate_chart_manifests.sh
+++ b/hack/setup/scripts/generate_chart_manifests.sh
@@ -25,7 +25,7 @@ kustomize build ${REPO_ROOT}/config/storagecontainers > ${REPO_ROOT}/charts/kser
 echo "✅ Built storagecontainer resources"
 
 # LocalModel and Common
-kustomize build ${REPO_ROOT}/config/localmodels > ${REPO_ROOT}/charts/kserve-localmodel-resources/files/resources.yaml
+kustomize build ${REPO_ROOT}/config/overlays/charts-localmodel > ${REPO_ROOT}/charts/kserve-localmodel-resources/files/resources.yaml
 
 # Generate values.yaml from common sections
 echo "Generating values.yaml files from common sections..."


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kserve-localmodelnode-agent` DaemonSet had `nodeSelector: {kserve/localmodel: worker}` hardcoded in the chart's `files/resources.yaml`. The same selector is injected by `files/daemonset-patch.yaml` from `.Values.kserve.localmodelnode.controller.nodeSelector` (default `{kserve/localmodel: worker}`). Since the base and the patch are deep-merged, the hardcoded value was redundant and could not be cleared by overriding the value.

`files/resources.yaml` is generated by `hack/setup/scripts/generate_chart_manifests.sh`, so editing it directly would not survive regeneration. Instead, this PR strips the selector at generation time:

- Adds a `config/overlays/charts-localmodel` Kustomize overlay that wraps `config/localmodels` and removes `/spec/template/spec/nodeSelector` from the agent DaemonSet.
- Points the generation script at the overlay for the chart's `files/resources.yaml`.
- Regenerates `files/resources.yaml` (only the two selector lines are removed).

Direct Kustomize builds of `config/localmodels` are unaffected and keep the selector; only the Helm chart input changes, where the selector comes from values.

Note: to clear the selector, set the value to `null`. An empty map (`{}`) does not clear it because Helm merges it with the chart's default.

**Feature/Issue validation/testing**:

- [x] Rerunning `hack/setup/scripts/generate_chart_manifests.sh` reproduces the committed `files/resources.yaml` byte for byte and is stable across reruns
- [x] Default `helm template` render is identical to master, the agent DaemonSet still carries `nodeSelector: {kserve/localmodel: worker}` (from the values patch only)
- [x] `--set kserve.localmodelnode.controller.nodeSelector.foo=bar` merges with the default
- [x] `--set kserve.localmodelnode.controller.nodeSelector=null` clears the selector, which was not possible before since the hardcoded base value was merged back in

**Release note**:
```release-note
NONE
```
