### PR TITLE
feat: add configurable storage volume for storage initializer

### DIFF
--- a/charts/kserve-llmisvc-resources/files/common/configmap.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap.yaml
@@ -774,7 +774,8 @@ data:
         "enableModelcar": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
-        "uidModelcar": 1010
+        "uidModelcar": 1010,
+        "modelVolumeSource": null
     }
 kind: ConfigMap
 metadata:

--- a/charts/kserve-resources/files/common/configmap.yaml
+++ b/charts/kserve-resources/files/common/configmap.yaml
@@ -774,7 +774,8 @@ data:
         "enableModelcar": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
-        "uidModelcar": 1010
+        "uidModelcar": 1010,
+        "modelVolumeSource": null
     }
 kind: ConfigMap
 metadata:

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -659,7 +659,8 @@ data:
         "enableModelcar": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
-        "uidModelcar": 1010
+        "uidModelcar": 1010,
+        "modelVolumeSource": null
     }
 
   credentials: |-

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -659,7 +659,8 @@ data:
         "enableModelcar": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
-        "uidModelcar": 1010
+        "uidModelcar": 1010,
+        "modelVolumeSource": null
     }
 
   credentials: |-

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -56091,7 +56091,8 @@ data:
         "enableModelcar": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
-        "uidModelcar": 1010
+        "uidModelcar": 1010,
+        "modelVolumeSource": null
     }
 kind: ConfigMap
 metadata:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -55677,7 +55677,8 @@ data:
         "enableModelcar": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
-        "uidModelcar": 1010
+        "uidModelcar": 1010,
+        "modelVolumeSource": null
     }
 kind: ConfigMap
 metadata:

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -402,9 +402,10 @@ func (r *LLMISVCReconciler) attachStorageInitializer(llmSvc *v1alpha2.LLMInferen
 		constants.DefaultModelLocalMountPath,
 	}
 	storageMountParams := utils.StorageMountParams{
-		MountPath:  constants.DefaultModelLocalMountPath,
-		VolumeName: constants.StorageInitializerVolumeName,
-		ReadOnly:   false,
+		MountPath:           constants.DefaultModelLocalMountPath,
+		VolumeName:          constants.StorageInitializerVolumeName,
+		ReadOnly:            false,
+		DefaultVolumeSource: storageConfig.ModelVolumeSource,
 	}
 
 	copied := *storageConfig
