### PR TITLE
fix(helm): apply kserve.storage.resources to storageInitializer config

### DIFF
--- a/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/charts/kserve-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-resources/files/common/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},


### PR DESCRIPTION
**What this PR does / why we need it**:

The `storageInitializer` block in the `inferenceservice-config` ConfigMap hardcoded its memory/CPU requests and limits. As a result, the chart's documented `kserve.storage.resources` value had no effect on the storage initializer init container — it was only applied to the `ClusterStorageContainer/default` resource.

This was misleading and broke large-model deploys: `LLMInferenceService` reads storage-init resources from the ConfigMap (not from `ClusterStorageContainer`), so setting e.g. `--set kserve.storage.resources.limits.memory=32Gi` silently had no effect and the init container OOMed (exit 137) on large models.

This PR templates the four resource fields (`memoryRequest`, `memoryLimit`, `cpuRequest`, `cpuLimit`) from `.Values.kserve.storage.resources` in the `configmap-patch.yaml` of both the `kserve-resources` and `kserve-llmisvc-resources` charts, matching the existing style of sibling blocks and the `ClusterStorageContainer` patch.

**Which issue(s) this PR fixes**:
Fixes #5412

**Feature/Issue validation/testing**:

Verified by rendering both charts with `helm template`, with defaults and with overrides:

- [x] **Default render — no regression** (values unchanged: `100Mi` / `1Gi` / `100m` / `1`)

  ```console
  $ helm template kserve charts/kserve-resources | grep -A6 'storageInitializer: |-'
    storageInitializer: |-
      {
          "image" : "kserve/storage-initializer:v0.19.0",
          "memoryRequest": "100Mi",
          "memoryLimit": "1Gi",
          "cpuRequest": "100m",
          "cpuLimit": "1",
  ```

- [x] **Override render — value now applied** (`512Mi` / `32Gi` / `500m` / `4`)

  ```console
  $ helm template kserve charts/kserve-resources \
      --set kserve.storage.resources.requests.memory=512Mi \
      --set kserve.storage.resources.limits.memory=32Gi \
      --set kserve.storage.resources.requests.cpu=500m \
      --set kserve.storage.resources.limits.cpu=4 \
      | grep -A6 'storageInitializer: |-'
    storageInitializer: |-
      {
          "image" : "kserve/storage-initializer:v0.19.0",
          "memoryRequest": "512Mi",
          "memoryLimit": "32Gi",
          "cpuRequest": "500m",
          "cpuLimit": "4",
  ```

- [x] Same results verified for the `kserve-llmisvc-resources` chart.
- [x] `helm lint` passes for both charts.

**Special notes for your reviewer**:

The codebase has been restructured since the issue was filed (v0.16.0): the ConfigMap is now built from a static base file merged with a `tpl`-rendered patch file via the `kserve-common.renderPatchedResource` helper. The base file is loaded raw (not templated), so the live value comes from `configmap-patch.yaml` — that's the file changed here. No `values.yaml` or README changes are needed, since `kserve.storage.resources` was already defined and documented.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? *(Validated via `helm template` render diffs above; the charts have no unit-test harness for ConfigMap content.)*
- [x] Has code been commented, particularly in hard-to-understand areas? *(N/A — templating change matching existing block style.)*
- [ ] Have you made corresponding changes to the documentation? *(N/A — value was already documented.)*

**Release note**:

```release-note
fix(helm): apply `kserve.storage.resources` to the storageInitializer config in the inferenceservice-config ConfigMap, so storage-init container memory/CPU requests and limits are now configurable (previously hardcoded and ignored for InferenceService and LLMInferenceService).
```
