### PR TITLE
fix(llmisvc): scope InferencePool readiness to gw refs

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stale_pool_parent_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stale_pool_parent_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KServe Authors.
+Copyright 2026 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package llmisvc_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,13 +34,7 @@ import (
 
 var _ = Describe("LLMInferenceService Controller", func() {
 	Context("Stale InferencePool parent handling", func() {
-		It("should not block readiness when a stale rejected parent from an old gateway is present", func(ctx SpecContext) {
-			// This test reproduces the scenario where a user switches gateway references
-			// on an LLMInferenceService. The gateway controller for the old gateway leaves
-			// a rejected parent entry in InferencePool.Status.Parents, while the current
-			// gateway has accepted the pool. The stale rejected parent should not prevent
-			// the service from reaching ready state.
-
+		It("should recover readiness after switching from a custom gateway to the default", func(ctx SpecContext) {
 			svcName := "test-stale-pool-parent"
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
@@ -56,74 +51,64 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
-			// Wait for the InferencePool to be created by the reconciler.
 			poolName := svcName + "-inference-pool"
 			Eventually(func(g Gomega, ctx context.Context) {
-				pool := &igwapi.InferencePool{}
 				g.Expect(envTest.Client.Get(ctx, client.ObjectKey{
 					Name: poolName, Namespace: testNs.Name,
-				}, pool)).To(Succeed())
+				}, &igwapi.InferencePool{})).To(Succeed())
 			}).WithContext(ctx).Should(Succeed())
 
-			// Simulate the gateway controller writing pool parents and mark all resources ready.
 			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
 
-			// Verify the service reaches ready state with the current gateway.
 			Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha2.LLMInferenceService) {
 				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.InferencePoolReady), "True"))
 			})).WithContext(ctx).Should(Succeed())
 
-			// Now inject a stale rejected parent from an old gateway into the pool status.
-			// This simulates what happens when:
-			// 1. The LLMISVC previously referenced data-science-gateway
-			// 2. The user switched to the default gateway (kserve-ingress-gateway)
-			// 3. The old gateway controller's rejected parent entry lingers in the pool status
-			pool := &igwapi.InferencePool{}
-			Expect(envTest.Client.Get(ctx, client.ObjectKey{
-				Name: poolName, Namespace: testNs.Name,
-			}, pool)).To(Succeed())
-
-			pool.Status.Parents = append(pool.Status.Parents, igwapi.ParentStatus{
-				ParentRef: igwapi.ParentReference{
+			// Simulate what happens when a user previously referenced a different gateway
+			// (e.g. data-science-gateway) and then switched to the default. The old gateway
+			// controller leaves a rejected parent entry in the pool status.
+			injectStalePoolParent(ctx, envTest.Client,
+				client.ObjectKey{Name: poolName, Namespace: testNs.Name},
+				igwapi.ParentReference{
 					Group:     ptr.To(igwapi.Group("networking.istio.io")),
 					Kind:      igwapi.Kind("Gateway"),
 					Name:      "data-science-gateway",
 					Namespace: "openshift-ingress",
 				},
-				Conditions: []metav1.Condition{
-					{
-						Type:               string(igwapi.InferencePoolConditionAccepted),
-						Status:             metav1.ConditionFalse,
-						Reason:             "HTTPRouteNotAccepted",
-						Message:            "namespace not allowed by the parent",
-						LastTransitionTime: metav1.Now(),
-					},
-				},
-			})
-			Expect(envTest.Client.Status().Update(ctx, pool)).To(Succeed())
+			)
 
-			// Wait for the reconciler to process the pool status change. The stale rejected
-			// parent causes the unfiltered IsInferencePoolReady check to return false, which
-			// flips InferencePoolReady to False.
-			Eventually(func(g Gomega, ctx context.Context) {
+			Consistently(func(g Gomega, ctx context.Context) {
 				current := &v1alpha2.LLMInferenceService{}
 				g.Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
-				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.InferencePoolReady), "False"))
-			}).WithContext(ctx).Should(Succeed(),
-				"InferencePoolReady should flip to False after stale parent injection (demonstrating the bug)")
-
-			// BUG: The service should recover to ready state because the current gateway
-			// (kserve-ingress-gateway) has accepted the pool. The stale parent from
-			// data-science-gateway is irrelevant - it belongs to a gateway the HTTPRoute
-			// no longer references. But the unfiltered readiness check treats ANY rejected
-			// parent as a hard failure.
-			//
-			// This assertion will fail on the unfixed code, proving the bug exists.
-			// After the fix, it will pass because readiness is scoped to current gateways.
-			Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha2.LLMInferenceService) {
 				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.InferencePoolReady), "True"),
 					"stale rejected parent from old gateway should not block readiness")
-			})).WithContext(ctx).Should(Succeed())
+			}).WithContext(ctx).WithTimeout(10 * time.Second).WithPolling(time.Second).Should(Succeed())
 		})
 	})
 })
