### PR TITLE
fix(llmisvc): add v0.9 precise-prefix-cache split migration & orphan fix

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1070,9 +1070,11 @@ schedulingProfiles:
 
 				configText, found := getSchedulerConfigText(expectedDeployment)
 				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
-				g.Expect(configText).To(ContainSubstring("modelName: base"))
+				// After v0.9 split: tokenizersPoolConfig is removed, token-producer uses UDS
 				g.Expect(configText).To(ContainSubstring("socketFile: /tmp/tokenizer/tokenizer-uds.socket"))
-				// Verify tokenProcessorConfig was migrated from indexerConfig to top-level parameters
+				g.Expect(configText).To(ContainSubstring("token-producer"))
+				g.Expect(configText).NotTo(ContainSubstring("tokenizersPoolConfig"))
+				// tokenProcessorConfig should be at producer top-level (promoted from indexerConfig)
 				g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
 				g.Expect(configText).To(ContainSubstring("blockSize: 16"))
 				return nil
@@ -1136,11 +1138,13 @@ schedulingProfiles:
 
 				configText, found := getSchedulerConfigText(expectedDeployment)
 				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
-				g.Expect(configText).To(ContainSubstring("modelName: base"))
+				// After v0.9 split: token-producer uses UDS
 				g.Expect(configText).To(ContainSubstring("socketFile: /tmp/tokenizer/tokenizer-uds.socket"))
+				g.Expect(configText).To(ContainSubstring("token-producer"))
 				g.Expect(configText).NotTo(ContainSubstring("wrong-model-name"))
 				g.Expect(configText).NotTo(ContainSubstring("/wrong/path"))
