### PR TITLE
fix(modelserver): bound V2 BYTES tensor decode to prevent unbounded work

### DIFF
--- a/python/kserve/kserve/constants/constants.py
+++ b/python/kserve/kserve/constants/constants.py
@@ -98,6 +98,15 @@ LLM_STATS_KEY = "llm-stats"
 # Default GRPC max message length
 MAX_GRPC_MESSAGE_LENGTH = 8388608
 
+# Upper bound on the number of elements decoded from a single BYTES (string)
+# tensor. Each element on the wire is at least a 4-byte length prefix, so the
+# default GRPC message limit already bounds a gRPC request to
+# MAX_GRPC_MESSAGE_LENGTH // 4 elements. The REST binary path has no such limit,
+# so this constant brings it to parity and prevents an unbounded blob of
+# zero-length prefixes from expanding into an unbounded object array. Operators
+# serving genuinely larger string tensors can raise it.
+MAX_BYTES_TENSOR_ELEMENTS = MAX_GRPC_MESSAGE_LENGTH // 4
+
 V2_ROUTE_PREFIX = "/v2"
 V1_ROUTE_PREFIX = "/v1"
 

--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -22,7 +22,10 @@ import uuid
 from google.protobuf.internal.containers import MessageMap
 
 from .rest.v2_datamodels import InferenceRequest
