### PR TITLE
feat(llmisvc): localModelCache support for LoRA adapters

### DIFF
--- a/docs/samples/llmisvc/lora-adapters/README.md
+++ b/docs/samples/llmisvc/lora-adapters/README.md
@@ -141,7 +141,43 @@ kubectl create secret generic s3-config \
 kubectl apply -f llm-inference-service-lora-s3.yaml
 ```
 
-### 4. PVC-Based LoRA Adapter ([llm-inference-service-lora-pvc.yaml](llm-inference-service-lora-pvc.yaml))
+### 4. LocalModelCache LoRA Adapter ([llm-inference-service-lora-localmodelcache.yaml](llm-inference-service-lora-localmodelcache.yaml))
+
+Deploy a base model and LoRA adapter from LocalModelCache when both URIs match cache entries.
+
+**Configuration:**
+- Base Model: HuggingFace URI cached via LocalModelCache
+- Adapter: HuggingFace URI cached via a separate LocalModelCache
+- Node group: targets GPU worker nodes
+
+**Use Case:**
+- Fast pod startup without downloading base model or adapters
+- Platform-managed local model distribution for multi-adapter LLM services
+- Adapter caching independent of base model caching
+
+**Deployment:**
+```bash
+kubectl apply -f llm-inference-service-lora-localmodelcache.yaml
+```
+
+**YAML snippet:**
+```yaml
+spec:
+  model:
+    uri: hf://my-org/my-base-model
+    lora:
+      adapters:
+        - name: sql-adapter
+          uri: hf://my-org/my-sql-lora-adapter
+```
+
+When the URIs match LocalModelCache CRs, the controller:
+- Sets local model metadata on the LLMInferenceService (base label + `localmodel-lora` annotation)
+- Mounts cached PVCs for the base model and adapters
+- Skips storage-initializer downloads for cached URIs
+- Blocks LocalModelCache deletion while the service references cached adapters
+
+### 5. PVC-Based LoRA Adapter ([llm-inference-service-lora-pvc.yaml](llm-inference-service-lora-pvc.yaml))
 
 Deploy with a LoRA adapter stored in a PersistentVolumeClaim.
 

--- a/docs/samples/llmisvc/lora-adapters/README.md
+++ b/docs/samples/llmisvc/lora-adapters/README.md
@@ -143,7 +143,43 @@ kubectl create secret generic s3-config \
 kubectl apply -f llm-inference-service-lora-s3.yaml
 ```
 
-### 4. PVC-Based LoRA Adapter ([llm-inference-service-lora-pvc.yaml](llm-inference-service-lora-pvc.yaml))
+### 4. LocalModelCache LoRA Adapter ([llm-inference-service-lora-localmodelcache.yaml](llm-inference-service-lora-localmodelcache.yaml))
+
+Deploy a base model and LoRA adapter from LocalModelCache when both URIs match cache entries.
+
+**Configuration:**
+- Base Model: HuggingFace URI cached via LocalModelCache
+- Adapter: HuggingFace URI cached via a separate LocalModelCache
+- Node group: targets GPU worker nodes
+
+**Use Case:**
+- Fast pod startup without downloading base model or adapters
+- Platform-managed local model distribution for multi-adapter LLM services
+- Adapter caching independent of base model caching
+
+**Deployment:**
+```bash
+kubectl apply -f llm-inference-service-lora-localmodelcache.yaml
+```
+
+**YAML snippet:**
+```yaml
+spec:
+  model:
+    uri: hf://my-org/my-base-model
+    lora:
+      adapters:
+        - name: sql-adapter
+          uri: hf://my-org/my-sql-lora-adapter
+```
+
+When the URIs match LocalModelCache CRs, the controller:
+- Sets local model metadata on the LLMInferenceService (base label + `localmodel-lora` annotation)
+- Mounts cached PVCs for the base model and adapters
+- Skips storage-initializer downloads for cached URIs
+- Blocks LocalModelCache deletion while the service references cached adapters
+
+### 5. PVC-Based LoRA Adapter ([llm-inference-service-lora-pvc.yaml](llm-inference-service-lora-pvc.yaml))
 
 Deploy with a LoRA adapter stored in a PersistentVolumeClaim.
 

--- a/docs/samples/llmisvc/lora-adapters/README.md
+++ b/docs/samples/llmisvc/lora-adapters/README.md
@@ -172,7 +172,8 @@ spec:
 ```
 
 When the URIs match LocalModelCache CRs, the controller:
-- Sets local model metadata on the LLMInferenceService (base label + `localmodel-lora` annotation)
+- Sets local model metadata on the LLMInferenceService (base label + slim `localmodel-lora` annotation with `cache` / optional `namespace`)
+- Resolves source URI and PVC name from the referenced cache at reconcile time
 - Mounts cached PVCs for the base model and adapters
 - Skips storage-initializer downloads for cached URIs
 - Blocks LocalModelCache deletion while the service references cached adapters

--- a/docs/samples/llmisvc/lora-adapters/README.md
+++ b/docs/samples/llmisvc/lora-adapters/README.md
@@ -174,7 +174,8 @@ spec:
 ```
 
 When the URIs match LocalModelCache CRs, the controller:
-- Sets local model metadata on the LLMInferenceService (base label + `localmodel-lora` annotation)
+- Sets local model metadata on the LLMInferenceService (base label + slim `localmodel-lora` annotation with `cache` / optional `namespace`)
+- Resolves source URI and PVC name from the referenced cache at reconcile time
 - Mounts cached PVCs for the base model and adapters
 - Skips storage-initializer downloads for cached URIs
 - Blocks LocalModelCache deletion while the service references cached adapters

--- a/docs/samples/llmisvc/lora-adapters/llm-inference-service-lora-localmodelcache.yaml
+++ b/docs/samples/llmisvc/lora-adapters/llm-inference-service-lora-localmodelcache.yaml
@@ -1,0 +1,70 @@
+# Example: LLMInferenceService with base model and LoRA adapter served from LocalModelCache.
+#
+# Prerequisites:
+#   - LocalModelNodeGroup targeting worker nodes
+#   - LocalModelCache CRs for the base model URI and each adapter URI
+#
+# When adapter URIs match a LocalModelCache, the controller mounts cached PVCs
+# instead of downloading artifacts at pod startup.
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: llm-lora-localmodelcache
+spec:
+  model:
+    uri: hf://my-org/my-base-model
+    lora:
+      adapters:
+        - name: sql-adapter
+          uri: hf://my-org/my-sql-lora-adapter
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: LocalModelNodeGroup
+metadata:
+  name: llm-lora-nodegroup
+spec:
+  storageLimit: 50Gi
+  persistentVolumeSpec:
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: standard
+    capacity:
+      storage: 50Gi
+    local:
+      path: /models
+    persistentVolumeReclaimPolicy: Delete
+    nodeAffinity:
+      required:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                  - gpu-node
+  persistentVolumeClaimSpec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 50Gi
+    storageClassName: standard
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: LocalModelCache
+metadata:
+  name: base-model-cache
+spec:
+  sourceModelUri: hf://my-org/my-base-model
+  modelSize: 20Gi
+  nodeGroups:
+    - llm-lora-nodegroup
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: LocalModelCache
+metadata:
+  name: sql-adapter-cache
+spec:
+  sourceModelUri: hf://my-org/my-sql-lora-adapter
+  modelSize: 1Gi
+  nodeGroups:
+    - llm-lora-nodegroup

--- a/docs/samples/llmisvc/lora-adapters/llm-inference-service-lora-localmodelcache.yaml
+++ b/docs/samples/llmisvc/lora-adapters/llm-inference-service-lora-localmodelcache.yaml
@@ -26,6 +26,8 @@ spec:
   storageLimit: 50Gi
   persistentVolumeSpec:
     accessModes:
+      # Node-local storage: each node gets its own PV (local.path below).
+      # Use ReadWriteMany/ReadOnlyMany for shared storage (e.g. NFS).
       - ReadWriteOnce
     storageClassName: standard
     capacity:
@@ -43,6 +45,7 @@ spec:
                   - gpu-node
   persistentVolumeClaimSpec:
     accessModes:
+      # Matches PV access mode; node-local storage assumption as above.
       - ReadWriteOnce
     resources:
       requests:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -180,6 +180,7 @@ var (
 	LocalModelPVCNameAnnotationKey                   = InferenceServiceInternalAnnotationsPrefix + "/localmodel-pvc-name"
 	ConfidentialEnabledAnnotationKey                 = InferenceServiceInternalAnnotationsPrefix + "/confidential-enabled"
 	ConfidentialResourceIdAnnotationKey              = InferenceServiceInternalAnnotationsPrefix + "/confidential-resource-id"
+	LocalModelLoRAAnnotationKey                      = InferenceServiceInternalAnnotationsPrefix + "/localmodel-lora"
 )
 
 // kserve networking constants

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -179,6 +179,7 @@ var (
 	LocalModelPVCNameAnnotationKey                   = InferenceServiceInternalAnnotationsPrefix + "/localmodel-pvc-name"
 	ConfidentialEnabledAnnotationKey                 = InferenceServiceInternalAnnotationsPrefix + "/confidential-enabled"
 	ConfidentialResourceIdAnnotationKey              = InferenceServiceInternalAnnotationsPrefix + "/confidential-resource-id"
+	LocalModelLoRAAnnotationKey                      = InferenceServiceInternalAnnotationsPrefix + "/localmodel-lora"
 )
 
 // kserve networking constants

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -494,6 +494,88 @@ var _ = Describe("CachedModel controller", func() {
 					cachedModel.Status.LLMInferenceServices[0].Namespace == llmSvcNamespace
 			}, timeout, interval).Should(BeTrue(), "Cache status should track the LLMInferenceService")
 		})
+
+		It("Should track LLMInferenceService referenced only via LoRA adapter in cluster-scoped cache status", func() {
+			defer GinkgoRecover()
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+			nodeGroup1 := &v1alpha1.LocalModelNodeGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu1",
+				},
+				Spec: localModelNodeGroupSpec1,
+			}
+			Expect(k8sClient.Create(ctx, nodeGroup1)).Should(Succeed())
+			defer k8sClient.Delete(ctx, nodeGroup1)
+
+			adapterURI := "hf://org/lora-adapter-only"
+			baseURI := "hf://org/remote-base"
+			modelName := fmt.Sprintf("lora-adapter-cache-%d", time.Now().UnixNano())
+			llmSvcName := "test-llm-lora-adapter-only"
+			llmSvcNamespace := "default"
+			cachedModel := &v1alpha1.LocalModelCache{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: modelName,
+				},
+				Spec: v1alpha1.LocalModelCacheSpec{
+					SourceModelUri: adapterURI,
+					ModelSize:      resource.MustParse("10Gi"),
+					NodeGroups:     []string{"gpu1"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cachedModel)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, cachedModel)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName}, cachedModel)
+					return err != nil && errors.IsNotFound(err)
+				}, timeout, interval).Should(BeTrue())
+			}()
+
+			baseModelURI, err := apis.ParseURL(baseURI)
+			Expect(err).NotTo(HaveOccurred())
+			adapterModelURI, err := apis.ParseURL(adapterURI)
+			Expect(err).NotTo(HaveOccurred())
+			llmSvc := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      llmSvcName,
+					Namespace: llmSvcNamespace,
+					Annotations: map[string]string{
+						constants.LocalModelLoRAAnnotationKey: fmt.Sprintf(
+							`{"my-adapter":{"cache":%q,"sourceUri":%q,"pvcName":%q}}`,
+							modelName, adapterURI, modelName+"-gpu1",
+						),
+					},
+				},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{
+						URI: *baseModelURI,
+						LoRA: &v1alpha2.LoRASpec{
+							Adapters: []v1alpha2.LLMModelSpec{
+								{
+									Name: ptr.To("my-adapter"),
+									URI:  *adapterModelURI,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, llmSvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, llmSvc)
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName}, cachedModel)
+				if err != nil {
+					return false
+				}
+				if len(cachedModel.Status.LLMInferenceServices) != 1 {
+					return false
+				}
+				return cachedModel.Status.LLMInferenceServices[0].Name == llmSvcName &&
+					cachedModel.Status.LLMInferenceServices[0].Namespace == llmSvcNamespace
+			}, timeout, interval).Should(BeTrue(), "Cache status should track the LLMInferenceService via LoRA adapter reference")
+		})
 	})
 
 	Context("When DisableVolumeManagement is set to true", func() {

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -1342,6 +1342,93 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 			// 2. Status correctly tracks the ISVC
 			// 3. The cleanup code path exists in ReconcileForIsvcs (verified by code inspection)
 		})
+
+		It("Should track LLMInferenceService referenced only via LoRA adapter in namespace-scoped cache status", func() {
+			defer GinkgoRecover()
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			testNamespace := fmt.Sprintf("test-ns-lora-%d", time.Now().UnixNano())
+			namespaceObj := createTestNamespace(ctx, testNamespace)
+			defer k8sClient.Delete(ctx, namespaceObj)
+
+			nodeGroup1 := &v1alpha1.LocalModelNodeGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu1",
+				},
+				Spec: localModelNodeGroupSpec1,
+			}
+			Expect(k8sClient.Create(ctx, nodeGroup1)).Should(Succeed())
+			defer k8sClient.Delete(ctx, nodeGroup1)
+
+			adapterURI := "hf://org/ns-lora-adapter-only"
+			baseURI := "hf://org/remote-base"
+			modelName := fmt.Sprintf("ns-lora-adapter-cache-%d", time.Now().UnixNano())
+			llmSvcName := "test-llm-ns-lora-adapter-only"
+			cachedModel := &v1alpha1.LocalModelNamespaceCache{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelName,
+					Namespace: testNamespace,
+				},
+				Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+					SourceModelUri: adapterURI,
+					ModelSize:      resource.MustParse("10Gi"),
+					NodeGroups:     []string{"gpu1"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cachedModel)).Should(Succeed())
+			defer func() {
+				Expect(k8sClient.Delete(ctx, cachedModel)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, cachedModel)
+					return err != nil && errors.IsNotFound(err)
+				}, timeout, interval).Should(BeTrue())
+			}()
+
+			baseModelURI, err := apis.ParseURL(baseURI)
+			Expect(err).NotTo(HaveOccurred())
+			adapterModelURI, err := apis.ParseURL(adapterURI)
+			Expect(err).NotTo(HaveOccurred())
+			llmSvc := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      llmSvcName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						constants.LocalModelLoRAAnnotationKey: fmt.Sprintf(
+							`{"my-adapter":{"cache":%q,"namespace":%q,"sourceUri":%q,"pvcName":%q}}`,
+							modelName, testNamespace, adapterURI, modelName+"-gpu1",
+						),
+					},
+				},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{
+						URI: *baseModelURI,
+						LoRA: &v1alpha2.LoRASpec{
+							Adapters: []v1alpha2.LLMModelSpec{
+								{
+									Name: ptr.To("my-adapter"),
+									URI:  *adapterModelURI,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, llmSvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, llmSvc)
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, cachedModel)
+				if err != nil {
+					return false
+				}
+				if len(cachedModel.Status.LLMInferenceServices) != 1 {
+					return false
+				}
+				return cachedModel.Status.LLMInferenceServices[0].Name == llmSvcName &&
+					cachedModel.Status.LLMInferenceServices[0].Namespace == testNamespace
+			}, timeout, interval).Should(BeTrue(), "Namespace cache status should track the LLMInferenceService via LoRA adapter reference")
+		})
 	})
 })
 

--- a/pkg/controller/v1alpha1/localmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodel/controller_test.go
@@ -542,8 +542,8 @@ var _ = Describe("CachedModel controller", func() {
 					Namespace: llmSvcNamespace,
 					Annotations: map[string]string{
 						constants.LocalModelLoRAAnnotationKey: fmt.Sprintf(
-							`{"my-adapter":{"cache":%q,"sourceUri":%q,"pvcName":%q}}`,
-							modelName, adapterURI, modelName+"-gpu1",
+							`{"my-adapter":{"cache":%q}}`,
+							modelName,
 						),
 					},
 				},
@@ -1395,8 +1395,8 @@ var _ = Describe("LocalModelNamespaceCache controller", func() {
 					Namespace: testNamespace,
 					Annotations: map[string]string{
 						constants.LocalModelLoRAAnnotationKey: fmt.Sprintf(
-							`{"my-adapter":{"cache":%q,"namespace":%q,"sourceUri":%q,"pvcName":%q}}`,
-							modelName, testNamespace, adapterURI, modelName+"-gpu1",
+							`{"my-adapter":{"cache":%q,"namespace":%q}}`,
+							modelName, testNamespace,
 						),
 					},
 				},

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	controllerutils "github.com/kserve/kserve/pkg/controller/v1alpha1/utils"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
@@ -170,27 +171,24 @@ func (c *LocalModelReconciler) isvcFunc(ctx context.Context, obj client.Object) 
 // Reconciles corresponding model cache CR when we found an update on an LLMInferenceService
 func (c *LocalModelReconciler) llmIsvcFunc(ctx context.Context, obj client.Object) []reconcile.Request {
 	llmSvc := obj.(*v1alpha2.LLMInferenceService)
-	if llmSvc.Labels == nil {
-		return []reconcile.Request{}
-	}
-	var modelName string
-	var ok bool
-	if modelName, ok = llmSvc.Labels[constants.LocalModelLabel]; !ok {
-		return []reconcile.Request{}
-	}
-	localModel := &v1alpha1.LocalModelCache{}
-	if err := c.Get(ctx, types.NamespacedName{Name: modelName}, localModel); err != nil {
-		c.Log.Error(err, "error getting localModel", "name", modelName)
+	cacheNames := localmodelcache.LLMISVCClusterCacheNames(llmSvc.Labels, llmSvc.Annotations)
+	if len(cacheNames) == 0 {
 		return []reconcile.Request{}
 	}
 
-	c.Log.Info("Reconcile localModel from LLM inference services", "name", modelName)
-
-	return []reconcile.Request{{
-		NamespacedName: types.NamespacedName{
-			Name: modelName,
-		},
-	}}
+	requests := make([]reconcile.Request, 0, len(cacheNames))
+	for _, modelName := range cacheNames {
+		localModel := &v1alpha1.LocalModelCache{}
+		if err := c.Get(ctx, types.NamespacedName{Name: modelName}, localModel); err != nil {
+			c.Log.Error(err, "error getting localModel", "name", modelName)
+			continue
+		}
+		c.Log.Info("Reconcile localModel from LLM inference services", "name", modelName)
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName},
+		})
+	}
+	return requests
 }
 
 // Given a node object, checks if it matches any node group CR, then reconcile all local models that has this node group to create download jobs.