@@ -517,16 +518,18 @@ func (r *LLMISVCReconciler) attachMultiStorageDownloads(
 	iname := initC.Name
 
 	if err := utils.AddModelMount(utils.StorageMountParams{
-		MountPath:  parent,
-		VolumeName: constants.StorageInitializerVolumeName,
-		ReadOnly:   false,
+		MountPath:           parent,
+		VolumeName:          constants.StorageInitializerVolumeName,
+		ReadOnly:            false,
+		DefaultVolumeSource: storageConfig.ModelVolumeSource,
 	}, iname, podSpec); err != nil {
 		return err
 	}
 	if err := utils.AddModelMount(utils.StorageMountParams{
-		MountPath:  parent,
-		VolumeName: constants.StorageInitializerVolumeName,
-		ReadOnly:   true,
+		MountPath:           parent,
+		VolumeName:          constants.StorageInitializerVolumeName,
+		ReadOnly:            true,
+		DefaultVolumeSource: storageConfig.ModelVolumeSource,
 	}, containerName, podSpec); err != nil {
 		return err
 	}

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage_volume_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage_volume_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	kserveTypes "github.com/kserve/kserve/pkg/types"
+)
+
+// baseStorageConfig returns a minimal StorageInitializerConfig suitable for unit tests.
+func baseStorageConfig() *kserveTypes.StorageInitializerConfig {
+	return &kserveTypes.StorageInitializerConfig{
+		Image:         "kserve/storage-initializer:latest",
+		CpuRequest:    "100m",
+		CpuLimit:      "1",
+		MemoryRequest: "256Mi",
+		MemoryLimit:   "1Gi",
+	}
+}
+
+func findVolume(podSpec *corev1.PodSpec, name string) *corev1.Volume {
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == name {
+			return &podSpec.Volumes[i]
+		}
+	}
+	return nil
+}
+
+// TestAttachStorageInitializer_ModelVolumeSource verifies that
+// attachStorageInitializer passes StorageConfig.ModelVolumeSource through to
+// the pod volume, covering all three storage scenarios.
+func TestAttachStorageInitializer_ModelVolumeSource(t *testing.T) {
+	storageClassName := "fast-nvme"
+
+	tests := []struct {
+		name              string
+		modelVolumeSource *corev1.VolumeSource
+		checkVolume       func(t *testing.T, vol *corev1.Volume)
+	}{
+		{
+			name:              "nil ModelVolumeSource uses emptyDir",
+			modelVolumeSource: nil,
+			checkVolume: func(t *testing.T, vol *corev1.Volume) {
+				require.NotNil(t, vol.EmptyDir, "expected emptyDir")
+				assert.Nil(t, vol.Ephemeral)
+				assert.Nil(t, vol.PersistentVolumeClaim)
+			},
+		},
+		{
+			name: "ephemeral VolumeClaimTemplate",
+			modelVolumeSource: &corev1.VolumeSource{
+				Ephemeral: &corev1.EphemeralVolumeSource{
+					VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							StorageClassName: &storageClassName,
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("50Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			checkVolume: func(t *testing.T, vol *corev1.Volume) {
+				require.NotNil(t, vol.Ephemeral, "expected ephemeral volume")
+				assert.Nil(t, vol.EmptyDir)
+				assert.Equal(t, "fast-nvme", *vol.Ephemeral.VolumeClaimTemplate.Spec.StorageClassName)
+				assert.Equal(t, "50Gi", vol.Ephemeral.VolumeClaimTemplate.Spec.Resources.Requests.Storage().String())
+			},
+		},
+		{
+			name: "dedicated PVC",
+			modelVolumeSource: &corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "model-cache-pvc",
+				},
+			},
+			checkVolume: func(t *testing.T, vol *corev1.Volume) {
+				require.NotNil(t, vol.PersistentVolumeClaim, "expected PVC volume")
+				assert.Equal(t, "model-cache-pvc", vol.PersistentVolumeClaim.ClaimName)
+				assert.Nil(t, vol.EmptyDir)
+			},
+		},
+		{
+			name: "per-service override: pre-existing volume is not replaced",
+			modelVolumeSource: &corev1.VolumeSource{
+				Ephemeral: &corev1.EphemeralVolumeSource{
+					VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						},
+					},
+				},
+			},
+			checkVolume: func(t *testing.T, vol *corev1.Volume) {
+				// The pod already had a user-defined volume; it must survive unchanged.
+				require.NotNil(t, vol.PersistentVolumeClaim, "user-supplied PVC must be preserved")
+				assert.Equal(t, "user-pvc", vol.PersistentVolumeClaim.ClaimName)
+				assert.Nil(t, vol.Ephemeral, "ModelVolumeSource must not overwrite existing volume")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseStorageConfig()
+			cfg.ModelVolumeSource = tc.modelVolumeSource
+
+			podSpec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: constants.InferenceServiceContainerName},
+				},
+			}
+
+			// For the per-service override test, pre-populate the volume.
+			if tc.name == "per-service override: pre-existing volume is not replaced" {
+				podSpec.Volumes = []corev1.Volume{
+					{
+						Name: constants.StorageInitializerVolumeName,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "user-pvc",
+							},
+						},
+					},
+				}
+			}
+
+			r := &LLMISVCReconciler{}
+			llmSvc := &v1alpha2.LLMInferenceService{}
+			err := r.attachStorageInitializer(
+				llmSvc,
+				"s3://bucket/model",
+				corev1.PodSpec{},
+				podSpec,
+				cfg,
+				constants.InferenceServiceContainerName,
+				constants.DefaultModelLocalMountPath,
+			)
+			require.NoError(t, err)
+
+			vol := findVolume(podSpec, constants.StorageInitializerVolumeName)
+			require.NotNil(t, vol, "kserve-provision-location volume must be present")
+			tc.checkVolume(t, vol)
+		})
+	}
+}

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package types
 
