### PR TITLE
docs(llmisvc): update sample for using explicit p/d roles for kv_role

### DIFF
--- a/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-pd-gpu-p-deepep-ht-d-deepep-ht.yaml
+++ b/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-pd-gpu-p-deepep-ht-d-deepep-ht.yaml
@@ -42,7 +42,7 @@ spec:
           #- name: VLLM_MOE_DP_CHUNK_SIZE
           #  value: "32"
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--gpu-memory-utilization 0.99 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+            value: "--gpu-memory-utilization 0.99 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
           - name: VLLM_NIXL_SIDE_CHANNEL_HOST
             valueFrom:
               fieldRef:
@@ -145,7 +145,7 @@ spec:
           #- name: VLLM_MOE_DP_CHUNK_SIZE
           #  value: "32"
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--gpu-memory-utilization 0.99 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+            value: "--gpu-memory-utilization 0.99 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
           - name: VLLM_NIXL_SIDE_CHANNEL_HOST
             valueFrom:
               fieldRef:
@@ -232,7 +232,7 @@ spec:
               value: "PCI_BUS_ID"
             # Memory optimizations
             - name: VLLM_ADDITIONAL_ARGS
-              value: "--gpu-memory-utilization 0.97 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+              value: "--gpu-memory-utilization 0.97 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
                 fieldRef:
@@ -321,7 +321,7 @@ spec:
               value: "PCI_BUS_ID"
             # Memory optimizations
             - name: VLLM_ADDITIONAL_ARGS
-              value: "--gpu-memory-utilization 0.97 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+              value: "--gpu-memory-utilization 0.97 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
                 fieldRef:

--- a/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-pd-gpu-p-deepep-ht-d-pplx.yaml
+++ b/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-pd-gpu-p-deepep-ht-d-pplx.yaml
@@ -35,7 +35,7 @@ spec:
             value: "PCI_BUS_ID"
           # Memory optimizations
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--gpu-memory-utilization 0.99 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+            value: "--gpu-memory-utilization 0.99 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
           - name: VLLM_NIXL_SIDE_CHANNEL_HOST
             valueFrom:
               fieldRef:
@@ -124,7 +124,7 @@ spec:
             value: "PCI_BUS_ID"
           # Memory optimizations
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--gpu-memory-utilization 0.99 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+            value: "--gpu-memory-utilization 0.99 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
           - name: VLLM_NIXL_SIDE_CHANNEL_HOST
             valueFrom:
               fieldRef:
@@ -211,7 +211,7 @@ spec:
               value: "PCI_BUS_ID"
             # Memory optimizations
             - name: VLLM_ADDITIONAL_ARGS
-              value: "--gpu-memory-utilization 0.97 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+              value: "--gpu-memory-utilization 0.97 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
                 fieldRef:
@@ -300,7 +300,7 @@ spec:
               value: "PCI_BUS_ID"
             # Memory optimizations
             - name: VLLM_ADDITIONAL_ARGS
-              value: "--gpu-memory-utilization 0.97 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+              value: "--gpu-memory-utilization 0.97 --max-model-len 4096 --enforce-eager --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
                 fieldRef:

--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -233,8 +233,8 @@ for an in depth description.
 
 This creates `llmisvc-config-pd-disagg`. It adds:
 
-- Decode container with vLLM args: `--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"`
-- Prefill container with 2 replicas and same vLLM args 
+- Decode container with vLLM args: `--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"`
+- Prefill container with 2 replicas and vLLM args: `--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"`
 - Scheduler needs `hf-token` secret for tokenizer download (already created above)
 
 ### 9.2 Switch Inference to prefill/decode disaggregation

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_pd_disagg.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_pd_disagg.yaml
@@ -27,7 +27,7 @@ spec:
                 fieldPath: status.podIP
           # Enable KV cache transfer via NixlConnector (RDMA-based)
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+            value: "--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
           # UCX configuration for RDMA transport
           - name: UCX_PROTO_INFO
             value: "y"
@@ -66,7 +66,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: VLLM_ADDITIONAL_ARGS
-              value: "--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+              value: "--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
             - name: UCX_PROTO_INFO
               value: "y"
             - name: UCX_TLS

--- a/docs/samples/llmisvc/single-node-gpu/llm-inference-service-pd-qwen2-7b-gpu.yaml
+++ b/docs/samples/llmisvc/single-node-gpu/llm-inference-service-pd-qwen2-7b-gpu.yaml
@@ -43,7 +43,7 @@ spec:
                 fieldPath: status.podIP
           # Enable KV cache transfer via NixlConnector (RDMA-based)
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+            value: "--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
           # UCX configuration for RDMA transport
           - name: UCX_PROTO_INFO
             value: "y"
@@ -97,7 +97,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: VLLM_ADDITIONAL_ARGS
-              value: "--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'"
+              value: "--kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
             - name: UCX_PROTO_INFO
               value: "y"
             - name: UCX_TLS


### PR DESCRIPTION
**What this PR does / why we need it**:
vLLM 0.23.0 deprecated kv_role "kv_both" for NixlConnector in P/D setups. 
Update sample manifests to use "kv_producer" for prefill and "kv_consumer" for decode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:
https://llm-d.slack.com/archives/C08T1E128PK/p1780927199423439
https://github.com/vllm-project/vllm/pull/43874


**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```