@@ -287,10 +285,7 @@ func (c *LocalModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if hasLLMISvcCRD {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1alpha2.LLMInferenceService{}, LocalModelKey, func(rawObj client.Object) []string {
 			llmSvc := rawObj.(*v1alpha2.LLMInferenceService)
-			if model, ok := llmSvc.GetLabels()[constants.LocalModelLabel]; ok {
-				return []string{model}
-			}
-			return nil
+			return localmodelcache.LLMISVCClusterCacheNames(llmSvc.Labels, llmSvc.Annotations)
 		}); err != nil {
 			return err
 		}
@@ -342,15 +337,20 @@ func (c *LocalModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	llmIsvcPredicates := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectOld.GetLabels()[constants.LocalModelLabel] != e.ObjectNew.GetLabels()[constants.LocalModelLabel]
+			old := e.ObjectOld.(*v1alpha2.LLMInferenceService)
+			new := e.ObjectNew.(*v1alpha2.LLMInferenceService)
+			return !localmodelcache.ClusterCacheNamesEqual(
+				localmodelcache.LLMISVCClusterCacheNames(old.Labels, old.Annotations),
+				localmodelcache.LLMISVCClusterCacheNames(new.Labels, new.Annotations),
+			)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			_, ok := e.Object.GetLabels()[constants.LocalModelLabel]
-			return ok
+			llmSvc := e.Object.(*v1alpha2.LLMInferenceService)
+			return len(localmodelcache.LLMISVCClusterCacheNames(llmSvc.Labels, llmSvc.Annotations)) > 0
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			_, ok := e.Object.GetLabels()[constants.LocalModelLabel]
-			return ok
+			llmSvc := e.Object.(*v1alpha2.LLMInferenceService)
+			return len(localmodelcache.LLMISVCClusterCacheNames(llmSvc.Labels, llmSvc.Annotations)) > 0
 		},
 	}
 

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler.go
@@ -339,7 +339,7 @@ func (c *LocalModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			old := e.ObjectOld.(*v1alpha2.LLMInferenceService)
 			new := e.ObjectNew.(*v1alpha2.LLMInferenceService)
-			return !localmodelcache.ClusterCacheNamesEqual(
+			return !localmodelcache.CacheNamesEqual(
 				localmodelcache.LLMISVCClusterCacheNames(old.Labels, old.Annotations),
 				localmodelcache.LLMISVCClusterCacheNames(new.Labels, new.Annotations),
 			)

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	controllerutils "github.com/kserve/kserve/pkg/controller/v1alpha1/utils"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
@@ -180,37 +181,24 @@ func (c *LocalModelNamespaceCacheReconciler) isvcFuncNamespaceCache(ctx context.
 // Reconciles corresponding namespace model cache CR when we found an update on an LLMInferenceService
 func (c *LocalModelNamespaceCacheReconciler) llmIsvcFuncNamespaceCache(ctx context.Context, obj client.Object) []reconcile.Request {
 	llmSvc := obj.(*v1alpha2.LLMInferenceService)
-	if llmSvc.Labels == nil {
-		return []reconcile.Request{}
-	}
-	var modelName string
-	var modelNamespace string
-	var ok bool
-	if modelName, ok = llmSvc.Labels[constants.LocalModelLabel]; !ok {
-		return []reconcile.Request{}
-	}
-	if modelNamespace, ok = llmSvc.Labels[constants.LocalModelNamespaceLabel]; !ok {
-		return []reconcile.Request{}
-	}
-	// Ensure the LLMIsvc is in the same namespace as the LocalModelNamespaceCache
-	if llmSvc.Namespace != modelNamespace {
+	cacheNames := localmodelcache.LLMISVCNamespaceCacheNames(llmSvc.Namespace, llmSvc.Labels, llmSvc.Annotations)
+	if len(cacheNames) == 0 {
 		return []reconcile.Request{}
 	}
 
-	localModel := &v1alpha1.LocalModelNamespaceCache{}
-	if err := c.Get(ctx, types.NamespacedName{Name: modelName, Namespace: modelNamespace}, localModel); err != nil {
-		c.Log.Error(err, "error getting namespace localModel", "name", modelName, "namespace", modelNamespace)
-		return []reconcile.Request{}
+	requests := make([]reconcile.Request, 0, len(cacheNames))
+	for _, modelName := range cacheNames {
+		localModel := &v1alpha1.LocalModelNamespaceCache{}
+		if err := c.Get(ctx, types.NamespacedName{Name: modelName, Namespace: llmSvc.Namespace}, localModel); err != nil {
+			c.Log.Error(err, "error getting namespace localModel", "name", modelName, "namespace", llmSvc.Namespace)
+			continue
+		}
+		c.Log.Info("Reconcile namespace localModel from LLM inference services", "name", modelName, "namespace", llmSvc.Namespace)
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: modelName, Namespace: llmSvc.Namespace},
+		})
 	}
-
-	c.Log.Info("Reconcile namespace localModel from LLM inference services", "name", modelName, "namespace", modelNamespace)
-
-	return []reconcile.Request{{
-		NamespacedName: types.NamespacedName{
-			Name:      modelName,
-			Namespace: modelNamespace,
-		},
-	}}
+	return requests
 }
 
 // Given a node object, checks if it matches any node group CR, then reconcile all namespace local models that has this node group.
@@ -298,12 +286,7 @@ func (c *LocalModelNamespaceCacheReconciler) SetupWithManager(mgr ctrl.Manager) 
 	if hasLLMISvcCRD {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &v1alpha2.LLMInferenceService{}, LocalModelNamespaceKey, func(rawObj client.Object) []string {
 			llmSvc := rawObj.(*v1alpha2.LLMInferenceService)
-			modelName, hasModel := llmSvc.GetLabels()[constants.LocalModelLabel]
-			modelNamespace, hasNamespace := llmSvc.GetLabels()[constants.LocalModelNamespaceLabel]
-			if hasModel && hasNamespace && llmSvc.Namespace == modelNamespace {
-				return []string{modelName}
-			}
-			return nil
+			return localmodelcache.LLMISVCNamespaceCacheNames(llmSvc.Namespace, llmSvc.Labels, llmSvc.Annotations)
 		}); err != nil {
 			return err
 		}
@@ -356,19 +339,20 @@ func (c *LocalModelNamespaceCacheReconciler) SetupWithManager(mgr ctrl.Manager) 
 
 	llmIsvcPredicates := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldModel := e.ObjectOld.GetLabels()[constants.LocalModelLabel]
-			newModel := e.ObjectNew.GetLabels()[constants.LocalModelLabel]
-			oldNsLabel := e.ObjectOld.GetLabels()[constants.LocalModelNamespaceLabel]
-			newNsLabel := e.ObjectNew.GetLabels()[constants.LocalModelNamespaceLabel]
-			return oldModel != newModel || oldNsLabel != newNsLabel
+			old := e.ObjectOld.(*v1alpha2.LLMInferenceService)
+			new := e.ObjectNew.(*v1alpha2.LLMInferenceService)
+			return !localmodelcache.ClusterCacheNamesEqual(
+				localmodelcache.LLMISVCNamespaceCacheNames(old.Namespace, old.Labels, old.Annotations),
+				localmodelcache.LLMISVCNamespaceCacheNames(new.Namespace, new.Labels, new.Annotations),
+			)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			_, ok := e.Object.GetLabels()[constants.LocalModelNamespaceLabel]
-			return ok
+			llmSvc := e.Object.(*v1alpha2.LLMInferenceService)
+			return len(localmodelcache.LLMISVCNamespaceCacheNames(llmSvc.Namespace, llmSvc.Labels, llmSvc.Annotations)) > 0
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			_, ok := e.Object.GetLabels()[constants.LocalModelNamespaceLabel]
-			return ok
+			llmSvc := e.Object.(*v1alpha2.LLMInferenceService)
+			return len(localmodelcache.LLMISVCNamespaceCacheNames(llmSvc.Namespace, llmSvc.Labels, llmSvc.Annotations)) > 0
 		},
 	}
 

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
@@ -341,7 +341,7 @@ func (c *LocalModelNamespaceCacheReconciler) SetupWithManager(mgr ctrl.Manager) 
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			old := e.ObjectOld.(*v1alpha2.LLMInferenceService)
 			new := e.ObjectNew.(*v1alpha2.LLMInferenceService)
-			return !localmodelcache.ClusterCacheNamesEqual(
+			return !localmodelcache.CacheNamesEqual(
 				localmodelcache.LLMISVCNamespaceCacheNames(old.Namespace, old.Labels, old.Annotations),
 				localmodelcache.LLMISVCNamespaceCacheNames(new.Namespace, new.Labels, new.Annotations),
 			)

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
@@ -118,6 +119,37 @@ func enumerateLoRAAdapters(spec v1alpha2.LLMInferenceServiceSpec) ([]resolvedLoR
 			uri:       uri,
 			scheme:    scheme,
 		})
+	}
+	return out, nil
+}
+
+// rewriteLoRAAdaptersFromLocalModelCache rewrites cached adapter URIs to pvc:// paths
+// using the localmodel-lora annotation set by the defaulter webhook.
+func rewriteLoRAAdaptersFromLocalModelCache(llmSvc *v1alpha2.LLMInferenceService, adapters []resolvedLoRAAdapter) ([]resolvedLoRAAdapter, error) {
+	if len(adapters) == 0 {
+		return adapters, nil
+	}
+	raw := llmSvc.Annotations[constants.LocalModelLoRAAnnotationKey]
+	if raw == "" {
+		return adapters, nil
+	}
+	entries, err := localmodelcache.ParseLoRACacheAnnotation(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return adapters, nil
+	}
+
+	out := make([]resolvedLoRAAdapter, len(adapters))
+	copy(out, adapters)
+	for i := range out {
+		entry, ok := entries[out[i].name]
+		if !ok {
+			continue
+		}
+		out[i].uri = localmodelcache.BuildCachedPVCURI(entry.SourceURI, entry.PVCName, out[i].uri)
+		out[i].scheme = constants.PvcURIPrefix
 	}
 	return out, nil
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora.go
@@ -26,10 +26,13 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/localmodelcache"
@@ -120,8 +123,14 @@ func enumerateLoRAAdapters(spec v1alpha2.LLMInferenceServiceSpec) ([]resolvedLoR
 }
 
 // rewriteLoRAAdaptersFromLocalModelCache rewrites cached adapter URIs to pvc:// paths
-// using the localmodel-lora annotation set by the defaulter webhook.
-func rewriteLoRAAdaptersFromLocalModelCache(llmSvc *v1alpha2.LLMInferenceService, adapters []resolvedLoRAAdapter) ([]resolvedLoRAAdapter, error) {
+// using the slim localmodel-lora annotation (cache + optional namespace). Source URI and PVC
+// name are resolved at reconcile time via Get on the referenced cache.
+func rewriteLoRAAdaptersFromLocalModelCache(
+	ctx context.Context,
+	c client.Client,
+	llmSvc *v1alpha2.LLMInferenceService,
+	adapters []resolvedLoRAAdapter,
+) ([]resolvedLoRAAdapter, error) {
 	if len(adapters) == 0 {
 		return adapters, nil
 	}
@@ -137,17 +146,57 @@ func rewriteLoRAAdaptersFromLocalModelCache(llmSvc *v1alpha2.LLMInferenceService
 		return adapters, nil
 	}
 
+	nodeGroup, nodeGroupExists := llmSvc.Annotations[constants.NodeGroupAnnotationKey]
+
 	out := make([]resolvedLoRAAdapter, len(adapters))
 	copy(out, adapters)
 	for i := range out {
 		entry, ok := entries[out[i].name]
-		if !ok {
+		if !ok || entry.Cache == "" {
 			continue
 		}
-		out[i].uri = localmodelcache.BuildCachedPVCURI(entry.SourceURI, entry.PVCName, out[i].uri)
+		sourceURI, pvcName, err := resolveLoRACachePVC(ctx, c, entry, nodeGroup, nodeGroupExists)
+		if err != nil {
+			return nil, fmt.Errorf("LoRA adapter %q: %w", out[i].name, err)
+		}
+		out[i].uri = localmodelcache.BuildCachedPVCURI(sourceURI, pvcName, out[i].uri)
 		out[i].scheme = constants.PvcURIPrefix
 	}
 	return out, nil
+}
+
+// resolveLoRACachePVC Gets the referenced LocalModelCache / LocalModelNamespaceCache and
+// derives source URI + serving PVC name for the LLMInferenceService node group.
+func resolveLoRACachePVC(
+	ctx context.Context,
+	c client.Client,
+	entry localmodelcache.CacheEntry,
+	nodeGroup string,
+	nodeGroupExists bool,
+) (sourceURI, pvcName string, err error) {
+	if entry.Namespace != "" {
+		nsCache := &v1alpha1.LocalModelNamespaceCache{}
+		if err := c.Get(ctx, types.NamespacedName{Name: entry.Cache, Namespace: entry.Namespace}, nsCache); err != nil {
+			return "", "", fmt.Errorf("get LocalModelNamespaceCache %s/%s: %w", entry.Namespace, entry.Cache, err)
+		}
+		pvc, ok := localmodelcache.PVCNameForNodeGroup(nsCache.Spec.NodeGroups, nodeGroup, nodeGroupExists, nsCache.Name)
+		if !ok {
+			return "", "", fmt.Errorf("LocalModelNamespaceCache %s/%s has no matching node group for annotation %q=%q",
+				entry.Namespace, entry.Cache, constants.NodeGroupAnnotationKey, nodeGroup)
+		}
+		return nsCache.Spec.SourceModelUri, pvc, nil
+	}
+
+	cache := &v1alpha1.LocalModelCache{}
+	if err := c.Get(ctx, types.NamespacedName{Name: entry.Cache}, cache); err != nil {
+		return "", "", fmt.Errorf("get LocalModelCache %s: %w", entry.Cache, err)
+	}
+	pvc, ok := localmodelcache.PVCNameForNodeGroup(cache.Spec.NodeGroups, nodeGroup, nodeGroupExists, cache.Name)
+	if !ok {
+		return "", "", fmt.Errorf("LocalModelCache %s has no matching node group for annotation %q=%q",
+			entry.Cache, constants.NodeGroupAnnotationKey, nodeGroup)
+	}
+	return cache.Spec.SourceModelUri, pvc, nil
 }
 
 // collectLoRADownloadPairs filters pre-resolved adapters to hf:// and s3:// uri/path pairs

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
@@ -114,6 +115,37 @@ func enumerateLoRAAdapters(spec v1alpha2.LLMInferenceServiceSpec) ([]resolvedLoR
 			uri:       uri,
 			scheme:    scheme,
 		})
+	}
+	return out, nil
+}
+
+// rewriteLoRAAdaptersFromLocalModelCache rewrites cached adapter URIs to pvc:// paths
+// using the localmodel-lora annotation set by the defaulter webhook.
+func rewriteLoRAAdaptersFromLocalModelCache(llmSvc *v1alpha2.LLMInferenceService, adapters []resolvedLoRAAdapter) ([]resolvedLoRAAdapter, error) {
+	if len(adapters) == 0 {
+		return adapters, nil
+	}
+	raw := llmSvc.Annotations[constants.LocalModelLoRAAnnotationKey]
+	if raw == "" {
+		return adapters, nil
+	}
+	entries, err := localmodelcache.ParseLoRACacheAnnotation(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return adapters, nil
+	}
+
+	out := make([]resolvedLoRAAdapter, len(adapters))
+	copy(out, adapters)
+	for i := range out {
+		entry, ok := entries[out[i].name]
+		if !ok {
+			continue
+		}
+		out[i].uri = localmodelcache.BuildCachedPVCURI(entry.SourceURI, entry.PVCName, out[i].uri)
+		out[i].scheme = constants.PvcURIPrefix
 	}
 	return out, nil
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora.go
@@ -26,10 +26,13 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/localmodelcache"
@@ -124,8 +127,14 @@ func enumerateLoRAAdapters(spec v1alpha2.LLMInferenceServiceSpec) ([]resolvedLoR
 }
 
 // rewriteLoRAAdaptersFromLocalModelCache rewrites cached adapter URIs to pvc:// paths
-// using the localmodel-lora annotation set by the defaulter webhook.
-func rewriteLoRAAdaptersFromLocalModelCache(llmSvc *v1alpha2.LLMInferenceService, adapters []resolvedLoRAAdapter) ([]resolvedLoRAAdapter, error) {
+// using the slim localmodel-lora annotation (cache + optional namespace). Source URI and PVC
+// name are resolved at reconcile time via Get on the referenced cache.
+func rewriteLoRAAdaptersFromLocalModelCache(
+	ctx context.Context,
+	c client.Client,
+	llmSvc *v1alpha2.LLMInferenceService,
+	adapters []resolvedLoRAAdapter,
+) ([]resolvedLoRAAdapter, error) {
 	if len(adapters) == 0 {
 		return adapters, nil
 	}
@@ -141,17 +150,57 @@ func rewriteLoRAAdaptersFromLocalModelCache(llmSvc *v1alpha2.LLMInferenceService
 		return adapters, nil
 	}
 
+	nodeGroup, nodeGroupExists := llmSvc.Annotations[constants.NodeGroupAnnotationKey]
+
 	out := make([]resolvedLoRAAdapter, len(adapters))
 	copy(out, adapters)
 	for i := range out {
 		entry, ok := entries[out[i].name]
-		if !ok {
+		if !ok || entry.Cache == "" {
 			continue
 		}
-		out[i].uri = localmodelcache.BuildCachedPVCURI(entry.SourceURI, entry.PVCName, out[i].uri)
+		sourceURI, pvcName, err := resolveLoRACachePVC(ctx, c, entry, nodeGroup, nodeGroupExists)
+		if err != nil {
+			return nil, fmt.Errorf("LoRA adapter %q: %w", out[i].name, err)
+		}
+		out[i].uri = localmodelcache.BuildCachedPVCURI(sourceURI, pvcName, out[i].uri)
 		out[i].scheme = constants.PvcURIPrefix
 	}
 	return out, nil
+}
+
+// resolveLoRACachePVC Gets the referenced LocalModelCache / LocalModelNamespaceCache and
+// derives source URI + serving PVC name for the LLMInferenceService node group.
+func resolveLoRACachePVC(
+	ctx context.Context,
+	c client.Client,
+	entry localmodelcache.CacheEntry,
+	nodeGroup string,
+	nodeGroupExists bool,
+) (sourceURI, pvcName string, err error) {
+	if entry.Namespace != "" {
+		nsCache := &v1alpha1.LocalModelNamespaceCache{}
+		if err := c.Get(ctx, types.NamespacedName{Name: entry.Cache, Namespace: entry.Namespace}, nsCache); err != nil {
+			return "", "", fmt.Errorf("get LocalModelNamespaceCache %s/%s: %w", entry.Namespace, entry.Cache, err)
+		}
+		pvc, ok := localmodelcache.PVCNameForNodeGroup(nsCache.Spec.NodeGroups, nodeGroup, nodeGroupExists, nsCache.Name)
+		if !ok {
+			return "", "", fmt.Errorf("LocalModelNamespaceCache %s/%s has no matching node group for annotation %q=%q",
+				entry.Namespace, entry.Cache, constants.NodeGroupAnnotationKey, nodeGroup)
+		}
+		return nsCache.Spec.SourceModelUri, pvc, nil
+	}
+
+	cache := &v1alpha1.LocalModelCache{}
+	if err := c.Get(ctx, types.NamespacedName{Name: entry.Cache}, cache); err != nil {
+		return "", "", fmt.Errorf("get LocalModelCache %s: %w", entry.Cache, err)
+	}
+	pvc, ok := localmodelcache.PVCNameForNodeGroup(cache.Spec.NodeGroups, nodeGroup, nodeGroupExists, cache.Name)
+	if !ok {
+		return "", "", fmt.Errorf("LocalModelCache %s has no matching node group for annotation %q=%q",
+			entry.Cache, constants.NodeGroupAnnotationKey, nodeGroup)
+	}
+	return cache.Spec.SourceModelUri, pvc, nil
 }
 
 // collectLoRADownloadPairs filters pre-resolved adapters to hf:// and s3:// uri/path pairs

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -17,100 +17,86 @@ limitations under the License.
 package llmisvc
 
 import (
+	"strings"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 )
 
-func TestSanitizeLoRAPathSegment(t *testing.T) {
+func TestRewriteLoRAAdaptersFromLocalModelCache(t *testing.T) {
 	t.Parallel()
-	if got, want := sanitizeLoRAPathSegment("k8s-lora"), "k8s-lora"; got != want {
-		t.Fatalf("got %q want %q", got, want)
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "cached-adapter", uri: "hf://org/adapter", scheme: constants.HfURIPrefix},
+		{name: "remote-adapter", uri: "hf://org/remote", scheme: constants.HfURIPrefix},
 	}
-	if got, want := sanitizeLoRAPathSegment("a/b"), "a-b"; got != want {
-		t.Fatalf("got %q want %q", got, want)
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"cached-adapter":{"cache":"adapter-cache","sourceUri":"hf://org/adapter","pvcName":"adapter-cache-gpu1"}}`,
+			},
+		},
 	}
-	if got, want := sanitizeLoRAPathSegment("@@@"), "---"; got != want {
-		t.Fatalf("got %q want %q", got, want)
-	}
-	if got, want := sanitizeLoRAPathSegment(""), "adapter"; got != want {
-		t.Fatalf("got %q want %q", got, want)
-	}
+
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	require.NoError(t, err)
+	require.Len(t, rewritten, 2)
+
+	assert.Equal(t, constants.PvcURIPrefix, rewritten[0].scheme)
+	assert.True(t, strings.HasPrefix(rewritten[0].uri, "pvc://adapter-cache-gpu1/models/"))
+	assert.Equal(t, constants.HfURIPrefix, rewritten[1].scheme)
+	assert.Equal(t, "hf://org/remote", rewritten[1].uri)
+
+	pairs := collectLoRADownloadPairs(rewritten)
+	require.Len(t, pairs, 1)
+	assert.Equal(t, "hf://org/remote", pairs[0].uri)
 }
 
-func TestAddLoRAVLLMArgs(t *testing.T) {
+func TestRewriteLoRAAdaptersFromLocalModelCache_NoAnnotation(t *testing.T) {
 	t.Parallel()
 
-	t.Run("all params set with model-routing aliases", func(t *testing.T) {
-		c := &corev1.Container{Name: "main", Args: []string{"--user-flag"}}
-		addLoRAVLLMArgs(c, []string{
-			`{"name":"a","path":"/mnt/lora/a"}`,
-			`{"name":"publishers/ns/models/a","path":"/mnt/lora/a"}`,
-			`{"name":"b","path":"/mnt/lora/b"}`,
-			`{"name":"publishers/ns/models/b","path":"/mnt/lora/b"}`,
-		}, ptr.To(int32(64)), ptr.To(int32(2)), ptr.To(int32(4)))
-		want := []string{
-			"--enable-lora",
-			"--max-lora-rank=64",
-			"--max-loras=2",
-			"--max-cpu-loras=4",
-			"--lora-modules",
-			`'{"name":"a","path":"/mnt/lora/a"}'`,
-			`'{"name":"publishers/ns/models/a","path":"/mnt/lora/a"}'`,
-			`'{"name":"b","path":"/mnt/lora/b"}'`,
-			`'{"name":"publishers/ns/models/b","path":"/mnt/lora/b"}'`,
-			"--user-flag",
-		}
-		if len(c.Args) != len(want) {
-			t.Fatalf("len(args)=%d want %d: %v", len(c.Args), len(want), c.Args)
-		}
-		for i := range want {
-			if c.Args[i] != want[i] {
-				t.Fatalf("args[%d]=%q want %q (full %v)", i, c.Args[i], want[i], c.Args)
-			}
-		}
-	})
+	adapters := []resolvedLoRAAdapter{
+		{name: "a", uri: "hf://org/a", scheme: constants.HfURIPrefix},
+	}
+	llmSvc := &v1alpha2.LLMInferenceService{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
 
-	t.Run("no optional params", func(t *testing.T) {
-		c := &corev1.Container{Name: "main", Args: []string{"--user-flag"}}
-		addLoRAVLLMArgs(c, []string{
-			`{"name":"a","path":"/mnt/lora/a"}`,
-			`{"name":"publishers/ns/models/a","path":"/mnt/lora/a"}`,
-		}, nil, nil, nil)
-		want := []string{
-			"--enable-lora",
-			"--lora-modules",
-			`'{"name":"a","path":"/mnt/lora/a"}'`,
-			`'{"name":"publishers/ns/models/a","path":"/mnt/lora/a"}'`,
-			"--user-flag",
-		}
-		if len(c.Args) != len(want) {
-			t.Fatalf("len(args)=%d want %d: %v", len(c.Args), len(want), c.Args)
-		}
-		for i := range want {
-			if c.Args[i] != want[i] {
-				t.Fatalf("args[%d]=%q want %q (full %v)", i, c.Args[i], want[i], c.Args)
-			}
-		}
-	})
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	require.NoError(t, err)
+	assert.Equal(t, adapters, rewritten)
 }
 
-func TestUserSuppliedLoRAConfig(t *testing.T) {
+func TestRewriteLoRAAdaptersFromLocalModelCache_Subpath(t *testing.T) {
 	t.Parallel()
-	if !userSuppliedLoRAConfig(&corev1.Container{
-		Env: []corev1.EnvVar{{Name: "VLLM_ADDITIONAL_ARGS", Value: "x --lora-modules y"}},
-	}) {
-		t.Fatal("expected true when VLLM_ADDITIONAL_ARGS has --lora-modules")
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "my-adapter", uri: "hf://org/model/subdir", scheme: constants.HfURIPrefix},
 	}
-	if userSuppliedLoRAConfig(&corev1.Container{
-		Env: []corev1.EnvVar{{Name: "VLLM_ADDITIONAL_ARGS", Value: "--enable-lora"}},
-	}) {
-		t.Fatal("expected false without --lora-modules")
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"c","sourceUri":"hf://org/model","pvcName":"c-gpu1"}}`,
+			},
+		},
 	}
-	if !userSuppliedLoRAConfig(&corev1.Container{
-		Args: []string{"--lora-modules", "x=y"},
-	}) {
-		t.Fatal("expected true when Args contains --lora-modules")
-	}
+
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	require.NoError(t, err)
+	assert.Contains(t, rewritten[0].uri, "/subdir")
+	assert.Equal(t, constants.PvcURIPrefix, rewritten[0].scheme)
+}
+
+func TestBuildCachedPVCURI_MatchesLocalModelCacheHelper(t *testing.T) {
+	t.Parallel()
+	got := localmodelcache.BuildCachedPVCURI("hf://org/model", "cache-gpu1", "hf://org/model/extra")
+	assert.True(t, strings.HasPrefix(got, "pvc://cache-gpu1/models/"))
+	assert.True(t, strings.HasSuffix(got, "/extra"))
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -22,12 +22,95 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/localmodelcache"
 )