+
+// injectStalePoolParent appends a rejected parent entry to an InferencePool's status,
+// simulating a gateway controller that hasn't cleaned up after the HTTPRoute stopped
+// referencing its gateway. Only runs in envtest (no-op against a real cluster where
+// the gateway controller manages pool status).
+func injectStalePoolParent(ctx context.Context, c client.Client, poolKey client.ObjectKey, parentRef igwapi.ParentReference) {
+	if envTest.UsingExistingCluster() {
+		return
+	}
+
+	pool := &igwapi.InferencePool{}
+	Expect(c.Get(ctx, poolKey, pool)).To(Succeed())
+
+	pool.Status.Parents = append(pool.Status.Parents, igwapi.ParentStatus{
+		ParentRef: parentRef,
+		Conditions: []metav1.Condition{{
+			Type:               string(igwapi.InferencePoolConditionAccepted),
+			Status:             metav1.ConditionFalse,
+			Reason:             "HTTPRouteNotAccepted",
+			Message:            "namespace not allowed by the parent",
+			LastTransitionTime: metav1.Now(),
+		}},
+	})
+
+	Expect(c.Status().Update(ctx, pool)).To(Succeed())
+}

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stale_pool_parent_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stale_pool_parent_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+	. "github.com/kserve/kserve/pkg/testing"
+)
+
+var _ = Describe("LLMInferenceService Controller", func() {
+	Context("Stale InferencePool parent handling", func() {
+		It("should not block readiness when a stale rejected parent from an old gateway is present", func(ctx SpecContext) {
+			// This test reproduces the scenario where a user switches gateway references
+			// on an LLMInferenceService. The gateway controller for the old gateway leaves
+			// a rejected parent entry in InferencePool.Status.Parents, while the current
+			// gateway has accepted the pool. The stale rejected parent should not prevent
+			// the service from reaching ready state.
+
+			svcName := "test-stale-pool-parent"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// Wait for the InferencePool to be created by the reconciler.
+			poolName := svcName + "-inference-pool"
+			Eventually(func(g Gomega, ctx context.Context) {
+				pool := &igwapi.InferencePool{}
+				g.Expect(envTest.Client.Get(ctx, client.ObjectKey{
+					Name: poolName, Namespace: testNs.Name,
+				}, pool)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Simulate the gateway controller writing pool parents and mark all resources ready.
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
+
+			// Verify the service reaches ready state with the current gateway.
+			Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha2.LLMInferenceService) {
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.InferencePoolReady), "True"))
+			})).WithContext(ctx).Should(Succeed())
+
+			// Now inject a stale rejected parent from an old gateway into the pool status.
+			// This simulates what happens when:
+			// 1. The LLMISVC previously referenced data-science-gateway
+			// 2. The user switched to the default gateway (kserve-ingress-gateway)
+			// 3. The old gateway controller's rejected parent entry lingers in the pool status
+			pool := &igwapi.InferencePool{}
+			Expect(envTest.Client.Get(ctx, client.ObjectKey{
+				Name: poolName, Namespace: testNs.Name,
+			}, pool)).To(Succeed())
+
+			pool.Status.Parents = append(pool.Status.Parents, igwapi.ParentStatus{
+				ParentRef: igwapi.ParentReference{
+					Group:     ptr.To(igwapi.Group("networking.istio.io")),
+					Kind:      igwapi.Kind("Gateway"),
+					Name:      "data-science-gateway",
+					Namespace: "openshift-ingress",
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(igwapi.InferencePoolConditionAccepted),
+						Status:             metav1.ConditionFalse,
+						Reason:             "HTTPRouteNotAccepted",
+						Message:            "namespace not allowed by the parent",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			})
+			Expect(envTest.Client.Status().Update(ctx, pool)).To(Succeed())
+
+			// Wait for the reconciler to process the pool status change. The stale rejected
+			// parent causes the unfiltered IsInferencePoolReady check to return false, which
+			// flips InferencePoolReady to False.
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.InferencePoolReady), "False"))
+			}).WithContext(ctx).Should(Succeed(),
+				"InferencePoolReady should flip to False after stale parent injection (demonstrating the bug)")
+
+			// BUG: The service should recover to ready state because the current gateway
+			// (kserve-ingress-gateway) has accepted the pool. The stale parent from
+			// data-science-gateway is irrelevant - it belongs to a gateway the HTTPRoute
+			// no longer references. But the unfiltered readiness check treats ANY rejected
+			// parent as a hard failure.
+			//
+			// This assertion will fail on the unfixed code, proving the bug exists.
+			// After the fix, it will pass because readiness is scoped to current gateways.
+			Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha2.LLMInferenceService) {
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.InferencePoolReady), "True"),
+					"stale rejected parent from old gateway should not block readiness")
+			})).WithContext(ctx).Should(Succeed())
+		})
+	})
+})

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -966,7 +966,9 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when - external pool becomes ready
 				updatedPool := &igwapi.InferencePool{}
 				Expect(envTest.Get(ctx, client.ObjectKeyFromObject(infPool), updatedPool)).To(Succeed())
-				WithInferencePoolReadyStatus()(updatedPool)
+				routes := &gwapiv1.HTTPRouteList{}
+				Expect(envTest.Client.List(ctx, routes, client.InNamespace(testNs.Name))).To(Succeed())
+				WithInferencePoolReadyStatus(InferencePoolParentRefsFromRoutes(routes.Items)...)(updatedPool)
 				Expect(envTest.Client.Status().Update(ctx, updatedPool)).To(Succeed())
 
 				// then - LLMInferenceService status should follow the external pool update.
@@ -2267,7 +2269,9 @@ func ensureHTTPRouteReady(ctx context.Context, c client.Client, route *gwapiv1.H
 	}).WithContext(ctx).Should(BeTrue())
 }
 
