### PR TITLE
deps(llmisvc): bump llm-d images to the latest 0.8 release

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -177,7 +177,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -256,7 +256,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -521,7 +521,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -604,7 +604,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -863,7 +863,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -1098,7 +1098,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1383,7 +1383,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1662,7 +1662,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -2004,7 +2004,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -2503,7 +2503,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2799,7 +2799,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -3078,7 +3078,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -7,7 +7,7 @@ spec:
     serving.kserve.io/model-based-routing-enabled: "true"
   template:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -239,7 +239,7 @@ spec:
     initContainers:
       - name: llm-d-routing-sidecar
         imagePullPolicy: IfNotPresent
-        image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
+        image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
         restartPolicy: Always
         ports:
           - containerPort: 8000

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -9,7 +9,7 @@ spec:
     initContainers:
       - name: llm-d-routing-sidecar
         imagePullPolicy: IfNotPresent
-        image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
+        image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
         restartPolicy: Always
         ports:
           - containerPort: 8000
@@ -68,7 +68,7 @@ spec:
           - name: SSL_CERT_DIR
             value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -350,7 +350,7 @@ spec:
           secretName: "{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}"
   worker:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -8,7 +8,7 @@ spec:
       serving.kserve.io/model-based-routing-enabled: "true"
     template:
       containers:
-        - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
           imagePullPolicy: IfNotPresent
           name: main
           ports:

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -8,7 +8,7 @@ spec:
       serving.kserve.io/model-based-routing-enabled: "true"
     template:
       containers:
-        - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
           imagePullPolicy: IfNotPresent
           name: main
           ports:
@@ -290,7 +290,7 @@ spec:
             secretName: "{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}"
     worker:
       containers:
-        - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
           imagePullPolicy: IfNotPresent
           name: main
           ports:

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -46,7 +46,7 @@ spec:
               - containerPort: 5557
                 name: zmq
                 protocol: TCP
-            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
+            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 3

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -7,7 +7,7 @@ spec:
     serving.kserve.io/model-based-routing-enabled: "true"
   template:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -7,7 +7,7 @@ spec:
     serving.kserve.io/model-based-routing-enabled: "true"
   template:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -289,7 +289,7 @@ spec:
           secretName: "{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}"
   worker:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         name: main
         ports:

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_default.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_default.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     containers:
       # Override image version and command from base config
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         name: main
         command: ["/bin/sh", "-c"]
         args:
@@ -38,7 +38,7 @@ spec:
         containers:
           - name: main
             # Override scheduler image version
-            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
+            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
             # Override args to enable secure serving
             args:
               - --pool-name

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_pd_disagg.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_pd_disagg.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     containers:
       - name: main
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         env:
           # Enable RDMA for KV cache transfer
           - name: KSERVE_INFER_ROCE
@@ -57,7 +57,7 @@ spec:
     template:
       containers:
         - name: main
-          image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+          image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
           env:
             - name: KSERVE_INFER_ROCE
               value: "false"

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   template:
     containers:
-      - image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      - image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         name: main
         command: ["/bin/sh", "-c"]
         args:
@@ -103,7 +103,7 @@ spec:
             emptyDir: {}
         containers:
           - name: main
-            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
+            image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
             ports:
               - containerPort: 5557
                 name: zmq

--- a/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
+++ b/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     containers:
       - name: main
-        image: ghcr.io/llm-d/llm-d-rocm:v0.7.0
+        image: ghcr.io/llm-d/llm-d-rocm:v0.8.0
         resources:
           limits:
             cpu: '4'

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-opt-125m-cpu-kv-cache-routing-simulator.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-opt-125m-cpu-kv-cache-routing-simulator.yaml
@@ -61,7 +61,7 @@ spec:
   template:
     containers:
       - name: main
-        image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.2
+        image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.0
         command: ["/app/llm-d-inference-sim"]
         args:
           - --port

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2781,7 +2781,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2860,7 +2860,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -3125,7 +3125,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -3208,7 +3208,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -3467,7 +3467,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -3702,7 +3702,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3987,7 +3987,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4266,7 +4266,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4608,7 +4608,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -5107,7 +5107,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -5403,7 +5403,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -5682,7 +5682,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2367,7 +2367,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2446,7 +2446,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2711,7 +2711,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -2794,7 +2794,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -3053,7 +3053,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -3288,7 +3288,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3573,7 +3573,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3852,7 +3852,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4194,7 +4194,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -4693,7 +4693,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -4989,7 +4989,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -5268,7 +5268,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.7.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.8.0
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -100,7 +100,7 @@ func TestPresetFiles(t *testing.T) {
 							InitContainers: []corev1.Container{
 								{
 									Name:  "llm-d-routing-sidecar",
-									Image: "ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0-rc.2",
+									Image: "ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0",
 									Command: []string{
 										"/app/pd-sidecar",
 										"--port=8000",
@@ -187,7 +187,7 @@ func TestPresetFiles(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:  "main",
-									Image: "ghcr.io/llm-d/llm-d-cuda:v0.7.0",
+									Image: "ghcr.io/llm-d/llm-d-cuda:v0.8.0",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8001,
@@ -336,7 +336,7 @@ func TestPresetFiles(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:  "main",
-									Image: "ghcr.io/llm-d/llm-d-cuda:v0.7.0",
+									Image: "ghcr.io/llm-d/llm-d-cuda:v0.8.0",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8001,
@@ -465,7 +465,7 @@ func TestPresetFiles(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:  "main",
-									Image: "ghcr.io/llm-d/llm-d-cuda:v0.7.0",
+									Image: "ghcr.io/llm-d/llm-d-cuda:v0.8.0",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8000,

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -156,7 +156,7 @@ schedulingProfiles:
 						Containers: []corev1.Container{
 							{
 								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2",
+								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0",
 								Args: []string{
 									"--config-text",
 									"existing-config-from-template",
@@ -904,7 +904,7 @@ schedulingProfiles:
 						Containers: []corev1.Container{
 							{
 								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2",
+								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0",
 								Args: []string{
 									"--ha-enable-leader-election",
 									"--poolName",

--- a/pkg/controller/v1alpha2/llmisvc/sample.go
+++ b/pkg/controller/v1alpha2/llmisvc/sample.go
@@ -189,7 +189,7 @@ func LLMInferenceServiceSample() *v1alpha2.LLMInferenceService {
 						Containers: []corev1.Container{
 							{
 								Name:  "scheduler",
-								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2",
+								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0",
 								Ports: []corev1.ContainerPort{
 									{
 										ContainerPort: 9002,


### PR DESCRIPTION
**What this PR does / why we need it**:

offical release of llm-d 0.8 is out
- llm-d-cuda to v0.8.0 from 0.7.0 which **include vllm from 0.19.1 to 0.23.0**
- llm-d-rocm to v0.8.0 from 0.7.0
- llm-d-inference-sim:v0.10.0
- llm-d-router-endpoint-picker/llm-d-router-disagg-sidecar from RC build to v0.9.0
- keep llm-d-uds-tokenzier as the same image

**vllm 0.22.0 includes the new Multi-tier KV cache offloading**



