### PR TITLE
fix(llmisvc): disable readOnlyRootFilesystem for nvidia-cdi-hook

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -201,7 +201,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -278,7 +278,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: FallbackToLogsOnError
@@ -540,7 +540,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -616,7 +616,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -857,7 +857,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -1095,7 +1095,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -1375,7 +1375,7 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -1629,7 +1629,7 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -2284,7 +2284,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -2575,7 +2575,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -2829,7 +2829,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -176,7 +176,8 @@ spec:
             value: /models
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # nvidia-cdi-hook requires a writable root filesystem
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           capabilities:
             drop:
@@ -237,7 +238,8 @@ spec:
         resources: { }
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # nvidia-cdi-hook requires a writable root filesystem
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           capabilities:
             drop:

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -16,7 +16,8 @@ spec:
             protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # nvidia-cdi-hook requires a writable root filesystem
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           capabilities:
             drop:
@@ -268,7 +269,8 @@ spec:
             value: /models
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # nvidia-cdi-hook requires a writable root filesystem
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           capabilities:
             add:
@@ -542,7 +544,8 @@ spec:
             value: "1"
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # nvidia-cdi-hook requires a writable root filesystem
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           capabilities:
             add:

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -177,7 +177,8 @@ spec:
               value: /models
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            # nvidia-cdi-hook requires a writable root filesystem
+            readOnlyRootFilesystem: false
             runAsNonRoot: true
             capabilities:
               drop:

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -209,7 +209,8 @@ spec:
               value: /models
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            # nvidia-cdi-hook requires a writable root filesystem
+            readOnlyRootFilesystem: false
             runAsNonRoot: true
             capabilities:
               add:
@@ -481,7 +482,8 @@ spec:
               value: /models
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            # nvidia-cdi-hook requires a writable root filesystem
+            readOnlyRootFilesystem: false
             runAsNonRoot: true
             capabilities:
               add:

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -176,7 +176,8 @@ spec:
             value: /models
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # nvidia-cdi-hook requires a writable root filesystem
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           capabilities:
             drop:

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -208,7 +208,8 @@ spec:
             value: /models
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # nvidia-cdi-hook requires a writable root filesystem
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           capabilities:
             add:
@@ -480,7 +481,8 @@ spec:
             value: /models
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          # nvidia-cdi-hook requires a writable root filesystem
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           capabilities:
             add:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2804,7 +2804,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -2881,7 +2881,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: FallbackToLogsOnError
@@ -3143,7 +3143,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -3219,7 +3219,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -3460,7 +3460,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -3698,7 +3698,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -3978,7 +3978,7 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -4232,7 +4232,7 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -4887,7 +4887,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -5178,7 +5178,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -5432,7 +5432,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2390,7 +2390,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -2467,7 +2467,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: FallbackToLogsOnError
@@ -2729,7 +2729,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -2805,7 +2805,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -3046,7 +3046,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -3284,7 +3284,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -3564,7 +3564,7 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -3818,7 +3818,7 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -4473,7 +4473,7 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -4764,7 +4764,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
@@ -5018,7 +5018,7 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
+        readOnlyRootFilesystem: false
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -140,7 +140,7 @@ func TestPresetFiles(t *testing.T) {
 										Capabilities: &corev1.Capabilities{
 											Drop: []corev1.Capability{"ALL"},
 										},
-										ReadOnlyRootFilesystem: ptr.To(true),
+										ReadOnlyRootFilesystem: ptr.To(false),
 										SeccompProfile: &corev1.SeccompProfile{
 											Type: corev1.SeccompProfileTypeRuntimeDefault,
 										},
@@ -289,7 +289,7 @@ func TestPresetFiles(t *testing.T) {
 										},
 										AllowPrivilegeEscalation: ptr.To(false),
 										RunAsNonRoot:             ptr.To(true),
-										ReadOnlyRootFilesystem:   ptr.To(true),
+										ReadOnlyRootFilesystem:   ptr.To(false),
 										SeccompProfile: &corev1.SeccompProfile{
 											Type: corev1.SeccompProfileTypeRuntimeDefault,
 										},
@@ -377,7 +377,7 @@ func TestPresetFiles(t *testing.T) {
 										},
 										AllowPrivilegeEscalation: ptr.To(false),
 										RunAsNonRoot:             ptr.To(true),
-										ReadOnlyRootFilesystem:   ptr.To(true),
+										ReadOnlyRootFilesystem:   ptr.To(false),
 										SeccompProfile: &corev1.SeccompProfile{
 											Type: corev1.SeccompProfileTypeRuntimeDefault,
 										},
@@ -562,7 +562,7 @@ func TestPresetFiles(t *testing.T) {
 										},
 										AllowPrivilegeEscalation: ptr.To(false),
 										RunAsNonRoot:             ptr.To(true),
-										ReadOnlyRootFilesystem:   ptr.To(true),
+										ReadOnlyRootFilesystem:   ptr.To(false),
 										SeccompProfile: &corev1.SeccompProfile{
 											Type: corev1.SeccompProfileTypeRuntimeDefault,
 										},


### PR DESCRIPTION
The nvidia-cdi-hook fails with exit code 1 when the container has a read-only root filesystem, preventing container creation on GPU nodes.

