### PR TITLE
docs: fix DataPlane.explain return docstring to match tuple return

### DIFF
--- a/python/kserve/kserve/protocol/dataplane.py
+++ b/python/kserve/kserve/protocol/dataplane.py
@@ -488,7 +488,9 @@ class DataPlane:
             headers: (Optional[Dict[str, str]]): Request headers.
 
         Returns:
-            Dict: Explanation result.
+            Tuple[Union[str, bytes, Dict, InferResponse], Dict[str, str]]:
+                - response: The explanation result.
+                - response_headers: Headers to construct the HTTP response.
 
         Raises:
             InvalidInput: An error when the body bytes can't be decoded as JSON.


### PR DESCRIPTION

**What this PR does / why we need it**:

`DataPlane.explain` in `python/kserve/kserve/protocol/dataplane.py` is annotated to
return a 2-tuple:

```python
) -> Tuple[Union[str, bytes, Dict, InferResponse], Dict[str, str]]:
```

and its body returns `response, response_headers` accordingly. However, its
docstring `Returns:` section only said:

```
Returns:
    Dict: Explanation result.
```

which documents a bare `Dict` and omits the `response_headers` element entirely.
A caller who trusts the docstring would treat the returned tuple as a plain dict.

The sibling `infer` method just above already documents this same tuple shape
correctly, so `explain`'s docstring was a stale copy that contradicted both the
method's return annotation and its actual return value. This PR aligns the
`explain` docstring with the annotation and with the `infer` method:

```
Returns:
    Tuple[Union[str, bytes, Dict, InferResponse], Dict[str, str]]:
        - response: The explanation result.
        - response_headers: Headers to construct the HTTP response.
```

Docstring-only change; no code or behavior change.

**Which issue(s) this PR fixes**:
Fixes #
(No tracking issue; this is a small documentation correction found while reading
the data plane code.)

**Feature/Issue validation/testing**:

This is a documentation-only change to a method docstring, so there is no runtime
behavior to test and no test asserts the docstring text. Validated by inspection
and lint:

- [x] Confirmed the `explain` return annotation is a 2-tuple
  (`Tuple[Union[str, bytes, Dict, InferResponse], Dict[str, str]]`) and the body
  returns `response, response_headers`, so the new docstring matches both.
- [x] `ruff format --check` and `ruff check` pass on the changed file
  (repo-pinned ruff 0.14.13).

- Logs

```
$ ruff format --check python/kserve/kserve/protocol/dataplane.py
1 file already formatted

$ ruff check python/kserve/kserve/protocol/dataplane.py
All checks passed!
```

**Special notes for your reviewer**:

Pure docstring correction, single hunk (+3 / -1), no image-version or behavior
changes. The wording deliberately mirrors the existing `infer` docstring style
for consistency.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? (N/A: docstring-only change; no test asserts docstring text)
- [x] Has code been commented, particularly in hard-to-understand areas? (This PR is the docstring correction itself)
- [ ] Have you made corresponding changes to the documentation? (The change *is* to an in-code docstring; no separate website docs reference this Returns block)

**Release note**:
```release-note
NONE
```

---

## Commit (already on branch `patch-7`, one commit)
```
49935b9f docs: fix DataPlane.explain return docstring to match tuple return
```
Body:
```
The Returns section of DataPlane.explain documented a bare Dict, but the
method returns a (response, response_headers) tuple as declared by its
return annotation. Align the docstring with the annotation and with the
sibling infer method, which documents the same tuple shape correctly.

Signed-off-by: Anas Khan <83116240+anxkhn@users.noreply.github.com>
```