+
+func TestSanitizeLoRAPathSegment(t *testing.T) {
+	t.Parallel()
+	if got, want := sanitizeLoRAPathSegment("k8s-lora"), "k8s-lora"; got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	if got, want := sanitizeLoRAPathSegment("a/b"), "a-b"; got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	if got, want := sanitizeLoRAPathSegment("@@@"), "---"; got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	if got, want := sanitizeLoRAPathSegment(""), "adapter"; got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestAddLoRAVLLMArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all params set", func(t *testing.T) {
+		c := &corev1.Container{Name: "main", Args: []string{"--user-flag"}}
+		addLoRAVLLMArgs(c, []string{"a=/mnt/lora/a", "b=/mnt/lora/b"}, ptr.To(int32(64)), ptr.To(int32(2)), ptr.To(int32(4)))
+		want := []string{
+			"--enable-lora",
+			"--max-lora-rank=64",
+			"--max-loras=2",
+			"--max-cpu-loras=4",
+			"--lora-modules",
+			"'a=/mnt/lora/a'",
+			"'b=/mnt/lora/b'",
+			"--user-flag",
+		}
+		if len(c.Args) != len(want) {
+			t.Fatalf("len(args)=%d want %d: %v", len(c.Args), len(want), c.Args)
+		}
+		for i := range want {
+			if c.Args[i] != want[i] {
+				t.Fatalf("args[%d]=%q want %q (full %v)", i, c.Args[i], want[i], c.Args)
+			}
+		}
+	})
+
+	t.Run("no optional params — vLLM uses its own defaults", func(t *testing.T) {
+		c := &corev1.Container{Name: "main", Args: []string{"--user-flag"}}
+		addLoRAVLLMArgs(c, []string{"a=/mnt/lora/a"}, nil, nil, nil)
+		want := []string{
+			"--enable-lora",
+			"--lora-modules",
+			"'a=/mnt/lora/a'",
+			"--user-flag",
+		}
+		if len(c.Args) != len(want) {
+			t.Fatalf("len(args)=%d want %d: %v", len(c.Args), len(want), c.Args)
+		}
+		for i := range want {
+			if c.Args[i] != want[i] {
+				t.Fatalf("args[%d]=%q want %q (full %v)", i, c.Args[i], want[i], c.Args)
+			}
+		}
+	})
+}
+
+func TestUserSuppliedLoRAConfig(t *testing.T) {
+	t.Parallel()
+	if !userSuppliedLoRAConfig(&corev1.Container{
+		Env: []corev1.EnvVar{{Name: "VLLM_ADDITIONAL_ARGS", Value: "x --lora-modules y"}},
+	}) {
+		t.Fatal("expected true when VLLM_ADDITIONAL_ARGS has --lora-modules")
+	}
+	if userSuppliedLoRAConfig(&corev1.Container{
+		Env: []corev1.EnvVar{{Name: "VLLM_ADDITIONAL_ARGS", Value: "--enable-lora"}},
+	}) {
+		t.Fatal("expected false without --lora-modules")
+	}
+	if !userSuppliedLoRAConfig(&corev1.Container{
+		Args: []string{"--lora-modules", "x=y"},
+	}) {
+		t.Fatal("expected true when Args contains --lora-modules")
+	}
+}
 
 func TestRewriteLoRAAdaptersFromLocalModelCache(t *testing.T) {
 	t.Parallel()

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package llmisvc
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -26,6 +29,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 )
 
 func TestSanitizeLoRAPathSegment(t *testing.T) {
@@ -167,4 +171,76 @@ func TestUserSuppliedLoRAConfig(t *testing.T) {
 	}) {
 		t.Fatal("expected true when Args contains --lora-modules")
 	}
+}
+
+func TestRewriteLoRAAdaptersFromLocalModelCache(t *testing.T) {
+	t.Parallel()
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "cached-adapter", uri: "hf://org/adapter", scheme: constants.HfURIPrefix},
+		{name: "remote-adapter", uri: "hf://org/remote", scheme: constants.HfURIPrefix},
+	}
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"cached-adapter":{"cache":"adapter-cache","sourceUri":"hf://org/adapter","pvcName":"adapter-cache-gpu1"}}`,
+			},
+		},
+	}
+
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	require.NoError(t, err)
+	require.Len(t, rewritten, 2)
+
+	assert.Equal(t, constants.PvcURIPrefix, rewritten[0].scheme)
+	assert.True(t, strings.HasPrefix(rewritten[0].uri, "pvc://adapter-cache-gpu1/models/"))
+	assert.Equal(t, constants.HfURIPrefix, rewritten[1].scheme)
+	assert.Equal(t, "hf://org/remote", rewritten[1].uri)
+
+	pairs := collectLoRADownloadPairs(rewritten)
+	require.Len(t, pairs, 1)
+	assert.Equal(t, "hf://org/remote", pairs[0].uri)
+}
+
+func TestRewriteLoRAAdaptersFromLocalModelCache_NoAnnotation(t *testing.T) {
+	t.Parallel()
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "a", uri: "hf://org/a", scheme: constants.HfURIPrefix},
+	}
+	llmSvc := &v1alpha2.LLMInferenceService{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	require.NoError(t, err)
+	assert.Equal(t, adapters, rewritten)
+}
+
+func TestRewriteLoRAAdaptersFromLocalModelCache_Subpath(t *testing.T) {
+	t.Parallel()
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "my-adapter", uri: "hf://org/model/subdir", scheme: constants.HfURIPrefix},
+	}
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"c","sourceUri":"hf://org/model","pvcName":"c-gpu1"}}`,
+			},
+		},
+	}
+
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	require.NoError(t, err)
+	assert.Contains(t, rewritten[0].uri, "/subdir")
+	assert.Equal(t, constants.PvcURIPrefix, rewritten[0].scheme)
+}
+
+func TestBuildCachedPVCURI_MatchesLocalModelCacheHelper(t *testing.T) {
+	t.Parallel()
+	got := localmodelcache.BuildCachedPVCURI("hf://org/model", "cache-gpu1", "hf://org/model/extra")
+	assert.True(t, strings.HasPrefix(got, "pvc://cache-gpu1/models/"))
+	assert.True(t, strings.HasSuffix(got, "/extra"))
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -23,9 +23,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/localmodelcache"
@@ -123,6 +127,14 @@ func TestUserSuppliedLoRAConfig(t *testing.T) {
 	}
 }
 
+func newLoRARewriteScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	return scheme
+}
+
 func TestRewriteLoRAAdaptersFromLocalModelCache(t *testing.T) {
 	t.Parallel()
 
@@ -131,17 +143,27 @@ func TestRewriteLoRAAdaptersFromLocalModelCache(t *testing.T) {
 		{name: "remote-adapter", uri: "hf://org/remote", scheme: constants.HfURIPrefix},
 	}
 
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "adapter-cache"},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "hf://org/adapter",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"gpu1"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).WithObjects(cache).Build()
+
 	llmSvc := &v1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "default",
 			Annotations: map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"cached-adapter":{"cache":"adapter-cache","sourceUri":"hf://org/adapter","pvcName":"adapter-cache-gpu1"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"cached-adapter":{"cache":"adapter-cache"}}`,
 			},
 		},
 	}
 
-	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
 	require.NoError(t, err)
 	require.Len(t, rewritten, 2)
 
@@ -162,8 +184,9 @@ func TestRewriteLoRAAdaptersFromLocalModelCache_NoAnnotation(t *testing.T) {
 		{name: "a", uri: "hf://org/a", scheme: constants.HfURIPrefix},
 	}
 	llmSvc := &v1alpha2.LLMInferenceService{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).Build()
 
-	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
 	require.NoError(t, err)
 	assert.Equal(t, adapters, rewritten)
 }
@@ -174,18 +197,79 @@ func TestRewriteLoRAAdaptersFromLocalModelCache_Subpath(t *testing.T) {
 	adapters := []resolvedLoRAAdapter{
 		{name: "my-adapter", uri: "hf://org/model/subdir", scheme: constants.HfURIPrefix},
 	}
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "c"},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "hf://org/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"gpu1"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).WithObjects(cache).Build()
+
 	llmSvc := &v1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"c","sourceUri":"hf://org/model","pvcName":"c-gpu1"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"c"}}`,
 			},
 		},
 	}
 
-	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
 	require.NoError(t, err)
 	assert.Contains(t, rewritten[0].uri, "/subdir")
 	assert.Equal(t, constants.PvcURIPrefix, rewritten[0].scheme)
+}
+
+func TestRewriteLoRAAdaptersFromLocalModelCache_NamespaceScoped(t *testing.T) {
+	t.Parallel()
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "my-adapter", uri: "hf://org/adapter", scheme: constants.HfURIPrefix},
+	}
+	nsCache := &v1alpha1.LocalModelNamespaceCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns-adapter-cache", Namespace: "default"},
+		Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+			SourceModelUri: "hf://org/adapter",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"gpu2"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).WithObjects(nsCache).Build()
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"ns-adapter-cache","namespace":"default"}}`,
+			},
+		},
+	}
+
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
+	require.NoError(t, err)
+	assert.Equal(t, constants.PvcURIPrefix, rewritten[0].scheme)
+	assert.True(t, strings.HasPrefix(rewritten[0].uri, "pvc://ns-adapter-cache-gpu2/models/"))
+}
+
+func TestRewriteLoRAAdaptersFromLocalModelCache_MissingCache(t *testing.T) {
+	t.Parallel()
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "my-adapter", uri: "hf://org/adapter", scheme: constants.HfURIPrefix},
+	}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).Build()
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"missing"}}`,
+			},
+		},
+	}
+
+	_, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get LocalModelCache")
 }
 
 func TestBuildCachedPVCURI_MatchesLocalModelCacheHelper(t *testing.T) {

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -50,17 +50,24 @@ func TestSanitizeLoRAPathSegment(t *testing.T) {
 func TestAddLoRAVLLMArgs(t *testing.T) {
 	t.Parallel()
 
-	t.Run("all params set", func(t *testing.T) {
+	t.Run("all params set with model-routing aliases", func(t *testing.T) {
 		c := &corev1.Container{Name: "main", Args: []string{"--user-flag"}}
-		addLoRAVLLMArgs(c, []string{"a=/mnt/lora/a", "b=/mnt/lora/b"}, ptr.To(int32(64)), ptr.To(int32(2)), ptr.To(int32(4)))
+		addLoRAVLLMArgs(c, []string{
+			`{"name":"a","path":"/mnt/lora/a"}`,
+			`{"name":"publishers/ns/models/a","path":"/mnt/lora/a"}`,
+			`{"name":"b","path":"/mnt/lora/b"}`,
+			`{"name":"publishers/ns/models/b","path":"/mnt/lora/b"}`,
+		}, ptr.To(int32(64)), ptr.To(int32(2)), ptr.To(int32(4)))
 		want := []string{
 			"--enable-lora",
 			"--max-lora-rank=64",
 			"--max-loras=2",
 			"--max-cpu-loras=4",
 			"--lora-modules",
-			"'a=/mnt/lora/a'",
-			"'b=/mnt/lora/b'",
+			`'{"name":"a","path":"/mnt/lora/a"}'`,
+			`'{"name":"publishers/ns/models/a","path":"/mnt/lora/a"}'`,
+			`'{"name":"b","path":"/mnt/lora/b"}'`,
+			`'{"name":"publishers/ns/models/b","path":"/mnt/lora/b"}'`,
 			"--user-flag",
 		}
 		if len(c.Args) != len(want) {
@@ -75,11 +82,15 @@ func TestAddLoRAVLLMArgs(t *testing.T) {
 
 	t.Run("no optional params — vLLM uses its own defaults", func(t *testing.T) {
 		c := &corev1.Container{Name: "main", Args: []string{"--user-flag"}}
-		addLoRAVLLMArgs(c, []string{"a=/mnt/lora/a"}, nil, nil, nil)
+		addLoRAVLLMArgs(c, []string{
+			`{"name":"a","path":"/mnt/lora/a"}`,
+			`{"name":"publishers/ns/models/a","path":"/mnt/lora/a"}`,
+		}, nil, nil, nil)
 		want := []string{
 			"--enable-lora",
 			"--lora-modules",
-			"'a=/mnt/lora/a'",
+			`'{"name":"a","path":"/mnt/lora/a"}'`,
+			`'{"name":"publishers/ns/models/a","path":"/mnt/lora/a"}'`,
 			"--user-flag",
 		}
 		if len(c.Args) != len(want) {

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -23,10 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/localmodelcache"
@@ -173,6 +177,14 @@ func TestUserSuppliedLoRAConfig(t *testing.T) {
 	}
 }
 
+func newLoRARewriteScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	return scheme
+}
+
 func TestRewriteLoRAAdaptersFromLocalModelCache(t *testing.T) {
 	t.Parallel()
 
@@ -181,17 +193,27 @@ func TestRewriteLoRAAdaptersFromLocalModelCache(t *testing.T) {
 		{name: "remote-adapter", uri: "hf://org/remote", scheme: constants.HfURIPrefix},
 	}
 
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "adapter-cache"},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "hf://org/adapter",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"gpu1"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).WithObjects(cache).Build()
+
 	llmSvc := &v1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "default",
 			Annotations: map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"cached-adapter":{"cache":"adapter-cache","sourceUri":"hf://org/adapter","pvcName":"adapter-cache-gpu1"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"cached-adapter":{"cache":"adapter-cache"}}`,
 			},
 		},
 	}
 
-	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
 	require.NoError(t, err)
 	require.Len(t, rewritten, 2)
 
@@ -212,8 +234,9 @@ func TestRewriteLoRAAdaptersFromLocalModelCache_NoAnnotation(t *testing.T) {
 		{name: "a", uri: "hf://org/a", scheme: constants.HfURIPrefix},
 	}
 	llmSvc := &v1alpha2.LLMInferenceService{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).Build()
 
-	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
 	require.NoError(t, err)
 	assert.Equal(t, adapters, rewritten)
 }
@@ -224,18 +247,79 @@ func TestRewriteLoRAAdaptersFromLocalModelCache_Subpath(t *testing.T) {
 	adapters := []resolvedLoRAAdapter{
 		{name: "my-adapter", uri: "hf://org/model/subdir", scheme: constants.HfURIPrefix},
 	}
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "c"},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "hf://org/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"gpu1"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).WithObjects(cache).Build()
+
 	llmSvc := &v1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"c","sourceUri":"hf://org/model","pvcName":"c-gpu1"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"c"}}`,
 			},
 		},
 	}
 
-	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(llmSvc, adapters)
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
 	require.NoError(t, err)
 	assert.Contains(t, rewritten[0].uri, "/subdir")
 	assert.Equal(t, constants.PvcURIPrefix, rewritten[0].scheme)
+}
+
+func TestRewriteLoRAAdaptersFromLocalModelCache_NamespaceScoped(t *testing.T) {
+	t.Parallel()
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "my-adapter", uri: "hf://org/adapter", scheme: constants.HfURIPrefix},
+	}
+	nsCache := &v1alpha1.LocalModelNamespaceCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns-adapter-cache", Namespace: "default"},
+		Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+			SourceModelUri: "hf://org/adapter",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"gpu2"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).WithObjects(nsCache).Build()
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"ns-adapter-cache","namespace":"default"}}`,
+			},
+		},
+	}
+
+	rewritten, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
+	require.NoError(t, err)
+	assert.Equal(t, constants.PvcURIPrefix, rewritten[0].scheme)
+	assert.True(t, strings.HasPrefix(rewritten[0].uri, "pvc://ns-adapter-cache-gpu2/models/"))
+}
+
+func TestRewriteLoRAAdaptersFromLocalModelCache_MissingCache(t *testing.T) {
+	t.Parallel()
+
+	adapters := []resolvedLoRAAdapter{
+		{name: "my-adapter", uri: "hf://org/adapter", scheme: constants.HfURIPrefix},
+	}
+	c := fake.NewClientBuilder().WithScheme(newLoRARewriteScheme(t)).Build()
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"missing"}}`,
+			},
+		},
+	}
+
+	_, err := rewriteLoRAAdaptersFromLocalModelCache(t.Context(), c, llmSvc, adapters)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get LocalModelCache")
 }
 
 func TestBuildCachedPVCURI_MatchesLocalModelCacheHelper(t *testing.T) {

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -29,11 +29,11 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/credentials"
 	"github.com/kserve/kserve/pkg/credentials/s3"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 	kserveTypes "github.com/kserve/kserve/pkg/types"
 	"github.com/kserve/kserve/pkg/utils"
 )
