### PR TITLE
chore(llmisvc): migrate EndpointPickerConfig apiversion

### DIFF
--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
@@ -47,7 +47,7 @@ spec:
     scheduler:
       config:
         inline:
-          apiVersion: inference.networking.x-k8s.io/v1alpha1
+          apiVersion: llm-d.ai/v1alpha1
           kind: EndpointPickerConfig
           plugins:
             - type: single-profile-handler

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-opt-125m-cpu-kv-cache-routing-simulator.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-opt-125m-cpu-kv-cache-routing-simulator.yaml
@@ -21,7 +21,7 @@ spec:
                 value: DEBUG
       config:
         inline:
-          apiVersion: inference.networking.x-k8s.io/v1alpha1
+          apiVersion: llm-d.ai/v1alpha1
           kind: EndpointPickerConfig
           plugins:
             - type: single-profile-handler

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
@@ -13,7 +13,7 @@ spec:
     scheduler:
       config:
         inline:
-          apiVersion: inference.networking.x-k8s.io/v1alpha1
+          apiVersion: llm-d.ai/v1alpha1
           kind: EndpointPickerConfig
           plugins:
             - type: single-profile-handler

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -49,7 +49,7 @@ var _ = Describe("LLMInferenceService Scheduler Config", func() {
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			customSchedulerConfig := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: custom-plugin
@@ -217,7 +217,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			configMapData := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: configmap-plugin
@@ -267,7 +267,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			configMapData := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: custom-key-plugin
@@ -317,7 +317,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			initialConfigData := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: initial-plugin
@@ -359,7 +359,7 @@ schedulingProfiles:
 
 			// when - update ConfigMap
 			updatedConfigData := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: updated-plugin
@@ -502,7 +502,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			systemConfigData := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: system-namespace-plugin
@@ -627,7 +627,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			schedulerConfigData := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: baseref-plugin
@@ -689,7 +689,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			inlineSchedulerConfig := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: inline-baseref-plugin
@@ -1054,7 +1054,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			precisePrefixConfig := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler
@@ -1119,7 +1119,7 @@ schedulingProfiles:
 
 			//nolint:gosec // G101: not a credential, scheduler config YAML
 			configWithExistingTokenizer := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler
@@ -1186,7 +1186,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			configWithoutPrecisePrefix := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler
@@ -1244,7 +1244,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			oldFormatConfig := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler
@@ -1308,7 +1308,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			newFormatConfig := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler
@@ -1569,7 +1569,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			configWithPrefixCacheParams := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler
@@ -1625,7 +1625,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			configWithOnlyDeprecatedParams := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler
@@ -1681,7 +1681,7 @@ schedulingProfiles:
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
 
 			configWithNoParams := `
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1340,6 +1340,7 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 	if v.Compare(*semver.New("0.9.0")) >= 0 {
 		opts = append(opts, withRemovePrefixCacheScorerParametersV09)
 		opts = append(opts, withRemoveUnnecessaryTokenizer(d))
+		opts = append(opts, withMigrateLLMDAPIVersion)
 	}
 
 	if err := mutateSchedulerConfig(ctx, d, opts...); err != nil {
@@ -1352,6 +1353,16 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 // disagg-headers-handler (v0.7.0 rename).
 func withMigrateDisaggHeadersHandler(ctx context.Context, u *unstructured.Unstructured) error {
 	return WithRenamePlugin("prefill-header-handler", "disagg-headers-handler")(ctx, u)
+}
+
+// withMigrateLLMDAPIVersion rewrites the deprecated EndpointPickerConfig
+// apiVersion inference.networking.x-k8s.io/v1alpha1 to llm-d.ai/v1alpha1, which
+// is the apiVersion accepted by the scheduler binary from v0.9.0 onward.
+func withMigrateLLMDAPIVersion(_ context.Context, u *unstructured.Unstructured) error {
+	if u.GetAPIVersion() == "inference.networking.x-k8s.io/v1alpha1" {
+		u.SetAPIVersion("llm-d.ai/v1alpha1")
+	}
+	return nil
 }
 
 // withMigrateCoreMetricsExtractor renames the model-server-protocol-metrics

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -506,7 +506,7 @@ func schedulerConfigText(llmSvc *v1alpha2.LLMInferenceService) string {
 			loraProfileEntry = fmt.Sprintf("  - pluginRef: %s\n    weight: 4\n", loraAffinityScorerPlugin)
 		}
 		return fmt.Sprintf(`
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: disagg-headers-handler
@@ -554,7 +554,7 @@ plugins:
 			loraProfileEntry = fmt.Sprintf("  - pluginRef: %s\n    weight: 4\n", loraAffinityScorerPlugin)
 		}
 		return fmt.Sprintf(`
-apiVersion: inference.networking.x-k8s.io/v1alpha1
+apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1404,7 +1404,7 @@ plugins:
 }
 
 func TestSchedulerTransform(t *testing.T) {
-	oldConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+	oldConfigYAML := `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: prefill-header-handler
@@ -1498,7 +1498,7 @@ func TestSchedulerTransformThreshold(t *testing.T) {
 	}{
 		{
 			name: "migrates non-zero threshold in full transform",
-			configYAML: `apiVersion: inference.networking.x-k8s.io/v1alpha1
+			configYAML: `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: prefill-header-handler
@@ -1525,7 +1525,7 @@ plugins:
 		},
 		{
 			name: "migrates non-zero threshold with deciderPluginName in full transform",
-			configYAML: `apiVersion: inference.networking.x-k8s.io/v1alpha1
+			configYAML: `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: prefill-header-handler
@@ -1551,7 +1551,7 @@ plugins:
 		},
 		{
 			name: "migrates threshold 0 in full transform",
-			configYAML: `apiVersion: inference.networking.x-k8s.io/v1alpha1
+			configYAML: `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: prefill-header-handler
@@ -1609,7 +1609,7 @@ plugins:
 
 func TestFullMigrationPipeline(t *testing.T) {
 	// Realistic old v0.6 config with all deprecated features.
-	oldConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+	oldConfigYAML := `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: prefill-header-handler
@@ -1805,7 +1805,7 @@ schedulingProfiles:
 }
 
 func TestFullMigrationPipelineNonZeroThreshold(t *testing.T) {
-	oldConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+	oldConfigYAML := `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: prefill-header-handler
@@ -1952,7 +1952,7 @@ func TestExtractDeprecatedMetricFlags(t *testing.T) {
 }
 
 func TestSchedulerTransformGatesMetricFlagExtraction(t *testing.T) {
-	configYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+	configYAML := `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: queue-scorer

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1489,6 +1489,81 @@ plugins:
 	}
 }
 
+func TestSchedulerTransformMigratesLLMDAPIVersion(t *testing.T) {
+	oldAPIVersionConfig := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+`
+
+	tests := []struct {
+		name           string
+		version        string
+		configYAML     string
+		validateConfig func(g Gomega, configText string)
+	}{
+		{
+			name:       "migrates apiVersion for v0.9.0",
+			version:    "0.9.0",
+			configYAML: oldAPIVersionConfig,
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("apiVersion: llm-d.ai/v1alpha1"))
+				g.Expect(configText).NotTo(ContainSubstring("inference.networking.x-k8s.io/v1alpha1"))
+			},
+		},
+		{
+			name:       "preserves old apiVersion for v0.8.0",
+			version:    "0.8.0",
+			configYAML: oldAPIVersionConfig,
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("apiVersion: inference.networking.x-k8s.io/v1alpha1"))
+				g.Expect(configText).NotTo(ContainSubstring("llm-d.ai/v1alpha1"))
+			},
+		},
+		{
+			name:    "leaves new apiVersion unchanged for v0.9.0",
+			version: "0.9.0",
+			configYAML: `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+`,
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("apiVersion: llm-d.ai/v1alpha1"))
+				g.Expect(configText).NotTo(ContainSubstring("inference.networking.x-k8s.io/v1alpha1"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			d := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"app.kubernetes.io/version": tt.version,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Args: []string{"--config-text", tt.configYAML}},
+							},
+						},
+					},
+				},
+			}
+
+			g.Expect(schedulerTransform(context.Background(), d)).To(Succeed())
+
+			configText := d.Spec.Template.Spec.Containers[0].Args[1]
+			tt.validateConfig(g, configText)
+		})
+	}
+}
+
 func TestSchedulerTransformThreshold(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1489,6 +1489,11 @@ plugins:
 	}
 }
 
