### PR TITLE
fix(ci): reduce max_tokens for LoRA llmisvc tests

### DIFF
--- a/test/e2e/llmisvc/test_llm_lora_adapters.py
+++ b/test/e2e/llmisvc/test_llm_lora_adapters.py
@@ -58,7 +58,7 @@ class LoRATestCase:
     expected_adapter_names: List[str]
     service_name: Optional[str] = None
     endpoint: str = "/v1/completions"
-    max_tokens: int = 100
+    max_tokens: int = 20
     wait_timeout: int = 900
     response_timeout: int = 60
 


### PR DESCRIPTION
100 max tokens just slows down CI runs since we're not testing performance nor we're using accelerators.