@@ -110,18 +110,19 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 		if !ok {
 			return fmt.Errorf("LLMInferenceService %s/%s: annotation %s not found", llmSvc.Namespace, llmSvc.Name, constants.LocalModelPVCNameAnnotationKey)
 		}
-		subPath, _ := strings.CutPrefix(modelUri, sourceUri)
-		if !strings.HasPrefix(subPath, "/") {
-			subPath = "/" + subPath
-		}
-		storageKey := v1alpha1.GetStorageKey(sourceUri)
-		modelUri = "pvc://" + pvcName + "/models/" + storageKey + subPath
+		modelUri = localmodelcache.BuildCachedPVCURI(sourceUri, pvcName, modelUri)
 		schema = "pvc"
 	}
 
+	var resolvedLoRAAdapters []resolvedLoRAAdapter
 	var loraPairs []storageDownloadPair
 	if attachLoRA {
-		loraPairs = collectLoRADownloadPairs(config.ResolvedLoRAAdapters)
+		var err error
+		resolvedLoRAAdapters, err = rewriteLoRAAdaptersFromLocalModelCache(llmSvc, config.ResolvedLoRAAdapters)
+		if err != nil {
+			return fmt.Errorf("rewrite LoRA adapters from local model cache: %w", err)
+		}
+		loraPairs = collectLoRADownloadPairs(resolvedLoRAAdapters)
 	}
 
 	// Handle model artifact downloads based on URI scheme
@@ -181,7 +182,7 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 
 	// Attach LoRA adapters (PVC mounts + vLLM flag injection) after model downloads
 	if attachLoRA {
-		if err := r.attachLoRAAdapters(ctx, llmSvc, podSpec, config.ResolvedLoRAAdapters); err != nil {
+		if err := r.attachLoRAAdapters(ctx, llmSvc, podSpec, resolvedLoRAAdapters); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -29,11 +29,11 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/credentials"
 	"github.com/kserve/kserve/pkg/credentials/s3"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 	kserveTypes "github.com/kserve/kserve/pkg/types"
 	"github.com/kserve/kserve/pkg/utils"
 )
@@ -113,18 +113,19 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 		if !ok {
 			return fmt.Errorf("LLMInferenceService %s/%s: annotation %s not found", llmSvc.Namespace, llmSvc.Name, constants.LocalModelPVCNameAnnotationKey)
 		}
-		subPath, _ := strings.CutPrefix(modelUri, sourceUri)
-		if !strings.HasPrefix(subPath, "/") {
-			subPath = "/" + subPath
-		}
-		storageKey := v1alpha1.GetStorageKey(sourceUri)
-		modelUri = "pvc://" + pvcName + "/models/" + storageKey + subPath
+		modelUri = localmodelcache.BuildCachedPVCURI(sourceUri, pvcName, modelUri)
 		schema = "pvc"
 	}
 
+	var resolvedLoRAAdapters []resolvedLoRAAdapter
 	var loraPairs []storageDownloadPair
 	if attachLoRA {
-		loraPairs = collectLoRADownloadPairs(config.ResolvedLoRAAdapters)
+		var err error
+		resolvedLoRAAdapters, err = rewriteLoRAAdaptersFromLocalModelCache(llmSvc, config.ResolvedLoRAAdapters)
+		if err != nil {
+			return fmt.Errorf("rewrite LoRA adapters from local model cache: %w", err)
+		}
+		loraPairs = collectLoRADownloadPairs(resolvedLoRAAdapters)
 	}
 
 	// Handle model artifact downloads based on URI scheme
