### PR TITLE
fix: honor disableHTTPRouteTimeout in LLMInferenceService router

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_loader.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader.go
@@ -94,6 +94,11 @@ type Config struct {
 	UrlScheme               string `json:"urlScheme,omitempty"`
 	EnableTLS               bool   `json:"enableTLS,omitempty"`
 
+	// DisableHTTPRouteTimeout omits the spec.rules.timeouts field from generated
+	// HTTPRoutes. Required for Gateway implementations (e.g. GKE) that reject the
+	// timeouts field. Mirrors the v1beta1 ingress reconciler's behavior.
+	DisableHTTPRouteTimeout bool `json:"disableHTTPRouteTimeout,omitempty"`
+
 	ModelBasedRoutingHeaderName string                `json:"modelBasedRoutingHeaderName,omitempty"`
 	ModelBasedRoutingMode       ModelBasedRoutingMode `json:"modelBasedRoutingMode,omitempty"`
 
@@ -170,6 +175,7 @@ func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *types.Storag
 		IngressGatewayName:          igwName,
 		UrlScheme:                   ingressConfig.UrlScheme,
 		EnableTLS:                   ingressConfig.EnableLLMInferenceServiceTLS,
+		DisableHTTPRouteTimeout:     ingressConfig.DisableHTTPRouteTimeout,
 		ModelBasedRoutingHeaderName: ingressConfig.ModelBasedRoutingHeaderName,
 		ModelBasedRoutingMode:       parseModelBasedRoutingMode(ingressConfig.ModelBasedRoutingMode),
 		StorageConfig:               storageConfig,

--- a/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
@@ -125,3 +125,48 @@ func TestLoadConfig(t *testing.T) {
 		t.Fatal("SchedulerConfig = nil, want populated config")
 	}
 }