-// ensureInferencePoolReady sets up InferencePool status conditions to simulate a ready InferencePool
+// ensureInferencePoolReady sets up InferencePool status conditions to simulate a ready InferencePool.
+// Gateway parent refs are derived from HTTPRoutes in the pool's namespace so that the pool's
+// status parents match the gateways the reconciler actually resolves.
 func ensureInferencePoolReady(ctx context.Context, c client.Client, pool *igwapi.InferencePool) {
 	if envTest.UsingExistingCluster() {
 		return
@@ -2275,10 +2279,14 @@ func ensureInferencePoolReady(ctx context.Context, c client.Client, pool *igwapi
 
 	createdPool := &igwapi.InferencePool{}
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(pool), createdPool)).To(Succeed())
-	WithInferencePoolReadyStatus()(createdPool)
+
+	routes := &gwapiv1.HTTPRouteList{}
+	Expect(c.List(ctx, routes, client.InNamespace(pool.Namespace))).To(Succeed())
+	gatewayRefs := InferencePoolParentRefsFromRoutes(routes.Items)
+
+	WithInferencePoolReadyStatus(gatewayRefs...)(createdPool)
 	Expect(c.Status().Update(ctx, createdPool)).To(Succeed())
 
-	// Verify the InferencePool is now ready
 	updatedPool := &igwapi.InferencePool{}
 	Eventually(func(g Gomega, ctx context.Context) bool {
 		updatedPool = &igwapi.InferencePool{}
@@ -2341,10 +2349,11 @@ func ensureRouterManagedResourcesAreReady(ctx context.Context, c client.Client, 
 		if err != nil && !errors.IsNotFound(err) {
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 		}
-		logf.FromContext(ctx).Info("Marking InferencePool resources ready", "inferencepools", infPools)
+		gatewayRefs := InferencePoolParentRefsFromRoutes(httpRoutes.Items)
+		logf.FromContext(ctx).Info("Marking InferencePool resources ready", "inferencepools", infPools, "gatewayRefs", gatewayRefs)
 		for _, pool := range infPools.Items {
 			updatedPool := pool.DeepCopy()
-			WithInferencePoolReadyStatus()(updatedPool)
+			WithInferencePoolReadyStatus(gatewayRefs...)(updatedPool)
 			g.Expect(c.Status().Update(ctx, updatedPool)).To(gomega.Succeed())
 		}
 

--- a/pkg/controller/v1alpha2/llmisvc/fixture/gwapi_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/gwapi_builders.go
@@ -17,6 +17,9 @@ limitations under the License.
 package fixture
 
 import (
+	"cmp"
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -730,15 +733,19 @@ func WithExtensionRef(group, kind, name string, port int32) InferencePoolOption 
 	return WithEndpointPickerRef(group, kind, name, port)
 }
 
-func WithInferencePoolReadyStatus() InferencePoolOption {
+func WithInferencePoolReadyStatus(gatewayRefs ...igwapi.ParentReference) InferencePoolOption {
 	return func(pool *igwapi.InferencePool) {
-		pool.Status.Parents = []igwapi.ParentStatus{
-			{
-				ParentRef: igwapi.ParentReference{
-					Group: ptr.To(igwapi.Group("gateway.networking.k8s.io")),
-					Kind:  igwapi.Kind("Gateway"),
-					Name:  igwapi.ObjectName("gateway"),
-				},
+		if len(gatewayRefs) == 0 {
+			gatewayRefs = []igwapi.ParentReference{{
+				Group: ptr.To(igwapi.Group("gateway.networking.k8s.io")),
+				Kind:  igwapi.Kind("Gateway"),
+				Name:  igwapi.ObjectName("gateway"),
+			}}
+		}
+		pool.Status.Parents = make([]igwapi.ParentStatus, 0, len(gatewayRefs))
+		for _, ref := range gatewayRefs {
+			pool.Status.Parents = append(pool.Status.Parents, igwapi.ParentStatus{
+				ParentRef: ref,
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(igwapi.InferencePoolConditionAccepted),
@@ -747,7 +754,36 @@ func WithInferencePoolReadyStatus() InferencePoolOption {
 						LastTransitionTime: metav1.Now(),
 					},
 				},
-			},
+			})
+		}
+		slices.SortFunc(pool.Status.Parents, func(a, b igwapi.ParentStatus) int {
+			if c := cmp.Compare(string(a.ParentRef.Namespace), string(b.ParentRef.Namespace)); c != 0 {
+				return c
+			}
+			return cmp.Compare(string(a.ParentRef.Name), string(b.ParentRef.Name))
+		})
+	}
+}
+
+// InferencePoolParentRefsFromRoutes converts HTTPRoute parentRefs to InferencePool ParentReferences.
+// Namespace is resolved to the route's namespace when omitted, matching Gateway API defaulting.
+func InferencePoolParentRefsFromRoutes(routes []gwapiv1.HTTPRoute) []igwapi.ParentReference {
+	var refs []igwapi.ParentReference
+	for _, route := range routes {
+		for _, pr := range route.Spec.ParentRefs {
+			ref := igwapi.ParentReference{
+				Name:      igwapi.ObjectName(pr.Name),
+				Namespace: igwapi.Namespace(ptr.Deref(pr.Namespace, gwapiv1.Namespace(route.Namespace))),
+			}
+			if pr.Group != nil {
+				g := igwapi.Group(*pr.Group)
+				ref.Group = &g
+			}
+			if pr.Kind != nil {
+				ref.Kind = igwapi.Kind(*pr.Kind)
+			}
+			refs = append(refs, ref)
 		}
 	}
+	return refs
 }

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -111,7 +111,7 @@ func (r *LLMISVCReconciler) reconcileRouter(ctx context.Context, llmSvc *v1alpha
 	}
 
 	// Evaluate the subconditions to determine overall router health
-	if err := r.EvaluateInferencePoolConditions(ctx, llmSvc); err != nil {
+	if err := r.EvaluateInferencePoolConditions(ctx, llmSvc, resolvedGWs); err != nil {
 		return fmt.Errorf("failed to evaluate Inference Pool conditions: %w", err)
 	}
 
@@ -609,7 +609,7 @@ func (r *LLMISVCReconciler) EvaluateHTTPRouteConditions(ctx context.Context, llm
 // and updates the InferencePoolReady condition accordingly.
 // During the v1alpha2 to v1 migration, it checks both pool versions for managed pools
 // and considers the pool ready if at least one is ready.
-func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
+func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, resolvedGWs []ResolvedGateway) error {
 	logger := log.FromContext(ctx).WithName("EvaluateInferencePoolConditions")
 
 	if utils.GetForceStopRuntime(llmSvc) {
@@ -623,6 +623,9 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 		llmSvc.MarkInferencePoolReadyUnset()
 		return nil
 	}
+
+	// Resolve gateway identities once for pool parent matching.
+	gatewayKeys := resolvedGatewayKeys(resolvedGWs)
 
 	// For referenced pools (external), only check that pool
 	if llmSvc.Spec.Router.Scheduler.Pool != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref.Name != "" {
@@ -646,7 +649,7 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 				Name:  gwapiv1.ObjectName(llmSvc.Spec.Router.EPPServiceName(llmSvc)),
 			},
 		)
-		return r.evaluateSingleInferencePoolCondition(ctx, llmSvc, curr)
+		return r.evaluateInferencePoolCondition(ctx, llmSvc, curr, gatewayKeys)
 	}
 
 	// For managed pools, check both v1 and v1alpha2 pools during migration.
@@ -656,15 +659,16 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 	poolName := expected.Name
 	poolNamespace := expected.Namespace
 
-	// Check v1 pool
+	// Check v1 pool - scoped to only the gateways currently in use. Without this,
+	// stale parent entries from previously-referenced gateways can block readiness.
 	v1Pool := &igwapi.InferencePool{}
 	v1Err := r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: poolName}, v1Pool)
-	v1Ready := v1Err == nil && IsInferencePoolReady(v1Pool)
+	v1Ready := v1Err == nil && IsInferencePoolReadyForGateways(v1Pool, gatewayKeys)
 
 	// Check v1alpha2 pool - treat CRD-not-installed as "version unavailable" (not an error)
 	v1alpha2Pool := &igwapiv1alpha2.InferencePool{}
 	v1alpha2Err := r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: poolName}, v1alpha2Pool)
-	v1alpha2Ready := v1alpha2Err == nil && IsInferencePoolV1Alpha2Ready(v1alpha2Pool)
+	v1alpha2Ready := v1alpha2Err == nil && IsInferencePoolV1Alpha2ReadyForGateways(v1alpha2Pool, gatewayKeys)
 
 	// Record the pool and EPP service refs in status - the pool name is deterministic
 	// regardless of whether the pool is ready or even exists yet.
@@ -698,25 +702,33 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 
 	// Neither is ready - report status from the one that exists (prefer v1 since it's the target)
 	if v1Err == nil {
-		return r.evaluateSingleInferencePoolCondition(ctx, llmSvc, v1Pool)
+		return r.evaluateInferencePoolCondition(ctx, llmSvc, v1Pool, gatewayKeys)
 	}
 
 	if v1alpha2Err == nil {
-		if len(v1alpha2Pool.Status.Parents) == 0 {
+		relevant := filterRelevantV1Alpha2Parents(v1alpha2Pool.Status.Parents, gatewayKeys, v1alpha2Pool.Namespace)
+		if len(relevant) == 0 {
 			llmSvc.MarkInferencePoolNotReady("WaitingForGateway",
 				"Inference Pool %s/%s exists but no Gateway controller has accepted it yet", poolNamespace, poolName)
 			return nil
 		}
-		topLevelCondition, _ := nonReadyInferencePoolV1Alpha2TopLevelCondition(v1alpha2Pool)
-		if topLevelCondition != nil {
+		for _, gw := range gatewayKeys {
+			if !hasMatchingV1Alpha2PoolParent(gw, relevant, v1alpha2Pool.Namespace) {
+				llmSvc.MarkInferencePoolNotReady("WaitingForGateway",
+					"Inference Pool %s/%s is not yet accepted by gateway %s/%s",
+					poolNamespace, poolName, gw.Namespace, gw.Name)
+				return nil
+			}
+		}
+		if cond := findNonReadyV1Alpha2Condition(relevant, string(igwapiv1alpha2.InferencePoolConditionAccepted), v1alpha2Pool.Generation); cond != nil {
 			llmSvc.MarkInferencePoolNotReady("InferencePoolNotReady", fmt.Sprintf(
 				"%s/%s: %v=%#v (reason %q, message %q)",
 				poolNamespace,
 				poolName,
-				topLevelCondition.Type,
-				topLevelCondition.Status,
-				topLevelCondition.Reason,
-				topLevelCondition.Message,
+				cond.Type,
+				cond.Status,
+				cond.Reason,
+				cond.Message,
 			))
 		} else {
 			llmSvc.MarkInferencePoolNotReady("InferencePoolNotReady", fmt.Sprintf("The inference pool %s/%s is not ready", poolNamespace, poolName))
@@ -738,29 +750,39 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 	return err
 }
 
-// evaluateSingleInferencePoolCondition evaluates a single v1 InferencePool and updates the condition.
-func (r *LLMISVCReconciler) evaluateSingleInferencePoolCondition(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, curr *igwapi.InferencePool) error {
-	if !IsInferencePoolReady(curr) {
-		if len(curr.Status.Parents) == 0 {
-			// Pool exists but no Gateway controller has claimed it yet.
-			// The Owns() watch will trigger re-reconciliation when the Gateway updates the pool's status.
+// evaluateInferencePoolCondition evaluates a single v1 InferencePool and updates the condition.
+// Only pool parents matching the given gateway keys are considered.
+func (r *LLMISVCReconciler) evaluateInferencePoolCondition(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, curr *igwapi.InferencePool, gateways []types.NamespacedName) error {
+	relevant := filterRelevantV1Parents(curr.Status.Parents, gateways, curr.Namespace)
+	if len(relevant) == 0 {
+		llmSvc.MarkInferencePoolNotReady("WaitingForGateway",
+			"Inference Pool %s/%s exists but no Gateway controller has accepted it yet", curr.Namespace, curr.Name)
+		return nil
+	}
+
+	for _, gw := range gateways {
+		if !hasMatchingV1PoolParent(gw, relevant, curr.Namespace) {
 			llmSvc.MarkInferencePoolNotReady("WaitingForGateway",
-				"Inference Pool %s/%s exists but no Gateway controller has accepted it yet", curr.Namespace, curr.Name)
+				"Inference Pool %s/%s is not yet accepted by gateway %s/%s",
+				curr.Namespace, curr.Name, gw.Namespace, gw.Name)
 			return nil
 		}
-		topLevelCondition, _ := nonReadyInferencePoolTopLevelCondition(curr)
-		if topLevelCondition != nil {
+	}
+
+	if !allParentsAccepted(relevant, curr.Generation) {
+		if cond := findNonReadyCondition(relevant, string(igwapi.InferencePoolConditionAccepted), curr.Generation); cond != nil {
 			llmSvc.MarkInferencePoolNotReady("InferencePoolNotReady", fmt.Sprintf(
 				"%s/%s: %v=%#v (reason %q, message %q)",
 				curr.Namespace,
 				curr.Name,
-				topLevelCondition.Type,
-				topLevelCondition.Status,
-				topLevelCondition.Reason,
-				topLevelCondition.Message,
+				cond.Type,
+				cond.Status,
+				cond.Reason,
+				cond.Message,
 			))
 		} else {
-			llmSvc.MarkInferencePoolNotReady("InferencePoolNotReady", fmt.Sprintf("The inference pool %s/%s is not ready", curr.Namespace, curr.Name))
+			llmSvc.MarkInferencePoolNotReady("InferencePoolNotReady",
+				fmt.Sprintf("The inference pool %s/%s is not ready", curr.Namespace, curr.Name))
 		}
 		return nil
 	}

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -40,8 +40,6 @@ import (
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	igwapiv1alpha2 "github.com/kserve/kserve/pkg/apis/gie/v1alpha2pool"
-
 	"github.com/kserve/kserve/pkg/constants"
 )
 
@@ -748,54 +746,122 @@ func nonReadyInferencePoolTopLevelCondition(pool *igwapi.InferencePool) (*metav1
 	return nil, false
 }
 
-// IsInferencePoolV1Alpha2Ready checks if a v1alpha2 InferencePool has been accepted by all parents.
-// This mirrors IsInferencePoolReady but for the v1alpha2 InferencePool type, which has a different
-// status structure (PoolStatus instead of ParentStatus).
-func IsInferencePoolV1Alpha2Ready(pool *igwapiv1alpha2.InferencePool) bool {
-	if pool == nil {
+// IsInferencePoolReadyForGateways checks if an InferencePool is ready, considering only
+// parents that correspond to the given gateways. When gateway refs change on an
+// LLMInferenceService, the gateway controller may leave stale parent entries in the pool's
+// status for gateways that are no longer referenced. Without filtering, a rejected parent
+// from an old gateway blocks readiness even though the current gateway accepts the pool.
+//
+// When gateways is empty, the pool is not ready.
+func IsInferencePoolReadyForGateways(pool *igwapi.InferencePool, gateways []types.NamespacedName) bool {
+	if pool == nil || len(gateways) == 0 {
 		return false
 	}
 
-	// No Gateway has claimed this pool yet - not ready for traffic
-	if len(pool.Status.Parents) == 0 {
+	relevant := filterRelevantV1Parents(pool.Status.Parents, gateways, pool.Namespace)
+	if len(relevant) == 0 {
 		return false
 	}
 
-	if cond, missing := nonReadyInferencePoolV1Alpha2TopLevelCondition(pool); cond != nil || missing {
-		return false
+	for _, gw := range gateways {
+		if !hasMatchingV1PoolParent(gw, relevant, pool.Namespace) {
+			return false
+		}
+	}
+
+	for _, parent := range relevant {
+		cond := meta.FindStatusCondition(parent.Conditions, string(igwapi.InferencePoolConditionAccepted))
+		if cond == nil {
+			return false
+		}
+		staleCondition := cond.ObservedGeneration > 0 && cond.ObservedGeneration < pool.Generation
+		if cond.Status != metav1.ConditionTrue || staleCondition {
+			return false
+		}
 	}
 
 	return true
 }
 
-// nonReadyInferencePoolV1Alpha2TopLevelCondition checks for any non-ready conditions in a v1alpha2 InferencePool.
-// Returns the first problematic condition or indicates missing conditions.
-func nonReadyInferencePoolV1Alpha2TopLevelCondition(pool *igwapiv1alpha2.InferencePool) (*metav1.Condition, bool) {
-	if pool == nil {
-		return nil, true
-	}
-
-	for _, parent := range pool.Status.Parents {
-		cond := meta.FindStatusCondition(parent.Conditions, string(igwapiv1alpha2.InferencePoolConditionAccepted))
-		if cond == nil {
-			return nil, true
+// resolvedGatewayKeys extracts gateway name+namespace pairs from resolved gateways,
+// resolving nil parentRef namespaces to the gateway object's actual namespace.
+func resolvedGatewayKeys(resolved []ResolvedGateway) []types.NamespacedName {
+	keys := make([]types.NamespacedName, 0, len(resolved))
+	for _, rg := range resolved {
+		ns := rg.Gateway.Namespace
+		if rg.ParentRef.Namespace != nil {
+			ns = string(*rg.ParentRef.Namespace)
 		}
-		staleCondition := cond.ObservedGeneration > 0 && cond.ObservedGeneration < pool.Generation
-		if cond.Status != metav1.ConditionTrue || staleCondition {
-			return cond, false
-		}
+		keys = append(keys, types.NamespacedName{Name: string(rg.ParentRef.Name), Namespace: ns})
 	}
-
-	return nil, false
+	return keys
 }
 
-// IsInferencePoolV1Alpha2Supported checks if an HTTPRoute has been accepted by the Gateway, and it's using v1alpha2
-// InferencePool.
-func IsInferencePoolV1Alpha2Supported(route *gwapiv1.HTTPRoute) metav1.ConditionStatus {
-	if isHTTPRouteUsingInferencePool(route, constants.InferencePoolV1Alpha2APIGroupName) {
-		return isBackendSupported(route)
+func filterRelevantV1Parents(parents []igwapi.ParentStatus, gateways []types.NamespacedName, defaultNS string) []igwapi.ParentStatus {
+	relevant := make([]igwapi.ParentStatus, 0, len(parents))
+	for _, parent := range parents {
+		ns := string(parent.ParentRef.Namespace)
+		if ns == "" {
+			ns = defaultNS
+		}
+		key := types.NamespacedName{Name: string(parent.ParentRef.Name), Namespace: ns}
+		if matchesAnyGateway(key, gateways) {
+			relevant = append(relevant, parent)
+		}
 	}
-	return metav1.ConditionUnknown
+	return relevant
+}
+
+// allParentsAccepted returns true only when every parent has an Accepted condition set to True
+// with a current ObservedGeneration.
+func allParentsAccepted(parents []igwapi.ParentStatus, generation int64) bool {
+	for _, parent := range parents {
+		cond := meta.FindStatusCondition(parent.Conditions, string(igwapi.InferencePoolConditionAccepted))
+		if cond == nil {
+			return false
+		}
+		stale := cond.ObservedGeneration > 0 && cond.ObservedGeneration < generation
+		if cond.Status != metav1.ConditionTrue || stale {
+			return false
+		}
+	}
+	return true
+}
+
+func findNonReadyCondition(parents []igwapi.ParentStatus, conditionType string, generation int64) *metav1.Condition {
+	for _, parent := range parents {
+		cond := meta.FindStatusCondition(parent.Conditions, conditionType)
+		if cond == nil {
+			continue
+		}
+		stale := cond.ObservedGeneration > 0 && cond.ObservedGeneration < generation
+		if cond.Status != metav1.ConditionTrue || stale {
+			return cond
+		}
+	}
+	return nil
+}
+
+func matchesAnyGateway(key types.NamespacedName, gateways []types.NamespacedName) bool {
+	for _, gw := range gateways {
+		if key == gw {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMatchingV1PoolParent(gw types.NamespacedName, parents []igwapi.ParentStatus, defaultNS string) bool {
+	for _, parent := range parents {
+		ns := string(parent.ParentRef.Namespace)
+		if ns == "" {
+			ns = defaultNS
+		}
+		if gw.Name == string(parent.ParentRef.Name) && gw.Namespace == ns {
+			return true
+		}
+	}
+	return false
 }
 
 // IsInferencePoolV1Supported checks if an HTTPRoute has been accepted by the Gateway, and it's using v1 InferencePool.

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_giev1alpha2.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_giev1alpha2.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains v1alpha2 InferencePool readiness helpers.
+// Delete this file when v1alpha2 InferencePool support is removed.
+
+package llmisvc
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	igwapiv1alpha2 "github.com/kserve/kserve/pkg/apis/gie/v1alpha2pool"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// IsInferencePoolV1Alpha2Ready checks if a v1alpha2 InferencePool has been accepted by all parents.
+// This mirrors IsInferencePoolReady but for the v1alpha2 InferencePool type, which has a different
+// status structure (PoolStatus instead of ParentStatus).
+func IsInferencePoolV1Alpha2Ready(pool *igwapiv1alpha2.InferencePool) bool {
+	if pool == nil {
+		return false
+	}
+
+	if len(pool.Status.Parents) == 0 {
+		return false
+	}
+
+	if cond, missing := nonReadyInferencePoolV1Alpha2TopLevelCondition(pool); cond != nil || missing {
+		return false
+	}
+
+	return true
+}
+
+func nonReadyInferencePoolV1Alpha2TopLevelCondition(pool *igwapiv1alpha2.InferencePool) (*metav1.Condition, bool) {
+	if pool == nil {
+		return nil, true
+	}
+
+	for _, parent := range pool.Status.Parents {
+		cond := meta.FindStatusCondition(parent.Conditions, string(igwapiv1alpha2.InferencePoolConditionAccepted))
+		if cond == nil {
+			return nil, true
+		}
+		staleCondition := cond.ObservedGeneration > 0 && cond.ObservedGeneration < pool.Generation
+		if cond.Status != metav1.ConditionTrue || staleCondition {
+			return cond, false
+		}
+	}
+
+	return nil, false
+}
+
+// IsInferencePoolV1Alpha2ReadyForGateways checks if a v1alpha2 InferencePool is ready,
+// considering only parents matching the given gateways.
+// See IsInferencePoolReadyForGateways for details.
+func IsInferencePoolV1Alpha2ReadyForGateways(pool *igwapiv1alpha2.InferencePool, gateways []types.NamespacedName) bool {
+	if pool == nil || len(gateways) == 0 {
+		return false
+	}
+
+	relevant := filterRelevantV1Alpha2Parents(pool.Status.Parents, gateways, pool.Namespace)
+	if len(relevant) == 0 {
+		return false
+	}
+
+	for _, gw := range gateways {
+		if !hasMatchingV1Alpha2PoolParent(gw, relevant, pool.Namespace) {
+			return false
+		}
+	}
+
+	for _, parent := range relevant {
+		cond := meta.FindStatusCondition(parent.Conditions, string(igwapiv1alpha2.InferencePoolConditionAccepted))
+		if cond == nil {
+			return false
+		}
+		staleCondition := cond.ObservedGeneration > 0 && cond.ObservedGeneration < pool.Generation
+		if cond.Status != metav1.ConditionTrue || staleCondition {
+			return false
+		}
+	}
+
+	return true
+}
+
+func v1alpha2ParentKey(parent igwapiv1alpha2.PoolStatus, defaultNS string) types.NamespacedName {
+	key := types.NamespacedName{Name: string(parent.GatewayRef.Name), Namespace: defaultNS}
+	if parent.GatewayRef.Namespace != nil {
+		key.Namespace = string(*parent.GatewayRef.Namespace)
+	}
+	return key
+}
+
+func filterRelevantV1Alpha2Parents(parents []igwapiv1alpha2.PoolStatus, gateways []types.NamespacedName, defaultNS string) []igwapiv1alpha2.PoolStatus {
+	relevant := make([]igwapiv1alpha2.PoolStatus, 0, len(parents))
+	for _, parent := range parents {
+		if matchesAnyGateway(v1alpha2ParentKey(parent, defaultNS), gateways) {
+			relevant = append(relevant, parent)
+		}
+	}
+	return relevant
+}
+
+func findNonReadyV1Alpha2Condition(parents []igwapiv1alpha2.PoolStatus, conditionType string, generation int64) *metav1.Condition {
+	for _, parent := range parents {
+		cond := meta.FindStatusCondition(parent.Conditions, conditionType)
+		if cond == nil {
+			continue
+		}
+		stale := cond.ObservedGeneration > 0 && cond.ObservedGeneration < generation
+		if cond.Status != metav1.ConditionTrue || stale {
+			return cond
+		}
+	}
+	return nil
+}
+
+func hasMatchingV1Alpha2PoolParent(gw types.NamespacedName, parents []igwapiv1alpha2.PoolStatus, defaultNS string) bool {
+	for _, parent := range parents {
+		if gw == v1alpha2ParentKey(parent, defaultNS) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsInferencePoolV1Alpha2Supported checks if an HTTPRoute has been accepted by the Gateway, and it's using v1alpha2
+// InferencePool.
+func IsInferencePoolV1Alpha2Supported(route *gwapiv1.HTTPRoute) metav1.ConditionStatus {
+	if isHTTPRouteUsingInferencePool(route, constants.InferencePoolV1Alpha2APIGroupName) {
+		return isBackendSupported(route)
+	}
+	return metav1.ConditionUnknown
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestResolvedGatewayKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []ResolvedGateway
+		expected []types.NamespacedName
+	}{
+		{
+			name:     "empty input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "nil parentRef namespace inferred from gateway object",
+			input: []ResolvedGateway{{
+				Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"}},
+				ParentRef: gwapiv1.ParentReference{Name: "my-gw"},
+			}},
+			expected: []types.NamespacedName{{Name: "my-gw", Namespace: "gw-ns"}},
+		},
+		{
+			name: "explicit namespace preserved",
+			input: []ResolvedGateway{{
+				Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"}},
+				ParentRef: gwapiv1.ParentReference{Name: "my-gw", Namespace: ptr.To(gwapiv1.Namespace("explicit-ns"))},
+			}},
+			expected: []types.NamespacedName{{Name: "my-gw", Namespace: "explicit-ns"}},
+		},
+		{
+			name: "mixed nil and explicit namespaces",
+			input: []ResolvedGateway{
+				{
+					Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a"}},
+					ParentRef: gwapiv1.ParentReference{Name: "gw-a"},
+				},
+				{
+					Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-b"}},
+					ParentRef: gwapiv1.ParentReference{Name: "gw-b", Namespace: ptr.To(gwapiv1.Namespace("custom-ns"))},
+				},
+			},
+			expected: []types.NamespacedName{
+				{Name: "gw-a", Namespace: "ns-a"},
+				{Name: "gw-b", Namespace: "custom-ns"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolvedGatewayKeys(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("got %d keys, want %d", len(got), len(tt.expected))
+			}
+			for i, key := range got {
+				if key != tt.expected[i] {
+					t.Errorf("key[%d] = %v, want %v", i, key, tt.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_pool_readiness_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_pool_readiness_test.go
@@ -19,13 +19,20 @@ package llmisvc_test
 import (
 	"testing"
 
+	"k8s.io/utils/ptr"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	igwapiv1alpha2 "github.com/kserve/kserve/pkg/apis/gie/v1alpha2pool"
 
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 )
+
+func gw(name, namespace string) types.NamespacedName {
+	return types.NamespacedName{Name: name, Namespace: namespace}
+}
 
 func TestIsInferencePoolReady(t *testing.T) {
 	tests := []struct {
@@ -348,6 +355,431 @@ func TestIsInferencePoolV1Alpha2Ready(t *testing.T) {
 			got := llmisvc.IsInferencePoolV1Alpha2Ready(tt.pool)
 			if got != tt.expected {
 				t.Errorf("IsInferencePoolV1Alpha2Ready() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsInferencePoolReadyForGateways(t *testing.T) {
+	tests := []struct {
+		name        string
+		pool        *igwapi.InferencePool
+		resolvedGWs []types.NamespacedName
+		expected    bool
+	}{
+		{
+			name: "stale rejected parent from old gateway does not block readiness",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							ParentRef: igwapi.ParentReference{Name: "old-gateway", Namespace: "gw-ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionFalse, Reason: "HTTPRouteNotAccepted"},
+							},
+						},
+						{
+							ParentRef: igwapi.ParentReference{Name: "current-gateway", Namespace: "gw-ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("current-gateway", "gw-ns")},
+			expected:    true,
+		},
+		{
+			name: "all relevant parents rejected means not ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							ParentRef: igwapi.ParentReference{Name: "current-gateway", Namespace: "gw-ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionFalse, Reason: "NotAllowedByListeners"},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("current-gateway", "gw-ns")},
+			expected:    false,
+		},
+		{
+			name: "no matching parents for current gateway means not ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							ParentRef: igwapi.ParentReference{Name: "old-gateway", Namespace: "old-ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("new-gateway", "ingress-ns")},
+			expected:    false,
+		},
+		{
+			name: "nil resolvedGWs means no gateways so not ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: nil,
+			expected:    false,
+		},
+		{
+			name: "pool parent with omitted namespace matches gateway in pool namespace",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							ParentRef: igwapi.ParentReference{Name: "same-ns-gateway", Namespace: "my-ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("same-ns-gateway", "my-ns")},
+			expected:    true,
+		},
+		{
+			name: "not ready when only some gateways have matching pool parents",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							ParentRef: igwapi.ParentReference{Name: "gateway-a", Namespace: "gw-ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{
+				gw("gateway-a", "gw-ns"),
+				gw("gateway-b", "gw-ns"),
+			},
+			expected: false,
+		},
+		{
+			name:        "nil pool is not ready",
+			pool:        nil,
+			resolvedGWs: []types.NamespacedName{gw("gw", "ns")},
+			expected:    false,
+		},
+		{
+			name: "pool with empty status parents is not ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{Parents: []igwapi.ParentStatus{}},
+			},
+			resolvedGWs: []types.NamespacedName{gw("gw", "ns")},
+			expected:    false,
+		},
+		{
+			name: "relevant parent with missing Accepted condition is not ready",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							ParentRef: igwapi.ParentReference{Name: "gw", Namespace: "ns"},
+							Conditions: []metav1.Condition{
+								{Type: "ResolvedRefs", Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("gw", "ns")},
+			expected:    false,
+		},
+		{
+			name: "relevant parent with stale Accepted condition is not ready",
+			pool: &igwapi.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{Generation: 5},
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							ParentRef: igwapi.ParentReference{Name: "gw", Namespace: "ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue, ObservedGeneration: 3},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("gw", "ns")},
+			expected:    false,
+		},
+		{
+			name: "stale accepted parent from old gateway does not make pool ready when current is rejected",
+			pool: &igwapi.InferencePool{
+				Status: igwapi.InferencePoolStatus{
+					Parents: []igwapi.ParentStatus{
+						{
+							ParentRef: igwapi.ParentReference{Name: "old-gateway", Namespace: "old-ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+						{
+							ParentRef: igwapi.ParentReference{Name: "current-gateway", Namespace: "current-ns"},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapi.InferencePoolConditionAccepted), Status: metav1.ConditionFalse, Reason: "NotAllowedByListeners"},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("current-gateway", "current-ns")},
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llmisvc.IsInferencePoolReadyForGateways(tt.pool, tt.resolvedGWs)
+			if got != tt.expected {
+				t.Errorf("IsInferencePoolReadyForGateways() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsInferencePoolV1Alpha2ReadyForGateways(t *testing.T) {
+	tests := []struct {
+		name        string
+		pool        *igwapiv1alpha2.InferencePool
+		resolvedGWs []types.NamespacedName
+		expected    bool
+	}{
+		{
+			name: "stale rejected parent from old gateway does not block readiness",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "old-gateway", Namespace: ptr.To(igwapiv1alpha2.Namespace("gw-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionFalse, Reason: "HTTPRouteNotAccepted"},
+							},
+						},
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "current-gateway", Namespace: ptr.To(igwapiv1alpha2.Namespace("gw-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("current-gateway", "gw-ns")},
+			expected:    true,
+		},
+		{
+			name: "all relevant parents rejected means not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "current-gateway", Namespace: ptr.To(igwapiv1alpha2.Namespace("gw-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionFalse, Reason: "NotAllowedByListeners"},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("current-gateway", "gw-ns")},
+			expected:    false,
+		},
+		{
+			name: "no matching parents for current gateway means not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "old-gateway", Namespace: ptr.To(igwapiv1alpha2.Namespace("old-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("new-gateway", "ingress-ns")},
+			expected:    false,
+		},
+		{
+			name: "nil resolvedGWs means no gateways so not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "gw", Namespace: ptr.To(igwapiv1alpha2.Namespace("ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: nil,
+			expected:    false,
+		},
+		{
+			name: "pool parent with omitted namespace matches gateway in pool namespace",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "same-ns-gw", Namespace: ptr.To(igwapiv1alpha2.Namespace("my-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("same-ns-gw", "my-ns")},
+			expected:    true,
+		},
+		{
+			name: "not ready when only some gateways have matching pool parents",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "gateway-a", Namespace: ptr.To(igwapiv1alpha2.Namespace("gw-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{
+				gw("gateway-a", "gw-ns"),
+				gw("gateway-b", "gw-ns"),
+			},
+			expected: false,
+		},
+		{
+			name:        "nil pool is not ready",
+			pool:        nil,
+			resolvedGWs: []types.NamespacedName{gw("gw", "ns")},
+			expected:    false,
+		},
+		{
+			name: "pool with empty status parents is not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{Parents: []igwapiv1alpha2.PoolStatus{}},
+			},
+			resolvedGWs: []types.NamespacedName{gw("gw", "ns")},
+			expected:    false,
+		},
+		{
+			name: "relevant parent with missing Accepted condition is not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "gw", Namespace: ptr.To(igwapiv1alpha2.Namespace("ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: "ResolvedRefs", Status: metav1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("gw", "ns")},
+			expected:    false,
+		},
+		{
+			name: "relevant parent with stale Accepted condition is not ready",
+			pool: &igwapiv1alpha2.InferencePool{
+				ObjectMeta: metav1.ObjectMeta{Generation: 5},
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "gw", Namespace: ptr.To(igwapiv1alpha2.Namespace("ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue, ObservedGeneration: 3},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("gw", "ns")},
+			expected:    false,
+		},
+		{
+			name: "stale accepted parent from old gateway does not make pool ready when current is rejected",
+			pool: &igwapiv1alpha2.InferencePool{
+				Status: igwapiv1alpha2.InferencePoolStatus{
+					Parents: []igwapiv1alpha2.PoolStatus{
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "old-gateway", Namespace: ptr.To(igwapiv1alpha2.Namespace("old-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionTrue},
+							},
+						},
+						{
+							GatewayRef: igwapiv1alpha2.ParentGatewayReference{
+								Name: "current-gateway", Namespace: ptr.To(igwapiv1alpha2.Namespace("current-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{Type: string(igwapiv1alpha2.InferencePoolConditionAccepted), Status: metav1.ConditionFalse, Reason: "NotAllowedByListeners"},
+							},
+						},
+					},
+				},
+			},
+			resolvedGWs: []types.NamespacedName{gw("current-gateway", "current-ns")},
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := llmisvc.IsInferencePoolV1Alpha2ReadyForGateways(tt.pool, tt.resolvedGWs)
+			if got != tt.expected {
+				t.Errorf("IsInferencePoolV1Alpha2ReadyForGateways() = %v, want %v", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

InferencePool.Status.Parents is managed by external gateway controllers, not by KServe. When evaluating pool readiness, only parents matching gateways currently referenced by the HTTPRoute are relevant; entries from previously referenced gateways should not affect the readiness decision.

The existing check iterated all parent entries and treated any rejected parent as a hard failure, causing `InferencePoolNotReady` after switching gateways until the external gateway controller reconciles the pool - even though the current gateway accepted the pool.

Scopes `InferencePool` readiness evaluation to only the gateways resolved from the current `HTTPRoute#parentRefs`.

Also moves all `v1alpha2.InferencePool` readiness helpers into a dedicated `router_discovery_giev1alpha2.go` file so dropping `v1alpha2` support will be a single file deletion.

**Feature/Issue validation/testing**:

- [x] Unit tests
- [x] Integration tests

**Special notes for your reviewer**:

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fixes stale InferencePool parent entries from previously-referenced gateways, blocking LLMInferenceService readiness after gateway ref changes.
```