### PR TITLE
fix(e2e): make TLS args conditional in PD simulator fixture

### DIFF
--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1151,14 +1151,16 @@ LLMINFERENCESERVICE_CONFIGS = {
                 {
                     "name": "main",
                     "image": "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2",
-                    "command": ["/app/llm-d-inference-sim"],
+                    "command": ["/bin/sh", "-c"],
                     "args": [
-                        "--port",
-                        "8001",
-                        "--model",
-                        "{{ .Spec.Model.Name }}",
-                        "--mode",
-                        "random",
+                        "/app/llm-d-inference-sim"
+                        " --port 8001"
+                        " --model '{{ .Spec.Model.Name }}'"
+                        " --mode random"
+                        "{{ if .GlobalConfig.EnableTLS }}"
+                        " --ssl-certfile /var/run/kserve/tls/tls.crt"
+                        " --ssl-keyfile /var/run/kserve/tls/tls.key"
+                        "{{ end }}"
                     ],
                     "resources": {
                         "limits": {"cpu": "1", "memory": "2Gi"},
@@ -1174,14 +1176,16 @@ LLMINFERENCESERVICE_CONFIGS = {
                     {
                         "name": "main",
                         "image": "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2",
-                        "command": ["/app/llm-d-inference-sim"],
+                        "command": ["/bin/sh", "-c"],
                         "args": [
-                            "--port",
-                            "8000",
-                            "--model",
-                            "{{ .Spec.Model.Name }}",
-                            "--mode",
-                            "random",
+                            "/app/llm-d-inference-sim"
+                            " --port 8000"
+                            " --model '{{ .Spec.Model.Name }}'"
+                            " --mode random"
+                            "{{ if .GlobalConfig.EnableTLS }}"
+                            " --ssl-certfile /var/run/kserve/tls/tls.crt"
+                            " --ssl-keyfile /var/run/kserve/tls/tls.key"
+                            "{{ end }}"
                         ],
                         "resources": {
                             "limits": {"cpu": "1", "memory": "2Gi"},

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -537,7 +537,11 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 service_name="scheduler-v06-pd-migration-test",
                 response_assertion=assert_200_with_choices,
             ),
-            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
         ),
         pytest.param(
             TestCase(
@@ -550,7 +554,11 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 service_name="scheduler-v06-threshold-migration-test",
                 response_assertion=assert_200_with_choices,
             ),
-            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
         ),
         # Precise prefix KV cache routing test
         pytest.param(


### PR DESCRIPTION
## Summary
The `workload-llmd-simulator-pd` fixture had unconditional `--ssl-certfile`/`--ssl-keyfile` args that crash in upstream CI where `enableLLMInferenceServiceTLS=false` (cert files don't exist). This makes the TLS args conditional using `{{ if .GlobalConfig.EnableTLS }}` Go template directives — the same pattern used in `config-llm-decode-template.yaml`.

**Changes:**
- Wrap TLS args in `{{ if .GlobalConfig.EnableTLS }}...{{ end }}` for both decode (port 8001) and prefill (port 8000) containers
- Use `/bin/sh -c` command wrapper to support inline template conditionals
- Add `llmd_simulator` marker to scheduler migration tests