### PR TITLE
fix(agent): prevent HTTP storage SSRF

### DIFF
--- a/pkg/agent/storage/http_client.go
+++ b/pkg/agent/storage/http_client.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"time"
+)
+
+const maxHTTPSRedirects = 10
+
+var blockedHTTPDestinationPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("::/128"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+}
+
+type restrictedHTTPTransport struct {
+	base http.RoundTripper
+}
+
+func defaultHTTPStorageClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	transport.DialContext = restrictedHTTPDialContext(dialer)
+
+	return &http.Client{
+		Transport:     restrictedHTTPTransport{base: transport},
+		CheckRedirect: checkHTTPStorageRedirect,
+	}
+}
+
+func (t restrictedHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := validateHTTPURL(req.Context(), req.URL); err != nil {
+		return nil, err
+	}
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+func restrictedHTTPDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network string, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateHTTPHost(ctx, host); err != nil {
+			return nil, err
+		}
+		return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+	}
+}
+
+func checkHTTPStorageRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxHTTPSRedirects {
+		return errors.New("stopped after 10 redirects")
+	}
+	return validateHTTPURL(req.Context(), req.URL)
+}
+
+func validateHTTPURL(ctx context.Context, uri *url.URL) error {
+	if uri == nil {
+		return errors.New("HTTP(S) storage URI is empty")
+	}
+	if uri.Scheme != "http" && uri.Scheme != "https" {
+		return fmt.Errorf("unsupported HTTP(S) storage URI scheme: %s", uri.Scheme)
+	}
+	if uri.Hostname() == "" {
+		return fmt.Errorf("HTTP(S) storage URI %q does not include a host", uri.String())
+	}
+	return validateHTTPHost(ctx, uri.Hostname())
+}
+
+func validateHTTPHost(ctx context.Context, host string) error {
+	if host == "" {
+		return errors.New("HTTP(S) storage URI host is empty")
+	}
+
+	if addr, err := netip.ParseAddr(host); err == nil {
+		return validateHTTPDestinationAddr(host, addr)
+	}
+
+	addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return fmt.Errorf("failed to resolve HTTP(S) storage URI host %q: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return fmt.Errorf("HTTP(S) storage URI host %q resolved to no addresses", host)
+	}
+	for _, addr := range addrs {
+		if err := validateHTTPDestinationAddr(host, addr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateHTTPDestinationAddr(host string, addr netip.Addr) error {
+	addr = addr.Unmap()
+	for _, prefix := range blockedHTTPDestinationPrefixes {
+		if prefix.Contains(addr) {
+			return fmt.Errorf("blocked unsafe HTTP(S) storage destination %q resolved to %s", host, addr)
+		}
+	}
+	return nil
+}

--- a/pkg/agent/storage/http_client.go
+++ b/pkg/agent/storage/http_client.go
@@ -24,10 +24,17 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"syscall"
 	"time"
 )
 
-const maxHTTPSRedirects = 10
+const (
+	maxHTTPSRedirects                = 10
+	httpStorageDialTimeout           = 30 * time.Second
+	httpStorageResponseHeaderTimeout = 30 * time.Second
+)
+
+var globalHTTPIPv6Prefix = netip.MustParsePrefix("2000::/3")
 
 var blockedHTTPDestinationPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("0.0.0.0/8"),
@@ -38,6 +45,7 @@ var blockedHTTPDestinationPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("172.16.0.0/12"),
 	netip.MustParsePrefix("192.0.0.0/24"),
 	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
 	netip.MustParsePrefix("192.168.0.0/16"),
 	netip.MustParsePrefix("198.18.0.0/15"),
 	netip.MustParsePrefix("198.51.100.0/24"),
@@ -52,6 +60,7 @@ var blockedHTTPDestinationPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("2001::/23"),
 	netip.MustParsePrefix("2001:db8::/32"),
 	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("3fff::/20"),
 	netip.MustParsePrefix("fc00::/7"),
 	netip.MustParsePrefix("fe80::/10"),
 	netip.MustParsePrefix("ff00::/8"),
@@ -65,19 +74,17 @@ type httpHostResolver interface {
 	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
 }
 
-type httpDialer interface {
-	DialContext(context.Context, string, string) (net.Conn, error)
-}
-
 func defaultHTTPStorageClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// A proxy would resolve the target outside the validated dial path.
+	// Proxies resolve the target outside this transport's validated dial path.
 	transport.Proxy = nil
 	dialer := &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
+		Timeout:        httpStorageDialTimeout,
+		KeepAlive:      30 * time.Second,
+		ControlContext: validateHTTPDialAddress,
 	}
-	transport.DialContext = restrictedHTTPDialContext(dialer, net.DefaultResolver)
+	transport.DialContext = dialer.DialContext
+	transport.ResponseHeaderTimeout = httpStorageResponseHeaderTimeout
 
 	return &http.Client{
 		Transport:     restrictedHTTPTransport{base: transport},
@@ -97,27 +104,16 @@ func (t restrictedHTTPTransport) RoundTrip(req *http.Request) (*http.Response, e
 	return base.RoundTrip(req)
 }
 
-func restrictedHTTPDialContext(dialer httpDialer, resolver httpHostResolver) func(context.Context, string, string) (net.Conn, error) {
-	return func(ctx context.Context, network string, address string) (net.Conn, error) {
-		host, port, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, err
-		}
-		addrs, err := resolveHTTPHost(ctx, resolver, host)
-		if err != nil {
-			return nil, err
-		}
-
-		var dialErrors []error
-		for _, addr := range addrs {
-			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(addr.Unmap().String(), port))
-			if dialErr == nil {
-				return conn, nil
-			}
-			dialErrors = append(dialErrors, dialErr)
-		}
-		return nil, fmt.Errorf("failed to dial HTTP(S) storage destination %q: %w", host, errors.Join(dialErrors...))
+func validateHTTPDialAddress(_ context.Context, _ string, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("invalid HTTP(S) storage dial address %q: %w", address, err)
 	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return fmt.Errorf("HTTP(S) storage dial address %q is not an IP address: %w", address, err)
+	}
+	return validateHTTPDestinationAddr(host, addr)
 }
 
 func checkHTTPStorageRedirect(req *http.Request, via []*http.Request) error {
@@ -177,6 +173,12 @@ func resolveHTTPHost(ctx context.Context, resolver httpHostResolver, host string
 
 func validateHTTPDestinationAddr(host string, addr netip.Addr) error {
 	addr = addr.Unmap().WithZone("")
+	if !addr.IsValid() {
+		return fmt.Errorf("blocked invalid HTTP(S) storage destination %q", host)
+	}
+	if addr.Is6() && !globalHTTPIPv6Prefix.Contains(addr) {
+		return fmt.Errorf("blocked unsafe HTTP(S) storage destination %q resolved to %s", host, addr)
+	}
 	for _, prefix := range blockedHTTPDestinationPrefixes {
 		if prefix.Contains(addr) {
 			return fmt.Errorf("blocked unsafe HTTP(S) storage destination %q resolved to %s", host, addr)

--- a/pkg/agent/storage/http_client.go
+++ b/pkg/agent/storage/http_client.go
@@ -37,12 +37,21 @@ var blockedHTTPDestinationPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("169.254.0.0/16"),
 	netip.MustParsePrefix("172.16.0.0/12"),
 	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
 	netip.MustParsePrefix("192.168.0.0/16"),
 	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
 	netip.MustParsePrefix("224.0.0.0/4"),
 	netip.MustParsePrefix("240.0.0.0/4"),
 	netip.MustParsePrefix("::/128"),
 	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("2002::/16"),
 	netip.MustParsePrefix("fc00::/7"),
 	netip.MustParsePrefix("fe80::/10"),
 	netip.MustParsePrefix("ff00::/8"),
@@ -52,13 +61,23 @@ type restrictedHTTPTransport struct {
 	base http.RoundTripper
 }
 
+type httpHostResolver interface {
+	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
+}
+
+type httpDialer interface {
+	DialContext(context.Context, string, string) (net.Conn, error)
+}
+
 func defaultHTTPStorageClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// A proxy would resolve the target outside the validated dial path.
+	transport.Proxy = nil
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
-	transport.DialContext = restrictedHTTPDialContext(dialer)
+	transport.DialContext = restrictedHTTPDialContext(dialer, net.DefaultResolver)
 
 	return &http.Client{
 		Transport:     restrictedHTTPTransport{base: transport},
@@ -78,16 +97,26 @@ func (t restrictedHTTPTransport) RoundTrip(req *http.Request) (*http.Response, e
 	return base.RoundTrip(req)
 }
 
-func restrictedHTTPDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+func restrictedHTTPDialContext(dialer httpDialer, resolver httpHostResolver) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network string, address string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(address)
 		if err != nil {
 			return nil, err
 		}
-		if err := validateHTTPHost(ctx, host); err != nil {
+		addrs, err := resolveHTTPHost(ctx, resolver, host)
+		if err != nil {
 			return nil, err
 		}
-		return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+
+		var dialErrors []error
+		for _, addr := range addrs {
+			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(addr.Unmap().String(), port))
+			if dialErr == nil {
+				return conn, nil
+			}
+			dialErrors = append(dialErrors, dialErr)
+		}
+		return nil, fmt.Errorf("failed to dial HTTP(S) storage destination %q: %w", host, errors.Join(dialErrors...))
 	}
 }
 
@@ -112,31 +141,42 @@ func validateHTTPURL(ctx context.Context, uri *url.URL) error {
 }
 
 func validateHTTPHost(ctx context.Context, host string) error {
+	_, err := resolveHTTPHost(ctx, net.DefaultResolver, host)
+	return err
+}
+
+func resolveHTTPHost(ctx context.Context, resolver httpHostResolver, host string) ([]netip.Addr, error) {
 	if host == "" {
-		return errors.New("HTTP(S) storage URI host is empty")
+		return nil, errors.New("HTTP(S) storage URI host is empty")
 	}
 
 	if addr, err := netip.ParseAddr(host); err == nil {
-		return validateHTTPDestinationAddr(host, addr)
+		if err := validateHTTPDestinationAddr(host, addr); err != nil {
+			return nil, err
+		}
+		return []netip.Addr{addr}, nil
 	}
 
-	addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	addrs, err := resolver.LookupNetIP(ctx, "ip", host)
 	if err != nil {
-		return fmt.Errorf("failed to resolve HTTP(S) storage URI host %q: %w", host, err)
+		return nil, fmt.Errorf("failed to resolve HTTP(S) storage URI host %q: %w", host, err)
 	}
 	if len(addrs) == 0 {
-		return fmt.Errorf("HTTP(S) storage URI host %q resolved to no addresses", host)
+		return nil, fmt.Errorf("HTTP(S) storage URI host %q resolved to no addresses", host)
 	}
 	for _, addr := range addrs {
 		if err := validateHTTPDestinationAddr(host, addr); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return addrs, nil
 }
 
 func validateHTTPDestinationAddr(host string, addr netip.Addr) error {
-	addr = addr.Unmap()
+	addr = addr.Unmap().WithZone("")
 	for _, prefix := range blockedHTTPDestinationPrefixes {
 		if prefix.Contains(addr) {
 			return fmt.Errorf("blocked unsafe HTTP(S) storage destination %q resolved to %s", host, addr)

--- a/pkg/agent/storage/http_client_test.go
+++ b/pkg/agent/storage/http_client_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+type staticHTTPResolver struct {
+	addrs []netip.Addr
+}
+
+func (r staticHTTPResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return r.addrs, nil
+}
+
+type recordingHTTPDialer struct {
+	addresses []string
+}
+
+func (d *recordingHTTPDialer) DialContext(_ context.Context, _, address string) (net.Conn, error) {
+	d.addresses = append(d.addresses, address)
+	return nil, errors.New("test dial stopped")
+}
+
+func TestRestrictedHTTPDialContextPinsValidatedAddress(t *testing.T) {
+	dialer := &recordingHTTPDialer{}
+	dial := restrictedHTTPDialContext(dialer, staticHTTPResolver{
+		addrs: []netip.Addr{netip.MustParseAddr("93.184.216.34")},
+	})
+
+	_, err := dial(context.Background(), "tcp", "models.example:443")
+	if err == nil {
+		t.Fatal("expected test dial to stop with an error")
+	}
+	if len(dialer.addresses) != 1 || dialer.addresses[0] != "93.184.216.34:443" {
+		t.Fatalf("dialed addresses = %v, want the validated IP address", dialer.addresses)
+	}
+}
+
+func TestRestrictedHTTPDialContextRejectsReboundAddress(t *testing.T) {
+	dialer := &recordingHTTPDialer{}
+	dial := restrictedHTTPDialContext(dialer, staticHTTPResolver{
+		addrs: []netip.Addr{netip.MustParseAddr("127.0.0.1")},
+	})
+
+	_, err := dial(context.Background(), "tcp", "models.example:80")
+	if err == nil || !strings.Contains(err.Error(), "blocked unsafe HTTP(S) storage destination") {
+		t.Fatalf("expected unsafe destination error, got: %v", err)
+	}
+	if len(dialer.addresses) != 0 {
+		t.Fatalf("dialed unsafe addresses: %v", dialer.addresses)
+	}
+}
+
+func TestValidateHTTPDestinationAddrRejectsIPv6ZoneBypass(t *testing.T) {
+	err := validateHTTPDestinationAddr("fe80::1%lo0", netip.MustParseAddr("fe80::1%lo0"))
+	if err == nil || !strings.Contains(err.Error(), "blocked unsafe HTTP(S) storage destination") {
+		t.Fatalf("expected zoned link-local address to be rejected, got: %v", err)
+	}
+}
+
+func TestDefaultHTTPStorageClientDoesNotUseEnvironmentProxy(t *testing.T) {
+	client := defaultHTTPStorageClient()
+	restrictedTransport, ok := client.Transport.(restrictedHTTPTransport)
+	if !ok {
+		t.Fatalf("transport type = %T, want restrictedHTTPTransport", client.Transport)
+	}
+	transport, ok := restrictedTransport.base.(*http.Transport)
+	if !ok {
+		t.Fatalf("base transport type = %T, want *http.Transport", restrictedTransport.base)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("HTTP storage client must not delegate target resolution to a proxy")
+	}
+}

--- a/pkg/agent/storage/http_client_test.go
+++ b/pkg/agent/storage/http_client_test.go
@@ -18,8 +18,6 @@ package storage
 
 import (
 	"context"
-	"errors"
-	"net"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -34,42 +32,26 @@ func (r staticHTTPResolver) LookupNetIP(context.Context, string, string) ([]neti
 	return r.addrs, nil
 }
 
-type recordingHTTPDialer struct {
-	addresses []string
-}
-
-func (d *recordingHTTPDialer) DialContext(_ context.Context, _, address string) (net.Conn, error) {
-	d.addresses = append(d.addresses, address)
-	return nil, errors.New("test dial stopped")
-}
-
-func TestRestrictedHTTPDialContextPinsValidatedAddress(t *testing.T) {
-	dialer := &recordingHTTPDialer{}
-	dial := restrictedHTTPDialContext(dialer, staticHTTPResolver{
-		addrs: []netip.Addr{netip.MustParseAddr("93.184.216.34")},
-	})
-
-	_, err := dial(context.Background(), "tcp", "models.example:443")
-	if err == nil {
-		t.Fatal("expected test dial to stop with an error")
-	}
-	if len(dialer.addresses) != 1 || dialer.addresses[0] != "93.184.216.34:443" {
-		t.Fatalf("dialed addresses = %v, want the validated IP address", dialer.addresses)
-	}
-}
-
-func TestRestrictedHTTPDialContextRejectsReboundAddress(t *testing.T) {
-	dialer := &recordingHTTPDialer{}
-	dial := restrictedHTTPDialContext(dialer, staticHTTPResolver{
-		addrs: []netip.Addr{netip.MustParseAddr("127.0.0.1")},
-	})
-
-	_, err := dial(context.Background(), "tcp", "models.example:80")
+func TestValidateHTTPDialAddressRejectsUnsafeResolvedAddress(t *testing.T) {
+	err := validateHTTPDialAddress(context.Background(), "tcp4", "127.0.0.1:80", nil)
 	if err == nil || !strings.Contains(err.Error(), "blocked unsafe HTTP(S) storage destination") {
 		t.Fatalf("expected unsafe destination error, got: %v", err)
 	}
-	if len(dialer.addresses) != 0 {
-		t.Fatalf("dialed unsafe addresses: %v", dialer.addresses)
+
+	if err := validateHTTPDialAddress(context.Background(), "tcp4", "93.184.216.34:443", nil); err != nil {
+		t.Fatalf("expected public dial address to be allowed: %v", err)
+	}
+}
+
+func TestResolveHTTPHostRejectsMixedPublicAndPrivateAddresses(t *testing.T) {
+	resolver := staticHTTPResolver{addrs: []netip.Addr{
+		netip.MustParseAddr("93.184.216.34"),
+		netip.MustParseAddr("10.0.0.1"),
+	}}
+
+	_, err := resolveHTTPHost(context.Background(), resolver, "models.example")
+	if err == nil || !strings.Contains(err.Error(), "blocked unsafe HTTP(S) storage destination") {
+		t.Fatalf("expected mixed DNS response to be rejected, got: %v", err)
 	}
 }
 
@@ -92,5 +74,38 @@ func TestDefaultHTTPStorageClientDoesNotUseEnvironmentProxy(t *testing.T) {
 	}
 	if transport.Proxy != nil {
 		t.Fatal("HTTP storage client must not delegate target resolution to a proxy")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("HTTP storage client must validate resolved socket addresses")
+	}
+	if transport.ResponseHeaderTimeout != httpStorageResponseHeaderTimeout {
+		t.Fatalf("response header timeout = %s, want %s", transport.ResponseHeaderTimeout, httpStorageResponseHeaderTimeout)
+	}
+}
+
+func TestValidateHTTPDestinationAddrRejectsSpecialRanges(t *testing.T) {
+	blocked := []string{
+		"192.88.99.2",
+		"100:0:0:1::1",
+		"3fff::1",
+		"5f00::1",
+		"fec0::1",
+		"4000::1",
+	}
+	for _, address := range blocked {
+		t.Run(address, func(t *testing.T) {
+			if err := validateHTTPDestinationAddr(address, netip.MustParseAddr(address)); err == nil {
+				t.Fatalf("expected special address %s to be rejected", address)
+			}
+		})
+	}
+
+	allowed := []string{"93.184.216.34", "2606:4700:4700::1111"}
+	for _, address := range allowed {
+		t.Run(address, func(t *testing.T) {
+			if err := validateHTTPDestinationAddr(address, netip.MustParseAddr(address)); err != nil {
+				t.Fatalf("expected public address %s to be allowed: %v", address, err)
+			}
+		})
 	}
 }

--- a/pkg/agent/storage/https_test.go
+++ b/pkg/agent/storage/https_test.go
@@ -17,9 +17,19 @@ limitations under the License.
 package storage
 
 import (
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestCreateNewFileValidation(t *testing.T) {
 	tests := []struct {
@@ -235,5 +245,125 @@ func TestCreateNewFileValidation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateHTTPURLRejectsUnsafeDestinations(t *testing.T) {
+	tests := []struct {
+		name       string
+		storageURI string
+	}{
+		{
+			name:       "IPv4 loopback",
+			storageURI: "http://127.0.0.1/model.joblib",
+		},
+		{
+			name:       "localhost",
+			storageURI: "http://localhost/model.joblib",
+		},
+		{
+			name:       "cloud metadata endpoint",
+			storageURI: "http://169.254.169.254/latest/meta-data",
+		},
+		{
+			name:       "private IPv4",
+			storageURI: "https://10.0.0.1/model.joblib",
+		},
+		{
+			name:       "IPv6 loopback",
+			storageURI: "http://[::1]/model.joblib",
+		},
+		{
+			name:       "IPv6 unique local",
+			storageURI: "http://[fd00::1]/model.joblib",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := GetProvider(map[Protocol]Provider{}, HTTP)
+			if err != nil {
+				t.Fatalf("failed to get HTTP provider: %v", err)
+			}
+
+			err = provider.DownloadModel(t.TempDir(), "model", tt.storageURI)
+			if err == nil {
+				t.Fatalf("expected %s to be rejected", tt.storageURI)
+			}
+			if !strings.Contains(err.Error(), "blocked unsafe HTTP(S) storage destination") {
+				t.Fatalf("expected unsafe destination error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRestrictedHTTPTransportAllowsPublicDestination(t *testing.T) {
+	const (
+		modelContents = "model contents"
+		storageURI    = "http://93.184.216.34/model.joblib"
+	)
+
+	client := &http.Client{
+		Transport: restrictedHTTPTransport{
+			base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.URL.String() != storageURI {
+					t.Fatalf("request URL = %q, want %q", req.URL.String(), storageURI)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/octet-stream"}},
+					Body:       io.NopCloser(strings.NewReader(modelContents)),
+					Request:    req,
+				}, nil
+			}),
+		},
+		CheckRedirect: checkHTTPStorageRedirect,
+	}
+
+	provider := &HTTPSProvider{Client: client}
+	modelDir := t.TempDir()
+	if err := provider.DownloadModel(modelDir, "model", storageURI); err != nil {
+		t.Fatalf("expected public destination download to succeed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(modelDir, "model", "model.joblib"))
+	if err != nil {
+		t.Fatalf("failed to read downloaded model: %v", err)
+	}
+	if string(got) != modelContents {
+		t.Fatalf("downloaded contents = %q, want %q", string(got), modelContents)
+	}
+}
+
+func TestHTTPStorageClientRejectsRedirectToUnsafeDestination(t *testing.T) {
+	const storageURI = "http://93.184.216.34/model.joblib"
+	requests := 0
+	client := &http.Client{
+		Transport: restrictedHTTPTransport{
+			base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requests++
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"http://127.0.0.1/metadata"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    req,
+				}, nil
+			}),
+		},
+		CheckRedirect: checkHTTPStorageRedirect,
+	}
+
+	resp, err := client.Get(storageURI)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected redirect to unsafe destination to be rejected")
+	}
+	if !strings.Contains(err.Error(), "blocked unsafe HTTP(S) storage destination") {
+		t.Fatalf("expected unsafe destination error, got: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("request count = %d, want 1", requests)
 	}
 }

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -249,14 +248,12 @@ func GetProvider(providers map[Protocol]Provider, protocol Protocol) (Provider, 
 			Uploader:   s3manager.NewUploaderWithClient(sessionClient, func(d *s3manager.Uploader) {}),
 		}
 	case HTTPS:
-		httpsClient := &http.Client{}
 		providers[HTTPS] = &HTTPSProvider{
-			Client: httpsClient,
+			Client: defaultHTTPStorageClient(),
 		}
 	case HTTP:
-		httpsClient := &http.Client{}
 		providers[HTTP] = &HTTPSProvider{
-			Client: httpsClient,
+			Client: defaultHTTPStorageClient(),
 		}
 	}
 

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -248,14 +247,12 @@ func GetProvider(providers map[Protocol]Provider, protocol Protocol) (Provider, 
 			TransferClient: transfermanager.New(s3Client),
 		}
 	case HTTPS:
-		httpsClient := &http.Client{}
 		providers[HTTPS] = &HTTPSProvider{
-			Client: httpsClient,
+			Client: defaultHTTPStorageClient(),
 		}
 	case HTTP:
-		httpsClient := &http.Client{}
 		providers[HTTP] = &HTTPSProvider{
-			Client: httpsClient,
+			Client: defaultHTTPStorageClient(),
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This remediates ADA-KUBEFL-02 from the Ada Logics Kubeflow security audit for KServe's HTTP(S) storage provider.

The provider previously passed a user-controlled model URL directly to `http.Client`. That allowed requests to loopback, private, link-local, metadata, reserved, and other non-public destinations, including through redirects. An initial validation followed by a normal hostname dial would still be vulnerable to DNS rebinding because the connection could resolve the hostname again and use a different address.

Default HTTP(S) providers now use a restricted transport that validates the initial URL and every redirect, rejects any hostname if one of its DNS answers is unsafe, and validates the concrete socket address through `net.Dialer.ControlContext` immediately before connection. Using the standard dialer preserves its shared timeout and IPv4/IPv6 address racing while preventing the address actually used by the socket from bypassing validation.

The destination policy now covers the missed IPv4 special-purpose range and fails closed for IPv6 addresses outside `2000::/3`, with explicit rejection for special allocations inside that space. A 30-second response-header timeout prevents a reachable public endpoint from holding the downloader indefinitely before sending headers; model body transfers remain unbounded so large downloads are not cut off.

Related tracking issue: https://github.com/kubeflow/community/issues/992#issuecomment-4785057657

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to kubeflow/community#992 (ADA-KUBEFL-02). The linked issue tracks multiple projects and findings, so this PR must not close it.

**Feature/Issue validation/testing**:

- [x] `go test -vet=off -p=1 ./pkg/agent/storage`
- [x] `go vet ./pkg/agent/storage`
- [x] `git diff --check`
- [x] Regression coverage for unsafe direct destinations, redirects, mixed DNS answers, socket-address validation, zoned IPv6 addresses, and omitted/reserved ranges
- [x] Regression coverage for allowed public IPv4 and IPv6 destinations

**Special notes for your reviewer**:

Environment proxy routing is intentionally disabled for this client. Go's standard HTTP proxy path delegates target DNS resolution to the proxy, so KServe cannot validate or pin the destination address with the same guarantee. Clusters that require an HTTP proxy for all egress will need an explicitly trusted transport rather than the default provider client.

This PR is separate from ADA-KUBEFL-03 / #5714. It preserves both existing `http://` and `https://` storage schemes and does not impose a deployment-specific hostname allowlist.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? Not applicable; this changes the default provider's security policy without adding a new API.

**Release note**:

```release-note
HTTP(S) model downloads now reject non-public destinations and redirects, validate the connected socket address, and time out stalled response headers. Environment proxy routing is disabled for the default HTTP(S) storage client.
```