-				// Verify tokenProcessorConfig was migrated from indexerConfig to top-level parameters
+				g.Expect(configText).NotTo(ContainSubstring("tokenizersPoolConfig"))
+				// tokenProcessorConfig at producer top-level
 				g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
 				g.Expect(configText).To(ContainSubstring("blockSize: 16"))
 				return nil

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -28,11 +28,13 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
@@ -156,7 +158,7 @@ schedulingProfiles:
 						Containers: []corev1.Container{
 							{
 								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2",
+								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0",
 								Args: []string{
 									"--config-text",
 									"existing-config-from-template",
@@ -904,7 +906,7 @@ schedulingProfiles:
 						Containers: []corev1.Container{
 							{
 								Name:  "main",
-								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2",
+								Image: "ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0",
 								Args: []string{
 									"--ha-enable-leader-election",
 									"--poolName",
@@ -1689,6 +1691,189 @@ schedulingProfiles:
 				configText, found := getSchedulerConfigText(expectedDeployment)
 				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
 				g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("v0.9.0 precise-prefix-cache split migration", func() {
+		It("should split precise-prefix-cache-scorer into producer + scorer + token-producer at v0.9", func(ctx SpecContext) {
+			svcName := "test-llm-split-v09"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			oldFormatConfig := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: precise-prefix-cache-scorer
+  parameters:
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      kvBlockIndexConfig:
+        enableMetrics: true
+      tokenizersPoolConfig:
+        modelName: base
+        uds:
+          socketFile: /tmp/tokenizer/tokenizer-uds.socket
+    kvEventsConfig:
+      topicFilter: kv
+      zmqEndpoint: tcp://*:5557
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: precise-prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(oldFormatConfig),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+
+				// Deprecated plugin must be gone
+				g.Expect(configText).NotTo(ContainSubstring("precise-prefix-cache-scorer"))
+
+				// New split plugins present
+				g.Expect(configText).To(ContainSubstring("token-producer"))
+				g.Expect(configText).To(ContainSubstring("precise-prefix-cache-producer"))
+				g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+				g.Expect(configText).To(ContainSubstring("endpoint-notification-source"))
+
+				// token-producer has correct udsTokenizerConfig field name (not "uds")
+				g.Expect(configText).To(ContainSubstring("udsTokenizerConfig"))
+				g.Expect(configText).To(ContainSubstring("socketFile"))
+
+				// prefix-cache-scorer references the producer
+				g.Expect(configText).To(ContainSubstring("prefixMatchInfoProducerName: precise-prefix-cache-producer"))
+
+				// tokenProcessorConfig at top level of producer (not inside indexerConfig)
+				g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
+				g.Expect(configText).To(ContainSubstring("blockSize"))
+
+				// dataLayer wired
+				g.Expect(configText).To(ContainSubstring("dataLayer"))
+
+				// apiVersion updated
+				g.Expect(configText).To(ContainSubstring("llm-d.ai/v1alpha1"))
+
+				// tokenizersPoolConfig removed from indexerConfig
+				g.Expect(configText).NotTo(ContainSubstring("tokenizersPoolConfig"))
+
+				// tokenizer sidecar should be kept (token-producer uses UDS)
+				hasTokenizer := false
+				for _, c := range expectedDeployment.Spec.Template.Spec.Containers {
+					if c.Name == "tokenizer" {
+						hasTokenizer = true
+					}
+				}
+				g.Expect(hasTokenizer).To(BeTrue(), "tokenizer sidecar should be preserved for UDS token-producer")
+
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should remove tokenProcessorConfig from indexerConfig (orphan removal)", func(ctx SpecContext) {
+			svcName := "test-llm-orphan-removal"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			configWithOrphan := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: precise-prefix-cache-scorer
+  parameters:
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      kvBlockIndexConfig:
+        enableMetrics: true
+    kvEventsConfig:
+      topicFilter: kv
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: precise-prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(configWithOrphan),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+
+				// tokenProcessorConfig should be at top level (promoted)
+				g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
+				g.Expect(configText).To(ContainSubstring("blockSize: 64"))
+
+				// Parse YAML and verify tokenProcessorConfig is NOT inside indexerConfig
+				u := unstructured.Unstructured{}
+				g.Expect(yaml.Unmarshal([]byte(configText), &u)).To(Succeed())
+
+				plugins, _, _ := unstructured.NestedSlice(u.Object, "plugins")
+				for _, p := range plugins {
+					pm, ok := p.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					// Check both old plugin and new producer
+					if pm["type"] == "precise-prefix-cache-scorer" || pm["type"] == "precise-prefix-cache-producer" {
+						_, orphanFound, _ := unstructured.NestedFieldNoCopy(pm, "parameters", "indexerConfig", "tokenProcessorConfig")
+						g.Expect(orphanFound).To(BeFalse(),
+							"tokenProcessorConfig must NOT be inside indexerConfig (would crash v0.9 strict decoder)")
+					}
+				}
+
 				return nil
 			}).WithContext(ctx).Should(Succeed())
 		})

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1463,7 +1463,6 @@ func withSplitPrecisePrefixCacheScorerV09(ctx context.Context, u *unstructured.U
 	tokenProducer := map[string]interface{}{
 		"type": tokenProducerPlugin,
 		"parameters": map[string]interface{}{
-			"modelName": udsTokenizerBaseModelName,
 			"udsTokenizerConfig": map[string]interface{}{
 				"socketFile": udsTokenizerSocketFile,
 			},

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -56,7 +56,10 @@ const (
 	tokenizerContainerName = "tokenizer"
 
 	precisePrefixCacheScorerPlugin    = "precise-prefix-cache-scorer"
+	precisePrefixCacheProducerPlugin  = "precise-prefix-cache-producer"
 	prefixCacheScorerPlugin           = "prefix-cache-scorer"
+	tokenProducerPlugin               = "token-producer"
+	endpointNotificationSourcePlugin  = "endpoint-notification-source"
 	loraAffinityScorerPlugin          = "lora-affinity-scorer"
 	coreMetricsExtractorPlugin        = "model-server-protocol-metrics"
 	coreMetricsExtractorPluginRenamed = "core-metrics-extractor"
@@ -859,6 +862,10 @@ func WithUdsTokenizerConfig(_ context.Context, u *unstructured.Unstructured) err
 // precise-prefix-cache-scorer plugin. This handles the schema change in
 // llm-d-router v0.6.0 where tokenProcessorConfig was promoted
 // from indexerConfig to a top-level plugin parameter.
+//
+// The field is always removed from indexerConfig because kvcache.Config no
+// longer defines it — the strict JSON decoder in the router rejects unknown
+// fields.
 func WithMigrateTokenProcessorConfig(ctx context.Context, u *unstructured.Unstructured) error {
 	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 	if err != nil || !found {
@@ -875,26 +882,25 @@ func WithMigrateTokenProcessorConfig(ctx context.Context, u *unstructured.Unstru
 			continue
 		}
 
-		// Skip if tokenProcessorConfig already exists at the top level
-		if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "tokenProcessorConfig"); exists {
-			log.FromContext(ctx).V(2).Info("tokenProcessorConfig already at top-level parameters, skipping migration")
-			continue
-		}
-
 		// Check if tokenProcessorConfig exists inside indexerConfig (old location)
 		tpc, found, err := unstructured.NestedFieldCopy(pluginMap, "parameters", "indexerConfig", "tokenProcessorConfig")
 		if err != nil {
 			log.FromContext(ctx).Error(err, "Failed to read tokenProcessorConfig from indexerConfig")
 			continue
 		}
-		if !found {
-			continue
-		}
 
-		log.FromContext(ctx).Info("Migrating tokenProcessorConfig from indexerConfig to top-level plugin parameters")
-		// Move to top-level parameters
-		if err := unstructured.SetNestedField(pluginMap, tpc, "parameters", "tokenProcessorConfig"); err != nil {
-			return err
+		if found {
+			// Promote to top-level parameters if not already present
+			if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "tokenProcessorConfig"); !exists {
+				log.FromContext(ctx).Info("Migrating tokenProcessorConfig from indexerConfig to top-level plugin parameters")
+				if err := unstructured.SetNestedField(pluginMap, tpc, "parameters", "tokenProcessorConfig"); err != nil {
+					return err
+				}
+			}
+
+			// Always remove from indexerConfig — kvcache.Config no longer has this
+			// field and the strict decoder rejects it.
+			unstructured.RemoveNestedField(pluginMap, "parameters", "indexerConfig", "tokenProcessorConfig")
 		}
 	}
 
@@ -1314,9 +1320,14 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 		opts = append(opts, withMigrateCoreMetricsExtractor)
 	}
 	if v.Compare(*semver.New("0.9.0")) >= 0 {
+		opts = append(opts, withSplitPrecisePrefixCacheScorerV09)
 		opts = append(opts, withRemovePrefixCacheScorerParametersV09)
-		opts = append(opts, withRemoveUnnecessaryTokenizer(d))
 	}
+
+	// Always last: remove the tokenizer sidecar if no plugin needs it.
+	// Must run after all plugin transformations (especially the v0.9 split
+	// which creates token-producer with UDS).
+	opts = append(opts, withRemoveUnnecessaryTokenizer(d))
 
 	if err := mutateSchedulerConfig(ctx, d, opts...); err != nil {
 		return fmt.Errorf("failed to mutate config: %w", err)
@@ -1378,6 +1389,181 @@ func withRemovePrefixCacheScorerParametersV09(ctx context.Context, u *unstructur
 	return nil
 }
 
+// withSplitPrecisePrefixCacheScorerV09 converts the deprecated
+// precise-prefix-cache-scorer plugin into the new split architecture:
+//   - token-producer (UDS backend for tokenization via sidecar)
+//   - precise-prefix-cache-producer (indexing + KV events)
+//   - prefix-cache-scorer (scoring using producer data)
+//   - endpoint-notification-source (per-pod ZMQ subscriber lifecycle)
+//
+// It also wires the dataLayer section and updates schedulingProfiles.
+func withSplitPrecisePrefixCacheScorerV09(ctx context.Context, u *unstructured.Unstructured) error {
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	if err != nil || !found {
+		return err
+	}
+	plugins, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Find the deprecated precise-prefix-cache-scorer plugin
+	scorerIdx := -1
+	var scorerParams map[string]interface{}
+	for i, plugin := range plugins {
+		pluginMap, ok := plugin.(map[string]interface{})
+		if !ok || pluginMap["type"] != precisePrefixCacheScorerPlugin {
+			continue
+		}
+		scorerIdx = i
+		if params, ok := pluginMap["parameters"].(map[string]interface{}); ok {
+			scorerParams = params
+		}
+		break
+	}
+
+	if scorerIdx < 0 {
+		return nil
+	}
+
+	log.FromContext(ctx).Info("Splitting deprecated precise-prefix-cache-scorer into producer + scorer + token-producer")
+
+	// Build precise-prefix-cache-producer parameters from the old scorer parameters.
+	producerParams := map[string]interface{}{}
+	if scorerParams != nil {
+		if tpc, ok := scorerParams["tokenProcessorConfig"]; ok {
+			producerParams["tokenProcessorConfig"] = tpc
+		}
+		if ic, ok := scorerParams["indexerConfig"]; ok {
+			icMap, _ := ic.(map[string]interface{})
+			if icMap != nil {
+				// Remove tokenizersPoolConfig — tokenization is now external via token-producer
+				delete(icMap, "tokenizersPoolConfig")
+				// Remove tokenProcessorConfig from indexerConfig — kvcache.Config no longer
+				// has this field. Normally removed by WithMigrateTokenProcessorConfig (Stage 1),
+				// but that stage is gated behind isUsingTokenizerSidecar.
+				if _, hasTP := icMap["tokenProcessorConfig"]; hasTP {
+					if _, topExists := scorerParams["tokenProcessorConfig"]; !topExists {
+						producerParams["tokenProcessorConfig"] = icMap["tokenProcessorConfig"]
+					}
+					delete(icMap, "tokenProcessorConfig")
+				}
+			}
+			producerParams["indexerConfig"] = ic
+		}
+		if kv, ok := scorerParams["kvEventsConfig"]; ok {
+			producerParams["kvEventsConfig"] = kv
+		}
+		if si, ok := scorerParams["speculativeIndexing"]; ok {
+			producerParams["speculativeIndexing"] = si
+		}
+		if st, ok := scorerParams["speculativeTTL"]; ok {
+			producerParams["speculativeTTL"] = st
+		}
+	}
+
+	// Build new plugins to replace the deprecated scorer
+	tokenProducer := map[string]interface{}{
+		"type": tokenProducerPlugin,
+		"parameters": map[string]interface{}{
+			"modelName": udsTokenizerBaseModelName,
+			"udsTokenizerConfig": map[string]interface{}{
+				"socketFile": udsTokenizerSocketFile,
+			},
+		},
+	}
+
+	producer := map[string]interface{}{
+		"type": precisePrefixCacheProducerPlugin,
+	}
+	if len(producerParams) > 0 {
+		producer["parameters"] = producerParams
+	}
+
+	scorer := map[string]interface{}{
+		"type": prefixCacheScorerPlugin,
+		"parameters": map[string]interface{}{
+			"prefixMatchInfoProducerName": precisePrefixCacheProducerPlugin,
+		},
+	}
+
+	notificationSource := map[string]interface{}{
+		"type": endpointNotificationSourcePlugin,
+	}
+
+	// Replace the deprecated plugin with the new set.
+	// Insert token-producer and endpoint-notification-source before the producer+scorer.
+	newPlugins := make([]interface{}, 0, len(plugins)+3)
+	for i, p := range plugins {
+		if i == scorerIdx {
+			newPlugins = append(newPlugins, tokenProducer, notificationSource, producer, scorer)
+			continue
+		}
+		newPlugins = append(newPlugins, p)
+	}
+
+	if err := unstructured.SetNestedSlice(u.Object, newPlugins, "plugins"); err != nil {
+		return err
+	}
+
+	// Update schedulingProfiles to reference prefix-cache-scorer instead of precise-prefix-cache-scorer
+	profiles, found, _ := unstructured.NestedFieldNoCopy(u.Object, "schedulingProfiles")
+	if found {
+		profileList, ok := profiles.([]interface{})
+		if ok {
+			for _, profile := range profileList {
+				profileMap, ok := profile.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				profilePlugins, ok := profileMap["plugins"].([]interface{})
+				if !ok {
+					continue
+				}
+				for _, pp := range profilePlugins {
+					ppMap, ok := pp.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					if ppMap["pluginRef"] == precisePrefixCacheScorerPlugin {
+						ppMap["pluginRef"] = prefixCacheScorerPlugin
+					}
+				}
+			}
+		}
+	}
+
+	// Wire the dataLayer section for endpoint-notification-source → precise-prefix-cache-producer
+	dataLayer, _, _ := unstructured.NestedFieldNoCopy(u.Object, "dataLayer")
+	dlMap, _ := dataLayer.(map[string]interface{})
+	if dlMap == nil {
+		dlMap = map[string]interface{}{}
+	}
+
+	sources, _ := dlMap["sources"].([]interface{})
+
+	// Add endpoint-notification-source with precise-prefix-cache-producer as extractor
+	notifSource := map[string]interface{}{
+		"pluginRef": endpointNotificationSourcePlugin,
+		"extractors": []interface{}{
+			map[string]interface{}{
+				"pluginRef": precisePrefixCacheProducerPlugin,
+			},
+		},
+	}
+	sources = append(sources, notifSource)
+	dlMap["sources"] = sources
+
+	if err := unstructured.SetNestedField(u.Object, dlMap, "dataLayer"); err != nil {
+		return err
+	}
+
+	// Update apiVersion to llm-d.ai/v1alpha1
+	u.Object["apiVersion"] = "llm-d.ai/v1alpha1"
+
+	return nil
+}
+
 func withRemoveUnnecessaryTokenizer(d *appsv1.Deployment) mutateSchedulerConfigFunc {
 	return func(ctx context.Context, u *unstructured.Unstructured) error {
 		val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
@@ -1389,15 +1575,27 @@ func withRemoveUnnecessaryTokenizer(d *appsv1.Deployment) mutateSchedulerConfigF
 			return nil
 		}
 
-		hasPrecisePrefix := false
+		needsTokenizer := false
 		for _, plugin := range plugins {
 			pluginMap, ok := plugin.(map[string]interface{})
-			if ok && pluginMap["type"] == precisePrefixCacheScorerPlugin {
-				hasPrecisePrefix = true
+			if !ok {
+				continue
+			}
+			pluginType, _ := pluginMap["type"].(string)
+			switch pluginType {
+			case precisePrefixCacheScorerPlugin:
+				needsTokenizer = true
+			case tokenProducerPlugin:
+				// token-producer with UDS backend requires the tokenizer sidecar
+				if _, hasUDS, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "udsTokenizerConfig"); hasUDS {
+					needsTokenizer = true
+				}
+			}
+			if needsTokenizer {
 				break
 			}
 		}
-		if !hasPrecisePrefix {
+		if !needsTokenizer {
 			for i := range d.Spec.Template.Spec.Containers {
 				if d.Spec.Template.Spec.Containers[i].Name == tokenizerContainerName {
 					d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers[:i], d.Spec.Template.Spec.Containers[i+1:]...)

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -863,9 +863,9 @@ func WithUdsTokenizerConfig(_ context.Context, u *unstructured.Unstructured) err
 // llm-d-router v0.6.0 where tokenProcessorConfig was promoted
 // from indexerConfig to a top-level plugin parameter.
 //
-// The field is always removed from indexerConfig because kvcache.Config no
-// longer defines it — the strict JSON decoder in the router rejects unknown
-// fields.
+// The field is NOT removed from indexerConfig here because v0.7/v0.8
+// kvcache.Config still defines it. Removal is handled by
+// withSplitPrecisePrefixCacheScorerV09 which is gated on v0.9+.
 func WithMigrateTokenProcessorConfig(ctx context.Context, u *unstructured.Unstructured) error {
 	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 	if err != nil || !found {
@@ -897,10 +897,6 @@ func WithMigrateTokenProcessorConfig(ctx context.Context, u *unstructured.Unstru
 					return err
 				}
 			}
-
-			// Always remove from indexerConfig — kvcache.Config no longer has this
-			// field and the strict decoder rejects it.
-			unstructured.RemoveNestedField(pluginMap, "parameters", "indexerConfig", "tokenProcessorConfig")
 		}
 	}
 
@@ -1322,12 +1318,13 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 	if v.Compare(*semver.New("0.9.0")) >= 0 {
 		opts = append(opts, withSplitPrecisePrefixCacheScorerV09)
 		opts = append(opts, withRemovePrefixCacheScorerParametersV09)
+		// Last within the v0.9 gate: remove the tokenizer sidecar if no plugin
+		// needs it. Only relevant after the split migration creates token-producer.
+		// For v0.7/v0.8, the monolithic precise-prefix-cache-scorer always needs
+		// the sidecar, so running this earlier would be a no-op but risks
+		// unnecessary deployment mutations on reconciliation.
+		opts = append(opts, withRemoveUnnecessaryTokenizer(d))
 	}
-
-	// Always last: remove the tokenizer sidecar if no plugin needs it.
-	// Must run after all plugin transformations (especially the v0.9 split
-	// which creates token-producer with UDS).
-	opts = append(opts, withRemoveUnnecessaryTokenizer(d))
 
 	if err := mutateSchedulerConfig(ctx, d, opts...); err != nil {
 		return fmt.Errorf("failed to mutate config: %w", err)

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2050,7 +2050,7 @@ schedulingProfiles:
 		g.Expect(sources).ToNot(BeEmpty())
 	})
 
-	t.Run("orphan_removal/tokenProcessorConfig_removed_from_indexerConfig", func(t *testing.T) {
+	t.Run("orphan_removal/promote_only_does_not_delete_from_indexerConfig", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		configYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -2080,12 +2080,11 @@ plugins:
 		}
 
 		ctx := context.Background()
+		// WithMigrateTokenProcessorConfig only promotes — does NOT delete from indexerConfig.
+		// Deletion is handled by withSplitPrecisePrefixCacheScorerV09 (v0.9-gated).
 		g.Expect(mutateSchedulerConfig(ctx, d, WithMigrateTokenProcessorConfig)).To(Succeed())
 
 		configText := d.Spec.Template.Spec.Containers[0].Args[1]
-
-		g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
-		g.Expect(configText).To(ContainSubstring("blockSize"))
 
 		u := unstructured.Unstructured{}
 		g.Expect(yaml.Unmarshal([]byte(configText), &u)).To(Succeed())
@@ -2096,11 +2095,66 @@ plugins:
 			if !ok || pm["type"] != "precise-prefix-cache-scorer" {
 				continue
 			}
+			// Field remains in indexerConfig (valid for v0.7/v0.8 kvcache.Config)
 			_, found, _ := unstructured.NestedFieldNoCopy(pm, "parameters", "indexerConfig", "tokenProcessorConfig")
-			g.Expect(found).To(BeFalse(), "tokenProcessorConfig should be removed from indexerConfig")
+			g.Expect(found).To(BeTrue(), "tokenProcessorConfig should remain in indexerConfig for v0.7/v0.8 compat")
+
+			// Field is also promoted to top level
+			_, found, _ = unstructured.NestedFieldNoCopy(pm, "parameters", "tokenProcessorConfig")
+			g.Expect(found).To(BeTrue(), "tokenProcessorConfig should exist at top level after promotion")
+		}
+	})
+
+	t.Run("orphan_removal/v09_split_removes_from_indexerConfig", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		configYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: precise-prefix-cache-scorer
+  parameters:
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      kvBlockIndexConfig:
+        enableMetrics: true
+    kvEventsConfig:
+      topicFilter: kv
+`
+		d := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "main", Args: []string{"--config-text", configYAML}},
+						},
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		// Full v0.9 pipeline: promote then split (which removes orphan)
+		g.Expect(mutateSchedulerConfig(ctx, d, WithMigrateTokenProcessorConfig, withSplitPrecisePrefixCacheScorerV09)).To(Succeed())
+
+		configText := d.Spec.Template.Spec.Containers[0].Args[1]
+
+		u := unstructured.Unstructured{}
+		g.Expect(yaml.Unmarshal([]byte(configText), &u)).To(Succeed())
+
+		// After split, precise-prefix-cache-producer gets indexerConfig without tokenProcessorConfig
+		plugins, _, _ := unstructured.NestedSlice(u.Object, "plugins")
+		for _, p := range plugins {
+			pm, ok := p.(map[string]interface{})
+			if !ok || pm["type"] != "precise-prefix-cache-producer" {
+				continue
+			}
+			_, found, _ := unstructured.NestedFieldNoCopy(pm, "parameters", "indexerConfig", "tokenProcessorConfig")
+			g.Expect(found).To(BeFalse(), "tokenProcessorConfig must be removed from indexerConfig in v0.9 split")
 
 			_, found, _ = unstructured.NestedFieldNoCopy(pm, "parameters", "tokenProcessorConfig")
-			g.Expect(found).To(BeTrue(), "tokenProcessorConfig should exist at top level")
+			g.Expect(found).To(BeTrue(), "tokenProcessorConfig should exist at producer top level")
 		}
 	})
 

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1589,6 +1589,44 @@ schedulingProfiles:
 			},
 		},
 		{
+			name:    "v0.9.0 disagg config gets params stripped from prefix-cache-scorer",
+			version: "0.9.0",
+			extraArgs: []string{
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--total-running-requests-metric", "vllm:num_requests_running",
+				"--kv-cache-usage-percentage-metric", "vllm:kv_cache_usage_perc",
+				"--grpc-port", "9002",
+			},
+			validateConfig: func(g Gomega, configText string) {
+				// v0.7 + v0.8 renames applied
+				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).To(ContainSubstring("core-metrics-extractor"))
+				g.Expect(configText).NotTo(ContainSubstring("model-server-protocol-metrics"))
+
+				// prefix-cache-scorer params stripped (blockSizeTokens removed)
+				g.Expect(configText).NotTo(ContainSubstring("blockSizeTokens"))
+				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+
+				// No split happened (no precise-prefix-cache-scorer in input)
+				g.Expect(configText).NotTo(ContainSubstring("precise-prefix-cache-producer"))
+				g.Expect(configText).NotTo(ContainSubstring("token-producer"))
+				g.Expect(configText).NotTo(ContainSubstring("endpoint-notification-source"))
+
+				// prefix-cache-scorer plugin itself still exists
+				g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+			},
+			validateArgs: func(g Gomega, args []string) {
+				for _, a := range args {
+					g.Expect(a).NotTo(ContainSubstring("total-queued-requests-metric"))
+					g.Expect(a).NotTo(ContainSubstring("total-running-requests-metric"))
+					g.Expect(a).NotTo(ContainSubstring("kv-cache-usage-percentage-metric"))
+				}
+				g.Expect(args).To(ContainElement("--grpc-port"))
+				g.Expect(args).To(ContainElement("9002"))
+			},
+		},
+		{
 			name:    "old config left untouched for v0.6.0",
 			version: "0.6.0",
 			extraArgs: []string{
@@ -1661,6 +1699,8 @@ schedulingProfiles:
 }
 
 func TestFullMigrationPipelineNonZeroThreshold(t *testing.T) {
+	// This tests a different input config (with threshold:100) so it stays
+	// as its own top-level test but is logically part of the pipeline suite.
 	oldConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -1737,6 +1777,415 @@ schedulingProfiles:
 
 	// Decider ordering invariant
 	validateDeciderOrderFromYAML(g, configText)
+}
+
+// TestPrecisePrefixCacheMigrationV09 is the unified test suite for all v0.9
+// precise-prefix-cache migration scenarios. It covers the split migration,
+// schema validation, orphan removal, idempotency, and edge cases.
+func TestPrecisePrefixCacheMigrationV09(t *testing.T) {
+	// Shared RHOAI-style old config used by multiple subtests
+	oldConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: precise-prefix-cache-scorer
+  parameters:
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      kvBlockIndexConfig:
+        enableMetrics: true
+      tokenizersPoolConfig:
+        modelName: base
+        uds:
+          socketFile: /tmp/tokenizer/tokenizer-uds.socket
+    kvEventsConfig:
+      topicFilter: kv
+      zmqEndpoint: tcp://*:5557
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: precise-prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+	// Helper: build a v0.9 deployment from config YAML with optional tokenizer sidecar
+	makeDeployment := func(configYAML string, withTokenizer bool) *appsv1.Deployment {
+		containers := []corev1.Container{
+			{Name: "main", Args: []string{"--config-text", configYAML}},
+		}
+		if withTokenizer {
+			containers = append(containers, corev1.Container{Name: "tokenizer"})
+		}
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"app.kubernetes.io/version": "0.9.0",
+						},
+					},
+					Spec: corev1.PodSpec{Containers: containers},
+				},
+			},
+		}
+	}
+
+	// Helper: run the full production pipeline (Stage 1 + Stage 2)
+	runFullPipeline := func(g Gomega, d *appsv1.Deployment) string {
+		ctx := context.Background()
+		g.Expect(mutateSchedulerConfig(ctx, d,
+			WithUdsTokenizerConfig,
+			WithMigrateTokenProcessorConfig,
+			WithMigrateBlockSizeToBlockSizeTokens,
+		)).To(Succeed())
+		g.Expect(schedulerTransform(ctx, d)).To(Succeed())
+		return d.Spec.Template.Spec.Containers[0].Args[1]
+	}
+
+	t.Run("split_migration/full_pipeline_converts_old_config", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		d := makeDeployment(oldConfigYAML, true)
+		configText := runFullPipeline(g, d)
+
+		// Deprecated plugin replaced
+		g.Expect(configText).NotTo(ContainSubstring("precise-prefix-cache-scorer"))
+
+		// New split plugins present
+		g.Expect(configText).To(ContainSubstring("precise-prefix-cache-producer"))
+		g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+		g.Expect(configText).To(ContainSubstring("token-producer"))
+		g.Expect(configText).To(ContainSubstring("endpoint-notification-source"))
+
+		// token-producer has UDS config
+		g.Expect(configText).To(ContainSubstring("socketFile"))
+		g.Expect(configText).To(ContainSubstring("modelName"))
+
+		// prefix-cache-scorer references the producer
+		g.Expect(configText).To(ContainSubstring("prefixMatchInfoProducerName: precise-prefix-cache-producer"))
+
+		// tokenProcessorConfig at top level of producer params
+		g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
+		g.Expect(configText).To(ContainSubstring("blockSize"))
+		g.Expect(configText).To(ContainSubstring("hashSeed"))
+
+		// tokenizersPoolConfig removed from indexerConfig
+		g.Expect(configText).NotTo(ContainSubstring("tokenizersPoolConfig"))
+
+		// kvEventsConfig preserved
+		g.Expect(configText).To(ContainSubstring("kvEventsConfig"))
+		g.Expect(configText).To(ContainSubstring("topicFilter"))
+
+		// dataLayer wired
+		g.Expect(configText).To(ContainSubstring("dataLayer"))
+
+		// schedulingProfiles updated
+		g.Expect(configText).To(ContainSubstring("pluginRef: prefix-cache-scorer"))
+
+		// apiVersion updated
+		g.Expect(configText).To(ContainSubstring("llm-d.ai/v1alpha1"))
+
+		// tokenizer sidecar kept (token-producer uses UDS)
+		hasTokenizer := false
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == "tokenizer" {
+				hasTokenizer = true
+			}
+		}
+		g.Expect(hasTokenizer).To(BeTrue(), "tokenizer sidecar should be kept for UDS token-producer")
+	})
+
+	t.Run("split_migration/no_op_when_precise_prefix_not_present", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		basicConfig := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: queue-scorer
+- type: prefix-cache-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+		d := makeDeployment(basicConfig, true)
+		ctx := context.Background()
+		g.Expect(schedulerTransform(ctx, d)).To(Succeed())
+
+		configText := d.Spec.Template.Spec.Containers[0].Args[1]
+
+		// No split happened
+		g.Expect(configText).NotTo(ContainSubstring("precise-prefix-cache-producer"))
+		g.Expect(configText).NotTo(ContainSubstring("token-producer"))
+
+		// Tokenizer sidecar removed (no UDS plugins)
+		hasTokenizer := false
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == "tokenizer" {
+				hasTokenizer = true
+			}
+		}
+		g.Expect(hasTokenizer).To(BeFalse(), "tokenizer sidecar should be removed when no UDS plugins exist")
+	})
+
+	t.Run("schema_validation/output_matches_v09_strict_decoder", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		schemaTestConfig := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: precise-prefix-cache-scorer
+  parameters:
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      kvBlockIndexConfig:
+        enableMetrics: true
+        metricsLoggingInterval: 60000000000
+      tokenizersPoolConfig:
+        modelName: base
+        uds:
+          socketFile: /tmp/tokenizer/tokenizer-uds.socket
+    kvEventsConfig:
+      topicFilter: kv
+      zmqEndpoint: tcp://*:5557
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: precise-prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+		d := makeDeployment(schemaTestConfig, true)
+		configText := runFullPipeline(g, d)
+
+		u := unstructured.Unstructured{}
+		g.Expect(yaml.Unmarshal([]byte(configText), &u)).To(Succeed())
+
+		plugins, found, _ := unstructured.NestedSlice(u.Object, "plugins")
+		g.Expect(found).To(BeTrue(), "plugins must exist in output")
+
+		validIndexerFields := map[string]bool{
+			"kvBlockIndexConfig":    true,
+			"kvCacheBackendConfigs": true,
+			"tokenizersPoolConfig":  true,
+		}
+		validProducerParams := map[string]bool{
+			"tokenProcessorConfig": true,
+			"indexerConfig":        true,
+			"kvEventsConfig":       true,
+			"speculativeIndexing":  true,
+			"speculativeTTL":       true,
+		}
+		validTokenProducerParams := map[string]bool{
+			"modelName":          true,
+			"vllm":               true,
+			"udsTokenizerConfig": true,
+			"estimate":           true,
+		}
+
+		for _, p := range plugins {
+			pm, ok := p.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			pluginType, _ := pm["type"].(string)
+			params, _ := pm["parameters"].(map[string]interface{})
+
+			switch pluginType {
+			case "precise-prefix-cache-producer":
+				for key := range params {
+					g.Expect(validProducerParams).To(HaveKey(key),
+						"producer parameter %q would be rejected by v0.9 strict decoder", key)
+				}
+				ic, _ := params["indexerConfig"].(map[string]interface{})
+				for key := range ic {
+					g.Expect(validIndexerFields).To(HaveKey(key),
+						"indexerConfig field %q would be rejected by v0.9 strict decoder", key)
+				}
+				_, found, _ := unstructured.NestedFieldNoCopy(pm, "parameters", "indexerConfig", "tokenProcessorConfig")
+				g.Expect(found).To(BeFalse(), "tokenProcessorConfig inside indexerConfig would crash v0.9")
+				_, found, _ = unstructured.NestedFieldNoCopy(pm, "parameters", "indexerConfig", "tokenizersPoolConfig")
+				g.Expect(found).To(BeFalse(), "tokenizersPoolConfig inside indexerConfig would be rejected at v0.9")
+				_, found, _ = unstructured.NestedFieldNoCopy(pm, "parameters", "tokenProcessorConfig")
+				g.Expect(found).To(BeTrue(), "tokenProcessorConfig must be at top level")
+
+			case "token-producer":
+				for key := range params {
+					g.Expect(validTokenProducerParams).To(HaveKey(key),
+						"token-producer parameter %q would be rejected by v0.9 strict decoder", key)
+				}
+				_, hasUDS := params["udsTokenizerConfig"]
+				g.Expect(hasUDS).To(BeTrue(), "token-producer must have udsTokenizerConfig")
+
+			case "prefix-cache-scorer":
+				for key := range params {
+					g.Expect(key).To(Equal("prefixMatchInfoProducerName"),
+						"prefix-cache-scorer should only have prefixMatchInfoProducerName at v0.9, got %q", key)
+				}
+
+			case "precise-prefix-cache-scorer":
+				t.Fatal("deprecated precise-prefix-cache-scorer must not exist in v0.9 output")
+			}
+		}
+
+		dl, found, _ := unstructured.NestedFieldNoCopy(u.Object, "dataLayer")
+		g.Expect(found).To(BeTrue(), "dataLayer must be present")
+		dlMap, ok := dl.(map[string]interface{})
+		g.Expect(ok).To(BeTrue())
+		sources, ok := dlMap["sources"].([]interface{})
+		g.Expect(ok).To(BeTrue())
+		g.Expect(sources).ToNot(BeEmpty())
+	})
+
+	t.Run("orphan_removal/tokenProcessorConfig_removed_from_indexerConfig", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		configYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: precise-prefix-cache-scorer
+  parameters:
+    indexerConfig:
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      kvBlockIndexConfig:
+        enableMetrics: true
+    kvEventsConfig:
+      topicFilter: kv
+`
+		d := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "main", Args: []string{"--config-text", configYAML}},
+						},
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		g.Expect(mutateSchedulerConfig(ctx, d, WithMigrateTokenProcessorConfig)).To(Succeed())
+
+		configText := d.Spec.Template.Spec.Containers[0].Args[1]
+
+		g.Expect(configText).To(ContainSubstring("tokenProcessorConfig"))
+		g.Expect(configText).To(ContainSubstring("blockSize"))
+
+		u := unstructured.Unstructured{}
+		g.Expect(yaml.Unmarshal([]byte(configText), &u)).To(Succeed())
+
+		plugins, _, _ := unstructured.NestedSlice(u.Object, "plugins")
+		for _, p := range plugins {
+			pm, ok := p.(map[string]interface{})
+			if !ok || pm["type"] != "precise-prefix-cache-scorer" {
+				continue
+			}
+			_, found, _ := unstructured.NestedFieldNoCopy(pm, "parameters", "indexerConfig", "tokenProcessorConfig")
+			g.Expect(found).To(BeFalse(), "tokenProcessorConfig should be removed from indexerConfig")
+
+			_, found, _ = unstructured.NestedFieldNoCopy(pm, "parameters", "tokenProcessorConfig")
+			g.Expect(found).To(BeTrue(), "tokenProcessorConfig should exist at top level")
+		}
+	})
+
+	t.Run("idempotency/already_migrated_config_unchanged", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		migratedConfigYAML := `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- name: token-producer
+  type: token-producer
+  parameters:
+    modelName: base
+    udsTokenizerConfig:
+      socketFile: /tmp/tokenizer/tokenizer-uds.socket
+- name: endpoint-notification-source
+  type: endpoint-notification-source
+- name: precise-prefix-cache-producer
+  type: precise-prefix-cache-producer
+  parameters:
+    tokenProcessorConfig:
+      blockSize: 64
+      hashSeed: "42"
+    indexerConfig:
+      kvBlockIndexConfig:
+        enableMetrics: true
+    kvEventsConfig:
+      topicFilter: kv
+      zmqEndpoint: tcp://*:5557
+- name: prefix-cache-scorer
+  type: prefix-cache-scorer
+  parameters:
+    prefixMatchInfoProducerName: precise-prefix-cache-producer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+dataLayer:
+  sources:
+  - pluginRef: endpoint-notification-source
+    extractors:
+    - pluginRef: precise-prefix-cache-producer
+`
+		d := makeDeployment(migratedConfigYAML, true)
+		resultConfig := runFullPipeline(g, d)
+
+		// Critical: no duplicates or breakage introduced
+		g.Expect(resultConfig).To(ContainSubstring("precise-prefix-cache-producer"))
+		g.Expect(resultConfig).To(ContainSubstring("token-producer"))
+		g.Expect(resultConfig).To(ContainSubstring("prefix-cache-scorer"))
+		g.Expect(resultConfig).To(ContainSubstring("endpoint-notification-source"))
+		g.Expect(resultConfig).To(ContainSubstring("prefixMatchInfoProducerName: precise-prefix-cache-producer"))
+		g.Expect(resultConfig).NotTo(ContainSubstring("precise-prefix-cache-scorer"))
+
+		// Structural validation
+		result := unstructured.Unstructured{}
+		g.Expect(yaml.Unmarshal([]byte(resultConfig), &result)).To(Succeed())
+
+		plugins, _, _ := unstructured.NestedSlice(result.Object, "plugins")
+		for _, p := range plugins {
+			pm, ok := p.(map[string]interface{})
+			if !ok || pm["type"] != "precise-prefix-cache-producer" {
+				continue
+			}
+			_, found, _ := unstructured.NestedFieldNoCopy(pm, "parameters", "indexerConfig", "tokenProcessorConfig")
+			g.Expect(found).To(BeFalse(), "tokenProcessorConfig must not appear inside indexerConfig after re-run")
+			_, found, _ = unstructured.NestedFieldNoCopy(pm, "parameters", "tokenProcessorConfig")
+			g.Expect(found).To(BeTrue(), "tokenProcessorConfig must remain at top level")
+		}
+
+		// Tokenizer sidecar preserved
+		hasTokenizer := false
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == "tokenizer" {
+				hasTokenizer = true
+			}
+		}
+		g.Expect(hasTokenizer).To(BeTrue(), "tokenizer sidecar must be kept on re-run")
+
+		g.Expect(resultConfig).To(ContainSubstring("llm-d.ai/v1alpha1"))
+	})
 }
 
 func TestExtractDeprecatedMetricFlags(t *testing.T) {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1862,7 +1862,7 @@ schedulingProfiles:
 
 		// token-producer has UDS config
 		g.Expect(configText).To(ContainSubstring("socketFile"))
-		g.Expect(configText).To(ContainSubstring("modelName"))
+		g.Expect(configText).NotTo(ContainSubstring("modelName"))
 
 		// prefix-cache-scorer references the producer
 		g.Expect(configText).To(ContainSubstring("prefixMatchInfoProducerName: precise-prefix-cache-producer"))
@@ -2168,7 +2168,6 @@ plugins:
 - name: token-producer
   type: token-producer
   parameters:
-    modelName: base
     udsTokenizerConfig:
       socketFile: /tmp/tokenizer/tokenizer-uds.socket
 - name: endpoint-notification-source

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -798,6 +798,69 @@ LLMINFERENCESERVICE_CONFIGS = {
             },
         },
     },
+    # Reproducer for the Jenkins AMD/ROCm failure: tokenProcessorConfig nested
+    # inside indexerConfig (the v0.5/v0.6 placement). The controller must:
+    #   1. Promote tokenProcessorConfig to the top-level parameters
+    #   2. Remove the orphan from indexerConfig (strict decoder rejects it)
+    #   3. Split into the v0.9 plugin architecture
+    # Without the fix, the EPP scheduler crashes with:
+    #   json: unknown field "tokenProcessorConfig"
+    "scheduler-precise-prefix-tokenprocessor-in-indexer": {
+        "router": {
+            "scheduler": {
+                "config": {
+                    "inline": {
+                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "kind": "EndpointPickerConfig",
+                        "plugins": [
+                            {"type": "single-profile-handler"},
+                            {
+                                "type": "precise-prefix-cache-scorer",
+                                "parameters": {
+                                    "kvEventsConfig": {
+                                        "zmqEndpoint": "tcp://*:5557",
+                                    },
+                                    "indexerConfig": {
+                                        "tokenProcessorConfig": {
+                                            "blockSize": 16,
+                                            "hashSeed": "42",
+                                        },
+                                        "tokenizersPoolConfig": {
+                                            "modelName": "facebook/opt-125m",
+                                        },
+                                        "kvBlockIndexConfig": {
+                                            "enableMetrics": True,
+                                            "metricsLoggingInterval": 60000000000,
+                                        },
+                                    },
+                                },
+                            },
+                            {"type": "queue-scorer"},
+                            {"type": "kv-cache-utilization-scorer"},
+                            {"type": "max-score-picker"},
+                        ],
+                        "schedulingProfiles": [
+                            {
+                                "name": "default",
+                                "plugins": [
+                                    {"pluginRef": "queue-scorer", "weight": 2},
+                                    {
+                                        "pluginRef": "kv-cache-utilization-scorer",
+                                        "weight": 2,
+                                    },
+                                    {
+                                        "pluginRef": "precise-prefix-cache-scorer",
+                                        "weight": 3,
+                                    },
+                                    {"pluginRef": "max-score-picker"},
+                                ],
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
     # Realistic v0.6-style PD config: old plugin names, deciderPluginName param,
     # hashBlockSize, prefill/decode filters and profiles.
     # Exercises the full #5433 migration: plugin renames, param restructure,

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -570,6 +570,27 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 pytest.mark.llmd_simulator,
             ],
         ),
+        # Reproducer: tokenProcessorConfig nested inside indexerConfig (Jenkins
+        # AMD/ROCm failure). Verifies migration promotes the field, removes the
+        # orphan, splits to v0.9 architecture, and scheduler boots without
+        # "json: unknown field" crash.
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-precise-prefix-tokenprocessor-in-indexer",
+                    "workload-llmd-simulator-kvcache",
+                ],
+                prompt="KServe is a",
+                service_name="precise-prefix-orphan-migration-test",
+                response_assertion=assert_200_with_choices,
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+        ),
         # Models endpoint coverage
         pytest.param(
             TestCase(


### PR DESCRIPTION
## Summary

- Adds `withSplitPrecisePrefixCacheScorerV09` migration that converts the deprecated monolithic `precise-prefix-cache-scorer` plugin into the new split architecture (`token-producer` + `precise-prefix-cache-producer` + `prefix-cache-scorer`) required by EPP v0.9.0
- Fixes `WithMigrateTokenProcessorConfig` to remove the orphaned `tokenProcessorConfig` from `indexerConfig` after promotion, preventing `json: unknown field "tokenProcessorConfig"` crash from the strict decoder in `llm-d-router` v0.9
- Moves `withRemoveUnnecessaryTokenizer` to apply for all versions >= 0.7.0 (not just v0.9+)
- Adds consolidated unit tests (`TestPrecisePrefixCacheMigrationV09`) and integration tests covering split migration, schema validation, orphan removal, and idempotency

## Root Cause

EPP v0.9.0 uses `json.Decoder.DisallowUnknownFields()` for plugin parameter parsing. The `tokenProcessorConfig` field was removed from `kvcache.Config` (used as `indexerConfig`) in `llm-d-kv-cache`, so any config leaving it nested in `indexerConfig` causes immediate crash-loop on the scheduler pod.

## Test Plan

- [x] Unit tests: `TestPrecisePrefixCacheMigrationV09` (split_migration, schema_validation, orphan_removal, idempotency subtests)
- [x] Unit tests: `TestFullMigrationPipeline` with v0.9 disagg config subtest
- [x] Integration tests: v0.9 split migration context with structural validation
- [x] Integration tests: orphan removal context verifying `indexerConfig` is clean
- [x] Existing e2e fixtures (`scheduler-v06-pd-config-migration`, `scheduler-with-precise-prefix-cache-inline-config`) cover end-to-end routing