### PR TITLE
docs: fix typo in performance testing guide

### DIFF
--- a/docs/samples/performance-testing/README.md
+++ b/docs/samples/performance-testing/README.md
@@ -1,6 +1,6 @@
 # HTTP Performance test
 
-This tutorial demonstrates performance testing for KServe inference services using HTTP. We will use [Iter8](https://iter8.tools) for generating load and validing service-level objectives (SLOs) for the inference service. [Iter8](https://iter8.tools) is an open-source Kubernetes release optimizer that makes it easy to ensure that your ML models perform well and maximize business value.
+This tutorial demonstrates performance testing for KServe inference services using HTTP. We will use [Iter8](https://iter8.tools) for generating load and validating service-level objectives (SLOs) for the inference service. [Iter8](https://iter8.tools) is an open-source Kubernetes release optimizer that makes it easy to ensure that your ML models perform well and maximize business value.
 
 ![Iter8 HTTP performance test](http.png)
 


### PR DESCRIPTION
What this PR does / why we need it:

Fixes a typo in the HTTP performance testing documentation by changing “validing” to “validating” for improved readability.

Which issue(s) this PR fixes (optional):

Fixes #

Feature/Issue validation/testing:

* Verified the documentation change locally
* Confirmed this is a documentation-only change with no functional impact
* Logs

N/A

Special notes for your reviewer:

This PR only fixes a documentation typo. No code or behavior has been changed.

Checklist:

* Have you added unit/e2e tests that prove your fix is effective or that this feature works?
* Has code been commented, particularly in hard-to-understand areas?
* Have you made corresponding changes to the documentation?

Release note:

NONE