### PR TITLE
fix(ci): disable HF xet-bridge and raise timeout for vllm cpu tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1486,7 +1486,7 @@ jobs:
           kubectl describe pods -n kserve
 
       - name: Run E2E tests
-        timeout-minutes: 45
+        timeout-minutes: 90
         run: |
           export PYTEST_MAXFAIL=3
           ./test/scripts/gh-actions/run-e2e-tests.sh "vllm" "1"

--- a/test/e2e/predictor/test_huggingface_vllm_cpu.py
+++ b/test/e2e/predictor/test_huggingface_vllm_cpu.py
@@ -47,6 +47,11 @@ ISVC_READY_TIMEOUT_S = 900
 # finish.
 ISVC_ANNOTATIONS = {"serving.knative.dev/progress-deadline": "20m"}
 
+# CNCF bare-metal runners route HuggingFace downloads via xet-bridge CDN which
+# returns 403 from outside Azure. Disabling xet forces the standard HTTP download
+# path which works from any network.
+HF_DISABLE_XET = client.V1EnvVar(name="HF_HUB_DISABLE_XET", value="1")
+
 
 @pytest.mark.vllm
 def test_huggingface_vllm_cpu_openai_chat_completions():
@@ -78,6 +83,7 @@ def test_huggingface_vllm_cpu_openai_chat_completions():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
+                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -143,6 +149,7 @@ def test_huggingface_vllm_cpu_text_completion_streaming():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
+                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -210,6 +217,7 @@ def test_huggingface_vllm_cpu_openai_completions():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
+                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -274,6 +282,7 @@ def test_huggingface_vllm_openai_chat_completions_streaming():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
+                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -344,6 +353,7 @@ def test_huggingface_vllm_cpu_rerank():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
+                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "6Gi"},

--- a/test/e2e/predictor/test_huggingface_vllm_cpu.py
+++ b/test/e2e/predictor/test_huggingface_vllm_cpu.py
@@ -47,11 +47,6 @@ ISVC_READY_TIMEOUT_S = 900
 # finish.
 ISVC_ANNOTATIONS = {"serving.knative.dev/progress-deadline": "20m"}
 
-# CNCF bare-metal runners route HuggingFace downloads via xet-bridge CDN which
-# returns 403 from outside Azure. Disabling xet forces the standard HTTP download
-# path which works from any network.
-HF_DISABLE_XET = client.V1EnvVar(name="HF_HUB_DISABLE_XET", value="1")
-
 
 @pytest.mark.vllm
 def test_huggingface_vllm_cpu_openai_chat_completions():
@@ -83,7 +78,6 @@ def test_huggingface_vllm_cpu_openai_chat_completions():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
-                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -149,7 +143,6 @@ def test_huggingface_vllm_cpu_text_completion_streaming():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
-                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -217,7 +210,6 @@ def test_huggingface_vllm_cpu_openai_completions():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
-                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -282,7 +274,6 @@ def test_huggingface_vllm_openai_chat_completions_streaming():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
-                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "7Gi"},
@@ -353,7 +344,6 @@ def test_huggingface_vllm_cpu_rerank():
                     name="VLLM_ENABLE_V1_MULTIPROCESSING",
                     value="0",
                 ),
-                HF_DISABLE_XET,
             ],
             resources=V1ResourceRequirements(
                 requests={"cpu": "2", "memory": "6Gi"},

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -81,7 +81,8 @@ if [[ $ENABLE_LLMISVC == "false" || $ENABLE_KSERVE_WITH_LLMISVC == "true" ]]; th
   echo "Applying test env patches to ClusterServingRuntimes..."
   kubectl patch clusterservingruntime kserve-huggingfaceserver --type=json -p='[
     {"op":"add","path":"/spec/containers/0/env/-","value":{"name":"TOKIO_WORKER_THREADS","value":"1"}},
-    {"op":"add","path":"/spec/containers/0/env/-","value":{"name":"HF_HUB_DISABLE_XET","value":"1"}}
+    {"op":"add","path":"/spec/containers/0/env/-","value":{"name":"HF_HUB_DISABLE_XET","value":"1"}},
+    {"op":"add","path":"/spec/containers/0/env/-","value":{"name":"HF_HUB_ENABLE_HF_TRANSFER","value":"0"}}
   ]'
 
   kubectl get events -A


### PR DESCRIPTION
**What this PR does / why we need it**