+
+// TestLoadConfigDisableHTTPRouteTimeout closes the ConfigMap -> Config loop for the
+// disableHTTPRouteTimeout ingress flag: it asserts that the value set on the
+// inferenceservice-config ConfigMap propagates through NewConfig into Config, which the
+// router consumes to strip spec.rules.timeouts. Without this, a mis-wire of the
+// propagation would silently resurface #5707 while the router-level test still passes.
+func TestLoadConfigDisableHTTPRouteTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		ingress string
+		want    bool
+	}{
+		{
+			name:    "flag true propagates",
+			ingress: `{"kserveIngressGateway": "kserve/kserve-ingress-gateway", "ingressGateway": "knative-serving/knative-ingress-gateway", "disableHTTPRouteTimeout": true}`,
+			want:    true,
+		},
+		{
+			name:    "flag omitted defaults to false",
+			ingress: `{"kserveIngressGateway": "kserve/kserve-ingress-gateway", "ingressGateway": "knative-serving/knative-ingress-gateway"}`,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Start from the full fixture (valid storageInitializer/credentials blocks)
+			// and override only the ingress block so LoadConfig parses end to end.
+			configMap := fixture.InferenceServiceCfgMap(constants.KServeNamespace)
+			configMap.Data["ingress"] = tt.ingress
+			c := fake.NewClientBuilder().
+				WithScheme(clientgoscheme.Scheme).
+				WithObjects(configMap).
+				Build()
+
+			got, err := llmisvc.LoadConfig(t.Context(), c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.DisableHTTPRouteTimeout != tt.want {
+				t.Errorf("DisableHTTPRouteTimeout = %v, want %v", got.DisableHTTPRouteTimeout, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -212,6 +212,16 @@ func (r *LLMISVCReconciler) expectedHTTPRoute(ctx context.Context, llmSvc *v1alp
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Route != nil && llmSvc.Spec.Router.Route.HTTP.HasSpec() {
 		httpRoute.Spec = *llmSvc.Spec.Router.Route.HTTP.Spec.DeepCopy()
 
+		// Omit spec.rules.timeouts when configured to do so. Some Gateway
+		// implementations (e.g. GKE) reject the timeouts field, so the generated
+		// route (whose rules carry timeouts from the router-route preset) must drop
+		// it. Mirrors resolveTimeout in the v1beta1 ingress reconciler.
+		if cfg.DisableHTTPRouteTimeout {
+			for i := range httpRoute.Spec.Rules {
+				httpRoute.Spec.Rules[i].Timeouts = nil
+			}
+		}
+
 		if r.isModelBasedRoutingEnabled(ctx, llmSvc, cfg) {
 			if llmSvc.Spec.Model.LoRA != nil {
 				expandLoRAAdapterMatches(

--- a/pkg/controller/v1alpha2/llmisvc/router_timeout_export_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_timeout_export_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+// ExpectedHTTPRouteForTest exposes the unexported expectedHTTPRoute for external
+// (package llmisvc_test) tests so they can reuse the shared gwapi fixture builders,
+// whose package imports llmisvc and therefore cannot be imported from within package llmisvc.
+func (r *LLMISVCReconciler) ExpectedHTTPRouteForTest(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, cfg *Config) *gwapiv1.HTTPRoute {
+	return r.expectedHTTPRoute(ctx, llmSvc, cfg)
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_timeout_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_timeout_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+// TestExpectedHTTPRouteDisableTimeout verifies that the v1alpha2 LLMISVC router
+// honors the disableHTTPRouteTimeout ingress flag by stripping spec.rules.timeouts
+// from the generated HTTPRoute. Some Gateway implementations (e.g. GKE) reject the
+// timeouts field, so when the flag is set the field must be omitted entirely.
+func TestExpectedHTTPRouteDisableTimeout(t *testing.T) {
+	tests := []struct {
+		name                    string
+		disableHTTPRouteTimeout bool
+		wantTimeouts            bool
+	}{
+		{
+			name:                    "timeouts preserved when flag disabled",
+			disableHTTPRouteTimeout: false,
+			wantTimeouts:            true,
+		},
+		{
+			name:                    "timeouts stripped when flag enabled",
+			disableHTTPRouteTimeout: true,
+			wantTimeouts:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Managed rules carry timeouts (0s on every rule), mirroring the shape
+			// produced by the config-llm-router-route preset.
+			llmSvc := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-llm", Namespace: "default"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Router: &v1alpha2.RouterSpec{
+						Route: &v1alpha2.GatewayRoutesSpec{
+							HTTP: &v1alpha2.HTTPRouteSpec{
+								Spec: &gwapiv1.HTTPRouteSpec{
+									Rules: []gwapiv1.HTTPRouteRule{
+										HTTPRouteRule(
+											WithMatches(PathPrefixMatch("/v1/completions")),
+											WithBackendRefs(BackendRefService("svc")),
+											WithTimeouts("0s", "0s"),
+										),
+										HTTPRouteRule(
+											WithMatches(PathPrefixMatch("/v1/chat/completions")),
+											WithBackendRefs(BackendRefService("svc")),
+											WithTimeouts("0s", "0s"),
+										),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			r := &llmisvc.LLMISVCReconciler{}
+			cfg := &llmisvc.Config{DisableHTTPRouteTimeout: tt.disableHTTPRouteTimeout}
+
+			route := r.ExpectedHTTPRouteForTest(t.Context(), llmSvc, cfg)
+
+			if len(route.Spec.Rules) == 0 {
+				t.Fatalf("expected generated HTTPRoute to have rules, got none")
+			}
+			for i, rule := range route.Spec.Rules {
+				if tt.wantTimeouts && rule.Timeouts == nil {
+					t.Errorf("rule[%d]: expected timeouts to be preserved, got nil", i)
+				}
+				if !tt.wantTimeouts && rule.Timeouts != nil {
+					t.Errorf("rule[%d]: expected timeouts to be stripped, got %+v", i, *rule.Timeouts)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

PR #5313 wired the `disableHTTPRouteTimeout` ingress flag into the **v1beta1** ingress reconciler only. The **v1alpha2 `LLMInferenceService`** router never read it.

The router copies the managed HTTPRoute spec from the `config-llm-router-route` preset verbatim, and that preset hardcodes `spec.rules.timeouts: {backendRequest: 0s, request: 0s}` on **every** rule. Because the flag was never consulted, generated HTTPRoutes always emitted `timeouts`, and Gateway implementations that do not support the field (e.g. GKE Gateway) rejected the entire route with `GWCER104`. Users had no escape hatch.

This threads the existing `IngressConfig.DisableHTTPRouteTimeout` flag through the llmisvc `Config` and strips `spec.rules.timeouts` from the generated HTTPRoute when the flag is set — mirroring `resolveTimeout` in the v1beta1 ingress reconciler (which omits the field entirely).

Custom routes supplied via `route.http.refs` are user-owned and left untouched; only the managed `route.http.spec` is affected.

## Which issue(s) this PR fixes

Fixes #5707

## Test plan

- New unit test `TestExpectedHTTPRouteDisableTimeout` (`router_timeout_internal_test.go`) asserts the rendered HTTPRoute **omits** `timeouts` when `disableHTTPRouteTimeout=true` and **preserves** them when `false`. Verified failing before the fix, passing after.
- Full package suite green: `make test TEST_PKGS="./pkg/controller/v1alpha2/llmisvc/..."`.

```release-note
Fixed the `disableHTTPRouteTimeout` ingress option being silently ignored by the LLMInferenceService (v1alpha2) router. Generated HTTPRoutes now omit `spec.rules.timeouts` when the flag is set, so they are no longer rejected by Gateway implementations (e.g. GKE) that do not support the timeouts field.
```

### Checklist

- [x] Tests added/updated
- [x] Linked issue