### PR TITLE
fix(agent): contain object storage downloads

### DIFF
--- a/pkg/agent/storage/azure.go
+++ b/pkg/agent/storage/azure.go
@@ -18,8 +18,8 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -58,16 +58,11 @@ func (a AzureProvider) DownloadModel(modelDir string, modelName string, storageU
 			return err
 		}
 		for _, _blob := range resp.Segment.BlobItems {
-			fileName := filepath.Join(modelDir, modelName, *_blob.Name)
-			log.Info("Downloading blob %s", "fileName", fileName)
-			file, err := os.Create(filepath.Clean(fileName))
+			file, fileName, err := createLocalModelFile(modelDir, modelName, *_blob.Name)
 			if err != nil {
 				return err
 			}
-			defer func(destFile *os.File) {
-				err = destFile.Close()
-				log.Error(err, "Error closing file")
-			}(file)
+			log.Info("Downloading blob %s", "fileName", fileName)
 
 			_, err = a.Client.DownloadFile(ctx, bucket, prefix, file,
 				&azblob.DownloadFileOptions{
@@ -77,7 +72,11 @@ func (a AzureProvider) DownloadModel(modelDir string, modelName string, storageU
 					},
 				})
 			if err != nil {
+				_ = file.Close()
 				return err
+			}
+			if err := file.Close(); err != nil {
+				return fmt.Errorf("failed to close file %s: %w", fileName, err)
 			}
 		}
 	}