PR #5724 moved `test-huggingface-server-vllm` to `cncf-ubuntu-16-64-x86` runners, which triggered 100% failure of the job since 2026-06-25 due to two issues. Issue 1 (403 on model downloads) was pre-existing but masked: `hf_transfer` was always routing downloads through the xet-bridge CDN (`us.aws.cdn.hf.co`), which ubuntu-latest runners can reach but CNCF runners cannot. PR #5657 attempted to fix this with `HF_HUB_DISABLE_XET=1`, but that flag only suppresses `hf_xet` — it has no effect on `hf_transfer`, which has its own xet-bridge integration. This gap went undetected because #5657's CI still ran on ubuntu-latest. Issue 2 (timeout) was directly introduced by #5724 — CNCF runners take ~15-17 min to download the 8.45 GB image artifact vs ~1.5 min on ubuntu-latest, leaving too little time for the 5 serial tests within the 45-min cap.

**Issue 1 — Model download fails with 403**

Each test deploys an ISVC that pulls model weights from HuggingFace Hub at runtime. The image ships with both `hf_xet` and `hf_transfer` installed (via `kserve-storage` → `huggingface-hub[hf-transfer]`). When `hf_transfer` is importable, `huggingface_hub` delegates all downloads to it. `hf_transfer 0.1.9` has its own xet-bridge integration: it fetches a presigned URL from HuggingFace that already points to `us.aws.cdn.hf.co/xet-bridge-us/...`, then downloads directly from there — entirely bypassing the `HF_HUB_DISABLE_XET` flag. The CNCF runners cannot reach that CDN and receive 403, crashing vLLM on startup:

```
hf_transfer.download(...)
Exception: ... 403 Forbidden ... https://us.aws.cdn.hf.co/xet-bridge-us/.../model.safetensors
RuntimeError: Engine core initialization failed. See root cause above.
```

This was confirmed in the PR #5732 CI logs: `HF_HUB_DISABLE_XET=1` was present in the pod env (injected correctly by the CSR patch from #5657), yet the 403s persisted because `hf_transfer` never checks that flag.

The correct fix is `HF_HUB_ENABLE_HF_TRANSFER=0`, which disables `hf_transfer` entirely and falls back to plain `requests`-based downloads via `huggingface.co`, which works from any network.

**Issue 2 — Timeout too short for CNCF runners**

The CNCF runners download the 8.45 GB HuggingFace server image artifact over a slower network path (~15-17 min vs ~1.5 min on `ubuntu-latest`), pushing total setup time from ~11 min to ~23 min. This left only ~22 min for 5 serial vLLM CPU tests against the 45-min cap. Raising to 90 min reflects the actual job runtime observed on these runners.

**Evidence**

| Period | Runner | Runs | Result |
|---|---|---|---|
| Before 2026-06-25 | `ubuntu-latest` | 5 | 5/5 ✓ |
| After 2026-06-25 | `cncf-ubuntu-16-64-x86` | 9 | 0/9 ✗ |

| Step | `ubuntu-latest` | CNCF runner |
|---|---|---|
| Download HF server image | ~1m30s | ~15-17m |
| Total setup | ~11m | ~23m |
| Time left for tests (45m limit) | ~34m ✓ | ~22m ✗ |

**Changes**

- `test/scripts/gh-actions/setup-kserve.sh`: add `HF_HUB_ENABLE_HF_TRANSFER=0` to the existing `kubectl patch clusterservingruntime kserve-huggingfaceserver` block, alongside `TOKIO_WORKER_THREADS=1` and `HF_HUB_DISABLE_XET=1` already set by #5657. This is the authoritative fix at the CSR level, applied once for both kustomize and helm install paths.
- `.github/workflows/e2e-test.yml`: raise `test-huggingface-server-vllm` `timeout-minutes` from 45 to 90.

**Long-term fix**

Using a dedicated HuggingFace account token (`HF_TOKEN` as a CI secret) injected into the test ISVCs would authenticate downloads, avoid CDN routing restrictions entirely, and protect against anonymous rate limiting. Tracked as a follow-up.

**Which issue(s) this PR fixes**

Restores `test-huggingface-server-vllm` after regression introduced by #5724. Supersedes the incomplete fix in the original version of this PR which set `HF_HUB_DISABLE_XET=1` at the ISVC level — that flag does not affect `hf_transfer`.

**Special notes for your reviewer**

CI-only change; no product code touched. The `test-huggingface-server-vllm` job on this PR itself is the validation — check that it passes on `cncf-ubuntu-16-64-x86`.

**Checklist**
- [x] Have you added unit/e2e tests? — N/A, CI-only fix; existing tests are the validation.
- [x] Has code been commented? — N/A, the commit message explains the root cause.
- [x] Documentation changes? — N/A.

**Release note**
```release-note
NONE
```