### PR TITLE
fix(storage): prevent S3 prefix matching sibling directories

### DIFF
--- a/pkg/agent/mocks/s3mock.go
+++ b/pkg/agent/mocks/s3mock.go
@@ -30,11 +30,15 @@ type MockS3Client struct {
 	s3iface.S3API
 }
 
-func (m *MockS3Client) ListObjects(*s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
+func (m *MockS3Client) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
+	key := "model.pt"
+	if input.Prefix != nil && *input.Prefix != "" {
+		key = *input.Prefix + "/model.pt"
+	}
 	return &s3.ListObjectsOutput{
 		Contents: []*s3.Object{
 			{
-				Key: proto.String("model.pt"),
+				Key: proto.String(key),
 			},
 		},
 	}, nil

--- a/pkg/agent/storage/s3.go
+++ b/pkg/agent/storage/s3.go
@@ -114,6 +114,13 @@ func (s *S3ObjectDownloader) GetAllObjects(s3Svc s3iface.S3API) ([]s3manager.Bat
 		if strings.HasSuffix(*object.Key, "/") {
 			continue
 		}
+		// S3's ListObjects Prefix is a plain string match, not a path-segment
+		// match, so a prefix like "model-a" also matches keys under the
+		// sibling "model-a-2/" directory. Require the key to be the prefix
+		// itself (single-object case) or to continue at a "/" boundary.
+		if s.Prefix != "" && *object.Key != s.Prefix && !strings.HasPrefix(*object.Key, s.Prefix+"/") {
+			continue
+		}
 		subObjectKey := strings.TrimPrefix(*object.Key, s.Prefix)
 		fileName := filepath.Join(s.ModelDir, s.ModelName, subObjectKey)
 

--- a/pkg/agent/storage/s3_test.go
+++ b/pkg/agent/storage/s3_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/onsi/gomega"
+)
+
+// fakeS3ListClient returns a fixed set of keys regardless of the request,
+// allowing tests to simulate a bucket containing sibling prefixes.
+type fakeS3ListClient struct {
+	s3iface.S3API
+	keys []string
+}
+
+func (f *fakeS3ListClient) ListObjects(*s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
+	contents := make([]*s3.Object, 0, len(f.keys))
+	for _, k := range f.keys {
+		contents = append(contents, &s3.Object{Key: aws.String(k)})
+	}
+	return &s3.ListObjectsOutput{Contents: contents}, nil
+}
+
+func TestS3ObjectDownloader_GetAllObjects_SiblingPrefixCollision(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tmpDir := t.TempDir()
+	client := &fakeS3ListClient{
+		keys: []string{
+			"merlinite-7b-lab/config.json",
+			"merlinite-7b-lab-hf/config.json",
+		},
+	}
+
+	downloader := &S3ObjectDownloader{
+		StorageUri: "s3://modelRepo/merlinite-7b-lab",
+		ModelDir:   tmpDir,
+		ModelName:  "model",
+		Bucket:     "modelRepo",
+		Prefix:     "merlinite-7b-lab",
+	}
+
+	objects, err := downloader.GetAllObjects(client)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(objects).To(gomega.HaveLen(1))
+	g.Expect(*objects[0].Object.Key).To(gomega.Equal("merlinite-7b-lab/config.json"))
+}
+
+func TestS3ObjectDownloader_GetAllObjects_SingleObjectKeyMatch(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tmpDir := t.TempDir()
+	client := &fakeS3ListClient{
+		keys: []string{"model.pt"},
+	}
+
+	downloader := &S3ObjectDownloader{
+		StorageUri: "s3://modelRepo/model.pt",
+		ModelDir:   tmpDir,
+		ModelName:  "model",
+		Bucket:     "modelRepo",
+		Prefix:     "model.pt",
+	}
+
+	objects, err := downloader.GetAllObjects(client)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(objects).To(gomega.HaveLen(1))
+	g.Expect(*objects[0].Object.Key).To(gomega.Equal("model.pt"))
+}
+
+func TestS3ObjectDownloader_GetAllObjects_EmptyPrefixMatchesEverything(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tmpDir := t.TempDir()
+	client := &fakeS3ListClient{
+		keys: []string{"a/model.pt", "b/model.pt"},
+	}
+
+	downloader := &S3ObjectDownloader{
+		StorageUri: "s3://modelRepo",
+		ModelDir:   tmpDir,
+		ModelName:  "model",
+		Bucket:     "modelRepo",
+		Prefix:     "",
+	}
+
+	objects, err := downloader.GetAllObjects(client)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(objects).To(gomega.HaveLen(2))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`S3ObjectDownloader.GetAllObjects` lists objects with `s3.ListObjectsInput{Prefix: s.Prefix}`, but S3's `Prefix` is a plain string match, not a path-segment match. A storage URI like `s3://bucket/merlinite-7b-lab` also matches keys under the sibling `merlinite-7b-lab-hf/` directory, so the storage initializer downloads files from both directories into the same model dir.

Adds a boundary check before downloading each listed object: the key must equal the prefix exactly (the single-object case, e.g. `s3://bucket/model.pt`) or continue at a `/` boundary (the directory case).

Also fixes `MockS3Client.ListObjects` in the test mocks, which returned a fixed `model.pt` key regardless of the requested prefix. That mock predates this fix and was masking the missing boundary check for the existing `pkg/agent` tests — it now echoes the requested prefix the same way a real S3 listing would.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3776

**Feature/Issue validation/testing**:

- [x] Added `TestS3ObjectDownloader_GetAllObjects_SiblingPrefixCollision`, reproducing the exact `merlinite-7b-lab` / `merlinite-7b-lab-hf` collision from the issue — confirmed it fails without the fix and passes with it.
- [x] Added `TestS3ObjectDownloader_GetAllObjects_SingleObjectKeyMatch` and `TestS3ObjectDownloader_GetAllObjects_EmptyPrefixMatchesEverything` to cover the single-object and bucket-root-prefix cases so the boundary check doesn't regress them.
- [x] Full `./pkg/agent/...` suite passes.

- Logs

```
--- PASS: TestS3ObjectDownloader_GetAllObjects_SiblingPrefixCollision (0.00s)
--- PASS: TestS3ObjectDownloader_GetAllObjects_SingleObjectKeyMatch (0.00s)
--- PASS: TestS3ObjectDownloader_GetAllObjects_EmptyPrefixMatchesEverything (0.00s)
ok  	github.com/kserve/kserve/pkg/agent/storage	1.392s
```

**Special notes for your reviewer**:

GCS (`pkg/agent/storage/gcs.go`) and Azure (`pkg/agent/storage/azure.go`) providers appear to share the same prefix-matching pattern, but I scoped this PR to the S3 path the issue reports. Happy to follow up on those if maintainers want the same fix there.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix storage initializer downloading objects from sibling S3 prefixes (e.g. `model-a` matching `model-a-hf/`) instead of just the requested model path.
```
