### PR TITLE
feat(e2e): add autogluon pytest marker to all autogluon tests

### DIFF
--- a/python/autogluonserver/pyproject.toml
+++ b/python/autogluonserver/pyproject.toml
@@ -42,3 +42,6 @@ build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "autogluon: autogluon server tests",
+]

--- a/python/autogluonserver/tests/test_autogluon_model_repository.py
+++ b/python/autogluonserver/tests/test_autogluon_model_repository.py
@@ -16,6 +16,8 @@ import pytest
 
 from autogluonserver import AutoGluonModelRepository
 
+pytestmark = pytest.mark.autogluon
+
 
 @pytest.mark.asyncio
 async def test_load_updates_repository_with_ready_model(monkeypatch, tmp_path):

--- a/python/autogluonserver/tests/test_model.py
+++ b/python/autogluonserver/tests/test_model.py
@@ -23,6 +23,8 @@ from autogluonserver.tabular_model import (
     _determine_prediction_datatype,
 )
 
+pytestmark = pytest.mark.autogluon
+
 
 class DummyFeatureMetadata:
     def __init__(self, type_map_raw=None):

--- a/python/autogluonserver/tests/test_predictor_detect.py
+++ b/python/autogluonserver/tests/test_predictor_detect.py
@@ -20,6 +20,8 @@ from kserve.errors import InferenceError
 
 from autogluonserver.predictor_detect import detect_and_load_predictor
 
+pytestmark = pytest.mark.autogluon
+
 
 def _timeseries_predictor():
     return TimeSeriesPredictor.__new__(TimeSeriesPredictor)

--- a/python/autogluonserver/tests/test_predictor_factory.py
+++ b/python/autogluonserver/tests/test_predictor_factory.py
@@ -15,12 +15,16 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
+
 from autogluonserver.predictor_factory import (
     AutoGluonDetectedModel,
     create_autogluon_model,
 )
 from autogluonserver.tabular_model import AutoGluonTabularModel
 from autogluonserver.timeseries_model import AutoGluonTimeSeriesModel
+
+pytestmark = pytest.mark.autogluon
 
 
 def test_factory_returns_detected_model(tmp_path):

--- a/python/autogluonserver/tests/test_runtime_paths.py
+++ b/python/autogluonserver/tests/test_runtime_paths.py
@@ -18,6 +18,8 @@ import pytest
 
 from autogluonserver.runtime_paths import ensure_autogluon_runtime_paths
 
+pytestmark = pytest.mark.autogluon
+
 
 @pytest.fixture
 def clean_runtime_env(monkeypatch):

--- a/python/autogluonserver/tests/test_timeseries_model.py
+++ b/python/autogluonserver/tests/test_timeseries_model.py
@@ -28,6 +28,8 @@ from autogluonserver.timeseries_model import (
     _load_ts_metadata,
 )
 
+pytestmark = pytest.mark.autogluon
+
 
 def _write_predictor_metadata(
     tmp_path,

--- a/python/autogluonserver/tests/test_version_compat.py
+++ b/python/autogluonserver/tests/test_version_compat.py
@@ -24,6 +24,8 @@ from autogluonserver.version_compat import (
     _get_installed_version,
 )
 
+pytestmark = pytest.mark.autogluon
+
 # ---------------------------------------------------------------------------
 # _read_saved_version
 # ---------------------------------------------------------------------------

--- a/test/e2e/predictor/test_autogluon.py
+++ b/test/e2e/predictor/test_autogluon.py
@@ -55,6 +55,7 @@ def _create_predictor(
     return V1beta1PredictorSpec(min_replicas=1, model=model)
 
 
+@pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_runtime_kserve_v1(rest_v1_client):
@@ -70,6 +71,7 @@ async def test_autogluon_runtime_kserve_v1(rest_v1_client):
     assert len(response["predictions"]) > 0
 
 
+@pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_runtime_kserve_v2(rest_v2_client):
@@ -85,6 +87,7 @@ async def test_autogluon_runtime_kserve_v2(rest_v2_client):
     assert len(response.outputs[0].data) > 0
 
 
+@pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
@@ -101,6 +104,7 @@ async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
             assert len(response.outputs[0].data) > 0
 
 
+@pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_runtime_kserve_v2_storage_uri_without_trailing_slash(

--- a/test/e2e/predictor/test_autogluon_timeseries.py
+++ b/test/e2e/predictor/test_autogluon_timeseries.py
@@ -66,6 +66,7 @@ async def _deploy_and_predict_v1(
     return await deploy_and_predict(service_name, predictor, rest_v1_client, input_path)
 
 
+@pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client):
@@ -79,6 +80,7 @@ async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client):
     assert len(response["predictions"]) > 0
 
 
+@pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_timeseries_runtime_kserve_v1_storage_uri_without_trailing_slash(

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -39,3 +39,4 @@ markers =
     llmd_simulator: test using llm-d simulator
     dual_protocol: test for dual protocol gRPC and REST predictor for Standard mode with Gateway API
     lora: e2e tests for LoRA adapters
+    autogluon: e2e tests for autogluon runtime


### PR DESCRIPTION
Register an `autogluon` marker in both unit and e2e pytest configs and apply it to every autogluon test, enabling selective test runs via `pytest -m autogluon`.