-from ..constants.constants import GRPC_CONTENT_DATATYPE_MAPPINGS
+from ..constants.constants import (
+    GRPC_CONTENT_DATATYPE_MAPPINGS,
+    MAX_BYTES_TENSOR_ELEMENTS,
+)
 from ..errors import InvalidInput, InferenceError
 from ..protocol.grpc.grpc_predict_v2_pb2 import (
     ModelInferRequest,
@@ -83,7 +86,29 @@ def serialize_byte_tensor(input_tensor: np.ndarray) -> np.ndarray:
     return flattened_array
 
 
-def deserialize_bytes_tensor(encoded_tensor: bytes) -> np.ndarray:
+def _expected_bytes_element_count(shape: List[int]) -> Optional[int]:
+    """Return the number of elements implied by a fully specified tensor shape.
+
+    Returns None when the shape is empty or contains a wildcard / non-positive
+    dimension (for example the numpy ``-1`` placeholder), in which case the
+    exact element count is not pinned by the shape and the caller falls back to
+    the configured maximum.
+    """
+    if not shape:
+        return None
+    count = 1
+    for dim in shape:
+        if dim is None or dim < 0:
+            return None
+        count *= dim
+    return count
+
+
+def deserialize_bytes_tensor(
+    encoded_tensor: bytes,
+    expected_element_count: Optional[int] = None,
+    max_element_count: int = MAX_BYTES_TENSOR_ELEMENTS,
+) -> np.ndarray:
     """
     Deserializes an encoded bytes tensor into a
     numpy array of dtype of python objects
@@ -93,20 +118,67 @@ def deserialize_bytes_tensor(encoded_tensor: bytes) -> np.ndarray:
             The encoded bytes tensor where each element
             has its length in first 4 bytes followed by
             the content
+        expected_element_count : Optional[int]
+            The number of elements the tensor shape requires, when it is fully
+            specified. When provided, decoding is bounded to that count and a
+            buffer that encodes a different number of elements is rejected.
+        max_element_count : int
+            Absolute upper bound on the number of decoded elements, applied when
+            the shape does not pin the count (for example a wildcard dimension).
+            Defaults to ``MAX_BYTES_TENSOR_ELEMENTS``.
     Returns:
         string_tensor : np.array
             The 1-D numpy array of type object containing the
             deserialized bytes in row-major form.
+
+    Raises:
+        InvalidInput: If the buffer is malformed (a length prefix or element
+            body runs past the end of the buffer) or if the number of encoded
+            elements exceeds the allowed bound or does not match
+            expected_element_count.
     """
+    if (
+        expected_element_count is not None
+        and expected_element_count > max_element_count
+    ):
+        raise InvalidInput(
+            f"BYTES tensor shape requires {expected_element_count} elements, "
+            f"which exceeds the maximum of {max_element_count}"
+        )
+    limit = (
+        expected_element_count
+        if expected_element_count is not None
+        else max_element_count
+    )
     strs = list()
     offset = 0
     val_buf = encoded_tensor
-    while offset < len(val_buf):
+    buf_len = len(val_buf)
+    while offset < buf_len:
+        if offset + 4 > buf_len:
+            raise InvalidInput(
+                "Unable to deserialize BYTES tensor: truncated 4-byte length prefix"
+            )
         length = struct.unpack_from("<I", val_buf, offset)[0]
         offset += 4
+        if offset + length > buf_len:
+            raise InvalidInput(
+                f"Unable to deserialize BYTES tensor: element length {length} "
+                "exceeds the remaining buffer"
+            )
+        if len(strs) >= limit:
+            raise InvalidInput(
+                "Unable to deserialize BYTES tensor: number of elements exceeds "
+                f"the allowed maximum of {limit}"
+            )
         sb = struct.unpack_from("<{}s".format(length), val_buf, offset)[0]
         offset += length
         strs.append(sb)
+    if expected_element_count is not None and len(strs) != expected_element_count:
+        raise InvalidInput(
+            f"Unable to deserialize BYTES tensor: decoded {len(strs)} elements "
+            f"but the tensor shape requires {expected_element_count}"
+        )
     return np.array(strs, dtype=np.object_)
 
 
@@ -238,7 +310,8 @@ class InferInput:
         Returns:
             A numpy array of the inference input data
         Raises:
-            InvalidInput: If the datatype of the inference input is not recognized.
+            InvalidInput: If the datatype of the inference input is not recognized
+                or the raw BYTES tensor is malformed or larger than allowed.
         """
         dtype = to_np_dtype(self.datatype)
         if dtype is None:
@@ -249,7 +322,10 @@ class InferInput:
                 # followed by the actual string characters. Hence,
                 # need to decode the raw bytes to convert into
                 # array elements.
-                np_array = deserialize_bytes_tensor(self._raw_data)
+                np_array = deserialize_bytes_tensor(
+                    self._raw_data,
+                    expected_element_count=_expected_bytes_element_count(self._shape),
+                )
             else:
                 np_array = np.frombuffer(self._raw_data, dtype=dtype)
             return np_array.reshape(self._shape)

--- a/python/kserve/test/test_infer_type.py
+++ b/python/kserve/test/test_infer_type.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 import copy
 import json
+import struct
 
 import numpy as np
 import pytest
 from orjson import orjson
 
 from kserve import InferRequest, InferInput, InferResponse, InferOutput
+from kserve.constants.constants import MAX_BYTES_TENSOR_ELEMENTS
 from kserve.errors import InvalidInput
 from kserve.protocol.grpc.grpc_predict_v2_pb2 import (
     ModelInferRequest,
@@ -26,6 +28,7 @@ from kserve.protocol.grpc.grpc_predict_v2_pb2 import (
     ModelInferResponse,
 )
 from kserve.protocol.infer_type import (
+    deserialize_bytes_tensor,
     serialize_byte_tensor,
     _contains_fp16_datatype,
     RequestedOutput,
@@ -1118,3 +1121,74 @@ def test_contains_fp16_datatype_with_no_outputs():
     )
 
     assert _contains_fp16_datatype(infer_response) is False
+
+
+def _encode_bytes_tensor(elements):
+    """Build a raw BYTES tensor blob: a 4-byte little-endian length prefix
+    followed by the content, per element."""
+    return b"".join(struct.pack("<I", len(e)) + e for e in elements)
+
+
+def test_deserialize_bytes_tensor_roundtrip_concrete_shape():
+    elements = [b"hello", b"", b"a longer value", b"\x00\x01\x02"]
+    blob = _encode_bytes_tensor(elements)
+    out = deserialize_bytes_tensor(blob, expected_element_count=len(elements))
+    assert list(out) == elements
+
+
+def test_deserialize_bytes_tensor_roundtrip_default_bound():
+    elements = [b"a", b"bc", b"def"]
+    blob = _encode_bytes_tensor(elements)
+    assert list(deserialize_bytes_tensor(blob)) == elements
+
+
+def test_deserialize_bytes_tensor_truncated_length_prefix():
+    # Fewer than 4 bytes remain for the length prefix.
+    with pytest.raises(InvalidInput):
+        deserialize_bytes_tensor(b"\x02\x00")
+
+
+def test_deserialize_bytes_tensor_element_length_exceeds_buffer():
+    # Length prefix claims 100 bytes but only 3 follow.
+    with pytest.raises(InvalidInput):
+        deserialize_bytes_tensor(struct.pack("<I", 100) + b"abc")
+
+
+def test_deserialize_bytes_tensor_more_elements_than_shape():
+    blob = _encode_bytes_tensor([b"", b""])
+    with pytest.raises(InvalidInput):
+        deserialize_bytes_tensor(blob, expected_element_count=1)
+
+
+def test_deserialize_bytes_tensor_fewer_elements_than_shape():
+    blob = _encode_bytes_tensor([b"x"])
+    with pytest.raises(InvalidInput):
+        deserialize_bytes_tensor(blob, expected_element_count=2)
+
+
+def test_deserialize_bytes_tensor_shape_count_over_maximum():
+    # A concrete shape larger than the cap is rejected before any decoding.
+    with pytest.raises(InvalidInput):
+        deserialize_bytes_tensor(
+            b"", expected_element_count=MAX_BYTES_TENSOR_ELEMENTS + 1
+        )
+
+
+def test_deserialize_bytes_tensor_unbounded_blob_is_capped():
+    # Wildcard shape (expected_element_count=None): a blob of zero-length
+    # prefixes is bounded by max_element_count instead of growing unbounded.
+    blob = struct.pack("<I", 0) * 5
+    with pytest.raises(InvalidInput):
+        deserialize_bytes_tensor(blob, max_element_count=3)
+
+
+def test_infer_request_from_bytes_bytes_shape_mismatch_rejected():
+    # A BYTES input whose declared shape requires fewer elements than the binary
+    # blob encodes is rejected during decode instead of being fully expanded.
+    json_header = (
+        b'{"id":"1","inputs":[{"name":"input1","shape":[1],"datatype":"BYTES",'
+        b'"parameters":{"binary_data_size":8}}]}'
+    )
+    body = json_header + struct.pack("<I", 0) * 2  # two zero-length elements
+    with pytest.raises(InvalidInput):
+        InferRequest.from_bytes(body, len(json_header), "test_model")


### PR DESCRIPTION
**What this PR does / why we need it**:

`deserialize_bytes_tensor` (`python/kserve/kserve/protocol/infer_type.py`)
decodes a BYTES (string) tensor by walking a 4-byte little-endian length
prefix per element. It appended one Python object per element with no bound on
the number of elements and no check that each declared length stayed inside the
buffer.

On the V2 Open Inference path this decode runs while the request is being
parsed, before the tensor shape is validated:

- REST: `InferRequest.from_bytes` slices the raw binary blob into the input and
  calls `as_numpy()`, which calls `deserialize_bytes_tensor`.
- gRPC: the `ModelInfer` `raw_input_contents` blob reaches the same decoder via
  `as_numpy()`.

A body made of zero-length prefixes therefore expands into one object per four
wire bytes. The gRPC path is already bounded by the default 8 MiB message limit
(`MAX_GRPC_MESSAGE_LENGTH`), but the REST server sets no request body size
limit, so a single large REST request can build a multi-million element object
array during decode. A malformed length prefix (one that runs past the buffer)
also raised a raw `struct.error` rather than a clean input error.

This change bounds the decode and validates framing so malformed or oversized
input is rejected cleanly instead of being fully expanded first.

**Changes**:

- `python/kserve/kserve/protocol/infer_type.py`
  - `deserialize_bytes_tensor` validates that each length prefix and element
    body fits within the buffer, raising `InvalidInput` on a truncated prefix
    or an over-reading length.
  - It accepts an optional `expected_element_count`. When the tensor shape is
    fully specified, the request path passes the element count the shape
    requires, so the decoder stops at that many elements and rejects a buffer
    that encodes a different number.
  - When the shape does not pin the count (for example a `-1` wildcard
    dimension), the decoder caps the element count at a configurable
    `max_element_count`.
  - `InferInput.as_numpy` passes the shape-derived expected count on the
    request path. The output/response decode keeps its previous behavior and
    simply gains the framing checks and the default cap.
- `python/kserve/kserve/constants/constants.py`
  - Adds `MAX_BYTES_TENSOR_ELEMENTS = MAX_GRPC_MESSAGE_LENGTH // 4`. Each BYTES
    element needs at least a 4-byte prefix, so this is the number of
    minimum-size elements that already fit within the default gRPC message
    limit. It brings the REST binary path to parity with the bound the gRPC
    path already has. Operators serving genuinely larger string tensors can
    raise it.

Well-formed requests are unaffected: a request whose declared shape matches the
data it sends decodes exactly as before.

This bounds the work the decode performs. The separate question of running the
synchronous decode off the event loop for sync predictors is tracked in #5019;
this PR does not change that path.

**Which issue(s) this PR fixes**:

Related to #5019 (event-loop blocking for synchronous work). This PR is
complementary and not a fix for that issue.

**Feature/Issue validation/testing**:

- [x] New unit tests for `deserialize_bytes_tensor`: round-trip of well-formed
  data (concrete and default-bounded), truncated length prefix, over-reading
  length, more elements than the shape allows, fewer elements than the shape
  requires, a shape count over the maximum rejected before decoding, the
  wildcard cap, and a custom `max_element_count`.
- [x] New request-path test: a BYTES input whose declared shape requires fewer
  elements than the binary blob encodes is rejected with `InvalidInput`.
- [x] Full `test_infer_type.py` passes (42 tests, the 33 existing plus 9 new).
- [x] `ruff format` and `ruff check` clean with the repo `ruff.toml`.

Logs:

```
42 passed in 1.31s
```

**Special notes for your reviewer**:

The new constant is a module-level default and is importable, so it can be
overridden. If you would prefer it wired to a model-server flag, I am happy to
add that.

On documentation: the behavior is covered by the function docstrings, and this
mirrors the existing `MAX_GRPC_MESSAGE_LENGTH` bound, which is not described in
the in-repo docs either, so I have not changed any docs here. If you would like
a note in the kserve/website inference docs, I am glad to open a follow-up there.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
Bound the V2 BYTES tensor decode so malformed or oversized binary inputs are rejected cleanly instead of expanding into a large object array during request parsing.
```