+// TestSchedulerTransformMigratesLLMDAPIVersion verifies the version-gated
+// (>=0.9.0) EndpointPickerConfig apiVersion rewrite in isolation:
+//   - 0.9.0: inference.networking.x-k8s.io/v1alpha1 -> llm-d.ai/v1alpha1
+//   - 0.8.0: old apiVersion preserved (the pre-0.9.0 binary still accepts it)
+//   - 0.9.0 + new apiVersion: left unchanged (idempotent)
 func TestSchedulerTransformMigratesLLMDAPIVersion(t *testing.T) {
 	oldAPIVersionConfig := `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
@@ -1683,7 +1688,7 @@ plugins:
 }
 
 func TestFullMigrationPipeline(t *testing.T) {
-	// Realistic old v0.6 config with all deprecated features.
+	// Config with all deprecated v0.6 features, on the current llm-d.ai apiVersion.
 	oldConfigYAML := `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -767,7 +767,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "scheduler": {
                 "config": {
                     "inline": {
-                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "apiVersion": "llm-d.ai/v1alpha1",
                         "kind": "EndpointPickerConfig",
                         "plugins": [
                             {"type": "single-profile-handler"},
@@ -795,7 +795,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "scheduler": {
                 "config": {
                     "inline": {
-                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "apiVersion": "llm-d.ai/v1alpha1",
                         "kind": "EndpointPickerConfig",
                         "plugins": [
                             {"type": "single-profile-handler"},
@@ -855,7 +855,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "scheduler": {
                 "config": {
                     "inline": {
-                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "apiVersion": "llm-d.ai/v1alpha1",
                         "kind": "EndpointPickerConfig",
                         "plugins": [
                             {"type": "prefill-header-handler"},
@@ -911,7 +911,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "scheduler": {
                 "config": {
                     "inline": {
-                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "apiVersion": "llm-d.ai/v1alpha1",
                         "kind": "EndpointPickerConfig",
                         "plugins": [
                             {"type": "prefill-header-handler"},
@@ -1034,7 +1034,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                                 "vllm:kv_cache_usage_perc",
                                 "--config-text",
                                 (
-                                    "apiVersion: inference.networking.x-k8s.io/v1alpha1\n"
+                                    "apiVersion: llm-d.ai/v1alpha1\n"
                                     "kind: EndpointPickerConfig\n"
                                     "plugins:\n"
                                     "- type: single-profile-handler\n"
@@ -1781,7 +1781,7 @@ def inject_k8s_proxy():
 
 
 # Scheduler config YAML used for ConfigMap ref tests
-SCHEDULER_CONFIG_YAML = """apiVersion: inference.networking.x-k8s.io/v1alpha1
+SCHEDULER_CONFIG_YAML = """apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
 - type: single-profile-handler

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1444,7 +1444,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "scheduler": {
                 "config": {
                     "inline": {
-                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "apiVersion": "llm-d.ai/v1alpha1",
                         "kind": "EndpointPickerConfig",
                         "featureGates": ["flowControl"],
                         "plugins": [
@@ -1503,7 +1503,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "scheduler": {
                 "config": {
                     "inline": {
-                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "apiVersion": "llm-d.ai/v1alpha1",
                         "kind": "EndpointPickerConfig",
                         "featureGates": ["flowControl"],
                         "plugins": [


### PR DESCRIPTION
**What this PR does / why we need it**:

- from `inference.networking.x-k8s.io/v1alpha1 `to `llm-d.ai/v1alpha1`
- mostly for tests and docs/sample
- schedulerConfigText() change wont impact existing llmisvc with old apiversion if epp pod is running with old image (<0.9.0)  otherwise, migrate from old API to new llm-d.ai/v1alpha1


cc @pierDipi 
