### PR TITLE
fix(llmisvc): honor disableHTTPRouteTimeout in v1alpha2 router

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_loader.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader.go
@@ -94,6 +94,11 @@ type Config struct {
 	UrlScheme               string `json:"urlScheme,omitempty"`
 	EnableTLS               bool   `json:"enableTLS,omitempty"`
 
+	// DisableHTTPRouteTimeout, when true, causes generated HTTPRoutes to omit
+	// spec.rules[*].timeouts. Some Gateway implementations (e.g. GKE Gateway)
+	// reject routes that set timeouts. Mirrors the v1beta1 ingress reconciler.
+	DisableHTTPRouteTimeout bool `json:"disableHTTPRouteTimeout,omitempty"`
+
 	ModelBasedRoutingHeaderName string                `json:"modelBasedRoutingHeaderName,omitempty"`
 	ModelBasedRoutingMode       ModelBasedRoutingMode `json:"modelBasedRoutingMode,omitempty"`
 
@@ -170,6 +175,7 @@ func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *types.Storag
 		IngressGatewayName:          igwName,
 		UrlScheme:                   ingressConfig.UrlScheme,
 		EnableTLS:                   ingressConfig.EnableLLMInferenceServiceTLS,
+		DisableHTTPRouteTimeout:     ingressConfig.DisableHTTPRouteTimeout,
 		ModelBasedRoutingHeaderName: ingressConfig.ModelBasedRoutingHeaderName,
 		ModelBasedRoutingMode:       parseModelBasedRoutingMode(ingressConfig.ModelBasedRoutingMode),
 		StorageConfig:               storageConfig,

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -227,6 +227,15 @@ func (r *LLMISVCReconciler) expectedHTTPRoute(ctx context.Context, llmSvc *v1alp
 				cfg.ModelBasedRoutingHeaderName,
 			)
 		}
+
+		// Some Gateway implementations (e.g. GKE Gateway) reject HTTPRoutes that
+		// set spec.rules[*].timeouts. When disableHTTPRouteTimeout is configured,
+		// omit timeouts from every rule. Mirrors the v1beta1 ingress reconciler.
+		if cfg.DisableHTTPRouteTimeout {
+			for i := range httpRoute.Spec.Rules {
+				httpRoute.Spec.Rules[i].Timeouts = nil
+			}
+		}
 	}
 
 	// Migration logic: check if we should switch from v1alpha2 to v1 InferencePool

