### PR TITLE
fix: prevent agent crash when model spec unmarshal fails

### DIFF
--- a/pkg/agent/syncer.go
+++ b/pkg/agent/syncer.go
@@ -71,7 +71,7 @@ func SyncModelDir(modelDir string, logger *zap.SugaredLogger) (map[string]modelW
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "error in syncing model dir")
+		return modelTracker, errors.Wrapf(err, "error in syncing model dir")
 	}
 	return modelTracker, nil
 }

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -67,6 +67,20 @@ var _ = Describe("Watcher", func() {
 	})
 
 	Describe("Sync models config on startup", func() {
+		It("should not crash after sync error", func() {
+			badModelDir := filepath.Join(modelDir, "bad-model")
+			configDir := filepath.Join(modelDir, "configs")
+			Expect(os.MkdirAll(badModelDir, os.ModePerm)).To(Succeed())                                       //nolint:gosec // G301: test directory
+			Expect(os.MkdirAll(configDir, os.ModePerm)).To(Succeed())                                         //nolint:gosec // G301: test directory
+			Expect(os.WriteFile(filepath.Join(badModelDir, "SUCCESS.bad"), []byte("{"), 0o644)).To(Succeed()) //nolint:gosec // G306: test file
+			modelConfigs := modelconfig.ModelConfigs{{Name: "model1"}}
+			data, err := json.Marshal(modelConfigs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(os.WriteFile(filepath.Join(configDir, constants.ModelConfigFileName), data, 0o644)).To(Succeed()) //nolint:gosec // G306: test file
+			Expect(func() {
+				NewWatcher(configDir, modelDir, sugar)
+			}).ToNot(Panic())
+		})
 		Context("Getting new model events", func() {
 			It("should download and load the new models", func() {
 				logger.Printf("Sync model config using temp dir %v\n", modelDir)


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents the model agent from crashing when `SyncModelDir` fails to unmarshal a recovered `SUCCESS.*` file. The agent already logs the sync error and continues startup, but `SyncModelDir` previously returned a nil model tracker on error, which could later panic in `parseConfig` with `assignment to entry in nil map`.

Fixes #2245

**Feature/Issue validation/testing**:

- Added a regression test covering malformed `SUCCESS.*` recovery metadata during watcher startup.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?