--- a/pkg/agent/storage/azure_test.go
+++ b/pkg/agent/storage/azure_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+)
+
+type azureTraversalClient struct {
+	blobName string
+}
+
+func (c *azureTraversalClient) NewListBlobsFlatPager(bucket string, _ *azblob.ListBlobsFlatOptions) *runtime.Pager[azblob.ListBlobsFlatResponse] {
+	return runtime.NewPager(runtime.PagingHandler[azblob.ListBlobsFlatResponse]{
+		More: func(azblob.ListBlobsFlatResponse) bool { return false },
+		Fetcher: func(context.Context, *azblob.ListBlobsFlatResponse) (azblob.ListBlobsFlatResponse, error) {
+			return azblob.ListBlobsFlatResponse{
+				ListBlobsFlatSegmentResponse: container.ListBlobsFlatSegmentResponse{
+					ContainerName: &bucket,
+					Segment: &container.BlobFlatListSegment{
+						BlobItems: []*container.BlobItem{{Name: &c.blobName}},
+					},
+				},
+			}, nil
+		},
+	})
+}
+
+func (c *azureTraversalClient) DownloadFile(context.Context, string, string, *os.File, *azblob.DownloadFileOptions) (int64, error) {
+	return 0, nil
+}
+
+func (c *azureTraversalClient) UploadBuffer(context.Context, string, string, []byte, *azblob.UploadBufferOptions) (azblob.UploadBufferResponse, error) {
+	return azblob.UploadBufferResponse{}, nil
+}
+
+func TestAzureDownloadModelRejectsPathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	outsidePath := filepath.Join(tmpDir, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("do not overwrite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := AzureProvider{Client: &azureTraversalClient{blobName: "prefix/../../../outside.txt"}}
+	err := provider.DownloadModel(filepath.Join(tmpDir, "models"), "model1", "https://container/prefix/")
+	if err == nil {
+		t.Fatal("expected path traversal blob to be rejected")
+	}
+	got, readErr := os.ReadFile(outsidePath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "do not overwrite" {
+		t.Fatalf("outside file contents = %q, want %q", string(got), "do not overwrite")
+	}
+}

--- a/pkg/agent/storage/azure_test.go
+++ b/pkg/agent/storage/azure_test.go
@@ -58,7 +58,7 @@ func (c *azureTraversalClient) UploadBuffer(context.Context, string, string, []b
 func TestAzureDownloadModelRejectsPathTraversal(t *testing.T) {
 	tmpDir := t.TempDir()
 	outsidePath := filepath.Join(tmpDir, "outside.txt")
-	if err := os.WriteFile(outsidePath, []byte("do not overwrite"), 0o644); err != nil {
+	if err := os.WriteFile(outsidePath, []byte("do not overwrite"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -67,7 +67,7 @@ func TestAzureDownloadModelRejectsPathTraversal(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected path traversal blob to be rejected")
 	}
-	got, readErr := os.ReadFile(outsidePath)
+	got, readErr := os.ReadFile(outsidePath) //nolint:gosec // G304: test path is rooted in t.TempDir
 	if readErr != nil {
 		t.Fatal(readErr)
 	}

--- a/pkg/agent/storage/gcs.go
+++ b/pkg/agent/storage/gcs.go
@@ -100,7 +100,10 @@ func (g *GCSObjectDownloader) Download(ctx context.Context, client stiface.Clien
 			return fmt.Errorf("an error occurred while iterating: %w", err)
 		}
 		objectValue := strings.TrimPrefix(attrs.Name, g.Item)
-		fileName := filepath.Join(g.ModelDir, g.ModelName, objectValue)
+		fileName, err := safeLocalModelPath(filepath.Join(g.ModelDir, g.ModelName), objectValue)
+		if err != nil {
+			return err
+		}
 
 		foundObject = true
 		if FileExists(fileName) {

--- a/pkg/agent/storage/gcs.go
+++ b/pkg/agent/storage/gcs.go
@@ -99,7 +99,10 @@ func (g *GCSObjectDownloader) Download(ctx context.Context, client stiface.Clien
 			return fmt.Errorf("an error occurred while iterating: %w", err)
 		}
 		objectValue := strings.TrimPrefix(attrs.Name, g.Item)
-		fileName := filepath.Join(g.ModelDir, g.ModelName, objectValue)
+		fileName, err := safeLocalModelPath(filepath.Join(g.ModelDir, g.ModelName), objectValue)
+		if err != nil {
+			return err
+		}
 
 		foundObject = true
 		if FileExists(fileName) {

--- a/pkg/agent/storage/gcs.go
+++ b/pkg/agent/storage/gcs.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	gstorage "cloud.google.com/go/storage"
@@ -99,24 +98,17 @@ func (g *GCSObjectDownloader) Download(ctx context.Context, client stiface.Clien
 			return fmt.Errorf("an error occurred while iterating: %w", err)
 		}
 		objectValue := strings.TrimPrefix(attrs.Name, g.Item)
-		fileName, err := safeLocalModelPath(filepath.Join(g.ModelDir, g.ModelName), objectValue)
+		file, fileName, err := createLocalModelFile(g.ModelDir, g.ModelName, objectValue)
 		if err != nil {
 			return err
 		}
 
 		foundObject = true
-		if FileExists(fileName) {
-			log.Info("Deleting file", "name", fileName)
-			if err := os.Remove(fileName); err != nil {
-				return fmt.Errorf("file is unable to be deleted: %w", err)
-			}
-		}
-		file, err := Create(fileName)
-		if err != nil {
-			return fmt.Errorf("file is already created: %w", err)
-		}
 		if err := g.DownloadFile(ctx, client, attrs, file); err != nil {
 			errs = append(errs, err)
+		}
+		if err := file.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close file %s: %w", fileName, err))
 		}
 	}
 	if !foundObject {

--- a/pkg/agent/storage/gcs.go
+++ b/pkg/agent/storage/gcs.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
 
 	gstorage "cloud.google.com/go/storage"
@@ -97,7 +98,13 @@ func (g *GCSObjectDownloader) Download(ctx context.Context, client stiface.Clien
 		if err != nil {
 			return fmt.Errorf("an error occurred while iterating: %w", err)
 		}
+		if strings.HasSuffix(attrs.Name, "/") {
+			continue
+		}
 		objectValue := strings.TrimPrefix(attrs.Name, g.Item)
+		if objectValue == "" {
+			objectValue = path.Base(strings.TrimSuffix(attrs.Name, "/"))
+		}
 		file, fileName, err := createLocalModelFile(g.ModelDir, g.ModelName, objectValue)
 		if err != nil {
 			return err

--- a/pkg/agent/storage/gcs_test.go
+++ b/pkg/agent/storage/gcs_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kserve/kserve/pkg/agent/mocks"
+)
+
+func writeGCSObject(t *testing.T, provider *GCSProvider, bucketName string, objectName string, contents string) {
+	t.Helper()
+
+	writer := provider.Client.Bucket(bucketName).Object(objectName).NewWriter(context.Background())
+	if _, err := writer.Write([]byte(contents)); err != nil {
+		t.Fatalf("failed to write object %q: %v", objectName, err)
+	}
+}
+
+func newTestGCSProvider(t *testing.T, bucketName string) *GCSProvider {
+	t.Helper()
+
+	client := mocks.NewMockClient()
+	if err := client.Bucket(bucketName).Create(context.Background(), "test", nil); err != nil {
+		t.Fatalf("failed to create bucket %q: %v", bucketName, err)
+	}
+	return &GCSProvider{Client: client}
+}
+
+func TestGCSDownloadAllowsNestedObjectPath(t *testing.T) {
+	const (
+		bucketName    = "testBucket"
+		modelName     = "model1"
+		modelContents = "Model Contents"
+	)
+
+	provider := newTestGCSProvider(t, bucketName)
+	writeGCSObject(t, provider, bucketName, "models/nested/model.bin", modelContents)
+
+	modelDir := t.TempDir()
+	if err := provider.DownloadModel(modelDir, modelName, "gs://testBucket/models"); err != nil {
+		t.Fatalf("expected download to succeed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(modelDir, modelName, "nested", "model.bin"))
+	if err != nil {
+		t.Fatalf("failed to read downloaded model: %v", err)
+	}
+	if string(got) != modelContents {
+		t.Fatalf("downloaded contents = %q, want %q", string(got), modelContents)
+	}
+}
+
+func TestGCSDownloadRejectsPathTraversal(t *testing.T) {
+	const (
+		bucketName       = "testBucket"
+		modelName        = "model1"
+		originalContents = "do not overwrite"
+	)
+
+	tmpDir := t.TempDir()
+	outsidePath := filepath.Join(tmpDir, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte(originalContents), 0o644); err != nil {
+		t.Fatalf("failed to write outside file: %v", err)
+	}
+
+	provider := newTestGCSProvider(t, bucketName)
+	writeGCSObject(t, provider, bucketName, "models/../../outside.txt", "malicious")
+
+	modelDir := filepath.Join(tmpDir, "models")
+	if err := provider.DownloadModel(modelDir, modelName, "gs://testBucket/models"); err == nil {
+		t.Fatal("expected path traversal object to be rejected")
+	}
+
+	got, err := os.ReadFile(outsidePath)
+	if err != nil {
+		t.Fatalf("failed to read outside file: %v", err)
+	}
+	if string(got) != originalContents {
+		t.Fatalf("outside file contents = %q, want %q", string(got), originalContents)
+	}
+}

--- a/pkg/agent/storage/gcs_test.go
+++ b/pkg/agent/storage/gcs_test.go
@@ -59,7 +59,7 @@ func TestGCSDownloadAllowsNestedObjectPath(t *testing.T) {
 		t.Fatalf("expected download to succeed: %v", err)
 	}
 
-	got, err := os.ReadFile(filepath.Join(modelDir, modelName, "nested", "model.bin"))
+	got, err := os.ReadFile(filepath.Join(modelDir, modelName, "nested", "model.bin")) //nolint:gosec // G304: test path is rooted in t.TempDir
 	if err != nil {
 		t.Fatalf("failed to read downloaded model: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestGCSDownloadRejectsPathTraversal(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	outsidePath := filepath.Join(tmpDir, "outside.txt")
-	if err := os.WriteFile(outsidePath, []byte(originalContents), 0o644); err != nil {
+	if err := os.WriteFile(outsidePath, []byte(originalContents), 0o600); err != nil {
 		t.Fatalf("failed to write outside file: %v", err)
 	}
 
@@ -89,11 +89,88 @@ func TestGCSDownloadRejectsPathTraversal(t *testing.T) {
 		t.Fatal("expected path traversal object to be rejected")
 	}
 
-	got, err := os.ReadFile(outsidePath)
+	got, err := os.ReadFile(outsidePath) //nolint:gosec // G304: test path is rooted in t.TempDir
 	if err != nil {
 		t.Fatalf("failed to read outside file: %v", err)
 	}
 	if string(got) != originalContents {
 		t.Fatalf("outside file contents = %q, want %q", string(got), originalContents)
+	}
+}
+
+func TestGCSDownloadAllowsEmptyModelName(t *testing.T) {
+	const (
+		bucketName    = "testBucket"
+		modelContents = "Model Contents"
+	)
+
+	provider := newTestGCSProvider(t, bucketName)
+	writeGCSObject(t, provider, bucketName, "nested/", "")
+	writeGCSObject(t, provider, bucketName, "nested/model.bin", modelContents)
+
+	modelDir := t.TempDir()
+	if err := provider.DownloadModel(modelDir, "", "gs://testBucket/"); err != nil {
+		t.Fatalf("expected whole-bucket download to succeed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(modelDir, "nested", "model.bin")) //nolint:gosec // G304: test path is rooted in t.TempDir
+	if err != nil {
+		t.Fatalf("failed to read downloaded model: %v", err)
+	}
+	if string(got) != modelContents {
+		t.Fatalf("downloaded contents = %q, want %q", string(got), modelContents)
+	}
+}
+
+func TestGCSDownloadWithEmptyModelNameRejectsPathTraversal(t *testing.T) {
+	const (
+		bucketName       = "testBucket"
+		originalContents = "do not overwrite"
+	)
+
+	tmpDir := t.TempDir()
+	outsidePath := filepath.Join(tmpDir, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte(originalContents), 0o600); err != nil {
+		t.Fatalf("failed to write outside file: %v", err)
+	}
+
+	provider := newTestGCSProvider(t, bucketName)
+	writeGCSObject(t, provider, bucketName, "../../outside.txt", "malicious")
+
+	modelDir := filepath.Join(tmpDir, "models")
+	if err := provider.DownloadModel(modelDir, "", "gs://testBucket/"); err == nil {
+		t.Fatal("expected whole-bucket traversal object to be rejected")
+	}
+
+	got, err := os.ReadFile(outsidePath) //nolint:gosec // G304: test path is rooted in t.TempDir
+	if err != nil {
+		t.Fatalf("failed to read outside file: %v", err)
+	}
+	if string(got) != originalContents {
+		t.Fatalf("outside file contents = %q, want %q", string(got), originalContents)
+	}
+}
+
+func TestGCSDownloadAllowsExactObjectPath(t *testing.T) {
+	const (
+		bucketName    = "testBucket"
+		modelName     = "model1"
+		modelContents = "Model Contents"
+	)
+
+	provider := newTestGCSProvider(t, bucketName)
+	writeGCSObject(t, provider, bucketName, "models/model.bin", modelContents)
+
+	modelDir := t.TempDir()
+	if err := provider.DownloadModel(modelDir, modelName, "gs://testBucket/models/model.bin"); err != nil {
+		t.Fatalf("expected exact-object download to succeed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(modelDir, modelName, "model.bin")) //nolint:gosec // G304: test path is rooted in t.TempDir
+	if err != nil {
+		t.Fatalf("failed to read downloaded model: %v", err)
+	}
+	if string(got) != modelContents {
+		t.Fatalf("downloaded contents = %q, want %q", string(got), modelContents)
 	}
 }

--- a/pkg/agent/storage/s3.go
+++ b/pkg/agent/storage/s3.go
@@ -19,8 +19,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -78,18 +76,9 @@ func (m *S3Provider) DownloadModel(modelDir string, modelName string, storageUri
 				continue
 			}
 			subObjectKey := strings.TrimPrefix(*object.Key, prefix)
-			fileName := filepath.Join(modelDir, modelName, subObjectKey)
-
-			if FileExists(fileName) {
-				// File got corrupted or is mid-download :(
-				// TODO: Figure out if we can maybe continue?
-				if err := os.Remove(fileName); err != nil {
-					return fmt.Errorf("file is unable to be deleted: %w", err)
-				}
-			}
-			file, err := Create(fileName)
+			file, fileName, err := createLocalModelFile(modelDir, modelName, subObjectKey)
 			if err != nil {
-				return fmt.Errorf("file is already created: %w", err)
+				return err
 			}
 
 			if _, err := m.TransferClient.DownloadObject(ctx, &transfermanager.DownloadObjectInput{

--- a/pkg/agent/storage/s3_test.go
+++ b/pkg/agent/storage/s3_test.go
@@ -252,3 +252,30 @@ func TestDownloadModel_NoPrefixInURI(t *testing.T) {
 		t.Error("expected model.pt to exist")
 	}
 }
+
+func TestDownloadModel_RejectsPathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	outsidePath := filepath.Join(tmpDir, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("do not overwrite"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &S3Provider{
+		Client: &mocks.MockS3PaginatedClient{
+			Pages: [][]string{{"prefix/../../outside.txt"}},
+		},
+		TransferClient: &mocks.MockS3TransferClient{},
+	}
+
+	err := provider.DownloadModel(filepath.Join(tmpDir, "models"), "model1", "s3://bucket/prefix/")
+	if err == nil {
+		t.Fatal("expected path traversal object to be rejected")
+	}
+	got, readErr := os.ReadFile(outsidePath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != "do not overwrite" {
+		t.Fatalf("outside file contents = %q, want %q", string(got), "do not overwrite")
+	}
+}

--- a/pkg/agent/storage/s3_test.go
+++ b/pkg/agent/storage/s3_test.go
@@ -256,7 +256,7 @@ func TestDownloadModel_NoPrefixInURI(t *testing.T) {
 func TestDownloadModel_RejectsPathTraversal(t *testing.T) {
 	tmpDir := t.TempDir()
 	outsidePath := filepath.Join(tmpDir, "outside.txt")
-	if err := os.WriteFile(outsidePath, []byte("do not overwrite"), 0o644); err != nil {
+	if err := os.WriteFile(outsidePath, []byte("do not overwrite"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -271,7 +271,7 @@ func TestDownloadModel_RejectsPathTraversal(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected path traversal object to be rejected")
 	}
-	got, readErr := os.ReadFile(outsidePath)
+	got, readErr := os.ReadFile(outsidePath) //nolint:gosec // G304: test path is rooted in t.TempDir
 	if readErr != nil {
 		t.Fatal(readErr)
 	}

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -47,6 +47,27 @@ import (
 	s3credential "github.com/kserve/kserve/pkg/credentials/s3"
 )
 
+func safeLocalModelPath(baseDir string, objectPath string) (string, error) {
+	baseDir = filepath.Clean(baseDir)
+	normalizedObjectPath := strings.ReplaceAll(objectPath, "\\", "/")
+	trimmedObjectPath := strings.TrimLeft(normalizedObjectPath, "/")
+	for _, segment := range strings.Split(trimmedObjectPath, "/") {
+		if segment == ".." {
+			return "", fmt.Errorf("path traversal detected in object path: %s", objectPath)
+		}
+	}
+
+	candidate := filepath.Clean(filepath.Join(baseDir, filepath.FromSlash(trimmedObjectPath)))
+	relativePath, err := filepath.Rel(baseDir, candidate)
+	if err != nil {
+		return "", fmt.Errorf("unable to validate object path %s: %w", objectPath, err)
+	}
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relativePath) {
+		return "", fmt.Errorf("object path escapes model directory: %s", objectPath)
+	}
+	return candidate, nil
+}
+
 func FileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -21,8 +21,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -46,25 +48,36 @@ import (
 	s3credential "github.com/kserve/kserve/pkg/credentials/s3"
 )
 
-func safeLocalModelPath(baseDir string, objectPath string) (string, error) {
-	baseDir = filepath.Clean(baseDir)
-	normalizedObjectPath := strings.ReplaceAll(objectPath, "\\", "/")
-	trimmedObjectPath := strings.TrimLeft(normalizedObjectPath, "/")
-	for _, segment := range strings.Split(trimmedObjectPath, "/") {
-		if segment == ".." {
-			return "", fmt.Errorf("path traversal detected in object path: %s", objectPath)
-		}
+func createLocalModelFile(modelDir string, modelName string, objectPath string) (*os.File, string, error) {
+	trimmedObjectPath := strings.TrimLeft(objectPath, "/")
+	if !fs.ValidPath(modelName) {
+		return nil, "", fmt.Errorf("invalid model name: %s", modelName)
+	}
+	if !fs.ValidPath(trimmedObjectPath) {
+		return nil, "", fmt.Errorf("invalid object path: %s", objectPath)
 	}
 
-	candidate := filepath.Clean(filepath.Join(baseDir, filepath.FromSlash(trimmedObjectPath)))
-	relativePath, err := filepath.Rel(baseDir, candidate)
+	relativePath := path.Join(modelName, trimmedObjectPath)
+	if err := os.MkdirAll(modelDir, os.ModePerm); err != nil { //nolint:gosec // G301: agent and model server run as different UIDs sharing an emptyDir volume
+		return nil, "", err
+	}
+	root, err := os.OpenRoot(modelDir)
 	if err != nil {
-		return "", fmt.Errorf("unable to validate object path %s: %w", objectPath, err)
+		return nil, "", err
 	}
-	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relativePath) {
-		return "", fmt.Errorf("object path escapes model directory: %s", objectPath)
+	defer root.Close()
+
+	parentDir := path.Dir(relativePath)
+	if parentDir != "." {
+		if err := root.MkdirAll(filepath.FromSlash(parentDir), os.ModePerm); err != nil { //nolint:gosec // G301: shared model volume must be traversable by the model server
+			return nil, "", fmt.Errorf("unable to create parent directory for object %s: %w", objectPath, err)
+		}
 	}
-	return candidate, nil
+	file, err := root.Create(filepath.FromSlash(relativePath))
+	if err != nil {
+		return nil, "", fmt.Errorf("unable to create file for object %s: %w", objectPath, err)
+	}
+	return file, filepath.Join(modelDir, filepath.FromSlash(relativePath)), nil
 }
 
 func FileExists(filename string) bool {

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -46,6 +46,27 @@ import (
 	s3credential "github.com/kserve/kserve/pkg/credentials/s3"
 )
 
+func safeLocalModelPath(baseDir string, objectPath string) (string, error) {
+	baseDir = filepath.Clean(baseDir)
+	normalizedObjectPath := strings.ReplaceAll(objectPath, "\\", "/")
+	trimmedObjectPath := strings.TrimLeft(normalizedObjectPath, "/")
+	for _, segment := range strings.Split(trimmedObjectPath, "/") {
+		if segment == ".." {
+			return "", fmt.Errorf("path traversal detected in object path: %s", objectPath)
+		}
+	}
+
+	candidate := filepath.Clean(filepath.Join(baseDir, filepath.FromSlash(trimmedObjectPath)))
+	relativePath, err := filepath.Rel(baseDir, candidate)
+	if err != nil {
+		return "", fmt.Errorf("unable to validate object path %s: %w", objectPath, err)
+	}
+	if relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relativePath) {
+		return "", fmt.Errorf("object path escapes model directory: %s", objectPath)
+	}
+	return candidate, nil
+}
+
 func FileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -50,14 +50,17 @@ import (
 
 func createLocalModelFile(modelDir string, modelName string, objectPath string) (*os.File, string, error) {
 	trimmedObjectPath := strings.TrimLeft(objectPath, "/")
-	if !fs.ValidPath(modelName) {
+	if modelName != "" && !fs.ValidPath(modelName) {
 		return nil, "", fmt.Errorf("invalid model name: %s", modelName)
 	}
 	if !fs.ValidPath(trimmedObjectPath) {
 		return nil, "", fmt.Errorf("invalid object path: %s", objectPath)
 	}
 
-	relativePath := path.Join(modelName, trimmedObjectPath)
+	relativePath := trimmedObjectPath
+	if modelName != "" {
+		relativePath = path.Join(modelName, trimmedObjectPath)
+	}
 	if err := os.MkdirAll(modelDir, os.ModePerm); err != nil { //nolint:gosec // G301: agent and model server run as different UIDs sharing an emptyDir volume
 		return nil, "", err
 	}

--- a/pkg/agent/storage/utils_test.go
+++ b/pkg/agent/storage/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"testing"
 
@@ -50,6 +51,55 @@ func TestCreate(t *testing.T) {
 	mode := info.Mode()
 	expectedMode := os.ModePerm
 	g.Expect(mode.Perm()).To(gomega.Equal(expectedMode))
+}
+
+func TestCreateLocalModelFileRejectsSymlinkEscape(t *testing.T) {
+	modelDir := t.TempDir()
+	outsideDir := t.TempDir()
+	modelPath := filepath.Join(modelDir, "model1")
+	if err := os.Mkdir(modelPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(modelPath, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	file, _, err := createLocalModelFile(modelDir, "model1", "link/model.bin")
+	if file != nil {
+		_ = file.Close()
+	}
+	if err == nil {
+		t.Fatal("expected symlink escape to be rejected")
+	}
+	if _, err := os.Stat(filepath.Join(outsideDir, "model.bin")); !os.IsNotExist(err) {
+		t.Fatalf("outside file was created: %v", err)
+	}
+}
+
+func TestCreateLocalModelFilePreservesBackslash(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("backslash is a path separator on Windows")
+	}
+
+	modelDir := t.TempDir()
+	file, fileName, err := createLocalModelFile(modelDir, "model1", `nested\model.bin`)
+	if err != nil {
+		t.Fatalf("expected object path to be accepted: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(modelDir, "model1", `nested\model.bin`)
+	if fileName != want {
+		t.Fatalf("file name = %q, want %q", fileName, want)
+	}
+	if !FileExists(want) {
+		t.Fatalf("expected literal backslash file %q to exist", want)
+	}
+	if FileExists(filepath.Join(modelDir, "model1", "nested", "model.bin")) {
+		t.Fatal("backslash object path was aliased to a slash-separated path")
+	}
 }
 
 func TestFileExists(t *testing.T) {

--- a/pkg/agent/storage/utils_test.go
+++ b/pkg/agent/storage/utils_test.go
@@ -57,7 +57,7 @@ func TestCreateLocalModelFileRejectsSymlinkEscape(t *testing.T) {
 	modelDir := t.TempDir()
 	outsideDir := t.TempDir()
 	modelPath := filepath.Join(modelDir, "model1")
-	if err := os.Mkdir(modelPath, 0o755); err != nil {
+	if err := os.Mkdir(modelPath, 0o750); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(outsideDir, filepath.Join(modelPath, "link")); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This remediates ADA-KUBEFL-03 from the Ada Logics Kubeflow security audit for KServe's object-storage downloaders.

GCS, S3, and Azure object names are remote-controlled path input. The downloaders previously combined those names with the shared model directory using `filepath.Join`, then created or replaced the resulting file. Parent-directory components such as `../../outside.txt` could escape the intended model location. A lexical containment check alone was insufficient because a model-server container sharing the volume could place a symlink in the destination path and redirect a later write outside the volume. Normalizing backslashes also caused distinct object keys such as `a\b` and `a/b` to collide on Linux.

The downloaders now create files through a common helper backed by `os.Root`. Object names must be valid slash-separated relative paths, parent traversal is rejected, and every directory and file operation stays rooted under the trusted model directory even when a path contains an escaping symlink. Literal backslashes remain part of Linux object names instead of being rewritten as separators. The same protected write path is used by GCS, S3, and Azure, including the S3 variant explicitly called out by the audit.

Related tracking issue: https://github.com/kubeflow/community/issues/992#issuecomment-4785057657

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to kubeflow/community#992 (ADA-KUBEFL-03). The linked issue tracks multiple projects and findings, so this PR must not close it.

**Feature/Issue validation/testing**:

- [x] `go test -vet=off -p=1 ./pkg/agent/storage`
- [x] `go vet ./pkg/agent/storage`
- [x] `git diff --check`
- [x] Regression coverage for GCS, S3, and Azure traversal attempts
- [x] Regression coverage for symlink escape and literal backslash preservation

**Special notes for your reviewer**:

This completes the known KServe code remediation for ADA-KUBEFL-03 across the object-storage downloaders identified during review. After merge, the remaining work is tracking only: link the merged PR from the original community issue as remediation evidence. ADA-KUBEFL-02 is handled separately by #5715.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? Not applicable; this changes internal path handling without changing the user-facing storage API.

**Release note**:

```release-note
Prevent GCS, S3, and Azure model object names and symlinks from escaping the configured model download directory.
```