+import corev1 "k8s.io/api/core/v1"
+
 // OCI model mode constants for OciModelMode field.
 const (
 	OciModelModeModelcar = "modelcar"
@@ -41,6 +43,12 @@ type StorageInitializerConfig struct {
 	// OciModelMode selects the materialization strategy for oci:// and oci+native:// URIs.
 	// Valid values: "modelcar" (default), "native", "fetch". Empty resolves to "modelcar".
 	OciModelMode string `json:"ociModelMode"`
+	// ModelVolumeSource overrides the default emptyDir volume used as the shared
+	// model staging area between the storage-initializer init container and the
+	// serving container. When nil, emptyDir is used. Any valid corev1.VolumeSource
+	// that supports ReadWriteOnce (or better) may be specified — e.g. ephemeral,
+	// persistentVolumeClaim, or hostPath.
+	ModelVolumeSource *corev1.VolumeSource `json:"modelVolumeSource,omitempty"`
 }
 
 // ResolveOciModelMode returns the effective OCI model mode for the given config.

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -35,6 +35,9 @@ type StorageMountParams struct {
 	VolumeName string
 	PVCName    string
 	ReadOnly   bool
+	// DefaultVolumeSource overrides the emptyDir used when PVCName is empty.
+	// When nil, emptyDir is used (backward-compatible default).
+	DefaultVolumeSource *corev1.VolumeSource
 }
 
 // ParsePvcURI parses a PVC URI of the form "pvc://<name>[/path]" into its components.
@@ -106,14 +109,16 @@ func addVolumeMountToContainer(container *corev1.Container, storageMountParams S
 //   - error: An error if the modelUri is invalid or if any other issue occurs; otherwise, nil.
 func AddModelMount(storageMountParams StorageMountParams, containerName string, podSpec *corev1.PodSpec) error {
 	var volumeSource corev1.VolumeSource
-
-	if storageMountParams.PVCName != "" {
+	switch {
+	case storageMountParams.PVCName != "":
 		volumeSource = corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: storageMountParams.PVCName,
 			},
 		}
-	} else {
+	case storageMountParams.DefaultVolumeSource != nil:
+		volumeSource = *storageMountParams.DefaultVolumeSource
+	default:
 		volumeSource = corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		}

--- a/pkg/utils/storage_test.go
+++ b/pkg/utils/storage_test.go
@@ -802,3 +802,148 @@ func TestConfigureOciNativeToContainer(t *testing.T) {
 
 	_ = g // suppress unused warning from outer scope
 }
+
+func TestAddModelMount_VolumeSource(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	containerName := "kserve-container"
+	mountPath := constants.DefaultModelLocalMountPath
+	volumeName := constants.StorageInitializerVolumeName
+
+	newPodSpec := func() *corev1.PodSpec {
+		return &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: containerName},
+			},
+		}
+	}
+
+	t.Run("nil DefaultVolumeSource uses emptyDir", func(t *testing.T) {
+		podSpec := newPodSpec()
+		err := AddModelMount(StorageMountParams{
+			MountPath:           mountPath,
+			VolumeName:          volumeName,
+			DefaultVolumeSource: nil,
+		}, containerName, podSpec)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+		g.Expect(podSpec.Volumes[0].EmptyDir).ToNot(gomega.BeNil(), "should default to emptyDir")
+		g.Expect(podSpec.Volumes[0].PersistentVolumeClaim).To(gomega.BeNil())
+		g.Expect(podSpec.Volumes[0].Ephemeral).To(gomega.BeNil())
+	})
+
+	t.Run("PVCName takes precedence over DefaultVolumeSource", func(t *testing.T) {
+		podSpec := newPodSpec()
+		ephemeral := &corev1.VolumeSource{
+			Ephemeral: &corev1.EphemeralVolumeSource{
+				VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+				},
+			},
+		}
+		err := AddModelMount(StorageMountParams{
+			MountPath:           mountPath,
+			VolumeName:          volumeName,
+			PVCName:             "my-pvc",
+			DefaultVolumeSource: ephemeral,
+		}, containerName, podSpec)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+		g.Expect(podSpec.Volumes[0].PersistentVolumeClaim).ToNot(gomega.BeNil())
+		g.Expect(podSpec.Volumes[0].PersistentVolumeClaim.ClaimName).To(gomega.Equal("my-pvc"))
+		g.Expect(podSpec.Volumes[0].Ephemeral).To(gomega.BeNil())
+	})
+
+	t.Run("dedicated PVC via PVCName", func(t *testing.T) {
+		podSpec := newPodSpec()
+		err := AddModelMount(StorageMountParams{
+			MountPath:  mountPath,
+			VolumeName: volumeName,
+			PVCName:    "model-cache-pvc",
+		}, containerName, podSpec)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+		g.Expect(podSpec.Volumes[0].PersistentVolumeClaim).ToNot(gomega.BeNil())
+		g.Expect(podSpec.Volumes[0].PersistentVolumeClaim.ClaimName).To(gomega.Equal("model-cache-pvc"))
+	})
+
+	t.Run("ephemeral VolumeClaimTemplate via DefaultVolumeSource", func(t *testing.T) {
+		podSpec := newPodSpec()
+		storageClassName := "fast-nvme"
+		ephemeral := &corev1.VolumeSource{
+			Ephemeral: &corev1.EphemeralVolumeSource{
+				VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						StorageClassName: &storageClassName,
+					},
+				},
+			},
+		}
+		err := AddModelMount(StorageMountParams{
+			MountPath:           mountPath,
+			VolumeName:          volumeName,
+			DefaultVolumeSource: ephemeral,
+		}, containerName, podSpec)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+		g.Expect(podSpec.Volumes[0].Ephemeral).ToNot(gomega.BeNil())
+		g.Expect(podSpec.Volumes[0].Ephemeral.VolumeClaimTemplate.Spec.StorageClassName).To(
+			gomega.HaveValue(gomega.Equal("fast-nvme")),
+		)
+		g.Expect(podSpec.Volumes[0].EmptyDir).To(gomega.BeNil())
+	})
+
+	t.Run("existing volume with same name is not replaced (per-service override)", func(t *testing.T) {
+		storageClassName := "user-sc"
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: containerName}},
+			Volumes: []corev1.Volume{
+				{
+					Name: volumeName,
+					VolumeSource: corev1.VolumeSource{
+						Ephemeral: &corev1.EphemeralVolumeSource{
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									StorageClassName: &storageClassName,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := AddModelMount(StorageMountParams{
+			MountPath:           mountPath,
+			VolumeName:          volumeName,
+			DefaultVolumeSource: nil,
+		}, containerName, podSpec)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(podSpec.Volumes).To(gomega.HaveLen(1))
+		g.Expect(podSpec.Volumes[0].Ephemeral).ToNot(gomega.BeNil(), "user-supplied ephemeral volume must not be overwritten")
+		g.Expect(podSpec.Volumes[0].Ephemeral.VolumeClaimTemplate.Spec.StorageClassName).To(
+			gomega.HaveValue(gomega.Equal("user-sc")),
+		)
+	})
+
+	t.Run("hostPath via DefaultVolumeSource", func(t *testing.T) {
+		podSpec := newPodSpec()
+		dirOrCreate := corev1.HostPathDirectoryOrCreate
+		hostPath := &corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/mnt/fast-nvme/models",
+				Type: &dirOrCreate,
+			},
+		}
+		err := AddModelMount(StorageMountParams{
+			MountPath:           mountPath,
+			VolumeName:          volumeName,
+			DefaultVolumeSource: hostPath,
+		}, containerName, podSpec)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(podSpec.Volumes[0].HostPath).ToNot(gomega.BeNil())
+		g.Expect(podSpec.Volumes[0].HostPath.Path).To(gomega.Equal("/mnt/fast-nvme/models"))
+	})
+}

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -492,11 +492,12 @@ func CommonStorageInitialization(ctx context.Context, params *StorageInitializer
 
 			// Create shared volume mount for non-PVC storage URIs
 			storageMountParams := utils.StorageMountParams{
-				MountPath:  nonPVCMountPath,
-				SubPath:    "",
-				VolumeName: utils.GetVolumeNameFromPath(nonPVCMountPath),
-				PVCName:    "",
-				ReadOnly:   params.IsReadOnly,
+				MountPath:           nonPVCMountPath,
+				SubPath:             "",
+				VolumeName:          utils.GetVolumeNameFromPath(nonPVCMountPath),
+				PVCName:             "",
+				ReadOnly:            params.IsReadOnly,
+				DefaultVolumeSource: params.Config.ModelVolumeSource,
 			}
 
 			// Apply volume mount to all relevant containers
@@ -511,11 +512,12 @@ func CommonStorageInitialization(ctx context.Context, params *StorageInitializer
 		storageURI := params.StorageURIs[0]
 
 		storageMountParams := utils.StorageMountParams{
-			MountPath:  constants.DefaultModelLocalMountPath,
-			SubPath:    "",
-			VolumeName: constants.StorageInitializerVolumeName,
-			PVCName:    "",
-			ReadOnly:   params.IsReadOnly,
+			MountPath:           constants.DefaultModelLocalMountPath,
+			SubPath:             "",
+			VolumeName:          constants.StorageInitializerVolumeName,
+			PVCName:             "",
+			ReadOnly:            params.IsReadOnly,
+			DefaultVolumeSource: params.Config.ModelVolumeSource,
 		}
 
 		mountContainerNames = append(mountContainerNames, userContainer.Name)

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -5821,4 +5822,190 @@ func TestCommonStorageInitializationSkipsOciNativeURI(t *testing.T) {
 		}
 	}
 	require.NotNil(t, imgVol, "oci+native:// must produce an ImageVolume on the pod spec")
+}
+
+func TestModelVolumeSource(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx := context.Background()
+
+	storageClassName := "fast-nvme"
+
+	baseConfig := &kserveTypes.StorageInitializerConfig{
+		CpuRequest:    StorageInitializerDefaultCPURequest,
+		CpuLimit:      StorageInitializerDefaultCPULimit,
+		MemoryRequest: StorageInitializerDefaultMemoryRequest,
+		MemoryLimit:   StorageInitializerDefaultMemoryLimit,
+	}
+
+	makePodSpec := func() *corev1.PodSpec {
+		return &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName},
+			},
+		}
+	}
+
+	// Use a PVC URI so credential injection is skipped — we only care about the
+	// VolumeSource selection logic tested here.
+	pvcURI := "pvc://my-pvc/models"
+
+	t.Run("nil ModelVolumeSource uses emptyDir for non-PVC shared volume", func(t *testing.T) {
+		cfg := *baseConfig
+		cfg.ModelVolumeSource = nil
+		podSpec := makePodSpec()
+		err := CommonStorageInitialization(ctx, &StorageInitializerParams{
+			Namespace:         "default",
+			StorageURIs:       []v1beta1.StorageUri{{Uri: pvcURI, MountPath: constants.DefaultModelLocalMountPath}},
+			IsReadOnly:        true,
+			PodSpec:           podSpec,
+			CredentialBuilder: &credentials.CredentialBuilder{},
+			Config:            &cfg,
+			IsvcAnnotations:   map[string]string{},
+			IsLegacyURI:       true,
+		})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		var modelVol *corev1.Volume
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].Name == constants.PvcSourceMountName {
+				modelVol = &podSpec.Volumes[i]
+				break
+			}
+		}
+		g.Expect(modelVol).ToNot(gomega.BeNil(), "PVC volume must be present")
+		g.Expect(modelVol.PersistentVolumeClaim).ToNot(gomega.BeNil())
+		g.Expect(modelVol.PersistentVolumeClaim.ClaimName).To(gomega.Equal("my-pvc"))
+	})
+
+	t.Run("ephemeral VolumeClaimTemplate from ModelVolumeSource wired through injector", func(t *testing.T) {
+		cfg := *baseConfig
+		cfg.ModelVolumeSource = &corev1.VolumeSource{
+			Ephemeral: &corev1.EphemeralVolumeSource{
+				VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						StorageClassName: &storageClassName,
+					},
+				},
+			},
+		}
+		podSpec := makePodSpec()
+		s3URI := "s3://my-bucket/model"
+		params := &StorageInitializerParams{
+			Namespace:         "default",
+			StorageURIs:       []v1beta1.StorageUri{{Uri: s3URI, MountPath: constants.DefaultModelLocalMountPath}},
+			IsReadOnly:        true,
+			PodSpec:           podSpec,
+			CredentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{Data: map[string]string{}}),
+			Client:            c,
+			Config:            &cfg,
+			IsvcAnnotations:   map[string]string{},
+			IsLegacyURI:       false,
+		}
+		err := CommonStorageInitialization(ctx, params)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		volumeName := utils.GetVolumeNameFromPath(constants.DefaultModelLocalMountPath)
+		var modelVol *corev1.Volume
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].Name == volumeName {
+				modelVol = &podSpec.Volumes[i]
+				break
+			}
+		}
+		g.Expect(modelVol).ToNot(gomega.BeNil(), "model staging volume must exist")
+		g.Expect(modelVol.Ephemeral).ToNot(gomega.BeNil(), "volume must be ephemeral")
+		g.Expect(modelVol.EmptyDir).To(gomega.BeNil())
+		g.Expect(modelVol.Ephemeral.VolumeClaimTemplate.Spec.StorageClassName).To(
+			gomega.HaveValue(gomega.Equal("fast-nvme")),
+		)
+	})
+
+	t.Run("per-service volume named kserve-provision-location is preserved", func(t *testing.T) {
+		cfg := *baseConfig
+		cfg.ModelVolumeSource = &corev1.VolumeSource{
+			Ephemeral: &corev1.EphemeralVolumeSource{
+				VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+				},
+			},
+		}
+		userSC := "user-storage-class"
+		podSpec := makePodSpec()
+		podSpec.Volumes = []corev1.Volume{
+			{
+				Name: constants.StorageInitializerVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Ephemeral: &corev1.EphemeralVolumeSource{
+						VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								StorageClassName: &userSC,
+							},
+						},
+					},
+				},
+			},
+		}
+		params := &StorageInitializerParams{
+			Namespace:         "default",
+			StorageURIs:       []v1beta1.StorageUri{{Uri: "s3://bucket/model", MountPath: constants.DefaultModelLocalMountPath}},
+			IsReadOnly:        true,
+			PodSpec:           podSpec,
+			CredentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{Data: map[string]string{}}),
+			Client:            c,
+			Config:            &cfg,
+			IsvcAnnotations:   map[string]string{},
+			IsLegacyURI:       true,
+		}
+		err := CommonStorageInitialization(ctx, params)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		var modelVol *corev1.Volume
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].Name == constants.StorageInitializerVolumeName {
+				modelVol = &podSpec.Volumes[i]
+				break
+			}
+		}
+		g.Expect(modelVol).ToNot(gomega.BeNil())
+		g.Expect(modelVol.Ephemeral.VolumeClaimTemplate.Spec.StorageClassName).To(
+			gomega.HaveValue(gomega.Equal("user-storage-class")),
+			"user-defined per-service volume must not be overwritten by ModelVolumeSource",
+		)
+	})
+
+	t.Run("pvc:// storageUri ignores ModelVolumeSource", func(t *testing.T) {
+		cfg := *baseConfig
+		cfg.ModelVolumeSource = &corev1.VolumeSource{
+			Ephemeral: &corev1.EphemeralVolumeSource{
+				VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+				},
+			},
+		}
+		podSpec := makePodSpec()
+		err := CommonStorageInitialization(ctx, &StorageInitializerParams{
+			Namespace:         "default",
+			StorageURIs:       []v1beta1.StorageUri{{Uri: pvcURI, MountPath: constants.DefaultModelLocalMountPath}},
+			IsReadOnly:        true,
+			PodSpec:           podSpec,
+			CredentialBuilder: &credentials.CredentialBuilder{},
+			Config:            &cfg,
+			IsvcAnnotations:   map[string]string{},
+			IsLegacyURI:       true,
+		})
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		var modelVol *corev1.Volume
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].Name == constants.PvcSourceMountName {
+				modelVol = &podSpec.Volumes[i]
+				break
+			}
+		}
+		g.Expect(modelVol).ToNot(gomega.BeNil(), "PVC volume must be present")
+		g.Expect(modelVol.PersistentVolumeClaim).ToNot(gomega.BeNil(), "must be a PVC volume, not ephemeral")
+		g.Expect(modelVol.PersistentVolumeClaim.ClaimName).To(gomega.Equal("my-pvc"))
+		g.Expect(modelVol.Ephemeral).To(gomega.BeNil(), "ModelVolumeSource must not override pvc:// URI")
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The shared volume between the storage-initializer init container and the serving container (`kserve-provision-location`) is hardcoded as `emptyDir`. This PR makes it configurable so users can use ephemeral volumes with a `VolumeClaimTemplate`, a pre-created PVC, or any other `corev1.VolumeSource` — enabling better I/O performance for large model artifacts by leveraging fast local SSDs, or model caching acceleration layers such as [Fluid](https://fluid-cloudnative.github.io/).

Two levels of configuration are supported:
- **Cluster-wide default** via `storageInitializer.modelVolumeSource` in `inferenceservice-config` ConfigMap — applies to all `InferenceService` and `LLMInferenceService` pods.
- **Per-service override** by placing a volume named `kserve-provision-location` in `spec.predictor.volumes` (ISVC) or `spec.template.volumes` / `spec.router.scheduler.template.volumes` (LLMInferenceService) — takes precedence over the ConfigMap default.

`pvc://` storage URIs are unaffected — the PVC from the URI always takes priority. Default behaviour (`emptyDir`) is fully preserved when `modelVolumeSource` is null.

**Which issue(s) this PR fixes**:
Fixes #4575

**Feature/Issue validation/testing**:

- [x] Unit tests: 14 new subtests across `pkg/utils`, `pkg/webhook/admission/pod`, and `pkg/controller/v1alpha2/llmisvc`
- [x] Cluster tested on Kubernetes with EBS CSI driver — all scenarios reached `Ready=True` and served inference

**Scenario 1 — emptyDir default (no change needed)**
```yaml
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: sklearn-emptydir
spec:
  predictor:
    sklearn:
      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
```

**Scenario 2 — cluster-wide ephemeral via ConfigMap**

```bash
kubectl edit configmap inferenceservice-config -n kserve
```
```json
"storageInitializer": "{..., \"modelVolumeSource\": {\"ephemeral\": {\"volumeClaimTemplate\": {\"spec\": {\"accessModes\": [\"ReadWriteOnce\"], \"storageClassName\": \"fast-nvme\", \"resources\": {\"requests\": {\"storage\": \"50Gi\"}}}}}}}"
```
Restart the controller. No change to InferenceService YAML needed — every pod automatically gets an auto-provisioned PVC per replica.

**Scenario 3 — per-service ephemeral override (InferenceService)**
```yaml
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: sklearn-ephemeral
spec:
  predictor:
    volumes:
      - name: kserve-provision-location
        ephemeral:
          volumeClaimTemplate:
            spec:
              accessModes: ["ReadWriteOnce"]
              storageClassName: fast-nvme
              resources:
                requests:
                  storage: 50Gi
    sklearn:
      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
```

**Scenario 4 — per-service ephemeral override (LLMInferenceService)**

LLMInferenceService creates two separate Deployments (main workload + router-scheduler), so volumes must be set in both `spec.template.volumes` and `spec.router.scheduler.template.volumes`:
```yaml
apiVersion: serving.kserve.io/v1alpha2
kind: LLMInferenceService
metadata:
  name: facebook-opt-125m
spec:
  model:
    uri: "hf://facebook/opt-125m"
    name: facebook/opt-125m
  replicas: 1
  router:
    scheduler:
      template:
        volumes:
          - name: kserve-provision-location
            ephemeral:
              volumeClaimTemplate:
                spec:
                  accessModes: ["ReadWriteOnce"]
                  storageClassName: fast-nvme
                  resources:
                    requests:
                      storage: 2Gi
    route: {}
    gateway: {}
  template:
    volumes:
      - name: kserve-provision-location
        ephemeral:
          volumeClaimTemplate:
            spec:
              accessModes: ["ReadWriteOnce"]
              storageClassName: fast-nvme
              resources:
                requests:
                  storage: 50Gi
    containers:
      - name: main
```

> **Note on `fsGroup`:** Some storage backends mount volumes owned by root by default — this includes block storage CSI drivers (e.g. local SSD) and acceleration layers backed by PVCs (e.g. [Fluid](https://fluid-cloudnative.github.io/)). When the storage-initializer runs as a non-root user (uid/gid 1000 in the default KServe image), writing to such volumes will fail with permission denied. Set `securityContext.fsGroup: 1000` on the pod spec to have the kubelet chown the mounted volume before the container starts. This is not set automatically by KServe to avoid unintended side effects on user-supplied containers. Clusters where the CSI driver has `fsGroupPolicy: File` configured handle this automatically without any pod-level setting.

**Special notes for your reviewer**:

- No CRD changes — `make generate` and `make manifests` are not required.
- The `volumeExists` guard in `AddModelMount` (pre-existing code) is what makes the per-service override work — if a volume named `kserve-provision-location` already exists in the pod spec, KServe skips adding one. No new logic was needed for this.
- `pvc://` storage URIs set `PVCName` on `StorageMountParams`, which takes priority over `DefaultVolumeSource` in the switch statement — so `modelVolumeSource` is silently ignored when a PVC URI is used.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Add configurable storage volume for the storage initializer. The shared
staging volume (kserve-provision-location) can now be set cluster-wide
via storageInitializer.modelVolumeSource in inferenceservice-config, or
per-service by placing a volume with that name in the predictor spec.
Supports ephemeral volumes with VolumeClaimTemplate, pre-created PVCs,
and any other corev1.VolumeSource. Default emptyDir behaviour is unchanged.
```