### PR TITLE
fix: resolve UnicodeDecodeError for binary gRPC payloads in as_dataframe

### DIFF
--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -856,10 +856,15 @@ class InferRequest:
         for input in self.inputs:
             input_data = input.data
             if input.datatype == "BYTES":
-                input_data = [
-                    str(val, "utf-8") if isinstance(val, bytes) else val
-                    for val in input.data
-                ]
+                input_data = []
+                for val in input.data:
+                    if isinstance(val, bytes):
+                        try:
+                            input_data.append(val.decode("utf-8"))
+                        except UnicodeDecodeError:
+                            input_data.append(val)
+                    else:
+                        input_data.append(val)
             dfs.append(pd.DataFrame(input_data, columns=[input.name]))
         return pd.concat(dfs, axis=1)
 

--- a/python/kserve/test/test_infer_type.py
+++ b/python/kserve/test/test_infer_type.py
@@ -621,6 +621,68 @@ class TestInferRequest:
         assert infer_request.inputs[0].data == [1, 2, 3]
         assert infer_request.request_outputs is None
 
+    def test_as_dataframe_with_binary_bytes(self):
+        """Test that as_dataframe handles non-UTF-8 binary BYTES inputs without raising UnicodeDecodeError.
+
+        Regression test for https://github.com/kserve/kserve/issues/3731
+        """
+        binary_data = [b"\xff\x00\xfe", b"\x80\x81\x82"]
+        infer_req = InferRequest(
+            model_name="TestModel",
+            infer_inputs=[
+                InferInput(
+                    name="input-0",
+                    datatype="BYTES",
+                    shape=[2],
+                    data=binary_data,
+                )
+            ],
+        )
+        # Should not raise UnicodeDecodeError
+        df = infer_req.as_dataframe()
+        assert list(df.columns) == ["input-0"]
+        assert len(df) == 2
+        # Binary data that can't be decoded as UTF-8 should be preserved as raw bytes
+        assert df["input-0"].iloc[0] == b"\xff\x00\xfe"
+        assert df["input-0"].iloc[1] == b"\x80\x81\x82"
+
+    def test_as_dataframe_with_utf8_bytes(self):
+        """Test that as_dataframe still correctly decodes valid UTF-8 BYTES inputs."""
+        utf8_data = [b"hello", b"world"]
+        infer_req = InferRequest(
+            model_name="TestModel",
+            infer_inputs=[
+                InferInput(
+                    name="input-0",
+                    datatype="BYTES",
+                    shape=[2],
+                    data=utf8_data,
+                )
+            ],
+        )
+        df = infer_req.as_dataframe()
+        assert list(df.columns) == ["input-0"]
+        assert df["input-0"].iloc[0] == "hello"
+        assert df["input-0"].iloc[1] == "world"
+
+    def test_as_dataframe_with_mixed_bytes(self):
+        """Test that as_dataframe handles a mix of valid UTF-8 and raw binary BYTES inputs."""
+        mixed_data = [b"hello", b"\xff\x00"]
+        infer_req = InferRequest(
+            model_name="TestModel",
+            infer_inputs=[
+                InferInput(
+                    name="input-0",
+                    datatype="BYTES",
+                    shape=[2],
+                    data=mixed_data,
+                )
+            ],
+        )
+        df = infer_req.as_dataframe()
+        assert df["input-0"].iloc[0] == "hello"
+        assert df["input-0"].iloc[1] == b"\xff\x00"
+
 
 class TestInferResponse:
     def test_to_grpc(self):


### PR DESCRIPTION
**What this PR does / why we need it**:
* Resolves a `UnicodeDecodeError` crash during DataFrame conversion when gRPC `ModelInfer` requests contain raw binary data in `BYTES`-typed tensors.
* Replaces the unconditional `str(val, 'utf-8')` list comprehension in `InferRequest.as_dataframe()` with a `try/except` loop. 
* Valid UTF-8 strings decode normally. Non-UTF-8 binary payloads (e.g., image tensors containing `0xff`) safely fall back to raw `bytes` in the resulting DataFrame, preserving the payload for downstream models.

**Which issue(s) this PR fixes**:
Fixes #3731

**Feature/Issue validation/testing**:
- [x] Added `test_as_dataframe_with_binary_bytes` to assert non-UTF-8 payloads do not raise exceptions and retain raw bytes.
- [x] Added `test_as_dataframe_with_utf8_bytes` to assert valid UTF-8 strings decode correctly without regression.
- [x] Added `test_as_dataframe_with_mixed_bytes` to assert mixed payloads within the same tensor are handled accurately.
- [x] Static analysis and formatting validated via `ruff`.

**Special notes for your reviewer**:
N/A

**Checklist**:
- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix: Resolve `UnicodeDecodeError` in `InferRequest.as_dataframe()` when processing non-UTF-8 binary gRPC payloads in `BYTES` tensors.