### PR TITLE
fix: all typos in repo

### DIFF
--- a/docs/samples/batcher/README.md
+++ b/docs/samples/batcher/README.md
@@ -8,7 +8,7 @@ the request is then sent to the model server container for inference.
 ![Batcher](../../diagrams/batcher.jpg)
 
 * We use webhook to inject the model agent container in the InferenceService pod to do the batching when batcher is enabled. 
-* We use go channels to transfer data between http requset handler and batcher go routines.
+* We use go channels to transfer data between http request handler and batcher go routines.
 * Currently we only implemented batching with KServe v1 HTTP protocol, gRPC is not supported yet.
 * When the number of instances (For example, the number of pictures) reaches the `maxBatchSize` or the latency meets the `maxLatency`, a batch prediction will be triggered.
 ```

--- a/docs/samples/drift-detection/alibi-detect/cifar10/cifar10_drift.ipynb
+++ b/docs/samples/drift-detection/alibi-detect/cifar10/cifar10_drift.ipynb
@@ -3,20 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Cifar10 Drift Detection\n",
-    "\n",
-    "In this example we will deploy an image classification model along with a drift detector trained on the same dataset. For in depth details on creating a drift detection model for your own dataset see the [alibi-detect project](https://github.com/SeldonIO/alibi-detect) and associated [documentation](https://docs.seldon.io/projects/alibi-detect/en/latest/). You can find details for this [CIFAR10 example in their documentation](https://docs.seldon.io/projects/alibi-detect/en/latest/examples/cd_ks_cifar10.html) as well.\n",
-    "\n",
-    "\n",
-    "Prequisites:\n",
-    "\n",
-    " * Running cluster with \n",
-    "    * [kfserving installed](https://github.com/kubeflow/kfserving/blob/master/README.md)\n",
-    "    * [Knative eventing installed](https://knative.dev/docs/install/) >= 0.18\n",
-    "    \n",
-    " Tested on GKE and Kind with Knative Eventing 0.18 and Istio 1.7.3"
-   ]
+   "source": "# Cifar10 Drift Detection\n\nIn this example we will deploy an image classification model along with a drift detector trained on the same dataset. For in depth details on creating a drift detection model for your own dataset see the [alibi-detect project](https://github.com/SeldonIO/alibi-detect) and associated [documentation](https://docs.seldon.io/projects/alibi-detect/en/latest/). You can find details for this [CIFAR10 example in their documentation](https://docs.seldon.io/projects/alibi-detect/en/latest/examples/cd_ks_cifar10.html) as well.\n\n\nPrerequisites:\n\n * Running cluster with \n    * [kfserving installed](https://github.com/kubeflow/kfserving/blob/master/README.md)\n    * [Knative eventing installed](https://knative.dev/docs/install/) >= 0.18\n    \n Tested on GKE and Kind with Knative Eventing 0.18 and Istio 1.7.3"
   },
   {
    "cell_type": "code",

--- a/docs/samples/outlier-detection/alibi-detect/cifar10/cifar10_outlier.ipynb
+++ b/docs/samples/outlier-detection/alibi-detect/cifar10/cifar10_outlier.ipynb
@@ -3,21 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# CIFAR-10 Outlier Detection\n",
-    "![demo](./demo.png)\n",
-    "\n",
-    "In this example, we will deploy an image classification model along with an outlier detector trained on the same dataset. For in depth details on creating an outlier detection model for your own dataset, check out the [Alibi Detect](https://github.com/SeldonIO/alibi-detect) project and its associated [documentation](https://docs.seldon.io/projects/alibi-detect/en/latest/). They also provide [documentation for this CIFAR10 sample](https://docs.seldon.io/projects/alibi-detect/en/latest/examples/od_vae_cifar10.html).\n",
-    "\n",
-    "\n",
-    "Prequisites:\n",
-    "\n",
-    " * Running cluster with \n",
-    "    * [KServe installed](https://github.com/kserve/kserve/blob/master/README.md#hammer_and_wrench-installation)\n",
-    "    * [Knative Eventing installed](https://knative.dev/docs/install/yaml-install/eventing/install-eventing-with-yaml/#install-knative-eventing) >= 1.2\n",
-    " \n",
-    "_Tested on GKE and kind with Knative 1.7 and Istio 1.15.0_"
-   ]
+   "source": "# CIFAR-10 Outlier Detection\n![demo](./demo.png)\n\nIn this example, we will deploy an image classification model along with an outlier detector trained on the same dataset. For in depth details on creating an outlier detection model for your own dataset, check out the [Alibi Detect](https://github.com/SeldonIO/alibi-detect) project and its associated [documentation](https://docs.seldon.io/projects/alibi-detect/en/latest/). They also provide [documentation for this CIFAR10 sample](https://docs.seldon.io/projects/alibi-detect/en/latest/examples/od_vae_cifar10.html).\n\n\nPrerequisites:\n\n * Running cluster with \n    * [KServe installed](https://github.com/kserve/kserve/blob/master/README.md#hammer_and_wrench-installation)\n    * [Knative Eventing installed](https://knative.dev/docs/install/yaml-install/eventing/install-eventing-with-yaml/#install-knative-eventing) >= 1.2\n \n_Tested on GKE and kind with Knative 1.7 and Istio 1.15.0_"
   },
   {
    "cell_type": "code",

--- a/docs/samples/performance-testing/grpc.md
+++ b/docs/samples/performance-testing/grpc.md
@@ -1,6 +1,6 @@
 # gRPC Performance test
 
-This tutorial demonstrates performance testing for KServe inference services using gRPC. We will use [Iter8](https://iter8.tools) for generating load and validing service-level objectives (SLOs) for the inference service. [Iter8](https://iter8.tools) is an open-source Kubernetes release optimizer that makes it easy to ensure that your ML models perform well and maximize business value.
+This tutorial demonstrates performance testing for KServe inference services using gRPC. We will use [Iter8](https://iter8.tools) for generating load and validating service-level objectives (SLOs) for the inference service. [Iter8](https://iter8.tools) is an open-source Kubernetes release optimizer that makes it easy to ensure that your ML models perform well and maximize business value.
 
 ![Iter8 gRPC performance test](grpc.png)
 

--- a/docs/samples/v1beta1/torchserve/README.md
+++ b/docs/samples/v1beta1/torchserve/README.md
@@ -36,7 +36,7 @@ The KServe/TorchServe integration expects following model store layout.
 
 The requests are converted from KServe inference request format to torchserve request format and sent to the `inference_address` configured via local socket.
 
-**Warning**: The `service_envelope` property has beed dreprecated and replaced with `enable_envvars_config` set to true. This enables the service envelope to be set on runtime.
+**Warning**: The `service_envelope` property has been deprecated and replaced with `enable_envvars_config` set to true. This enables the service envelope to be set on runtime.
 
 ## TorchServe with KFS Envelope Inference Endpoints
 

--- a/hack/verify-doc-links.py
+++ b/hack/verify-doc-links.py
@@ -326,7 +326,7 @@ def verify_doc_links() -> [(str, int, str, str)]:
 
 
 def apply_monkey_patch_to_force_ipv4_connections():
-    # Monkey-patch socket.getaddrinfo to force IPv4 conections, since some older
+    # Monkey-patch socket.getaddrinfo to force IPv4 connections, since some older
     # routers and some internet providers don't support IPv6, in which case Python
     # will first try an IPv6 connection which will hang until timeout and only
     # then attempt a successful IPv4 connection

--- a/pkg/apis/serving/v1alpha1/storage_container_types_test.go
+++ b/pkg/apis/serving/v1alpha1/storage_container_types_test.go
@@ -68,7 +68,7 @@ func TestStorageContainerSpec_IsStorageUriSupported(t *testing.T) {
 		},
 		{
 			name:       "custom spec does not support Azure",
-			spec:       s3AzureSpec,
+			spec:       customSpec,
 			storageUri: "https://account.blob.core.windows.net/myblob",
 			supported:  false,
 		},

--- a/pkg/apis/serving/v1alpha1/storage_container_types_test.go
+++ b/pkg/apis/serving/v1alpha1/storage_container_types_test.go
@@ -69,7 +69,7 @@ func TestStorageContainerSpec_IsStorageUriSupported(t *testing.T) {
 		{
 			name:       "custom spec does not support Azure",
 			spec:       s3AzureSpec,
-			storageUri: "https://account.blob.core.windoes.net/myblob",
+			storageUri: "https://account.blob.core.windows.net/myblob",
 			supported:  false,
 		},
 		{

--- a/pkg/controller/v1alpha1/localmodelnode/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller_test.go
@@ -500,7 +500,7 @@ var _ = Describe("LocalModelNode controller", func() {
 			orphanedStorageKey := "abc123def456"
 			fsMock.mockModel(&MockFileInfo{name: orphanedStorageKey, isDir: true})
 
-			nodeName = "worker" // Definied in controller.go, representing the name of the current node
+			nodeName = "worker" // Defined in controller.go, representing the name of the current node
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: nodeName,
@@ -571,7 +571,7 @@ var _ = Describe("LocalModelNode controller", func() {
 			Expect(k8sClient.Create(ctx, nodeGroup)).Should(Succeed())
 			defer k8sClient.Delete(ctx, nodeGroup)
 
-			nodeName = "test3" // Definied in controller.go, representing the name of the current node
+			nodeName = "test3" // Defined in controller.go, representing the name of the current node
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: nodeName,

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -144,7 +144,7 @@ func (r *TrainedModelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return reconcile.Result{}, err
 	}
 
-	// update URL and Address fo TrainedModel
+	// update URL and Address of TrainedModel
 	if err := r.updateStatus(ctx, req, tm); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controller/v1alpha1/utils/utils.go
+++ b/pkg/controller/v1alpha1/utils/utils.go
@@ -111,7 +111,7 @@ func CheckZeroInitialScaleAllowed(ctx context.Context, clientset kubernetes.Inte
 // When the annotation is set validation is performed. If any of this validation fails, the annotation will
 // be removed and the default initial scale behavior will be used.
 func ValidateInitialScaleAnnotation(annotations map[string]string, allowZeroInitialScale bool, log logr.Logger) {
-	// Check that the annoation is set.
+	// Check that the annotation is set.
 	_, set := annotations[autoscaling.InitialScaleAnnotationKey]
 	if !set {
 		return

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -324,7 +324,7 @@ func (r *LLMISVCReconciler) expectedPrefillMultiNodeLWS(ctx context.Context, llm
 
 		serviceAccount, _, err := r.expectedMultiNodePrefillServiceAccount(ctx, llmSvc)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create exptected multi node service account: %w", err)
+			return nil, fmt.Errorf("failed to create expected multi node service account: %w", err)
 		}
 
 		currLWS := &lwsapi.LeaderWorkerSet{}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -599,7 +599,7 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	}
 
 	// Add required environment variables: PipelineParallelSize, TensorParallelSize
-	// Deployment node deployement
+	// Deployment node deployment
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.PipelineParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.PipelineParallelSize)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.PipelineParallelSizeEnvName, constants.InferenceServiceContainerName)
 	}
@@ -626,7 +626,7 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 			return nil, errors.Wrapf(err, "failed to add MODEL_DIR environment to the container(%s)", constants.DefaultModelLocalMountPath)
 		}
 	}
-	// Worker node deployement
+	// Worker node deployment
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RayNodeCountEnvName, strconv.Itoa(nodeCount)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.WorkerContainerName)
 	}

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -458,7 +458,7 @@ func inferenceServiceReadinessFalse(status v1beta1.InferenceServiceStatus) bool 
 func inferenceServiceStatusEqual(s1, s2 v1beta1.InferenceServiceStatus, deploymentMode constants.DeploymentModeType) bool {
 	if deploymentMode == constants.ModelMeshDeployment {
 		// If the deployment mode is ModelMesh, reduce the status scope to compare.
-		// Exclude Predictor and ModelStatus which are mananged by ModelMesh controllers
+		// Exclude Predictor and ModelStatus which are managed by ModelMesh controllers
 		return equality.Semantic.DeepEqual(s1.Address, s2.Address) &&
 			equality.Semantic.DeepEqual(s1.URL, s2.URL) &&
 			equality.Semantic.DeepEqual(s1.Status, s2.Status) &&

--- a/pkg/credentials/s3/utils_test.go
+++ b/pkg/credentials/s3/utils_test.go
@@ -224,7 +224,7 @@ func TestBuildS3EnvVars(t *testing.T) {
 			secret: &map[string][]byte{
 				S3Endpoint:             []byte("s3.aws.com-secret"),
 				S3VerifySSL:            []byte("1"),
-				AWSAnonymousCredential: []byte("fase"),
+				AWSAnonymousCredential: []byte("false"),
 				AWSRegion:              []byte("us-east-2-secret"),
 				S3UseVirtualBucket:     []byte("false"),
 				S3UseAccelerate:        []byte("false"),

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -233,7 +233,7 @@ func IsCrdAvailable(config *rest.Config, groupVersion, kind string) (bool, error
 }
 
 // GetAvailableResourcesForApi returns the list of discovered resources that belong
-// to the API specified in groupVersion. The first query to a specifig groupVersion will
+// to the API specified in groupVersion. The first query to a specific groupVersion will
 // query the cluster API server to discover the available resources and the discovered
 // resources will be cached and returned to subsequent invocations to prevent additional
 // queries to the API server.
@@ -259,7 +259,7 @@ func GetAvailableResourcesForApi(config *rest.Config, groupVersion string) (*met
 	return gvResources, nil
 }
 
-// SetAvailableResourcesForApi stores the value fo resources argument in the global cache
+// SetAvailableResourcesForApi stores the value of resources argument in the global cache
 // of discovered API resources. This function should never be called directly. It is exported
 // for usage in tests.
 func SetAvailableResourcesForApi(groupVersion string, resources *metav1.APIResourceList) {

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
@@ -163,9 +163,9 @@ func validateModelFormatPrioritySame(newSpec *v1alpha1.ServingRuntimeSpec) error
 	nameToPriority := make(map[string]*int32)
 
 	// Validate when same model format has same priority under same runtime.
-	// If the same model format has different prority value then throws the error
+	// If the same model format has different priority value then throws the error
 	for _, newModelFormat := range newSpec.SupportedModelFormats {
-		// Only validate priority if autoselect is ture
+		// Only validate priority if autoselect is true
 		if newModelFormat.IsAutoSelectEnabled() {
 			if existingPriority, ok := nameToPriority[newModelFormat.Name]; ok {
 				if existingPriority != nil && newModelFormat.Priority != nil && (*existingPriority != *newModelFormat.Priority) {
@@ -195,7 +195,7 @@ func validateServingRuntimePriority(newSpec *v1alpha1.ServingRuntimeSpec, existi
 	if isTheProtocolSame {
 		for _, existingModelFormat := range existingSpec.SupportedModelFormats {
 			for _, newModelFormat := range newSpec.SupportedModelFormats {
-				// Only validate priority if autoselect is ture
+				// Only validate priority if autoselect is true
 				if existingModelFormat.IsAutoSelectEnabled() && newModelFormat.IsAutoSelectEnabled() && areSupportedModelFormatsEqual(existingModelFormat, newModelFormat) {
 					if existingModelFormat.Priority != nil && newModelFormat.Priority != nil && *existingModelFormat.Priority == *newModelFormat.Priority {
 						return fmt.Errorf(InvalidPriorityError, newModelFormat.Name)

--- a/python/huggingfaceserver/README.md
+++ b/python/huggingfaceserver/README.md
@@ -247,6 +247,6 @@ spec:
 
 **Points to note**:
 
-- The Hugging Face vLLM Runtime CPU image is compatible with all x86-64 CPUs that support at least the AVX2 instruction set architecture (ISA). On CPUs lacking atleast AVX2 support, model loading will fail.
+- The Hugging Face vLLM Runtime CPU image is compatible with all x86-64 CPUs that support at least the AVX2 instruction set architecture (ISA). On CPUs lacking at least AVX2 support, model loading will fail.
 - LoRA serving is not supported.
 - Tensor and pipeline parallelism are not currently enabled in vLLM integration.

--- a/python/huggingfaceserver/huggingfaceserver/encoder_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/encoder_model.py
@@ -154,7 +154,7 @@ class HuggingfaceEncoderModel(Model, OpenAIEncoderModel):  # pylint:disable=c-ex
         self.max_length = _get_and_verify_max_len(self.model_config, self.max_length)
         model_cls = get_model_class_for_task(self.task)
 
-        # device_map = "auto" enables model parallelism but all model architcture dont support it.
+        # device_map = "auto" enables model parallelism but all model architecture dont support it.
         # For pre-check we initialize the model class without weights to check the `_no_split_modules`
         # device_map = "auto" for models that support this else set to either cuda/cpu
         with init_empty_weights():

--- a/python/huggingfaceserver/huggingfaceserver/generative_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/generative_model.py
@@ -509,7 +509,7 @@ class HuggingfaceGenerativeModel(OpenAIChatAdapterModel):  # pylint:disable=c-ex
     def apply_chat_template(
         self,
         request: ChatCompletionRequest,
-    ) -> ChatPrompt:  # TODO: Does not supprot multi-modal, also does not solve mistral tokenizer issue.
+    ) -> ChatPrompt:  # TODO: Does not support multi-modal, also does not solve mistral tokenizer issue.
         """
         Given a list of chat completion messages, convert them to a prompt.
         """


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix all typos in repo flagged by codespell (added in #5756).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #2493.