### PR TITLE
ci: wait for llmisvc webhook Certificate before proceeding on Helm install

### DIFF
--- a/hack/setup/infra/manage.kserve-helm.sh
+++ b/hack/setup/infra/manage.kserve-helm.sh
@@ -364,6 +364,22 @@ install() {
 
     log_success "Successfully installed KServe"
 
+    # Helm's sortManifestsByKind applies the llmisvc-controller-manager Deployment
+    # (a known kind) before cert-manager's Certificate CR (a custom kind, sorted
+    # last), so the pod can be scheduled and attempt to mount
+    # llmisvc-webhook-server-cert before cert-manager has issued it, hitting
+    # FailedMount and kubelet's mount-retry backoff. Wait for the Certificate to
+    # be issued and restart the deployment to reset that backoff before waiting
+    # for it to become ready.
+    if is_positive "${ENABLE_LLMISVC}"; then
+        log_info "Waiting for llmisvc webhook Certificate to be ready..."
+        kubectl wait --for=condition=Ready certificate/llmisvc-serving-cert \
+            -n "${KSERVE_NAMESPACE}" --timeout=180s
+
+        log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
+        kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+    fi
+
     # Wait for all controller managers to be ready
     log_info "Waiting for KServe controllers to be ready..."
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -1502,6 +1502,22 @@ install_kserve_helm() {
 
     log_success "Successfully installed KServe"
 
+    # Helm's sortManifestsByKind applies the llmisvc-controller-manager Deployment
+    # (a known kind) before cert-manager's Certificate CR (a custom kind, sorted
+    # last), so the pod can be scheduled and attempt to mount
+    # llmisvc-webhook-server-cert before cert-manager has issued it, hitting
+    # FailedMount and kubelet's mount-retry backoff. Wait for the Certificate to
+    # be issued and restart the deployment to reset that backoff before waiting
+    # for it to become ready.
+    if is_positive "${ENABLE_LLMISVC}"; then
+        log_info "Waiting for llmisvc webhook Certificate to be ready..."
+        kubectl wait --for=condition=Ready certificate/llmisvc-serving-cert \
+            -n "${KSERVE_NAMESPACE}" --timeout=180s
+
+        log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
+        kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+    fi
+
     # Wait for all controller managers to be ready
     log_info "Waiting for KServe controllers to be ready..."
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -1093,6 +1093,22 @@ install_kserve_helm() {
 
     log_success "Successfully installed KServe"
 
+    # Helm's sortManifestsByKind applies the llmisvc-controller-manager Deployment
+    # (a known kind) before cert-manager's Certificate CR (a custom kind, sorted
+    # last), so the pod can be scheduled and attempt to mount
+    # llmisvc-webhook-server-cert before cert-manager has issued it, hitting
+    # FailedMount and kubelet's mount-retry backoff. Wait for the Certificate to
+    # be issued and restart the deployment to reset that backoff before waiting
+    # for it to become ready.
+    if is_positive "${ENABLE_LLMISVC}"; then
+        log_info "Waiting for llmisvc webhook Certificate to be ready..."
+        kubectl wait --for=condition=Ready certificate/llmisvc-serving-cert \
+            -n "${KSERVE_NAMESPACE}" --timeout=180s
+
+        log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
+        kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+    fi
+
     # Wait for all controller managers to be ready
     log_info "Waiting for KServe controllers to be ready..."
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -1472,6 +1472,22 @@ install_kserve_helm() {
 
     log_success "Successfully installed KServe"
 
+    # Helm's sortManifestsByKind applies the llmisvc-controller-manager Deployment
+    # (a known kind) before cert-manager's Certificate CR (a custom kind, sorted
+    # last), so the pod can be scheduled and attempt to mount
+    # llmisvc-webhook-server-cert before cert-manager has issued it, hitting
+    # FailedMount and kubelet's mount-retry backoff. Wait for the Certificate to
+    # be issued and restart the deployment to reset that backoff before waiting
+    # for it to become ready.
+    if is_positive "${ENABLE_LLMISVC}"; then
+        log_info "Waiting for llmisvc webhook Certificate to be ready..."
+        kubectl wait --for=condition=Ready certificate/llmisvc-serving-cert \
+            -n "${KSERVE_NAMESPACE}" --timeout=180s
+
+        log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
+        kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+    fi
+
     # Wait for all controller managers to be ready
     log_info "Waiting for KServe controllers to be ready..."
     for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do


### PR DESCRIPTION
Fixes an intermittent Helm-install-path failure on `test-llmisvc (helm)` where the llmisvc-controller-manager pod fails to mount `llmisvc-webhook-server-cert` because Helm's `sortManifestsByKind` applies the Deployment (known kind) before cert-manager's Certificate and Issuer (custom kinds, sorted last). The kustomize install path passes reliably because it applies all resources in one `kubectl apply --server-side` batch.

This PR adds a minimal wait on Certificate readiness in `hack/setup/infra/manage.kserve-helm.sh` after the resource charts install, followed by a rollout restart to reset any accumulated FailedMount backoff on the initial pod. CI-only change; mirrors the pattern `manage.kserve-kustomize.sh` already uses.

Follow-up to the merged hardening pass in #5574 (which did not address the Helm kind-sort race for cert-manager resources).

### Verification

Ran a targeted end-to-end verification against a kind cluster via `bash test/scripts/gh-actions/setup-kserve.sh INSTALL_METHOD=helm ENABLE_LLMISVC=true` — the exact code path CI invokes for `test-llmisvc (helm)`. The run live-reproduced the FailedMount race on the initial pod (`MountVolume.SetUp failed for volume "cert" : secret "llmisvc-webhook-server-cert" not found`), then confirmed the patch's Certificate wait + rollout restart resolved it. Post-restart pod observed: zero FailedMount events, Certificate `Ready=True`, Deployment `1/1` Available.

### Diagnosis summary

- Failing job: `test-llmisvc (helm)` — `MountVolume.SetUp failed for volume "cert" : secret "llmisvc-webhook-server-cert" not found`, followed by `tls: bad certificate` on the admission webhook
- Passing twin: `test-llmisvc (kustomize)` — same test surface, different install method → asymmetry rules out product code
- Diff scope: only `hack/setup/infra/manage.kserve-helm.sh` (+16 lines); no product-code, no chart-lifecycle changes
