### PR TITLE
feat(localmodel): allow overriding isvc-config namespace

### DIFF
--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -189,13 +189,13 @@ type ServiceConfig struct {
 	ServiceClusterIPNone bool `json:"serviceClusterIPNone,omitempty"`
 }
 
-func GetInferenceServiceConfigMap(ctx context.Context, clientset kubernetes.Interface) (*corev1.ConfigMap, error) {
-	if configMap, err := clientset.CoreV1().ConfigMaps(constants.KServeNamespace).Get(
-		ctx, constants.InferenceServiceConfigMapName, metav1.GetOptions{}); err != nil {
-		return nil, err
-	} else {
-		return configMap, nil
+func GetInferenceServiceConfigMap(ctx context.Context, clientset kubernetes.Interface, namespace ...string) (*corev1.ConfigMap, error) {
+	ns := constants.KServeNamespace
+	if len(namespace) > 0 && namespace[0] != "" {
+		ns = namespace[0]
 	}
+	return clientset.CoreV1().ConfigMaps(ns).Get(
+		ctx, constants.InferenceServiceConfigMapName, metav1.GetOptions{})
 }
 
 func NewOtelCollectorConfig(isvcConfigMap *corev1.ConfigMap) (*OtelCollectorConfig, error) {

--- a/pkg/apis/serving/v1beta1/configmap_test.go
+++ b/pkg/apis/serving/v1beta1/configmap_test.go
@@ -533,6 +533,37 @@ func TestNewLocalModelConfig(t *testing.T) {
 	})
 }
 
+func TestGetInferenceServiceConfigMap_OptionalNamespace(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("uses explicit namespace when provided", func(t *testing.T) {
+		clientset := fakeclientset.NewSimpleClientset(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: "app-ns",
+			},
+			Data: map[string]string{LocalModelConfigName: `{}`},
+		})
+
+		cm, err := GetInferenceServiceConfigMap(t.Context(), clientset, "app-ns")
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(cm.Namespace).To(gomega.Equal("app-ns"))
+	})
+
+	t.Run("defaults to KServeNamespace when namespace omitted", func(t *testing.T) {
+		clientset := fakeclientset.NewSimpleClientset(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.InferenceServiceConfigMapName,
+				Namespace: constants.KServeNamespace,
+			},
+		})
+
+		cm, err := GetInferenceServiceConfigMap(t.Context(), clientset)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(cm.Namespace).To(gomega.Equal(constants.KServeNamespace))
+	})
+}
+
 func TestNewSecurityConfig(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler.go
@@ -58,7 +58,7 @@ type LocalModelReconciler struct {
 // Step 4 - Creates PV & PVCs for namespaces with isvcs using this cached model
 func (c *LocalModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	c.Log.Info("Reconciling localmodel", "name", req.Name)
-	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, c.Clientset)
+	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, c.Clientset, controllerutils.InferenceServiceConfigNamespace())
 	if err != nil {
 		c.Log.Error(err, "unable to get configmap", "name", constants.InferenceServiceConfigMapName, "namespace", constants.KServeNamespace)
 		return reconcile.Result{}, err
@@ -244,7 +244,7 @@ func (c *LocalModelReconciler) localmodelNodeFunc(ctx context.Context, obj clien
 }
 
 func (c *LocalModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(context.Background(), c.Clientset)
+	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(context.Background(), c.Clientset, controllerutils.InferenceServiceConfigNamespace())
 	if err != nil {
 		c.Log.Error(err, "unable to get configmap", "name", constants.InferenceServiceConfigMapName, "namespace", constants.KServeNamespace)
 		return err

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
@@ -58,7 +58,7 @@ type LocalModelNamespaceCacheReconciler struct {
 // Step 4 - Creates PV & PVCs for ISVCs in the same namespace using this cached model
 func (c *LocalModelNamespaceCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	c.Log.Info("Reconciling namespace-scoped localmodel", "name", req.Name, "namespace", req.Namespace)
-	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, c.Clientset)
+	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, c.Clientset, controllerutils.InferenceServiceConfigNamespace())
 	if err != nil {
 		c.Log.Error(err, "unable to get configmap", "name", constants.InferenceServiceConfigMapName, "namespace", constants.KServeNamespace)
 		return reconcile.Result{}, err
@@ -266,7 +266,7 @@ func (c *LocalModelNamespaceCacheReconciler) localmodelNodeFuncNamespaceCache(ct
 }
 
 func (c *LocalModelNamespaceCacheReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(context.Background(), c.Clientset)
+	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(context.Background(), c.Clientset, controllerutils.InferenceServiceConfigNamespace())
 	if err != nil {
 		c.Log.Error(err, "unable to get configmap", "name", constants.InferenceServiceConfigMapName, "namespace", constants.KServeNamespace)
 		return err

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/utils.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/utils.go
@@ -263,7 +263,7 @@ func DeleteModelFromNodes(
 
 			// Delete download PVC from jobNamespace (where download jobs run)
 			downloadPVCName := downloadPVName
-			isvcConfigMap, cfgErr := v1beta1.GetInferenceServiceConfigMap(ctx, clientset)
+			isvcConfigMap, cfgErr := v1beta1.GetInferenceServiceConfigMap(ctx, clientset, controllerutils.InferenceServiceConfigNamespace())
 			if cfgErr == nil {
 				localModelConfig, cfgErr := v1beta1.NewLocalModelConfig(isvcConfigMap)
 				if cfgErr == nil {

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -533,9 +533,9 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	c.Log.Info("Agent reconciling LocalModelNode", "name", req.Name, "node", nodeName)
 
 	// 1. Load config
-	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, c.Clientset)
+	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, c.Clientset, utils.InferenceServiceConfigNamespace())
 	if err != nil {
-		c.Log.Error(err, "unable to get configmap", "name", constants.InferenceServiceConfigMapName, "namespace", constants.KServeNamespace)
+		c.Log.Error(err, "unable to get configmap", "name", constants.InferenceServiceConfigMapName, "namespace", utils.InferenceServiceConfigNamespace())
 		return reconcile.Result{}, err
 	}
 	c.IsvcConfigMap = isvcConfigMap

--- a/pkg/controller/v1alpha1/utils/utils.go
+++ b/pkg/controller/v1alpha1/utils/utils.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -32,6 +33,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 )
+
+// KServeConfigNamespaceEnv is set on localmodel/localmodelnode workloads when they run outside the
+// application namespace so they can read inferenceservice-config from the operator namespace.
+const KServeConfigNamespaceEnv = "KSERVE_CONFIG_NAMESPACE"
+
+// InferenceServiceConfigNamespace returns the namespace of the inferenceservice-config ConfigMap
+// for modelcache controllers.
+func InferenceServiceConfigNamespace() string {
+	if ns := os.Getenv(KServeConfigNamespaceEnv); ns != "" {
+		return ns
+	}
+	return constants.KServeNamespace
+}
 
 // CheckNodeAffinity returns true if the node matches the node affinity specified in the PV Spec
 func CheckNodeAffinity(pvSpec *corev1.PersistentVolumeSpec, node corev1.Node) (bool, error) {

--- a/pkg/controller/v1alpha1/utils/utils_test.go
+++ b/pkg/controller/v1alpha1/utils/utils_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The KServe Authors.
+Copyright 2026 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/v1alpha1/utils/utils_test.go
+++ b/pkg/controller/v1alpha1/utils/utils_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestInferenceServiceConfigNamespace(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("uses KSERVE_CONFIG_NAMESPACE when set", func(t *testing.T) {
+		t.Setenv(KServeConfigNamespaceEnv, "app-ns")
+		g.Expect(InferenceServiceConfigNamespace()).To(gomega.Equal("app-ns"))
+	})
+
+	t.Run("falls back to KServeNamespace when unset", func(t *testing.T) {
+		t.Setenv(KServeConfigNamespaceEnv, "")
+		g.Expect(InferenceServiceConfigNamespace()).To(gomega.Equal(constants.KServeNamespace))
+	})
+}


### PR DESCRIPTION
## Summary

- Add an optional namespace parameter to `GetInferenceServiceConfigMap` so callers can load `inferenceservice-config` from a namespace other than the default KServe namespace.
- Introduce `KSERVE_CONFIG_NAMESPACE` and `InferenceServiceConfigNamespace()` for localmodel/localmodelnode controllers to resolve the ConfigMap namespace at runtime.
- Update localmodel and localmodelnode reconcilers to use the resolved namespace when fetching operator config.

## Motivation

ModelCache controllers may run in a dedicated namespace while the operator ConfigMap remains in the application namespace. This change lets those controllers read config without hardcoding namespace values.

## Test plan

- [x] `make precommit`
- [ ] `make test` (deferred)