--- a/pkg/controller/v1alpha2/llmisvc/router_disable_timeout_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_disable_timeout_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// TestExpectedHTTPRoute_DisableHTTPRouteTimeout verifies that the v1alpha2
+// LLMInferenceService router honors the disableHTTPRouteTimeout config flag by
+// omitting spec.rules[*].timeouts from the generated HTTPRoute, mirroring the
+// v1beta1 ingress reconciler. Regression test for issue #5707.
+func TestExpectedHTTPRoute_DisableHTTPRouteTimeout(t *testing.T) {
+	cases := []struct {
+		name                    string
+		disableHTTPRouteTimeout bool
+		expectTimeouts          bool
+		// withScheduler exercises the managed-pool path: a non-nil Scheduler
+		// (with no pool Ref) passes the Scheduler==nil guard so the migration
+		// block runs. This guards against a future regression where the
+		// migration block is extended to touch Timeouts.
+		withScheduler bool
+	}{
+		{
+			name:                    "flag set omits timeouts",
+			disableHTTPRouteTimeout: true,
+			expectTimeouts:          false,
+		},
+		{
+			name:                    "flag unset keeps timeouts",
+			disableHTTPRouteTimeout: false,
+			expectTimeouts:          true,
+		},
+		{
+			name:                    "flag set omits timeouts on managed-pool migration path",
+			disableHTTPRouteTimeout: true,
+			expectTimeouts:          false,
+			withScheduler:           true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// The preset-rendered route spec always carries per-rule timeouts.
+			ruleWithTimeouts := gwapiv1.HTTPRouteRule{
+				Timeouts: &gwapiv1.HTTPRouteTimeouts{
+					BackendRequest: ptr.To(gwapiv1.Duration("0s")),
+					Request:        ptr.To(gwapiv1.Duration("0s")),
+				},
+			}
+			llmSvc := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Router: &v1alpha2.RouterSpec{
+						Route: &v1alpha2.GatewayRoutesSpec{
+							HTTP: &v1alpha2.HTTPRouteSpec{
+								Spec: &gwapiv1.HTTPRouteSpec{
+									Rules: []gwapiv1.HTTPRouteRule{ruleWithTimeouts},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			r := &LLMISVCReconciler{}
+
+			if tc.withScheduler {
+				// A managed pool (Scheduler set, no Ref) enters the migration
+				// block. Add a default backendRef so the block mutates its
+				// Group, proving the block actually ran past the early return.
+				defaultPool := (&v1alpha2.SchedulerSpec{}).InferencePoolName(llmSvc)
+				llmSvc.Spec.Router.Scheduler = &v1alpha2.SchedulerSpec{}
+				llmSvc.Spec.Router.Route.HTTP.Spec.Rules[0].BackendRefs = []gwapiv1.HTTPBackendRef{
+					{
+						BackendRef: gwapiv1.BackendRef{
+							BackendObjectReference: gwapiv1.BackendObjectReference{
+								Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+								Name: gwapiv1.ObjectName(defaultPool),
+							},
+						},
+					},
+				}
+
+				// r.Get in the migration block needs a real client. The route
+				// doesn't exist, so Get returns NotFound and the reconciler
+				// keeps the v1alpha2 API group (not yet migrated).
+				scheme := runtime.NewScheme()
+				g.Expect(gwapiv1.Install(scheme)).To(Succeed())
+				r.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+			}
+
+			cfg := &Config{DisableHTTPRouteTimeout: tc.disableHTTPRouteTimeout}
+
+			route := r.expectedHTTPRoute(context.Background(), llmSvc, cfg)
+
+			g.Expect(route.Spec.Rules).To(HaveLen(1))
+			if tc.expectTimeouts {
+				g.Expect(route.Spec.Rules[0].Timeouts).ToNot(BeNil(),
+					"expected Timeouts to be set when disableHTTPRouteTimeout is false")
+			} else {
+				g.Expect(route.Spec.Rules[0].Timeouts).To(BeNil(),
+					"expected Timeouts to be nil when disableHTTPRouteTimeout is true")
+			}
+
+			if tc.withScheduler {
+				// Confirm the migration block executed (didn't return early):
+				// the default backendRef's Group is set to the v1alpha2 pool
+				// group. The nil-Timeouts assertion above must survive it.
+				g.Expect(route.Spec.Rules[0].BackendRefs).To(HaveLen(1))
+				g.Expect(route.Spec.Rules[0].BackendRefs[0].Group).ToNot(BeNil())
+				g.Expect(string(*route.Spec.Rules[0].BackendRefs[0].Group)).
+					To(Equal(constants.InferencePoolV1Alpha2APIGroupName),
+						"expected migration block to run and set the v1alpha2 pool group")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #5313 added the `disableHTTPRouteTimeout` flag so that generated HTTPRoutes omit `spec.rules[*].timeouts` (GKE Gateway rejects routes that set timeouts). That fix only touched the v1beta1 `InferenceService` ingress reconciler. The v1alpha2 `LLMInferenceService` router ignored the flag: its route preset bakes `timeouts` into every rule and `expectedHTTPRoute` copied them verbatim, so the flag was silently a no-op for LLMISVC even though the chart still exposes it.

This wires the read side:

- `config_loader.go`: plumb `DisableHTTPRouteTimeout` from the shared `IngressConfig` into the llmisvc `Config` (no CRD change — the flag already exists in `IngressConfig`).
- `router.go`: in `expectedHTTPRoute`, clear each rule's `Timeouts` when the flag is set. This single choke point sits inside the `HasSpec` block, after model-based routing rules are applied and before the migration block, so it covers both the non-migration and managed-pool migration InferencePool paths. BYO routes via `Refs` are untouched.

```mermaid
flowchart TD
    A[expectedHTTPRoute] --> B{Router/Route/HasSpec?}
    B -- no --> R[return route]
    B -- yes --> C[build rules from spec]
    C --> D{DisableHTTPRouteTimeout?}
    D -- yes --> E[Timeouts = nil on every rule]
    D -- no --> F[keep timeouts]
    E --> G{managed pool<br/>Scheduler set, no Ref?}
    F --> G
    G -- no --> R
    G -- yes --> H[migration block:<br/>set BackendRef.Group only]
    H --> R
```

**Which issue(s) this PR fixes**:
Fixes #5707

**Feature/Issue validation/testing**:

Table-driven unit test `TestExpectedHTTPRoute_DisableHTTPRouteTimeout` calls `expectedHTTPRoute` directly (no envtest/apiserver needed):

- flag set -> `timeouts` omitted from the rule
- flag unset -> `timeouts` retained
- flag set on the managed-pool migration path (non-nil `Scheduler`, fake client) -> `timeouts` still omitted, and the migration block is proven to run (default backendRef `Group` is set), guarding against a future regression if that block is extended to touch `Timeouts`.

- Logs

```
$ gofmt -l pkg/controller/v1alpha2/llmisvc/{config_loader,router,router_disable_timeout_test}.go   # clean
$ go vet ./pkg/controller/v1alpha2/llmisvc/                                                          # no issues
$ go test ./pkg/controller/v1alpha2/llmisvc/ -run TestExpectedHTTPRoute_DisableHTTPRouteTimeout      # PASS (3 cases)
```

**Special notes for your reviewer**:

Managed routes only; BYO routes via `Refs` are unaffected by design. A full envtest integration test asserting the reconcile path is a reasonable follow-up.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix: the v1alpha2 LLMInferenceService router now honors `disableHTTPRouteTimeout`, omitting `spec.rules[*].timeouts` from generated HTTPRoutes so gateways that reject route timeouts (e.g. GKE Gateway) accept them.
```