@@ -205,7 +206,7 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 
 	// Attach LoRA adapters (PVC mounts + vLLM flag injection) after model downloads
 	if attachLoRA {
-		if err := r.attachLoRAAdapters(ctx, llmSvc, podSpec, config.ResolvedLoRAAdapters); err != nil {
+		if err := r.attachLoRAAdapters(ctx, llmSvc, podSpec, resolvedLoRAAdapters); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -121,7 +121,7 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 	var loraPairs []storageDownloadPair
 	if attachLoRA {
 		var err error
-		resolvedLoRAAdapters, err = rewriteLoRAAdaptersFromLocalModelCache(llmSvc, config.ResolvedLoRAAdapters)
+		resolvedLoRAAdapters, err = rewriteLoRAAdaptersFromLocalModelCache(ctx, r.Client, llmSvc, config.ResolvedLoRAAdapters)
 		if err != nil {
 			return fmt.Errorf("rewrite LoRA adapters from local model cache: %w", err)
 		}

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -118,7 +118,7 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 	var loraPairs []storageDownloadPair
 	if attachLoRA {
 		var err error
-		resolvedLoRAAdapters, err = rewriteLoRAAdaptersFromLocalModelCache(llmSvc, config.ResolvedLoRAAdapters)
+		resolvedLoRAAdapters, err = rewriteLoRAAdaptersFromLocalModelCache(ctx, r.Client, llmSvc, config.ResolvedLoRAAdapters)
 		if err != nil {
 			return fmt.Errorf("rewrite LoRA adapters from local model cache: %w", err)
 		}

--- a/pkg/localmodelcache/metadata.go
+++ b/pkg/localmodelcache/metadata.go
@@ -111,11 +111,12 @@ func pvcNameForNodeGroup(nodeGroups []string, nodeGroup string, nodeGroupExists 
 // BuildCachedPVCURI rewrites storageURI to a local model cache PVC path.
 // subPath under sourceURI is preserved (e.g. hf://org/model/subdir).
 func BuildCachedPVCURI(sourceURI, pvcName, storageURI string) string {
-	subPath, _ := strings.CutPrefix(storageURI, sourceURI)
+	normalizedSourceURI := strings.TrimSuffix(sourceURI, "/")
+	subPath, _ := strings.CutPrefix(storageURI, normalizedSourceURI)
 	if !strings.HasPrefix(subPath, "/") {
 		subPath = "/" + subPath
 	}
-	storageKey := v1alpha1.GetStorageKey(sourceURI)
+	storageKey := v1alpha1.GetStorageKey(normalizedSourceURI)
 	return "pvc://" + pvcName + "/models/" + storageKey + subPath
 }
 
@@ -156,8 +157,16 @@ func LoRACacheEntryFromMatch(match *CacheMatch) LoRACacheEntry {
 	}
 }
 
+func loRACacheAnnotationRaw(annotations map[string]string) string {
+	if annotations == nil {
+		return ""
+	}
+	return annotations[constants.LocalModelLoRAAnnotationKey]
+}
+
 // LLMISVCClusterCacheNames returns cluster-scoped LocalModelCache names referenced by an
 // LLMInferenceService via the base-model label or LoRA adapter annotation.
+// Malformed LoRA annotation JSON is ignored here; LLMISVCReferencesClusterCache fails closed instead.
 func LLMISVCClusterCacheNames(labels, annotations map[string]string) []string {
 	var names []string
 	if labels != nil {
@@ -167,7 +176,7 @@ func LLMISVCClusterCacheNames(labels, annotations map[string]string) []string {
 			}
 		}
 	}
-	if entries, err := ParseLoRACacheAnnotation(annotations[constants.LocalModelLoRAAnnotationKey]); err == nil {
+	if entries, err := ParseLoRACacheAnnotation(loRACacheAnnotationRaw(annotations)); err == nil {
 		for _, entry := range entries {
 			if entry.Cache != "" && entry.Namespace == "" {
 				names = append(names, entry.Cache)
@@ -179,6 +188,7 @@ func LLMISVCClusterCacheNames(labels, annotations map[string]string) []string {
 
 // LLMISVCNamespaceCacheNames returns LocalModelNamespaceCache names in llmSvcNamespace
 // referenced by an LLMInferenceService via the base-model labels or LoRA adapter annotation.
+// Malformed LoRA annotation JSON is ignored here; LLMISVCReferencesNamespaceCache fails closed instead.
 func LLMISVCNamespaceCacheNames(llmSvcNamespace string, labels, annotations map[string]string) []string {
 	var names []string
 	if labels != nil {
@@ -188,7 +198,7 @@ func LLMISVCNamespaceCacheNames(llmSvcNamespace string, labels, annotations map[
 			names = append(names, name)
 		}
 	}
-	if entries, err := ParseLoRACacheAnnotation(annotations[constants.LocalModelLoRAAnnotationKey]); err == nil {
+	if entries, err := ParseLoRACacheAnnotation(loRACacheAnnotationRaw(annotations)); err == nil {
 		for _, entry := range entries {
 			if entry.Cache != "" && entry.Namespace == llmSvcNamespace {
 				names = append(names, entry.Cache)
@@ -204,16 +214,40 @@ func ClusterCacheNamesEqual(a, b []string) bool {
 }
 
 // LLMISVCReferencesClusterCache reports whether labels/annotations reference a cluster-scoped cache.
+// A non-empty but malformed LoRA annotation is treated as a reference (fail-closed) so cache
+// deletion stays blocked until the annotation is fixed or removed.
 func LLMISVCReferencesClusterCache(cacheName string, labels, annotations map[string]string) bool {
-	return slices.Contains(LLMISVCClusterCacheNames(labels, annotations), cacheName)
+	if slices.Contains(LLMISVCClusterCacheNames(labels, annotations), cacheName) {
+		return true
+	}
+	raw := loRACacheAnnotationRaw(annotations)
+	if raw == "" {
+		return false
+	}
+	if _, err := ParseLoRACacheAnnotation(raw); err != nil {
+		return true
+	}
+	return false
 }
 
 // LLMISVCReferencesNamespaceCache reports whether labels/annotations reference a namespace-scoped cache.
+// A non-empty but malformed LoRA annotation is treated as a reference (fail-closed) so cache
+// deletion stays blocked until the annotation is fixed or removed.
 func LLMISVCReferencesNamespaceCache(cacheName, cacheNamespace, llmSvcNamespace string, labels, annotations map[string]string) bool {
 	if llmSvcNamespace != cacheNamespace {
 		return false
 	}
-	return slices.Contains(LLMISVCNamespaceCacheNames(llmSvcNamespace, labels, annotations), cacheName)
+	if slices.Contains(LLMISVCNamespaceCacheNames(llmSvcNamespace, labels, annotations), cacheName) {
+		return true
+	}
+	raw := loRACacheAnnotationRaw(annotations)
+	if raw == "" {
+		return false
+	}
+	if _, err := ParseLoRACacheAnnotation(raw); err != nil {
+		return true
+	}
+	return false
 }
 
 func uniqueSorted(names []string) []string {

--- a/pkg/localmodelcache/metadata.go
+++ b/pkg/localmodelcache/metadata.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localmodelcache
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// CacheMatch describes a LocalModelCache or LocalModelNamespaceCache hit for a storage URI.
+type CacheMatch struct {
+	Name      string
+	Namespace string // set for LocalModelNamespaceCache; empty for cluster-scoped LocalModelCache
+	SourceURI string
+	PVCName   string
+}
+
+// LoRACacheEntry is one adapter's local model cache metadata stored in the LoRA JSON annotation.
+type LoRACacheEntry struct {
+	Cache     string `json:"cache"`
+	Namespace string `json:"namespace,omitempty"`
+	SourceURI string `json:"sourceUri"`
+	PVCName   string `json:"pvcName"`
+}
+
+// MatchCacheForURI finds a namespace-scoped or cluster-scoped cache matching storageURI.
+// LocalModelNamespaceCache takes precedence over LocalModelCache.
+func MatchCacheForURI(
+	storageURI string,
+	nodeGroup string,
+	nodeGroupExists bool,
+	models *v1alpha1.LocalModelCacheList,
+	nsModels *v1alpha1.LocalModelNamespaceCacheList,
+) *CacheMatch {
+	if storageURI == "" {
+		return nil
+	}
+
+	if nsModels != nil {
+		for i := range nsModels.Items {
+			nsModel := &nsModels.Items[i]
+			if !nsModel.Spec.MatchStorageURI(storageURI) {
+				continue
+			}
+			pvcName, ok := pvcNameForNodeGroup(nsModel.Spec.NodeGroups, nodeGroup, nodeGroupExists, nsModel.Name)
+			if !ok {
+				continue
+			}
+			return &CacheMatch{
+				Name:      nsModel.Name,
+				Namespace: nsModel.Namespace,
+				SourceURI: nsModel.Spec.SourceModelUri,
+				PVCName:   pvcName,
+			}
+		}
+	}
+
+	if models == nil {
+		return nil
+	}
+	for i := range models.Items {
+		model := &models.Items[i]
+		if !model.Spec.MatchStorageURI(storageURI) {
+			continue
+		}
+		pvcName, ok := pvcNameForNodeGroup(model.Spec.NodeGroups, nodeGroup, nodeGroupExists, model.Name)
+		if !ok {
+			continue
+		}
+		return &CacheMatch{
+			Name:      model.Name,
+			SourceURI: model.Spec.SourceModelUri,
+			PVCName:   pvcName,
+		}
+	}
+	return nil
+}
+
+func pvcNameForNodeGroup(nodeGroups []string, nodeGroup string, nodeGroupExists bool, cacheName string) (string, bool) {
+	if nodeGroupExists {
+		if !slices.Contains(nodeGroups, nodeGroup) {
+			return "", false
+		}
+		return cacheName + "-" + nodeGroup, true
+	}
+	if len(nodeGroups) == 0 {
+		return "", false
+	}
+	return cacheName + "-" + nodeGroups[0], true
+}
+
+// BuildCachedPVCURI rewrites storageURI to a local model cache PVC path.
+// subPath under sourceURI is preserved (e.g. hf://org/model/subdir).
+func BuildCachedPVCURI(sourceURI, pvcName, storageURI string) string {
+	subPath, _ := strings.CutPrefix(storageURI, sourceURI)
+	if !strings.HasPrefix(subPath, "/") {
+		subPath = "/" + subPath
+	}
+	storageKey := v1alpha1.GetStorageKey(sourceURI)
+	return "pvc://" + pvcName + "/models/" + storageKey + subPath
+}
+
+// MarshalLoRACacheAnnotation serializes adapter cache metadata to JSON.
+func MarshalLoRACacheAnnotation(entries map[string]LoRACacheEntry) (string, error) {
+	if len(entries) == 0 {
+		return "", nil
+	}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return "", fmt.Errorf("marshal LoRA local model cache annotation: %w", err)
+	}
+	return string(data), nil
+}
+
+// ParseLoRACacheAnnotation deserializes adapter cache metadata from JSON.
+func ParseLoRACacheAnnotation(raw string) (map[string]LoRACacheEntry, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var entries map[string]LoRACacheEntry
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return nil, fmt.Errorf("parse LoRA local model cache annotation: %w", err)
+	}
+	return entries, nil
+}
+
+// LoRACacheEntryFromMatch builds a LoRACacheEntry from a cache match.
+func LoRACacheEntryFromMatch(match *CacheMatch) LoRACacheEntry {
+	if match == nil {
+		return LoRACacheEntry{}
+	}
+	return LoRACacheEntry{
+		Cache:     match.Name,
+		Namespace: match.Namespace,
+		SourceURI: match.SourceURI,
+		PVCName:   match.PVCName,
+	}
+}
+
+// LLMISVCClusterCacheNames returns cluster-scoped LocalModelCache names referenced by an
+// LLMInferenceService via the base-model label or LoRA adapter annotation.
+func LLMISVCClusterCacheNames(labels, annotations map[string]string) []string {
+	var names []string
+	if labels != nil {
+		if name, ok := labels[constants.LocalModelLabel]; ok && name != "" {
+			if _, nsOk := labels[constants.LocalModelNamespaceLabel]; !nsOk {
+				names = append(names, name)
+			}
+		}
+	}
+	if entries, err := ParseLoRACacheAnnotation(annotations[constants.LocalModelLoRAAnnotationKey]); err == nil {
+		for _, entry := range entries {
+			if entry.Cache != "" && entry.Namespace == "" {
+				names = append(names, entry.Cache)
+			}
+		}
+	}
+	return uniqueSorted(names)
+}
+
+// LLMISVCNamespaceCacheNames returns LocalModelNamespaceCache names in llmSvcNamespace
+// referenced by an LLMInferenceService via the base-model labels or LoRA adapter annotation.
+func LLMISVCNamespaceCacheNames(llmSvcNamespace string, labels, annotations map[string]string) []string {
+	var names []string
+	if labels != nil {
+		name, hasModel := labels[constants.LocalModelLabel]
+		modelNamespace, hasNamespace := labels[constants.LocalModelNamespaceLabel]
+		if hasModel && hasNamespace && llmSvcNamespace == modelNamespace {
+			names = append(names, name)
+		}
+	}
+	if entries, err := ParseLoRACacheAnnotation(annotations[constants.LocalModelLoRAAnnotationKey]); err == nil {
+		for _, entry := range entries {
+			if entry.Cache != "" && entry.Namespace == llmSvcNamespace {
+				names = append(names, entry.Cache)
+			}
+		}
+	}
+	return uniqueSorted(names)
+}
+
+// ClusterCacheNamesEqual reports whether two cluster cache name lists are equal (order ignored).
+func ClusterCacheNamesEqual(a, b []string) bool {
+	return slices.Equal(uniqueSorted(a), uniqueSorted(b))
+}
+
+// LLMISVCReferencesClusterCache reports whether labels/annotations reference a cluster-scoped cache.
+func LLMISVCReferencesClusterCache(cacheName string, labels, annotations map[string]string) bool {
+	return slices.Contains(LLMISVCClusterCacheNames(labels, annotations), cacheName)
+}
+
+// LLMISVCReferencesNamespaceCache reports whether labels/annotations reference a namespace-scoped cache.
+func LLMISVCReferencesNamespaceCache(cacheName, cacheNamespace, llmSvcNamespace string, labels, annotations map[string]string) bool {
+	if llmSvcNamespace != cacheNamespace {
+		return false
+	}
+	return slices.Contains(LLMISVCNamespaceCacheNames(llmSvcNamespace, labels, annotations), cacheName)
+}
+
+func uniqueSorted(names []string) []string {
+	if len(names) == 0 {
+		return nil
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}

--- a/pkg/localmodelcache/metadata.go
+++ b/pkg/localmodelcache/metadata.go
@@ -140,14 +140,6 @@ func ParseLoRACacheAnnotation(raw string) (map[string]CacheEntry, error) {
 	return entries, nil
 }
 
-// AnnotationRef returns a CacheEntry with only the fields stored in the LoRA annotation.
-func AnnotationRef(entry CacheEntry) CacheEntry {
-	return CacheEntry{
-		Cache:     entry.Cache,
-		Namespace: entry.Namespace,
-	}
-}
-
 func loRACacheAnnotationRaw(annotations map[string]string) string {
 	if annotations == nil {
 		return ""

--- a/pkg/localmodelcache/metadata.go
+++ b/pkg/localmodelcache/metadata.go
@@ -208,8 +208,8 @@ func LLMISVCNamespaceCacheNames(llmSvcNamespace string, labels, annotations map[
 	return uniqueSorted(names)
 }
 
-// ClusterCacheNamesEqual reports whether two cluster cache name lists are equal (order ignored).
-func ClusterCacheNamesEqual(a, b []string) bool {
+// CacheNamesEqual reports whether two cache name lists are equal (order ignored).
+func CacheNamesEqual(a, b []string) bool {
 	return slices.Equal(uniqueSorted(a), uniqueSorted(b))
 }
 

--- a/pkg/localmodelcache/metadata.go
+++ b/pkg/localmodelcache/metadata.go
@@ -254,6 +254,7 @@ func uniqueSorted(names []string) []string {
 	if len(names) == 0 {
 		return nil
 	}
+	names = slices.Clone(names)
 	slices.Sort(names)
 	return slices.Compact(names)
 }

--- a/pkg/localmodelcache/metadata.go
+++ b/pkg/localmodelcache/metadata.go
@@ -26,20 +26,14 @@ import (
 	"github.com/kserve/kserve/pkg/constants"
 )
 
-// CacheMatch describes a LocalModelCache or LocalModelNamespaceCache hit for a storage URI.
-type CacheMatch struct {
-	Name      string
-	Namespace string // set for LocalModelNamespaceCache; empty for cluster-scoped LocalModelCache
-	SourceURI string
-	PVCName   string
-}
-
-// LoRACacheEntry is one adapter's local model cache metadata stored in the LoRA JSON annotation.
-type LoRACacheEntry struct {
+// CacheEntry is a LocalModelCache or LocalModelNamespaceCache reference.
+// For the LoRA annotation, only Cache and Namespace are serialized. SourceURI and PVCName
+// are runtime-only fields populated by MatchCacheForURI (and ignored by JSON marshal).
+type CacheEntry struct {
 	Cache     string `json:"cache"`
-	Namespace string `json:"namespace,omitempty"`
-	SourceURI string `json:"sourceUri"`
-	PVCName   string `json:"pvcName"`
+	Namespace string `json:"namespace,omitempty"` // set for LocalModelNamespaceCache; empty for cluster-scoped
+	SourceURI string `json:"-"`
+	PVCName   string `json:"-"`
 }
 
 // MatchCacheForURI finds a namespace-scoped or cluster-scoped cache matching storageURI.
@@ -50,7 +44,7 @@ func MatchCacheForURI(
 	nodeGroupExists bool,
 	models *v1alpha1.LocalModelCacheList,
 	nsModels *v1alpha1.LocalModelNamespaceCacheList,
-) *CacheMatch {
+) *CacheEntry {
 	if storageURI == "" {
 		return nil
 	}
@@ -61,12 +55,12 @@ func MatchCacheForURI(
 			if !nsModel.Spec.MatchStorageURI(storageURI) {
 				continue
 			}
-			pvcName, ok := pvcNameForNodeGroup(nsModel.Spec.NodeGroups, nodeGroup, nodeGroupExists, nsModel.Name)
+			pvcName, ok := PVCNameForNodeGroup(nsModel.Spec.NodeGroups, nodeGroup, nodeGroupExists, nsModel.Name)
 			if !ok {
 				continue
 			}
-			return &CacheMatch{
-				Name:      nsModel.Name,
+			return &CacheEntry{
+				Cache:     nsModel.Name,
 				Namespace: nsModel.Namespace,
 				SourceURI: nsModel.Spec.SourceModelUri,
 				PVCName:   pvcName,
@@ -82,12 +76,12 @@ func MatchCacheForURI(
 		if !model.Spec.MatchStorageURI(storageURI) {
 			continue
 		}
-		pvcName, ok := pvcNameForNodeGroup(model.Spec.NodeGroups, nodeGroup, nodeGroupExists, model.Name)
+		pvcName, ok := PVCNameForNodeGroup(model.Spec.NodeGroups, nodeGroup, nodeGroupExists, model.Name)
 		if !ok {
 			continue
 		}
-		return &CacheMatch{
-			Name:      model.Name,
+		return &CacheEntry{
+			Cache:     model.Name,
 			SourceURI: model.Spec.SourceModelUri,
 			PVCName:   pvcName,
 		}
@@ -95,7 +89,8 @@ func MatchCacheForURI(
 	return nil
 }
 
-func pvcNameForNodeGroup(nodeGroups []string, nodeGroup string, nodeGroupExists bool, cacheName string) (string, bool) {
+// PVCNameForNodeGroup returns the serving PVC name for a cache and node group selection.
+func PVCNameForNodeGroup(nodeGroups []string, nodeGroup string, nodeGroupExists bool, cacheName string) (string, bool) {
 	if nodeGroupExists {
 		if !slices.Contains(nodeGroups, nodeGroup) {
 			return "", false
@@ -110,18 +105,19 @@ func pvcNameForNodeGroup(nodeGroups []string, nodeGroup string, nodeGroupExists 
 
 // BuildCachedPVCURI rewrites storageURI to a local model cache PVC path.
 // subPath under sourceURI is preserved (e.g. hf://org/model/subdir).
+// Trailing slashes are trimmed only for CutPrefix so subdirectory matching works;
+// GetStorageKey uses sourceURI as stored so the hash matches the download job folder.
 func BuildCachedPVCURI(sourceURI, pvcName, storageURI string) string {
-	normalizedSourceURI := strings.TrimSuffix(sourceURI, "/")
-	subPath, _ := strings.CutPrefix(storageURI, normalizedSourceURI)
+	subPath, _ := strings.CutPrefix(storageURI, strings.TrimSuffix(sourceURI, "/"))
 	if !strings.HasPrefix(subPath, "/") {
 		subPath = "/" + subPath
 	}
-	storageKey := v1alpha1.GetStorageKey(normalizedSourceURI)
+	storageKey := v1alpha1.GetStorageKey(sourceURI)
 	return "pvc://" + pvcName + "/models/" + storageKey + subPath
 }
 
-// MarshalLoRACacheAnnotation serializes adapter cache metadata to JSON.
-func MarshalLoRACacheAnnotation(entries map[string]LoRACacheEntry) (string, error) {
+// MarshalLoRACacheAnnotation serializes adapter cache refs (cache + optional namespace) to JSON.
+func MarshalLoRACacheAnnotation(entries map[string]CacheEntry) (string, error) {
 	if len(entries) == 0 {
 		return "", nil
 	}
@@ -132,28 +128,23 @@ func MarshalLoRACacheAnnotation(entries map[string]LoRACacheEntry) (string, erro
 	return string(data), nil
 }
 
-// ParseLoRACacheAnnotation deserializes adapter cache metadata from JSON.
-func ParseLoRACacheAnnotation(raw string) (map[string]LoRACacheEntry, error) {
+// ParseLoRACacheAnnotation deserializes adapter cache refs from JSON.
+func ParseLoRACacheAnnotation(raw string) (map[string]CacheEntry, error) {
 	if raw == "" {
 		return nil, nil
 	}
-	var entries map[string]LoRACacheEntry
+	var entries map[string]CacheEntry
 	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
 		return nil, fmt.Errorf("parse LoRA local model cache annotation: %w", err)
 	}
 	return entries, nil
 }
 
-// LoRACacheEntryFromMatch builds a LoRACacheEntry from a cache match.
-func LoRACacheEntryFromMatch(match *CacheMatch) LoRACacheEntry {
-	if match == nil {
-		return LoRACacheEntry{}
-	}
-	return LoRACacheEntry{
-		Cache:     match.Name,
-		Namespace: match.Namespace,
-		SourceURI: match.SourceURI,
-		PVCName:   match.PVCName,
+// AnnotationRef returns a CacheEntry with only the fields stored in the LoRA annotation.
+func AnnotationRef(entry CacheEntry) CacheEntry {
+	return CacheEntry{
+		Cache:     entry.Cache,
+		Namespace: entry.Namespace,
 	}
 }
 

--- a/pkg/localmodelcache/metadata_test.go
+++ b/pkg/localmodelcache/metadata_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localmodelcache
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestMatchCacheForURI_ClusterScoped(t *testing.T) {
+	models := &v1alpha1.LocalModelCacheList{
+		Items: []v1alpha1.LocalModelCache{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-cache"},
+			Spec: v1alpha1.LocalModelCacheSpec{
+				SourceModelUri: "hf://org/model",
+				ModelSize:      resource.MustParse("1Gi"),
+				NodeGroups:     []string{"gpu1"},
+			},
+		}},
+	}
+
+	match := MatchCacheForURI("hf://org/model", "", false, models, nil)
+	assert.NotNil(t, match)
+	assert.Equal(t, "my-cache", match.Name)
+	assert.Empty(t, match.Namespace)
+	assert.Equal(t, "my-cache-gpu1", match.PVCName)
+}
+
+func TestMatchCacheForURI_NamespaceScopedPrecedence(t *testing.T) {
+	models := &v1alpha1.LocalModelCacheList{
+		Items: []v1alpha1.LocalModelCache{{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-cache"},
+			Spec: v1alpha1.LocalModelCacheSpec{
+				SourceModelUri: "hf://org/model",
+				ModelSize:      resource.MustParse("1Gi"),
+				NodeGroups:     []string{"gpu1"},
+			},
+		}},
+	}
+	nsModels := &v1alpha1.LocalModelNamespaceCacheList{
+		Items: []v1alpha1.LocalModelNamespaceCache{{
+			ObjectMeta: metav1.ObjectMeta{Name: "ns-cache", Namespace: "default"},
+			Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+				SourceModelUri: "hf://org/model",
+				ModelSize:      resource.MustParse("1Gi"),
+				NodeGroups:     []string{"gpu2"},
+			},
+		}},
+	}
+
+	match := MatchCacheForURI("hf://org/model", "", false, models, nsModels)
+	assert.NotNil(t, match)
+	assert.Equal(t, "ns-cache", match.Name)
+	assert.Equal(t, "default", match.Namespace)
+	assert.Equal(t, "ns-cache-gpu2", match.PVCName)
+}
+
+func TestMarshalParseLoRACacheAnnotation(t *testing.T) {
+	raw, err := MarshalLoRACacheAnnotation(map[string]LoRACacheEntry{
+		"adapter-a": {
+			Cache:     "adapter-cache",
+			SourceURI: "hf://org/adapter",
+			PVCName:   "adapter-cache-gpu1",
+		},
+	})
+	assert.NoError(t, err)
+
+	entries, err := ParseLoRACacheAnnotation(raw)
+	assert.NoError(t, err)
+	assert.Equal(t, "adapter-cache", entries["adapter-a"].Cache)
+	assert.Equal(t, "hf://org/adapter", entries["adapter-a"].SourceURI)
+}
+
+func TestBuildCachedPVCURI(t *testing.T) {
+	sourceURI := "hf://org/model"
+	pvcName := "my-cache-gpu1"
+	got := BuildCachedPVCURI(sourceURI, pvcName, sourceURI)
+	assert.True(t, strings.HasPrefix(got, "pvc://my-cache-gpu1/models/"))
+	assert.True(t, strings.HasSuffix(got, "/"))
+
+	subdir := BuildCachedPVCURI(sourceURI, pvcName, "hf://org/model/adapter-subdir")
+	assert.Contains(t, subdir, "/adapter-subdir")
+}
+
+func TestLLMISVCClusterCacheNames(t *testing.T) {
+	baseOnly := LLMISVCClusterCacheNames(
+		map[string]string{constants.LocalModelLabel: "base-cache"},
+		nil,
+	)
+	assert.Equal(t, []string{"base-cache"}, baseOnly)
+
+	loraOnly := LLMISVCClusterCacheNames(
+		nil,
+		map[string]string{
+			constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache","sourceUri":"hf://x"}}`,
+		},
+	)
+	assert.Equal(t, []string{"adapter-cache"}, loraOnly)
+
+	nsBase := LLMISVCClusterCacheNames(
+		map[string]string{
+			constants.LocalModelLabel:          "ns-cache",
+			constants.LocalModelNamespaceLabel: "default",
+		},
+		nil,
+	)
+	assert.Empty(t, nsBase)
+
+	mixed := LLMISVCClusterCacheNames(
+		map[string]string{constants.LocalModelLabel: "base-cache"},
+		map[string]string{
+			constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache","sourceUri":"hf://x"}}`,
+		},
+	)
+	assert.Equal(t, []string{"adapter-cache", "base-cache"}, mixed)
+}
+
+func TestLLMISVCNamespaceCacheNames(t *testing.T) {
+	names := LLMISVCNamespaceCacheNames(
+		"default",
+		map[string]string{
+			constants.LocalModelLabel:          "ns-cache",
+			constants.LocalModelNamespaceLabel: "default",
+		},
+		map[string]string{
+			constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-ns-cache","namespace":"default","sourceUri":"hf://x"}}`,
+		},
+	)
+	assert.Equal(t, []string{"adapter-ns-cache", "ns-cache"}, names)
+}

--- a/pkg/localmodelcache/metadata_test.go
+++ b/pkg/localmodelcache/metadata_test.go
@@ -103,6 +103,38 @@ func TestBuildCachedPVCURI(t *testing.T) {
 	assert.Contains(t, subdir, "/adapter-subdir")
 }
 
+func TestBuildCachedPVCURI_TrailingSlashSourceURI(t *testing.T) {
+	sourceURI := "hf://org/model/"
+	pvcName := "my-cache-gpu1"
+	got := BuildCachedPVCURI(sourceURI, pvcName, "hf://org/model/extra")
+	assert.True(t, strings.HasPrefix(got, "pvc://my-cache-gpu1/models/"))
+	assert.True(t, strings.HasSuffix(got, "/extra"))
+	assert.NotContains(t, got, "hf://")
+}
+
+func TestLLMISVCReferencesClusterCache_MalformedLoRAAnnotation(t *testing.T) {
+	assert.True(t, LLMISVCReferencesClusterCache(
+		"any-cache",
+		nil,
+		map[string]string{constants.LocalModelLoRAAnnotationKey: `{invalid`},
+	))
+	assert.False(t, LLMISVCReferencesClusterCache(
+		"any-cache",
+		nil,
+		map[string]string{constants.LocalModelLoRAAnnotationKey: ""},
+	))
+}
+
+func TestLLMISVCReferencesNamespaceCache_MalformedLoRAAnnotation(t *testing.T) {
+	assert.True(t, LLMISVCReferencesNamespaceCache(
+		"any-cache",
+		"default",
+		"default",
+		nil,
+		map[string]string{constants.LocalModelLoRAAnnotationKey: `{invalid`},
+	))
+}
+
 func TestLLMISVCClusterCacheNames(t *testing.T) {
 	baseOnly := LLMISVCClusterCacheNames(
 		map[string]string{constants.LocalModelLabel: "base-cache"},

--- a/pkg/localmodelcache/metadata_test.go
+++ b/pkg/localmodelcache/metadata_test.go
@@ -42,7 +42,7 @@ func TestMatchCacheForURI_ClusterScoped(t *testing.T) {
 
 	match := MatchCacheForURI("hf://org/model", "", false, models, nil)
 	assert.NotNil(t, match)
-	assert.Equal(t, "my-cache", match.Name)
+	assert.Equal(t, "my-cache", match.Cache)
 	assert.Empty(t, match.Namespace)
 	assert.Equal(t, "my-cache-gpu1", match.PVCName)
 }
@@ -71,25 +71,38 @@ func TestMatchCacheForURI_NamespaceScopedPrecedence(t *testing.T) {
 
 	match := MatchCacheForURI("hf://org/model", "", false, models, nsModels)
 	assert.NotNil(t, match)
-	assert.Equal(t, "ns-cache", match.Name)
+	assert.Equal(t, "ns-cache", match.Cache)
 	assert.Equal(t, "default", match.Namespace)
 	assert.Equal(t, "ns-cache-gpu2", match.PVCName)
 }
 
 func TestMarshalParseLoRACacheAnnotation(t *testing.T) {
-	raw, err := MarshalLoRACacheAnnotation(map[string]LoRACacheEntry{
+	raw, err := MarshalLoRACacheAnnotation(map[string]CacheEntry{
 		"adapter-a": {
 			Cache:     "adapter-cache",
-			SourceURI: "hf://org/adapter",
+			SourceURI: "hf://org/adapter", // runtime-only; must not appear in JSON
 			PVCName:   "adapter-cache-gpu1",
 		},
 	})
 	assert.NoError(t, err)
+	assert.NotContains(t, raw, "sourceUri")
+	assert.NotContains(t, raw, "pvcName")
 
 	entries, err := ParseLoRACacheAnnotation(raw)
 	assert.NoError(t, err)
 	assert.Equal(t, "adapter-cache", entries["adapter-a"].Cache)
-	assert.Equal(t, "hf://org/adapter", entries["adapter-a"].SourceURI)
+	assert.Empty(t, entries["adapter-a"].SourceURI)
+	assert.Empty(t, entries["adapter-a"].PVCName)
+}
+
+func TestAnnotationRef(t *testing.T) {
+	got := AnnotationRef(CacheEntry{
+		Cache:     "c",
+		Namespace: "ns",
+		SourceURI: "hf://x",
+		PVCName:   "c-gpu1",
+	})
+	assert.Equal(t, CacheEntry{Cache: "c", Namespace: "ns"}, got)
 }
 
 func TestBuildCachedPVCURI(t *testing.T) {
@@ -110,6 +123,9 @@ func TestBuildCachedPVCURI_TrailingSlashSourceURI(t *testing.T) {
 	assert.True(t, strings.HasPrefix(got, "pvc://my-cache-gpu1/models/"))
 	assert.True(t, strings.HasSuffix(got, "/extra"))
 	assert.NotContains(t, got, "hf://")
+	// Hash must match download job, which keys off sourceURI as stored (with trailing slash).
+	assert.Contains(t, got, v1alpha1.GetStorageKey(sourceURI))
+	assert.NotContains(t, got, v1alpha1.GetStorageKey(strings.TrimSuffix(sourceURI, "/")))
 }
 
 func TestLLMISVCReferencesClusterCache_MalformedLoRAAnnotation(t *testing.T) {
@@ -152,7 +168,7 @@ func TestLLMISVCClusterCacheNames(t *testing.T) {
 		got := LLMISVCClusterCacheNames(
 			nil,
 			map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache","sourceUri":"hf://x"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache"}}`,
 			},
 		)
 		assert.Equal(t, []string{"adapter-cache"}, got)
@@ -175,7 +191,7 @@ func TestLLMISVCClusterCacheNames(t *testing.T) {
 		got := LLMISVCClusterCacheNames(
 			map[string]string{constants.LocalModelLabel: "base-cache"},
 			map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache","sourceUri":"hf://x"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache"}}`,
 			},
 		)
 		assert.Equal(t, []string{"adapter-cache", "base-cache"}, got)
@@ -194,7 +210,7 @@ func TestLLMISVCNamespaceCacheNames(t *testing.T) {
 				constants.LocalModelNamespaceLabel: "default",
 			},
 			map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-ns-cache","namespace":"default","sourceUri":"hf://x"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-ns-cache","namespace":"default"}}`,
 			},
 		)
 		assert.Equal(t, []string{"adapter-ns-cache", "ns-cache"}, got)

--- a/pkg/localmodelcache/metadata_test.go
+++ b/pkg/localmodelcache/metadata_test.go
@@ -95,16 +95,6 @@ func TestMarshalParseLoRACacheAnnotation(t *testing.T) {
 	assert.Empty(t, entries["adapter-a"].PVCName)
 }
 
-func TestAnnotationRef(t *testing.T) {
-	got := AnnotationRef(CacheEntry{
-		Cache:     "c",
-		Namespace: "ns",
-		SourceURI: "hf://x",
-		PVCName:   "c-gpu1",
-	})
-	assert.Equal(t, CacheEntry{Cache: "c", Namespace: "ns"}, got)
-}
-
 func TestBuildCachedPVCURI(t *testing.T) {
 	sourceURI := "hf://org/model"
 	pvcName := "my-cache-gpu1"

--- a/pkg/localmodelcache/metadata_test.go
+++ b/pkg/localmodelcache/metadata_test.go
@@ -136,48 +136,67 @@ func TestLLMISVCReferencesNamespaceCache_MalformedLoRAAnnotation(t *testing.T) {
 }
 
 func TestLLMISVCClusterCacheNames(t *testing.T) {
-	baseOnly := LLMISVCClusterCacheNames(
-		map[string]string{constants.LocalModelLabel: "base-cache"},
-		nil,
-	)
-	assert.Equal(t, []string{"base-cache"}, baseOnly)
+	t.Parallel()
 
-	loraOnly := LLMISVCClusterCacheNames(
-		nil,
-		map[string]string{
-			constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache","sourceUri":"hf://x"}}`,
-		},
-	)
-	assert.Equal(t, []string{"adapter-cache"}, loraOnly)
+	t.Run("base model label only", func(t *testing.T) {
+		t.Parallel()
+		got := LLMISVCClusterCacheNames(
+			map[string]string{constants.LocalModelLabel: "base-cache"},
+			nil,
+		)
+		assert.Equal(t, []string{"base-cache"}, got)
+	})
 
-	nsBase := LLMISVCClusterCacheNames(
-		map[string]string{
-			constants.LocalModelLabel:          "ns-cache",
-			constants.LocalModelNamespaceLabel: "default",
-		},
-		nil,
-	)
-	assert.Empty(t, nsBase)
+	t.Run("lora annotation only", func(t *testing.T) {
+		t.Parallel()
+		got := LLMISVCClusterCacheNames(
+			nil,
+			map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache","sourceUri":"hf://x"}}`,
+			},
+		)
+		assert.Equal(t, []string{"adapter-cache"}, got)
+	})
 
-	mixed := LLMISVCClusterCacheNames(
-		map[string]string{constants.LocalModelLabel: "base-cache"},
-		map[string]string{
-			constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache","sourceUri":"hf://x"}}`,
-		},
-	)
-	assert.Equal(t, []string{"adapter-cache", "base-cache"}, mixed)
+	t.Run("namespace scoped base excluded", func(t *testing.T) {
+		t.Parallel()
+		got := LLMISVCClusterCacheNames(
+			map[string]string{
+				constants.LocalModelLabel:          "ns-cache",
+				constants.LocalModelNamespaceLabel: "default",
+			},
+			nil,
+		)
+		assert.Empty(t, got)
+	})
+
+	t.Run("base and lora combined", func(t *testing.T) {
+		t.Parallel()
+		got := LLMISVCClusterCacheNames(
+			map[string]string{constants.LocalModelLabel: "base-cache"},
+			map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-cache","sourceUri":"hf://x"}}`,
+			},
+		)
+		assert.Equal(t, []string{"adapter-cache", "base-cache"}, got)
+	})
 }
 
 func TestLLMISVCNamespaceCacheNames(t *testing.T) {
-	names := LLMISVCNamespaceCacheNames(
-		"default",
-		map[string]string{
-			constants.LocalModelLabel:          "ns-cache",
-			constants.LocalModelNamespaceLabel: "default",
-		},
-		map[string]string{
-			constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-ns-cache","namespace":"default","sourceUri":"hf://x"}}`,
-		},
-	)
-	assert.Equal(t, []string{"adapter-ns-cache", "ns-cache"}, names)
+	t.Parallel()
+
+	t.Run("base and lora namespace caches", func(t *testing.T) {
+		t.Parallel()
+		got := LLMISVCNamespaceCacheNames(
+			"default",
+			map[string]string{
+				constants.LocalModelLabel:          "ns-cache",
+				constants.LocalModelNamespaceLabel: "default",
+			},
+			map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"a":{"cache":"adapter-ns-cache","namespace":"default","sourceUri":"hf://x"}}`,
+			},
+		)
+		assert.Equal(t, []string{"adapter-ns-cache", "ns-cache"}, got)
+	})
 }

--- a/pkg/webhook/admission/llminferenceservice/defaulter.go
+++ b/pkg/webhook/admission/llminferenceservice/defaulter.go
@@ -19,7 +19,6 @@ package llminferenceservice
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -31,6 +30,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 )
 
 var defaulterLogger = logf.Log.WithName("llminferenceservice-defaulter")
@@ -173,89 +173,82 @@ func applyDefaults(
 
 // SetLocalModelLabel sets local model labels on the LLMInferenceService if a matching cache exists.
 // Namespace-scoped LocalModelNamespaceCache takes precedence over cluster-scoped LocalModelCache.
+// LoRA adapter URIs are matched independently and recorded in the LoRA JSON annotation.
 func SetLocalModelLabel(llmSvc *v1alpha2.LLMInferenceService, models *v1alpha1.LocalModelCacheList, nsModels *v1alpha1.LocalModelNamespaceCacheList) {
-	modelUri := llmSvc.Spec.Model.URI.String()
-	if modelUri == "" {
-		return
-	}
-
 	isvcNodeGroup, isvcNodeGroupExists := llmSvc.Annotations[constants.NodeGroupAnnotationKey]
 
-	// Check namespace-scoped LocalModelNamespaceCache first (higher priority)
-	if nsModels != nil {
-		for i, nsModel := range nsModels.Items {
-			if nsModel.Spec.MatchStorageURI(modelUri) {
-				var localModelPVCName string
-				if isvcNodeGroupExists {
-					if slices.Contains(nsModel.Spec.NodeGroups, isvcNodeGroup) {
-						localModelPVCName = nsModel.Name + "-" + isvcNodeGroup
-					} else {
-						continue
-					}
-				} else {
-					localModelPVCName = nsModel.Name + "-" + nsModel.Spec.NodeGroups[0]
-				}
-				if llmSvc.Labels == nil {
-					llmSvc.Labels = make(map[string]string)
-				}
-				if llmSvc.Annotations == nil {
-					llmSvc.Annotations = make(map[string]string)
-				}
-				llmSvc.Labels[constants.LocalModelLabel] = nsModels.Items[i].Name
-				llmSvc.Labels[constants.LocalModelNamespaceLabel] = nsModels.Items[i].Namespace
-				llmSvc.Annotations[constants.LocalModelSourceUriAnnotationKey] = nsModels.Items[i].Spec.SourceModelUri
-				llmSvc.Annotations[constants.LocalModelPVCNameAnnotationKey] = localModelPVCName
-
-				defaulterLogger.Info("LocalModelNamespaceCache found", "model", nsModels.Items[i].Name,
-					"modelNamespace", nsModels.Items[i].Namespace, "llmSvcNamespace", llmSvc.Namespace, "llmSvc", llmSvc.Name)
-				return
-			}
-		}
+	modelUri := llmSvc.Spec.Model.URI.String()
+	if match := localmodelcache.MatchCacheForURI(modelUri, isvcNodeGroup, isvcNodeGroupExists, models, nsModels); match != nil {
+		applyBaseLocalModelCache(llmSvc, match)
+	} else {
+		clearBaseLocalModelMetadata(llmSvc)
 	}
 
-	// Fall back to cluster-scoped LocalModelCache
-	if models == nil {
-		DeleteLocalModelMetadata(llmSvc)
-		return
-	}
-	var localModel *v1alpha1.LocalModelCache
-	var localModelPVCName string
-	for i, model := range models.Items {
-		if model.Spec.MatchStorageURI(modelUri) {
-			if isvcNodeGroupExists {
-				if slices.Contains(model.Spec.NodeGroups, isvcNodeGroup) {
-					localModelPVCName = model.Name + "-" + isvcNodeGroup
-				} else {
-					continue
-				}
-			} else {
-				localModelPVCName = model.Name + "-" + model.Spec.NodeGroups[0]
-			}
-			localModel = &models.Items[i]
-			break
-		}
-	}
-	if localModel == nil {
-		DeleteLocalModelMetadata(llmSvc)
-		return
-	}
+	setLoRALocalModelMetadata(llmSvc, models, nsModels, isvcNodeGroup, isvcNodeGroupExists)
+}
+
+func applyBaseLocalModelCache(llmSvc *v1alpha2.LLMInferenceService, match *localmodelcache.CacheMatch) {
 	if llmSvc.Labels == nil {
 		llmSvc.Labels = make(map[string]string)
 	}
 	if llmSvc.Annotations == nil {
 		llmSvc.Annotations = make(map[string]string)
 	}
-	llmSvc.Labels[constants.LocalModelLabel] = localModel.Name
-	// Remove namespace label for cluster-scoped model (in case it was previously set)
-	delete(llmSvc.Labels, constants.LocalModelNamespaceLabel)
-	llmSvc.Annotations[constants.LocalModelSourceUriAnnotationKey] = localModel.Spec.SourceModelUri
-	llmSvc.Annotations[constants.LocalModelPVCNameAnnotationKey] = localModelPVCName
-
-	defaulterLogger.Info("LocalModelCache found", "model", localModel.Name, "namespace", llmSvc.Namespace, "llmSvc", llmSvc.Name)
+	llmSvc.Labels[constants.LocalModelLabel] = match.Name
+	if match.Namespace != "" {
+		llmSvc.Labels[constants.LocalModelNamespaceLabel] = match.Namespace
+		defaulterLogger.Info("LocalModelNamespaceCache found", "model", match.Name,
+			"modelNamespace", match.Namespace, "llmSvcNamespace", llmSvc.Namespace, "llmSvc", llmSvc.Name)
+	} else {
+		delete(llmSvc.Labels, constants.LocalModelNamespaceLabel)
+		defaulterLogger.Info("LocalModelCache found", "model", match.Name, "namespace", llmSvc.Namespace, "llmSvc", llmSvc.Name)
+	}
+	llmSvc.Annotations[constants.LocalModelSourceUriAnnotationKey] = match.SourceURI
+	llmSvc.Annotations[constants.LocalModelPVCNameAnnotationKey] = match.PVCName
 }
 
-// DeleteLocalModelMetadata removes local model cache internal labels and annotations
-func DeleteLocalModelMetadata(llmSvc *v1alpha2.LLMInferenceService) {
+func setLoRALocalModelMetadata(
+	llmSvc *v1alpha2.LLMInferenceService,
+	models *v1alpha1.LocalModelCacheList,
+	nsModels *v1alpha1.LocalModelNamespaceCacheList,
+	nodeGroup string,
+	nodeGroupExists bool,
+) {
+	if llmSvc.Spec.Model.LoRA == nil || len(llmSvc.Spec.Model.LoRA.Adapters) == 0 {
+		clearLoRALocalModelMetadata(llmSvc)
+		return
+	}
+
+	entries := make(map[string]localmodelcache.LoRACacheEntry)
+	for _, adapter := range llmSvc.Spec.Model.LoRA.Adapters {
+		if adapter.Name == nil {
+			continue
+		}
+		adapterURI := adapter.URI.String()
+		if match := localmodelcache.MatchCacheForURI(adapterURI, nodeGroup, nodeGroupExists, models, nsModels); match != nil {
+			entries[*adapter.Name] = localmodelcache.LoRACacheEntryFromMatch(match)
+			defaulterLogger.Info("LocalModelCache found for LoRA adapter", "adapter", *adapter.Name,
+				"cache", match.Name, "llmSvc", llmSvc.Name)
+		}
+	}
+
+	if len(entries) == 0 {
+		clearLoRALocalModelMetadata(llmSvc)
+		return
+	}
+
+	raw, err := localmodelcache.MarshalLoRACacheAnnotation(entries)
+	if err != nil {
+		defaulterLogger.Error(err, "Failed to marshal LoRA local model cache annotation", "llmSvc", llmSvc.Name)
+		return
+	}
+	if llmSvc.Annotations == nil {
+		llmSvc.Annotations = make(map[string]string)
+	}
+	llmSvc.Annotations[constants.LocalModelLoRAAnnotationKey] = raw
+}
+
+func clearBaseLocalModelMetadata(llmSvc *v1alpha2.LLMInferenceService) {
 	if llmSvc.Labels != nil {
 		delete(llmSvc.Labels, constants.LocalModelLabel)
 		delete(llmSvc.Labels, constants.LocalModelNamespaceLabel)
@@ -264,4 +257,16 @@ func DeleteLocalModelMetadata(llmSvc *v1alpha2.LLMInferenceService) {
 		delete(llmSvc.Annotations, constants.LocalModelSourceUriAnnotationKey)
 		delete(llmSvc.Annotations, constants.LocalModelPVCNameAnnotationKey)
 	}
+}
+
+func clearLoRALocalModelMetadata(llmSvc *v1alpha2.LLMInferenceService) {
+	if llmSvc.Annotations != nil {
+		delete(llmSvc.Annotations, constants.LocalModelLoRAAnnotationKey)
+	}
+}
+
+// DeleteLocalModelMetadata removes local model cache internal labels and annotations.
+func DeleteLocalModelMetadata(llmSvc *v1alpha2.LLMInferenceService) {
+	clearBaseLocalModelMetadata(llmSvc)
+	clearLoRALocalModelMetadata(llmSvc)
 }

--- a/pkg/webhook/admission/llminferenceservice/defaulter.go
+++ b/pkg/webhook/admission/llminferenceservice/defaulter.go
@@ -240,6 +240,7 @@ func setLoRALocalModelMetadata(
 	raw, err := localmodelcache.MarshalLoRACacheAnnotation(entries)
 	if err != nil {
 		defaulterLogger.Error(err, "Failed to marshal LoRA local model cache annotation", "llmSvc", llmSvc.Name)
+		clearLoRALocalModelMetadata(llmSvc)
 		return
 	}
 	if llmSvc.Annotations == nil {

--- a/pkg/webhook/admission/llminferenceservice/defaulter.go
+++ b/pkg/webhook/admission/llminferenceservice/defaulter.go
@@ -226,8 +226,8 @@ func setLoRALocalModelMetadata(
 		}
 		adapterURI := adapter.URI.String()
 		if match := localmodelcache.MatchCacheForURI(adapterURI, nodeGroup, nodeGroupExists, models, nsModels); match != nil {
-			// Persist only cache identity; reconcile-time Get derives sourceUri/PVC.
-			entries[*adapter.Name] = localmodelcache.AnnotationRef(*match)
+			// json:"-" omits sourceUri/PVC from the annotation; reconcile-time Get derives them.
+			entries[*adapter.Name] = *match
 			defaulterLogger.Info("LocalModelCache found for LoRA adapter", "adapter", *adapter.Name,
 				"cache", match.Cache, "llmSvc", llmSvc.Name)
 		}

--- a/pkg/webhook/admission/llminferenceservice/defaulter.go
+++ b/pkg/webhook/admission/llminferenceservice/defaulter.go
@@ -187,21 +187,21 @@ func SetLocalModelLabel(llmSvc *v1alpha2.LLMInferenceService, models *v1alpha1.L
 	setLoRALocalModelMetadata(llmSvc, models, nsModels, isvcNodeGroup, isvcNodeGroupExists)
 }
 
-func applyBaseLocalModelCache(llmSvc *v1alpha2.LLMInferenceService, match *localmodelcache.CacheMatch) {
+func applyBaseLocalModelCache(llmSvc *v1alpha2.LLMInferenceService, match *localmodelcache.CacheEntry) {
 	if llmSvc.Labels == nil {
 		llmSvc.Labels = make(map[string]string)
 	}
 	if llmSvc.Annotations == nil {
 		llmSvc.Annotations = make(map[string]string)
 	}
-	llmSvc.Labels[constants.LocalModelLabel] = match.Name
+	llmSvc.Labels[constants.LocalModelLabel] = match.Cache
 	if match.Namespace != "" {
 		llmSvc.Labels[constants.LocalModelNamespaceLabel] = match.Namespace
-		defaulterLogger.Info("LocalModelNamespaceCache found", "model", match.Name,
+		defaulterLogger.Info("LocalModelNamespaceCache found", "model", match.Cache,
 			"modelNamespace", match.Namespace, "llmSvcNamespace", llmSvc.Namespace, "llmSvc", llmSvc.Name)
 	} else {
 		delete(llmSvc.Labels, constants.LocalModelNamespaceLabel)
-		defaulterLogger.Info("LocalModelCache found", "model", match.Name, "namespace", llmSvc.Namespace, "llmSvc", llmSvc.Name)
+		defaulterLogger.Info("LocalModelCache found", "model", match.Cache, "namespace", llmSvc.Namespace, "llmSvc", llmSvc.Name)
 	}
 	llmSvc.Annotations[constants.LocalModelSourceUriAnnotationKey] = match.SourceURI
 	llmSvc.Annotations[constants.LocalModelPVCNameAnnotationKey] = match.PVCName
@@ -219,16 +219,17 @@ func setLoRALocalModelMetadata(
 		return
 	}
 
-	entries := make(map[string]localmodelcache.LoRACacheEntry)
+	entries := make(map[string]localmodelcache.CacheEntry)
 	for _, adapter := range llmSvc.Spec.Model.LoRA.Adapters {
 		if adapter.Name == nil {
 			continue
 		}
 		adapterURI := adapter.URI.String()
 		if match := localmodelcache.MatchCacheForURI(adapterURI, nodeGroup, nodeGroupExists, models, nsModels); match != nil {
-			entries[*adapter.Name] = localmodelcache.LoRACacheEntryFromMatch(match)
+			// Persist only cache identity; reconcile-time Get derives sourceUri/PVC.
+			entries[*adapter.Name] = localmodelcache.AnnotationRef(*match)
 			defaulterLogger.Info("LocalModelCache found for LoRA adapter", "adapter", *adapter.Name,
-				"cache", match.Name, "llmSvc", llmSvc.Name)
+				"cache", match.Cache, "llmSvc", llmSvc.Name)
 		}
 	}
 

--- a/pkg/webhook/admission/llminferenceservice/defaulter_test.go
+++ b/pkg/webhook/admission/llminferenceservice/defaulter_test.go
@@ -18,14 +18,17 @@ package llminferenceservice
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -33,6 +36,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 )
 
 func newLLMSvc(modelUri string) *v1alpha2.LLMInferenceService {
@@ -49,6 +53,30 @@ func newLLMSvc(modelUri string) *v1alpha2.LLMInferenceService {
 		},
 	}
 	return llmSvc
+}
+
+func newLLMSvcWithLoRA(modelUri string, adapters ...v1alpha2.LLMModelSpec) *v1alpha2.LLMInferenceService {
+	llmSvc := newLLMSvc(modelUri)
+	llmSvc.Spec.Model.LoRA = &v1alpha2.LoRASpec{Adapters: adapters}
+	return llmSvc
+}
+
+const testLoRAAdapterName = "my-adapter"
+
+func newLoRAAdapter(uri string) v1alpha2.LLMModelSpec {
+	parsed, _ := apis.ParseURL(uri)
+	return v1alpha2.LLMModelSpec{
+		Name: ptr.To(testLoRAAdapterName),
+		URI:  *parsed,
+	}
+}
+
+func parseLoRAAnnotation(t *testing.T, llmSvc *v1alpha2.LLMInferenceService) map[string]localmodelcache.LoRACacheEntry {
+	t.Helper()
+	raw := llmSvc.Annotations[constants.LocalModelLoRAAnnotationKey]
+	entries, err := localmodelcache.ParseLoRACacheAnnotation(raw)
+	require.NoError(t, err)
+	return entries
 }
 
 func TestSetLocalModelLabel_ClusterScoped(t *testing.T) {
@@ -158,9 +186,14 @@ func TestDeleteLocalModelMetadata(t *testing.T) {
 		constants.LocalModelNamespaceLabel: "default",
 		"other-label":                      "value",
 	}
+	loraJSON, err := json.Marshal(map[string]localmodelcache.LoRACacheEntry{
+		"my-adapter": {Cache: "adapter-cache", PVCName: "adapter-cache-gpu1"},
+	})
+	require.NoError(t, err)
 	llmSvc.Annotations = map[string]string{
 		constants.LocalModelSourceUriAnnotationKey: "s3://mybucket/mymodel",
 		constants.LocalModelPVCNameAnnotationKey:   "my-cache-gpu1",
+		constants.LocalModelLoRAAnnotationKey:      string(loraJSON),
 		"other-annotation":                         "value",
 	}
 
@@ -171,6 +204,7 @@ func TestDeleteLocalModelMetadata(t *testing.T) {
 	assert.Equal(t, "value", llmSvc.Labels["other-label"])
 	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelSourceUriAnnotationKey)
 	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelPVCNameAnnotationKey)
+	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelLoRAAnnotationKey)
 	assert.Equal(t, "value", llmSvc.Annotations["other-annotation"])
 }
 
@@ -281,6 +315,154 @@ func TestDefault_V1Alpha1Object_DoesNotErrorAndSetsMetadata(t *testing.T) {
 	assert.Equal(t, "my-cache-gpu1", llmSvc.Annotations[constants.LocalModelPVCNameAnnotationKey])
 }
 
+func TestSetLocalModelLabel_LoRAAdapter_ClusterScoped(t *testing.T) {
+	llmSvc := newLLMSvcWithLoRA("s3://mybucket/base", newLoRAAdapter("hf://org/adapter"))
+	models := &v1alpha1.LocalModelCacheList{
+		Items: []v1alpha1.LocalModelCache{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "adapter-cache"},
+				Spec: v1alpha1.LocalModelCacheSpec{
+					SourceModelUri: "hf://org/adapter",
+					ModelSize:      resource.MustParse("1Gi"),
+					NodeGroups:     []string{"gpu1"},
+				},
+			},
+		},
+	}
+
+	SetLocalModelLabel(llmSvc, models, nil)
+
+	assert.NotContains(t, llmSvc.Labels, constants.LocalModelLabel)
+	entries := parseLoRAAnnotation(t, llmSvc)
+	assert.Equal(t, "adapter-cache", entries["my-adapter"].Cache)
+	assert.Equal(t, "hf://org/adapter", entries["my-adapter"].SourceURI)
+	assert.Equal(t, "adapter-cache-gpu1", entries["my-adapter"].PVCName)
+}
+
+func TestSetLocalModelLabel_LoRAAdapter_NamespaceScoped(t *testing.T) {
+	llmSvc := newLLMSvcWithLoRA("s3://mybucket/base", newLoRAAdapter("hf://org/adapter"))
+	models := &v1alpha1.LocalModelCacheList{
+		Items: []v1alpha1.LocalModelCache{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-adapter-cache"},
+				Spec: v1alpha1.LocalModelCacheSpec{
+					SourceModelUri: "hf://org/adapter",
+					ModelSize:      resource.MustParse("1Gi"),
+					NodeGroups:     []string{"gpu1"},
+				},
+			},
+		},
+	}
+	nsModels := &v1alpha1.LocalModelNamespaceCacheList{
+		Items: []v1alpha1.LocalModelNamespaceCache{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ns-adapter-cache", Namespace: "default"},
+				Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+					SourceModelUri: "hf://org/adapter",
+					ModelSize:      resource.MustParse("1Gi"),
+					NodeGroups:     []string{"gpu2"},
+				},
+			},
+		},
+	}
+
+	SetLocalModelLabel(llmSvc, models, nsModels)
+
+	entries := parseLoRAAnnotation(t, llmSvc)
+	assert.Equal(t, "ns-adapter-cache", entries["my-adapter"].Cache)
+	assert.Equal(t, "default", entries["my-adapter"].Namespace)
+	assert.Equal(t, "ns-adapter-cache-gpu2", entries["my-adapter"].PVCName)
+}
+
+func TestSetLocalModelLabel_LoRAAdapter_NoMatch(t *testing.T) {
+	llmSvc := newLLMSvcWithLoRA("s3://mybucket/base", newLoRAAdapter("hf://org/other"))
+	llmSvc.Annotations = map[string]string{
+		constants.LocalModelLoRAAnnotationKey: `{"stale":{"cache":"old"}}`,
+	}
+	models := &v1alpha1.LocalModelCacheList{
+		Items: []v1alpha1.LocalModelCache{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "adapter-cache"},
+				Spec: v1alpha1.LocalModelCacheSpec{
+					SourceModelUri: "hf://org/adapter",
+					ModelSize:      resource.MustParse("1Gi"),
+					NodeGroups:     []string{"gpu1"},
+				},
+			},
+		},
+	}
+
+	SetLocalModelLabel(llmSvc, models, nil)
+
+	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelLoRAAnnotationKey)
+}
+
+func TestSetLocalModelLabel_MixedBaseCachedAdapterRemote(t *testing.T) {
+	llmSvc := newLLMSvcWithLoRA("s3://mybucket/base", newLoRAAdapter("hf://org/remote-adapter"))
+	models := &v1alpha1.LocalModelCacheList{
+		Items: []v1alpha1.LocalModelCache{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "base-cache"},
+				Spec: v1alpha1.LocalModelCacheSpec{
+					SourceModelUri: "s3://mybucket/base",
+					ModelSize:      resource.MustParse("10Gi"),
+					NodeGroups:     []string{"gpu1"},
+				},
+			},
+		},
+	}
+
+	SetLocalModelLabel(llmSvc, models, nil)
+
+	assert.Equal(t, "base-cache", llmSvc.Labels[constants.LocalModelLabel])
+	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelLoRAAnnotationKey)
+}
+
+func TestSetLocalModelLabel_MixedBaseRemoteAdapterCached(t *testing.T) {
+	llmSvc := newLLMSvcWithLoRA("s3://mybucket/remote-base", newLoRAAdapter("hf://org/adapter"))
+	models := &v1alpha1.LocalModelCacheList{
+		Items: []v1alpha1.LocalModelCache{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "adapter-cache"},
+				Spec: v1alpha1.LocalModelCacheSpec{
+					SourceModelUri: "hf://org/adapter",
+					ModelSize:      resource.MustParse("1Gi"),
+					NodeGroups:     []string{"gpu1"},
+				},
+			},
+		},
+	}
+
+	SetLocalModelLabel(llmSvc, models, nil)
+
+	assert.NotContains(t, llmSvc.Labels, constants.LocalModelLabel)
+	entries := parseLoRAAnnotation(t, llmSvc)
+	assert.Equal(t, "adapter-cache", entries["my-adapter"].Cache)
+}
+
+func TestSetLocalModelLabel_LoRAAdapter_NodeGroupNotMatching(t *testing.T) {
+	llmSvc := newLLMSvcWithLoRA("s3://mybucket/base", newLoRAAdapter("hf://org/adapter"))
+	llmSvc.Annotations = map[string]string{
+		constants.NodeGroupAnnotationKey: "gpu3",
+	}
+	models := &v1alpha1.LocalModelCacheList{
+		Items: []v1alpha1.LocalModelCache{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "adapter-cache"},
+				Spec: v1alpha1.LocalModelCacheSpec{
+					SourceModelUri: "hf://org/adapter",
+					ModelSize:      resource.MustParse("1Gi"),
+					NodeGroups:     []string{"gpu1", "gpu2"},
+				},
+			},
+		},
+	}
+
+	SetLocalModelLabel(llmSvc, models, nil)
+
+	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelLoRAAnnotationKey)
+}
+
 func TestDefault_V1Alpha1Object_Disabled_CleansStaleMetadata(t *testing.T) {
 	defaulter := newDefaulterForDefaultTests(t, true)
 	llmSvc := newLLMSvcV1("s3://mybucket/mymodel")
@@ -294,10 +476,13 @@ func TestDefault_V1Alpha1Object_Disabled_CleansStaleMetadata(t *testing.T) {
 		constants.LocalModelNamespaceLabel: "default",
 	}
 
+	llmSvc.Annotations[constants.LocalModelLoRAAnnotationKey] = `{"adapter":{"cache":"old"}}`
+
 	err := defaulter.Default(context.Background(), llmSvc)
 	assert.NoError(t, err)
 	assert.NotContains(t, llmSvc.Labels, constants.LocalModelLabel)
 	assert.NotContains(t, llmSvc.Labels, constants.LocalModelNamespaceLabel)
 	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelSourceUriAnnotationKey)
 	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelPVCNameAnnotationKey)
+	assert.NotContains(t, llmSvc.Annotations, constants.LocalModelLoRAAnnotationKey)
 }

--- a/pkg/webhook/admission/llminferenceservice/defaulter_test.go
+++ b/pkg/webhook/admission/llminferenceservice/defaulter_test.go
@@ -71,7 +71,7 @@ func newLoRAAdapter(uri string) v1alpha2.LLMModelSpec {
 	}
 }
 
-func parseLoRAAnnotation(t *testing.T, llmSvc *v1alpha2.LLMInferenceService) map[string]localmodelcache.LoRACacheEntry {
+func parseLoRAAnnotation(t *testing.T, llmSvc *v1alpha2.LLMInferenceService) map[string]localmodelcache.CacheEntry {
 	t.Helper()
 	raw := llmSvc.Annotations[constants.LocalModelLoRAAnnotationKey]
 	entries, err := localmodelcache.ParseLoRACacheAnnotation(raw)
@@ -186,8 +186,8 @@ func TestDeleteLocalModelMetadata(t *testing.T) {
 		constants.LocalModelNamespaceLabel: "default",
 		"other-label":                      "value",
 	}
-	loraJSON, err := json.Marshal(map[string]localmodelcache.LoRACacheEntry{
-		"my-adapter": {Cache: "adapter-cache", PVCName: "adapter-cache-gpu1"},
+	loraJSON, err := json.Marshal(map[string]localmodelcache.CacheEntry{
+		"my-adapter": {Cache: "adapter-cache"},
 	})
 	require.NoError(t, err)
 	llmSvc.Annotations = map[string]string{
@@ -335,8 +335,12 @@ func TestSetLocalModelLabel_LoRAAdapter_ClusterScoped(t *testing.T) {
 	assert.NotContains(t, llmSvc.Labels, constants.LocalModelLabel)
 	entries := parseLoRAAnnotation(t, llmSvc)
 	assert.Equal(t, "adapter-cache", entries["my-adapter"].Cache)
-	assert.Equal(t, "hf://org/adapter", entries["my-adapter"].SourceURI)
-	assert.Equal(t, "adapter-cache-gpu1", entries["my-adapter"].PVCName)
+	assert.Empty(t, entries["my-adapter"].Namespace)
+	assert.Empty(t, entries["my-adapter"].SourceURI)
+	assert.Empty(t, entries["my-adapter"].PVCName)
+	raw := llmSvc.Annotations[constants.LocalModelLoRAAnnotationKey]
+	assert.NotContains(t, raw, "sourceUri")
+	assert.NotContains(t, raw, "pvcName")
 }
 
 func TestSetLocalModelLabel_LoRAAdapter_NamespaceScoped(t *testing.T) {
@@ -371,7 +375,8 @@ func TestSetLocalModelLabel_LoRAAdapter_NamespaceScoped(t *testing.T) {
 	entries := parseLoRAAnnotation(t, llmSvc)
 	assert.Equal(t, "ns-adapter-cache", entries["my-adapter"].Cache)
 	assert.Equal(t, "default", entries["my-adapter"].Namespace)
-	assert.Equal(t, "ns-adapter-cache-gpu2", entries["my-adapter"].PVCName)
+	assert.Empty(t, entries["my-adapter"].PVCName)
+	assert.Empty(t, entries["my-adapter"].SourceURI)
 }
 
 func TestSetLocalModelLabel_LoRAAdapter_NoMatch(t *testing.T) {

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 )
 
 // logger for the validation webhook.
@@ -128,11 +129,7 @@ func (v *LocalModelCacheValidator) ValidateDelete(ctx context.Context, obj runti
 			localModelCacheValidatorLogger.Error(err, "Error getting LLMInferenceService", "name", llmIsvcMeta.Name)
 			return nil, err
 		}
-		modelName, ok := llmIsvc.Labels[constants.LocalModelLabel]
-		if !ok {
-			continue
-		}
-		if modelName == localModelCache.Name {
+		if localmodelcache.LLMISVCReferencesClusterCache(localModelCache.Name, llmIsvc.Labels, llmIsvc.Annotations) {
 			return admission.Warnings{}, fmt.Errorf("LocalModelCache %s is being used by LLMInferenceService %s", localModelCache.Name, llmIsvcMeta.Name)
 		}
 	}

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
@@ -107,6 +107,9 @@ func (v *LocalModelCacheValidator) ValidateDelete(ctx context.Context, obj runti
 	for _, isvcMeta := range localModelCache.Status.InferenceServices {
 		isvc := v1beta1.InferenceService{}
 		if err := v.Get(ctx, client.ObjectKey(isvcMeta), &isvc); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			localModelCacheValidatorLogger.Error(err, "Error getting InferenceService", "name", isvcMeta.Name)
 			return nil, err
 		}

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
@@ -103,7 +103,10 @@ func (v *LocalModelCacheValidator) ValidateDelete(ctx context.Context, obj runti
 	}
 	localModelCacheValidatorLogger.Info("validate delete", "name", localModelCache.Name)
 
-	// Check if current LocalModelCache is being used
+	// Delete protection relies on Status.InferenceServices / Status.LLMInferenceServices
+	// being up-to-date. A newly created consumer may not appear in status yet if the
+	// reconciler has not run, so deletion can race and succeed until the next reconcile.
+	// This gap already existed for base-model references; LoRA adapter references inherit it.
 	for _, isvcMeta := range localModelCache.Status.InferenceServices {
 		isvc := v1beta1.InferenceService{}
 		if err := v.Get(ctx, client.ObjectKey(isvcMeta), &isvc); err != nil {

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
@@ -151,6 +151,46 @@ func TestUnableToDeleteLocalModelCacheWithActiveLLMIsvc(t *testing.T) {
 	g.Expect(err).To(gomega.MatchError(fmt.Errorf("LocalModelCache %s is being used by LLMInferenceService %s", lmc.Name, llmIsvc.Name)))
 }
 
+func makeTestLLMInferenceServiceWithLoRAAdapterOnly() v1alpha2.LLMInferenceService {
+	return v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llm-lora-only",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"iris","sourceUri":"hf://org/adapter","pvcName":"iris-gpu1"}}`,
+			},
+		},
+	}
+}
+
+func makeTestLocalModelCacheWithLoRAOnlyLLMIsvc() v1alpha1.LocalModelCache {
+	lmc := makeTestLocalModelCache()
+	lmc.Status.InferenceServices = nil
+	lmc.Status.LLMInferenceServices = []v1alpha1.NamespacedName{
+		{
+			Namespace: "default",
+			Name:      "llm-lora-only",
+		},
+	}
+	return lmc
+}
+
+func TestUnableToDeleteLocalModelCacheWithActiveLLMIsvcLoRAAdapterOnly(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	lmc := makeTestLocalModelCacheWithLoRAOnlyLLMIsvc()
+	llmIsvc := makeTestLLMInferenceServiceWithLoRAAdapterOnly()
+	s := runtime.NewScheme()
+	err := v1alpha2.AddToScheme(s)
+	if err != nil {
+		t.Errorf("unable to add scheme : %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithObjects(&llmIsvc).WithScheme(s).Build()
+	validator := LocalModelCacheValidator{fakeClient}
+	warnings, err := validator.ValidateDelete(t.Context(), &lmc)
+	g.Expect(warnings).NotTo(gomega.BeNil())
+	g.Expect(err).To(gomega.MatchError(fmt.Errorf("LocalModelCache %s is being used by LLMInferenceService %s", lmc.Name, llmIsvc.Name)))
+}
+
 func TestUnableToCreateLocalModelCacheWithSameStorageURI(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	lmc := makeTestLocalModelCache()

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
@@ -191,6 +191,46 @@ func TestUnableToDeleteLocalModelCacheWithActiveLLMIsvcLoRAAdapterOnly(t *testin
 	g.Expect(err).To(gomega.MatchError(fmt.Errorf("LocalModelCache %s is being used by LLMInferenceService %s", lmc.Name, llmIsvc.Name)))
 }
 
+func TestDeleteLocalModelCacheWithStaleIsvcStatusEntry(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	lmc := makeTestLocalModelCache()
+	s := runtime.NewScheme()
+	err := v1beta1.AddToScheme(s)
+	if err != nil {
+		t.Errorf("unable to add scheme : %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	validator := LocalModelCacheValidator{fakeClient}
+	warnings, err := validator.ValidateDelete(t.Context(), &lmc)
+	g.Expect(warnings).To(gomega.BeNil())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+}
+
+func TestUnableToDeleteLocalModelCacheWithMalformedLoRAAnnotation(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	lmc := makeTestLocalModelCacheWithLoRAOnlyLLMIsvc()
+	lmc.Status.LLMInferenceServices[0].Name = "llm-malformed-lora"
+	llmIsvc := v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llm-malformed-lora",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{invalid`,
+			},
+		},
+	}
+	s := runtime.NewScheme()
+	err := v1alpha2.AddToScheme(s)
+	if err != nil {
+		t.Errorf("unable to add scheme : %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithObjects(&llmIsvc).WithScheme(s).Build()
+	validator := LocalModelCacheValidator{fakeClient}
+	warnings, err := validator.ValidateDelete(t.Context(), &lmc)
+	g.Expect(warnings).NotTo(gomega.BeNil())
+	g.Expect(err).To(gomega.MatchError(fmt.Errorf("LocalModelCache %s is being used by LLMInferenceService %s", lmc.Name, llmIsvc.Name)))
+}
+
 func TestUnableToCreateLocalModelCacheWithSameStorageURI(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	lmc := makeTestLocalModelCache()

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
@@ -157,7 +157,7 @@ func makeTestLLMInferenceServiceWithLoRAAdapterOnly() v1alpha2.LLMInferenceServi
 			Name:      "llm-lora-only",
 			Namespace: "default",
 			Annotations: map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"iris","sourceUri":"hf://org/adapter","pvcName":"iris-gpu1"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"iris"}}`,
 			},
 		},
 	}

--- a/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
+++ b/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/localmodelcache"
 )
 
 // logger for the validation webhook.
@@ -124,12 +125,13 @@ func (v *LocalModelNamespaceCacheValidator) ValidateDelete(ctx context.Context, 
 			localModelNamespaceCacheValidatorLogger.Error(err, "Error getting LLMInferenceService", "name", llmIsvcMeta.Name, "namespace", llmIsvcMeta.Namespace)
 			return nil, err
 		}
-		modelName, ok := llmIsvc.Labels[constants.LocalModelLabel]
-		if !ok {
-			continue
-		}
-		modelNamespace := llmIsvc.Labels[constants.LocalModelNamespaceLabel]
-		if modelName == localModelNamespaceCache.Name && modelNamespace == localModelNamespaceCache.Namespace {
+		if localmodelcache.LLMISVCReferencesNamespaceCache(
+			localModelNamespaceCache.Name,
+			localModelNamespaceCache.Namespace,
+			llmIsvc.Namespace,
+			llmIsvc.Labels,
+			llmIsvc.Annotations,
+		) {
 			return admission.Warnings{}, fmt.Errorf("LocalModelNamespaceCache %s/%s is being used by LLMInferenceService %s/%s",
 				localModelNamespaceCache.Namespace, localModelNamespaceCache.Name, llmIsvcMeta.Namespace, llmIsvcMeta.Name)
 		}

--- a/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
+++ b/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
@@ -101,6 +101,9 @@ func (v *LocalModelNamespaceCacheValidator) ValidateDelete(ctx context.Context, 
 	for _, isvcMeta := range localModelNamespaceCache.Status.InferenceServices {
 		isvc := v1beta1.InferenceService{}
 		if err := v.Get(ctx, client.ObjectKey(isvcMeta), &isvc); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			localModelNamespaceCacheValidatorLogger.Error(err, "Error getting InferenceService", "name", isvcMeta.Name, "namespace", isvcMeta.Namespace)
 			return nil, err
 		}

--- a/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
+++ b/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
@@ -97,7 +97,10 @@ func (v *LocalModelNamespaceCacheValidator) ValidateDelete(ctx context.Context, 
 	}
 	localModelNamespaceCacheValidatorLogger.Info("validate delete", "name", localModelNamespaceCache.Name, "namespace", localModelNamespaceCache.Namespace)
 
-	// Check if current LocalModelNamespaceCache is being used by InferenceServices in the same namespace
+	// Delete protection relies on Status.InferenceServices / Status.LLMInferenceServices
+	// being up-to-date. A newly created consumer may not appear in status yet if the
+	// reconciler has not run, so deletion can race and succeed until the next reconcile.
+	// This gap already existed for base-model references; LoRA adapter references inherit it.
 	for _, isvcMeta := range localModelNamespaceCache.Status.InferenceServices {
 		isvc := v1beta1.InferenceService{}
 		if err := v.Get(ctx, client.ObjectKey(isvcMeta), &isvc); err != nil {

--- a/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation_test.go
+++ b/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation_test.go
@@ -160,6 +160,47 @@ func TestUnableToDeleteLocalModelNamespaceCacheWithActiveLLMIsvc(t *testing.T) {
 		lmnc.Namespace, lmnc.Name, llmIsvc.Namespace, llmIsvc.Name)))
 }
 
+func makeTestLLMInferenceServiceWithLoRAAdapterOnlyForNamespaceCache() v1alpha2.LLMInferenceService {
+	return v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llm-lora-only",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"iris","namespace":"default","sourceUri":"hf://org/adapter","pvcName":"iris-gpu1"}}`,
+			},
+		},
+	}
+}
+
+func makeTestLocalModelNamespaceCacheWithLoRAOnlyLLMIsvc() v1alpha1.LocalModelNamespaceCache {
+	lmnc := makeTestLocalModelNamespaceCache()
+	lmnc.Status.InferenceServices = nil
+	lmnc.Status.LLMInferenceServices = []v1alpha1.NamespacedName{
+		{
+			Namespace: "default",
+			Name:      "llm-lora-only",
+		},
+	}
+	return lmnc
+}
+
+func TestUnableToDeleteLocalModelNamespaceCacheWithActiveLLMIsvcLoRAAdapterOnly(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	lmnc := makeTestLocalModelNamespaceCacheWithLoRAOnlyLLMIsvc()
+	llmIsvc := makeTestLLMInferenceServiceWithLoRAAdapterOnlyForNamespaceCache()
+	s := runtime.NewScheme()
+	err := v1alpha2.AddToScheme(s)
+	if err != nil {
+		t.Errorf("unable to add scheme : %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithObjects(&llmIsvc).WithScheme(s).Build()
+	validator := LocalModelNamespaceCacheValidator{Client: fakeClient}
+	warnings, err := validator.ValidateDelete(t.Context(), &lmnc)
+	g.Expect(warnings).NotTo(gomega.BeNil())
+	g.Expect(err).To(gomega.MatchError(fmt.Errorf("LocalModelNamespaceCache %s/%s is being used by LLMInferenceService %s/%s",
+		lmnc.Namespace, lmnc.Name, llmIsvc.Namespace, llmIsvc.Name)))
+}
+
 func TestUnableToCreateLocalModelNamespaceCacheWithMissingNodeGroup(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	lmnc := makeTestLocalModelNamespaceCache()

--- a/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation_test.go
+++ b/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation_test.go
@@ -166,7 +166,7 @@ func makeTestLLMInferenceServiceWithLoRAAdapterOnlyForNamespaceCache() v1alpha2.
 			Name:      "llm-lora-only",
 			Namespace: "default",
 			Annotations: map[string]string{
-				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"iris","namespace":"default","sourceUri":"hf://org/adapter","pvcName":"iris-gpu1"}}`,
+				constants.LocalModelLoRAAnnotationKey: `{"my-adapter":{"cache":"iris","namespace":"default"}}`,
 			},
 		},
 	}

--- a/test/e2e/modelcache/test_llmisvc_localmodelcache_lora.py
+++ b/test/e2e/modelcache/test_llmisvc_localmodelcache_lora.py
@@ -1,0 +1,360 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import time
+import uuid
+
+import pytest
+from kubernetes import client
+from kubernetes.client import (
+    V1ResourceRequirements,
+    V1PersistentVolumeSpec,
+    V1LocalVolumeSource,
+    V1VolumeNodeAffinity,
+    V1PersistentVolumeClaimSpec,
+)
+from kubernetes.client.exceptions import ApiException
+
+from kserve import constants
+from kserve.api.kserve_client import KServeClient
+from kserve.models.v1alpha1_local_model_node_group import V1alpha1LocalModelNodeGroup
+from kserve.models.v1alpha1_local_model_node_group_spec import (
+    V1alpha1LocalModelNodeGroupSpec,
+)
+from kserve.models.v1alpha1_local_model_cache import V1alpha1LocalModelCache
+from kserve.models.v1alpha1_local_model_cache_spec import V1alpha1LocalModelCacheSpec
+from ..common.utils import KSERVE_TEST_NAMESPACE
+
+
+KSERVE_V1ALPHA2_VERSION = "v1alpha2"
+LLMISVC_PLURAL = "llminferenceservices"
+LOCALMODEL_LABEL = "internal.serving.kserve.io/localmodel"
+LOCALMODEL_LORA_ANNOTATION = "internal.serving.kserve.io/localmodel-lora"
+
+ADAPTER_NAME = "lora-adapter"
+NODES = ["minikube-m02", "minikube-m03"]
+
+
+def _node_group_pv_pvc_specs():
+    pv_spec = V1PersistentVolumeSpec(
+        access_modes=["ReadWriteOnce"],
+        storage_class_name="standard",
+        capacity={"storage": "1Gi"},
+        local=V1LocalVolumeSource(path="/models"),
+        persistent_volume_reclaim_policy="Delete",
+        node_affinity=V1VolumeNodeAffinity(
+            required=client.V1NodeSelector(
+                node_selector_terms=[
+                    client.V1NodeSelectorTerm(
+                        match_expressions=[
+                            client.V1NodeSelectorRequirement(
+                                key="kubernetes.io/hostname",
+                                operator="In",
+                                values=NODES,
+                            )
+                        ]
+                    )
+                ]
+            )
+        ),
+    )
+    pvc_spec = V1PersistentVolumeClaimSpec(
+        access_modes=["ReadWriteOnce"],
+        resources=V1ResourceRequirements(requests={"storage": "1Gi"}),
+        storage_class_name="standard",
+    )
+    return pv_spec, pvc_spec
+
+
+def _wait_for_llmisvc_deployment(
+    apps_api: client.AppsV1Api, llmisvc_name: str, namespace: str, timeout: int = 60
+) -> dict:
+    deployment_name = f"{llmisvc_name}-kserve"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            deployment = apps_api.read_namespaced_deployment(deployment_name, namespace)
+            return deployment.to_dict()
+        except ApiException as exc:
+            if exc.status != 404:
+                raise
+        time.sleep(2)
+    pytest.fail(
+        f"Deployment {deployment_name} was not created in namespace {namespace} within {timeout}s"
+    )
+
+
+def _pod_spec(deployment: dict) -> dict:
+    return deployment.get("spec", {}).get("template", {}).get("spec", {}) or {}
+
+
+def _storage_initializer_args(deployment: dict) -> list[str]:
+    init_containers = _pod_spec(deployment).get("init_containers") or []
+    for container in init_containers:
+        if container.get("name") == "storage-initializer":
+            return container.get("args") or []
+    return []
+
+
+def _volume_names(deployment: dict) -> set[str]:
+    volumes = _pod_spec(deployment).get("volumes") or []
+    return {volume.get("name") for volume in volumes}
+
+
+def _pvc_claim_names(deployment: dict) -> set[str]:
+    volumes = _pod_spec(deployment).get("volumes") or []
+    return {
+        volume.get("persistent_volume_claim", {}).get("claim_name")
+        for volume in volumes
+        if volume.get("persistent_volume_claim")
+    }
+
+
+def _wait_until_deleted(get_fn, timeout: int = 60) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            get_fn()
+        except ApiException as exc:
+            if exc.status == 404:
+                return True
+            raise
+        time.sleep(2)
+    return False
+
+
+def _cleanup_test_resources(
+    kserve_client: KServeClient,
+    k8s_client,
+    *,
+    llmisvc_name: str,
+    base_cache_name: str,
+    adapter_cache_name: str,
+    node_group_name: str,
+) -> None:
+    try:
+        k8s_client.delete_namespaced_custom_object(
+            constants.KSERVE_GROUP,
+            KSERVE_V1ALPHA2_VERSION,
+            KSERVE_TEST_NAMESPACE,
+            LLMISVC_PLURAL,
+            llmisvc_name,
+        )
+    except Exception:
+        pass
+
+    _wait_until_deleted(
+        lambda: k8s_client.get_namespaced_custom_object(
+            constants.KSERVE_GROUP,
+            KSERVE_V1ALPHA2_VERSION,
+            KSERVE_TEST_NAMESPACE,
+            LLMISVC_PLURAL,
+            llmisvc_name,
+        ),
+        timeout=120,
+    )
+
+    for cache_name in (adapter_cache_name, base_cache_name):
+        try:
+            kserve_client.delete_local_model_cache(cache_name)
+        except Exception:
+            pass
+        _wait_until_deleted(
+            lambda cache_name=cache_name: k8s_client.get_cluster_custom_object(
+                constants.KSERVE_GROUP,
+                constants.KSERVE_V1ALPHA1_VERSION,
+                "localmodelcaches",
+                cache_name,
+            ),
+            timeout=120,
+        )
+
+    try:
+        kserve_client.delete_local_model_node_group(node_group_name)
+    except Exception:
+        pass
+    _wait_until_deleted(
+        lambda: k8s_client.get_cluster_custom_object(
+            constants.KSERVE_GROUP,
+            constants.KSERVE_V1ALPHA1_VERSION,
+            constants.KSERVE_PLURAL_LOCALMODELNODEGROUP,
+            node_group_name,
+        ),
+        timeout=120,
+    )
+
+
+@pytest.mark.modelcache
+@pytest.mark.asyncio(scope="session")
+async def test_llmisvc_localmodelcache_lora_adapters():
+    """Test LocalModelCache integration for LLMISVC LoRA adapters."""
+    suffix = uuid.uuid4().hex[:8]
+    node_group_name = f"llmisvc-lora-ng-{suffix}"
+    base_cache_name = f"llmisvc-lora-base-{suffix}"
+    adapter_cache_name = f"llmisvc-lora-adapter-{suffix}"
+    llmisvc_name = f"llmisvc-lora-e2e-{suffix}"
+    base_uri = f"hf://test-org/lora-e2e-base-{suffix}"
+    adapter_uri = f"hf://test-org/lora-e2e-adapter-{suffix}"
+
+    pv_spec, pvc_spec = _node_group_pv_pvc_specs()
+
+    node_group = V1alpha1LocalModelNodeGroup(
+        api_version=constants.KSERVE_V1ALPHA1,
+        kind=constants.KSERVE_KIND_LOCALMODELNODEGROUP,
+        metadata=client.V1ObjectMeta(name=node_group_name),
+        spec=V1alpha1LocalModelNodeGroupSpec(
+            storage_limit="1Gi",
+            persistent_volume_spec=pv_spec,
+            persistent_volume_claim_spec=pvc_spec,
+        ),
+    )
+
+    base_cache = V1alpha1LocalModelCache(
+        api_version=constants.KSERVE_V1ALPHA1,
+        kind=constants.KSERVE_KIND_LOCALMODELCACHE,
+        metadata=client.V1ObjectMeta(name=base_cache_name),
+        spec=V1alpha1LocalModelCacheSpec(
+            model_size="100Mi",
+            node_groups=[node_group_name],
+            source_model_uri=base_uri,
+        ),
+    )
+
+    adapter_cache = V1alpha1LocalModelCache(
+        api_version=constants.KSERVE_V1ALPHA1,
+        kind=constants.KSERVE_KIND_LOCALMODELCACHE,
+        metadata=client.V1ObjectMeta(name=adapter_cache_name),
+        spec=V1alpha1LocalModelCacheSpec(
+            model_size="100Mi",
+            node_groups=[node_group_name],
+            source_model_uri=adapter_uri,
+        ),
+    )
+
+    llmisvc = {
+        "apiVersion": f"serving.kserve.io/{KSERVE_V1ALPHA2_VERSION}",
+        "kind": "LLMInferenceService",
+        "metadata": {
+            "name": llmisvc_name,
+            "namespace": KSERVE_TEST_NAMESPACE,
+        },
+        "spec": {
+            "model": {
+                "uri": base_uri,
+                "lora": {
+                    "adapters": [
+                        {
+                            "name": ADAPTER_NAME,
+                            "uri": adapter_uri,
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+    k8s_client = kserve_client.api_instance
+    apps_api = client.AppsV1Api()
+
+    try:
+        kserve_client.create_local_model_node_group(node_group)
+        kserve_client.create_local_model_cache(base_cache)
+        kserve_client.create_local_model_cache(adapter_cache)
+
+        k8s_client.create_namespaced_custom_object(
+            constants.KSERVE_GROUP,
+            KSERVE_V1ALPHA2_VERSION,
+            KSERVE_TEST_NAMESPACE,
+            LLMISVC_PLURAL,
+            llmisvc,
+        )
+
+        time.sleep(5)
+
+        llmisvc_result = k8s_client.get_namespaced_custom_object(
+            constants.KSERVE_GROUP,
+            KSERVE_V1ALPHA2_VERSION,
+            KSERVE_TEST_NAMESPACE,
+            LLMISVC_PLURAL,
+            llmisvc_name,
+        )
+
+        labels = llmisvc_result.get("metadata", {}).get("labels", {})
+        assert labels.get(LOCALMODEL_LABEL) == base_cache_name
+
+        annotations = llmisvc_result.get("metadata", {}).get("annotations", {})
+        lora_raw = annotations.get(LOCALMODEL_LORA_ANNOTATION)
+        assert lora_raw, f"Expected {LOCALMODEL_LORA_ANNOTATION} annotation"
+        lora_entries = json.loads(lora_raw)
+        assert lora_entries[ADAPTER_NAME]["cache"] == adapter_cache_name
+        assert lora_entries[ADAPTER_NAME]["sourceUri"] == adapter_uri
+
+        deployment = _wait_for_llmisvc_deployment(
+            apps_api, llmisvc_name, KSERVE_TEST_NAMESPACE
+        )
+        volume_names = _volume_names(deployment)
+        assert f"lora-pvc-{ADAPTER_NAME}" in volume_names
+        assert f"{base_cache_name}-{node_group_name}" in _pvc_claim_names(deployment)
+
+        init_args = _storage_initializer_args(deployment)
+        assert base_uri not in init_args
+        assert adapter_uri not in init_args
+
+        for cache_name in (base_cache_name, adapter_cache_name):
+            max_retries = 10
+            for _ in range(max_retries):
+                cache_result = k8s_client.get_cluster_custom_object(
+                    constants.KSERVE_GROUP,
+                    constants.KSERVE_V1ALPHA1_VERSION,
+                    "localmodelcaches",
+                    cache_name,
+                )
+                llm_svcs = cache_result.get("status", {}).get(
+                    "llmInferenceServices", []
+                )
+                if any(
+                    svc.get("name") == llmisvc_name
+                    and svc.get("namespace") == KSERVE_TEST_NAMESPACE
+                    for svc in llm_svcs
+                ):
+                    break
+                time.sleep(2)
+            else:
+                pytest.fail(
+                    f"Cache {cache_name} did not track {llmisvc_name} after {max_retries} retries"
+                )
+
+        with pytest.raises(ApiException) as exc:
+            k8s_client.delete_cluster_custom_object(
+                constants.KSERVE_GROUP,
+                constants.KSERVE_V1ALPHA1_VERSION,
+                "localmodelcaches",
+                adapter_cache_name,
+            )
+        assert exc.value.status == 403
+
+    finally:
+        _cleanup_test_resources(
+            kserve_client,
+            k8s_client,
+            llmisvc_name=llmisvc_name,
+            base_cache_name=base_cache_name,
+            adapter_cache_name=adapter_cache_name,
+            node_group_name=node_group_name,
+        )

--- a/test/e2e/modelcache/test_llmisvc_localmodelcache_lora.py
+++ b/test/e2e/modelcache/test_llmisvc_localmodelcache_lora.py
@@ -303,7 +303,8 @@ async def test_llmisvc_localmodelcache_lora_adapters():
         assert lora_raw, f"Expected {LOCALMODEL_LORA_ANNOTATION} annotation"
         lora_entries = json.loads(lora_raw)
         assert lora_entries[ADAPTER_NAME]["cache"] == adapter_cache_name
-        assert lora_entries[ADAPTER_NAME]["sourceUri"] == adapter_uri
+        assert "sourceUri" not in lora_entries[ADAPTER_NAME]
+        assert "pvcName" not in lora_entries[ADAPTER_NAME]
 
         deployment = _wait_for_llmisvc_deployment(
             apps_api, llmisvc_name, KSERVE_TEST_NAMESPACE


### PR DESCRIPTION
**What this PR does / why we need it**:

LLMInferenceService already supports LocalModelCache for the base model URI. This PR extends that to LoRA adapter URIs so cached adapters are mounted from PVCs instead of being downloaded at pod startup. Adapter caching is independent of whether the base model is cached.

Changes:
- **Defaulter**: match LoRA adapter URIs against LMC/LMNC and set a `localmodel-lora` annotation with cache metadata
- **Workload reconciler**: rewrite cached adapters to PVC mounts; skip adapter URIs in storage-initializer
- **LMC/LMNC reconcilers**: index and track adapter-only LLMISVC references in cache status
- **Delete webhooks**: block LMC/LMNC deletion while an LLMISVC references a cached adapter
- **`pkg/localmodelcache`**: shared helpers for cache matching, annotation parsing, and reference checks
- **E2E**: `test_llmisvc_localmodelcache_lora_adapters` in the modelcache suite (annotations, PVC mounts, status tracking, delete protection)
- **Samples**: `docs/samples/llmisvc/lora-adapters/llm-inference-service-lora-localmodelcache.yaml` and README section 4

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] Unit tests for defaulter, workload rewrite, reconciler status, and delete webhooks
- [x] E2E test `test_llmisvc_localmodelcache_lora_adapters` (runs in `e2e-test-modelcache` CI)
- [x] Manual Minikube validation (annotation, PVC mount, storage-initializer args, status tracking, delete protection)

**Reviewer notes**:

**Reviewer testing guide:** https://gist.github.com/mholder6/84574a2e662290c85d70fc850876cdf9

CI runs the new E2E via the modelcache workflow. Reviewers can also run locally:

```bash
PYTEST_ARGS="-k test_llmisvc_localmodelcache_lora" ./test/scripts/gh-actions/run-e2e-tests.sh modelcache 1
```

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
LLMInferenceService LoRA adapters can now be served from LocalModelCache and LocalModelNamespaceCache when the adapter URI matches a cache entry.
```