### PR TITLE
ci: run heavy LLM/vLLM e2e jobs on cncf-ubuntu-16-64-x86 runners

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -172,7 +172,7 @@ jobs:
           if-no-files-found: error
 
   test-llmisvc:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     needs: [detect-changes, llmisvc-image-build, seed-model-cache]
     strategy:
       fail-fast: false
@@ -295,7 +295,7 @@ jobs:
           name: test-results-llmisvc-${{ matrix.install-method }}
 
   test-llmisvc-wva-autoscaling-hpa:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     needs: [detect-changes, llmisvc-image-build, seed-model-cache]
     strategy:
       fail-fast: false
@@ -400,7 +400,7 @@ jobs:
           name: test-results-llmisvc-autoscaling-hpa-${{ matrix.install-method }}
 
   test-llmisvc-wva-autoscaling-keda:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     needs: [detect-changes, llmisvc-image-build, seed-model-cache]
     strategy:
       fail-fast: false
@@ -506,7 +506,7 @@ jobs:
           name: test-results-llmisvc-autoscaling-keda-${{ matrix.install-method }}
 
   test-llmisvc-tracing:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     needs: [detect-changes, llmisvc-image-build]
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1336,7 +1336,7 @@ jobs:
           name: test-results-kourier-${{ matrix.install-method }}
 
   test-llm:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     needs: [detect-changes, kserve-image-build, predictor-runtime-build]
     strategy:
       fail-fast: false
@@ -1419,7 +1419,7 @@ jobs:
           name: test-results-llm-${{ matrix.install-method }}
 
   test-huggingface-server-vllm:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     needs: [detect-changes, kserve-image-build, predictor-runtime-build]
     strategy:
       fail-fast: false
@@ -1503,7 +1503,7 @@ jobs:
           name: test-results-vllm-${{ matrix.install-method }}
 
   test-vllm-runtime:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     needs: [detect-changes, kserve-image-build, predictor-runtime-build]
     strategy:
       fail-fast: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the resource-heavy LLM/vLLM E2E test jobs from `ubuntu-latest` (4 vCPU / 16 GB) to CNCF-provided `cncf-ubuntu-16-64-x86` runners (16 vCPU / 64 GB).

On stock `ubuntu-latest` runners, after kube-system, Istio, Knative, cert-manager, KServe controllers, and SeaweedFS are installed, only ~2000m CPU remains — exactly the request of a vLLM test pod. Any new sidecar, tracing collector, or controller pushes scheduling past the allocatable limit. The bigger runners provide headroom for upcoming work (tracing, autoscaling, DRA, multi-model serving).

Jobs moved:
- `e2e-test.yml`: `test-llm`, `test-huggingface-server-vllm`, `test-vllm-runtime`
- `e2e-test-llmisvc.yaml`: `test-llmisvc`, `test-llmisvc-wva-autoscaling-hpa`, `test-llmisvc-wva-autoscaling-keda`, `test-llmisvc-tracing`

Lightweight jobs (predictor, graph, raw, qpext, modelcache, image builds) remain on `ubuntu-latest`.

**Which issue(s) this PR fixes**:
Fixes #5658

**Feature/Issue validation/testing**:

- [x] CI will exercise the new runners on this PR itself — verify the affected jobs schedule on `cncf-ubuntu-16-64-x86` and pass.

**Special notes for your reviewer**:

Pure CI configuration change; no product code touched. The `cncf-ubuntu-16-64-x86` label is one of the runner pools CNCF provides to the project (see issue thread for the full list).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? — N/A, CI-only change; the existing e2e jobs are the validation.
- [x] Has code been commented, particularly in hard-to-understand areas? — N/A, single-line `runs-on` swaps.
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? — N/A.

**Release note**:
```release-note
NONE
```