### PR TITLE
fix(llmisvc): reduce K8s object noise in test assertion output

### DIFF
--- a/test/e2e/llmisvc/diagnostic.py
+++ b/test/e2e/llmisvc/diagnostic.py
@@ -22,6 +22,16 @@ from typing import Callable, Optional
 _log = logging.getLogger(__name__)
 
 
+def strip_managed_fields(d):
+    """Remove managed_fields from a K8s object dict to reduce log noise."""
+    if isinstance(d, dict):
+        d.pop("managed_fields", None)
+        metadata = d.get("metadata")
+        if isinstance(metadata, dict):
+            metadata.pop("managed_fields", None)
+    return d
+
+
 def print_all_events_table(
     namespace: str,
     max_events: int = 50,

--- a/test/e2e/llmisvc/test_llm_autoscaling.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling.py
@@ -331,16 +331,20 @@ def assert_metrics_pipeline_ready(actuator="hpa"):
             namespace=PROMETHEUS_NAMESPACE,
             label_selector="app.kubernetes.io/name=prometheus-adapter",
         )
-        running = [p for p in pods.items if p.status.phase == "Running"]
-        assert len(running) > 0, "No running Prometheus Adapter pods found"
+        running_names = [
+            p.metadata.name for p in pods.items if p.status.phase == "Running"
+        ]
+        assert running_names, "No running Prometheus Adapter pods found"
     elif actuator == "keda":
         v1 = client.CoreV1Api()
         pods = v1.list_namespaced_pod(
             namespace=KEDA_NAMESPACE,
             label_selector="app.kubernetes.io/name=keda-operator",
         )
-        running = [p for p in pods.items if p.status.phase == "Running"]
-        assert len(running) > 0, "No running KEDA operator pods found"
+        running_names = [
+            p.metadata.name for p in pods.items if p.status.phase == "Running"
+        ]
+        assert running_names, "No running KEDA operator pods found"
 
 
 def assert_wva_metric_exists(service_name, namespace=KSERVE_TEST_NAMESPACE):

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -28,6 +28,7 @@ from .diagnostic import (
     collect_pod_logs,
     kinds_matching_by_labels,
     print_all_events_table,
+    strip_managed_fields,
 )
 from .fixtures import (
     KSERVE_TEST_NAMESPACE,
@@ -969,8 +970,9 @@ def _wait_for_llmisvc_pods_deleted(
 
     def assert_no_pods():
         pods = core_v1.list_namespaced_pod(namespace, label_selector=label_selector)
-        assert not pods.items, (
-            f"{len(pods.items)} pod(s) for {service_name} still terminating"
+        pod_names = [p.metadata.name for p in pods.items]
+        assert not pod_names, (
+            f"{len(pod_names)} pod(s) for {service_name} still terminating: {pod_names}"
         )
 
     try:
@@ -1238,4 +1240,6 @@ def _collect_diagnostics(
     all_resources = kinds_matching_by_labels(ns, labels)
     for obj in all_resources:
         logger.info(f"{log_prefix} ---")
-        logger.info(yaml.safe_dump(obj.to_dict(), sort_keys=False))
+        logger.info(
+            yaml.safe_dump(strip_managed_fields(obj.to_dict()), sort_keys=False)
+        )

--- a/test/e2e/llmisvc/test_pod_watch.py
+++ b/test/e2e/llmisvc/test_pod_watch.py
@@ -33,6 +33,7 @@ from kubernetes import client
 
 from kserve import KServeClient, V1alpha1LLMInferenceService, constants
 
+from .diagnostic import strip_managed_fields
 from .fixtures import (
     KSERVE_TEST_NAMESPACE,
     OPT_125M_MODEL_URI,
@@ -95,7 +96,7 @@ def get_pods_for_llmisvc(name: str, namespace: str) -> list[dict]:
             namespace=namespace,
             label_selector=f"{LLMISVC_POD_LABEL_PART_OF}={LLMISVC_POD_LABEL_PART_OF_VALUE},{LLMISVC_POD_LABEL_NAME}={name}",
         )
-        return [pod.to_dict() for pod in pods.items]
+        return [strip_managed_fields(pod.to_dict()) for pod in pods.items]
     except Exception as e:
         return [{"error": f"Failed to list pods for LLMISVC {name}: {e}"}]
 
@@ -108,7 +109,7 @@ def get_deployments_for_llmisvc(name: str, namespace: str) -> list[dict]:
             namespace=namespace,
             label_selector=f"{LLMISVC_POD_LABEL_PART_OF}={LLMISVC_POD_LABEL_PART_OF_VALUE},{LLMISVC_POD_LABEL_NAME}={name}",
         )
-        return [dep.to_dict() for dep in deployments.items]
+        return [strip_managed_fields(dep.to_dict()) for dep in deployments.items]
     except Exception as e:
         return [{"error": f"Failed to list deployments for LLMISVC {name}: {e}"}]
 

--- a/test/e2e/llmisvc/test_prestop_hook.py
+++ b/test/e2e/llmisvc/test_prestop_hook.py
@@ -143,8 +143,11 @@ def wait_for_workload_pod_running(
             if p.status.phase == "Running"
             and all(cs.ready for cs in (p.status.container_statuses or []))
         ]
-        assert running, f"No Running pods found for {label_selector} in {namespace}"
-        return running[0].metadata.name
+        running_names = [p.metadata.name for p in running]
+        assert running_names, (
+            f"No Running pods found for {label_selector} in {namespace}"
+        )
+        return running_names[0]
 
     return wait_for(assert_pod_running, timeout=timeout_seconds, interval=5.0)
 


### PR DESCRIPTION
Assert on pod names instead of full V1Pod objects so pytest's assert introspection shows useful info rather than pages of managed_fields and None values. Strip managed_fields from diagnostic dumps as well.

An example https://github.com/kserve/kserve/actions/runs/27759842580/job/82132722768?pr=5400