### PR TITLE
fix: template storage resources in inferenceservice-config ConfigMap

### DIFF
--- a/charts/_common/common-patches/configmap-patch.yaml
+++ b/charts/_common/common-patches/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/charts/kserve-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-resources/files/common/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},


### PR DESCRIPTION
**What this PR does / why we need it**:

The `storageInitializer` section in the `inferenceservice-config` ConfigMap has hardcoded resource values (`100Mi`/`1Gi`/`100m`/`1`) in the `kserve-resources`, `kserve-llmisvc-resources`, and `_common` chart patches.

Setting `kserve.storage.resources` in `values.yaml` only updates the `ClusterStorageContainer` but not the ConfigMap. `LLMInferenceService` reads storage-init resources from the ConfigMap, so it still uses the old 1Gi memory limit and OOMs on large models.

This PR templates the four resource fields from `.Values.kserve.storage.resources` so the chart value works for both `InferenceService` and `LLMInferenceService`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5412

**Feature/Issue validation/testing**:

- [x] `make lint-helm-charts` passes for all charts
- [x] `make verify-helm-helpers-consistency` passes
- [x] `helm template` with default values renders identical output to before (backward compatible)
- [x] `helm template` with `--set kserve.storage.resources.limits.memory=32Gi` correctly renders `"memoryLimit": "32Gi"` in the ConfigMap

```bash
# Verify override works
helm template test charts/kserve-resources \
  --set kserve.storage.resources.limits.memory=32Gi | \
  grep -A4 '"storageInitializer"'
```

Fix kserve.storage.resources values not being applied to the inferenceservice-config ConfigMap storageInitializer section, causing LLMInferenceService storage-init containers to OOM with the hardcoded 1Gi memory limit.
