### PR TITLE
feat(charts): make uidModelCar setting nullable

### DIFF
--- a/charts/_common/common-patches/configmap-patch.yaml
+++ b/charts/_common/common-patches/configmap-patch.yaml
@@ -108,7 +108,9 @@ data:
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},
+        {{- if .Values.kserve.storage.uidModelcar }}
         "uidModelcar": {{ .Values.kserve.storage.uidModelcar }},
+        {{- end }}
         "cpuModelcar": "{{ .Values.kserve.storage.cpuModelcar }}",
         "memoryModelcar": "{{ .Values.kserve.storage.memoryModelcar }}"
     }

--- a/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
@@ -108,7 +108,9 @@ data:
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},
+        {{- if .Values.kserve.storage.uidModelcar }}
         "uidModelcar": {{ .Values.kserve.storage.uidModelcar }},
+        {{- end }}
         "cpuModelcar": "{{ .Values.kserve.storage.cpuModelcar }}",
         "memoryModelcar": "{{ .Values.kserve.storage.memoryModelcar }}"
     }

--- a/charts/kserve-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-resources/files/common/configmap-patch.yaml
@@ -108,7 +108,9 @@ data:
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},
+        {{- if .Values.kserve.storage.uidModelcar }}
         "uidModelcar": {{ .Values.kserve.storage.uidModelcar }},
+        {{- end }}
         "cpuModelcar": "{{ .Values.kserve.storage.cpuModelcar }}",
         "memoryModelcar": "{{ .Values.kserve.storage.memoryModelcar }}"
     }


### PR DESCRIPTION

**What this PR does / why we need it**:

This is just a small patch to allow setting of uidModelCar in the inferenceservice-config map via the chart, optional, as the present template forces a value to be set. Per the example config, this should be optional, and I was able to confirm this did resolve a nagging issue trying to use modelcars across components that may disagree on UID.
 
**Feature/Issue validation/testing**:

- I've deployed with this variation to confirm it can NOT set the uidModelCar, when the input values sets it explicitly to `null`, and by helm conventions, the field becomes unset from it's default value. Prior to this patch, the configmap would simply contain invalid config, with a missing value for uidModelCar. (And that I can now leverage the feature of not forcing UIDs across containers by not setting it in inferenceservice-config by doing so.)

**Checklist**:

Not sure what if any of this is needed, considering how narrow this change is. In terms of documentation, if anything, the helm is more aligned to the documented fact this feature should be optional. (I can add a note to readmes or other places, just let me know where.)

- Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- Has code been commented, particularly in hard-to-understand areas?
- Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Fixed helm expression of inferenceservice-config to allow uidModelCar to be optional
```