### PR TITLE
feat: set NextProtos (ALPN) on logger TLS client transport

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -83,7 +83,6 @@ type Options struct {
 	enableLeaderElection  bool
 	probeAddr             string
 	metricsSecure         bool
-	enableHTTP2           bool
 	migrationTimeout      time.Duration
 	migrationPollInterval time.Duration
 	zapOpts               zap.Options
@@ -96,7 +95,6 @@ func DefaultOptions() Options {
 		enableLeaderElection:  false,
 		probeAddr:             ":8081",
 		metricsSecure:         true,
-		enableHTTP2:           false,
 		migrationTimeout:      1 * time.Hour,
 		migrationPollInterval: 30 * time.Second,
 		zapOpts:               zap.Options{},
@@ -113,7 +111,6 @@ func GetOptions() Options {
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
 	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metric via HTTPS.")
-	flag.BoolVar(&opts.enableHTTP2, "enable-http2", false, "If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.DurationVar(&opts.migrationTimeout, "storage-migration-timeout", opts.migrationTimeout, "Total retry budget for storage version migration.")
 	flag.DurationVar(&opts.migrationPollInterval, "storage-migration-poll-interval", opts.migrationPollInterval, "Polling interval for storage version migration retries after initial backoff.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
@@ -153,19 +150,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// http/2 should be disabled due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
-
-	var tlsOpts []func(*tls.Config)
-	if !options.enableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
+	tlsOpts := []func(*tls.Config){
+		func(c *tls.Config) {
+			c.NextProtos = []string{"h2", "http/1.1"}
+		},
 	}
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:

--- a/cmd/localmodel/main.go
+++ b/cmd/localmodel/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"os"
 
@@ -99,14 +100,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	tlsOpts := []func(*tls.Config){
+		func(c *tls.Config) {
+			c.NextProtos = []string{"h2", "http/1.1"}
+		},
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/cmd/localmodelnode/main.go
+++ b/cmd/localmodelnode/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"os"
 
@@ -92,14 +93,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	tlsOpts := []func(*tls.Config){
+		func(c *tls.Config) {
+			c.NextProtos = []string{"h2", "http/1.1"}
+		},
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"net/http"
 	"os"
@@ -124,12 +125,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	tlsOpts := []func(*tls.Config){
+		func(c *tls.Config) {
+			c.NextProtos = []string{"h2", "http/1.1"}
+		},
+	}
+
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -107,6 +107,7 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 					RootCAs:            clientCertPool,
 					MinVersion:         tls.VersionTLS12,
 					InsecureSkipVerify: logReq.TlsSkipVerify, // #nosec G402
+					NextProtos:         []string{"h2", "http/1.1"},
 				},
 			}
 			t.Client.Transport = tlsTransport


### PR DESCRIPTION
## Summary

- Sets `NextProtos: ["h2", "http/1.1"]` on the logger TLS client transport for proper ALPN negotiation
- Removes the vestigial `enableHTTP2` flag from llmisvc. CVE-2023-44487 (HTTP/2 Rapid Reset) is fixed in Go's net/http since Go 1.21.3, and kserve uses Go 1.25.8. The flag defaulted to false, which set `NextProtos: ["http/1.1"]` and blocked HTTP/2 unnecessarily. Now always sets `NextProtos: ["h2", "http/1.1"]` for proper ALPN compliance.

## Changes

- `pkg/logger/worker.go`: Set `NextProtos: ["h2", "http/1.1"]` on logger HTTP client TLS config
- `cmd/llmisvc/main.go`: Remove `--enable-http2` CLI flag, `enableHTTP2` Options field, and `disableHTTP2` function. Always enable HTTP/2 via ALPN.

## Motivation

Without explicit `NextProtos`, Go's TLS client does not advertise protocol preferences during the TLS handshake. This can cause protocol mismatches with servers that require ALPN (like OCP infrastructure services).

The `enableHTTP2` flag was introduced as a mitigation for CVE-2023-44487, but Go 1.21.3+ already includes the fix in the stdlib. On Go 1.25.8, the flag just unnecessarily blocks HTTP/2.