### PR TITLE
refactor(isvc): remove no-op namespace filter in clusterServingRuntimeFunc

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -511,7 +511,11 @@ func (r *InferenceServiceReconciler) clusterServingRuntimeFunc(ctx context.Conte
 	}
 
 	var isvcList v1beta1.InferenceServiceList
-	if err := r.List(ctx, &isvcList, client.InNamespace(clusterServingRuntimeObj.Namespace)); err != nil {
+	// ClusterServingRuntime is cluster-scoped, so it can be referenced by
+	// InferenceServices in any namespace. List across all namespaces (no
+	// InNamespace filter), unlike servingRuntimeFunc above which is
+	// namespace-scoped.
+	if err := r.List(ctx, &isvcList); err != nil {
 		r.Log.Error(err, "unable to list InferenceServices", "clusterServingRuntime", clusterServingRuntimeObj.Name)
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`clusterServingRuntimeFunc` listed InferenceServices with `client.InNamespace(clusterServingRuntimeObj.Namespace)`. `ClusterServingRuntime` is cluster-scoped, so its `Namespace` is always `""`, and `client.InNamespace("")` applies no namespace restriction — the call already listed InferenceServices across all namespaces, but only by relying on that empty-field coincidence. It also reads identically to the namespace-scoped `servingRuntimeFunc` directly above it (which *does* filter by namespace), making the intent easy to misread.

This drops the no-op `InNamespace` option and adds a comment documenting that the listing is intentionally cluster-wide. No behavior change: the set of enqueued InferenceServices is identical. It guards against a future edit "restoring" a namespace filter and silently breaking cross-namespace reconciliation of `ClusterServingRuntime`.

**Which issue(s) this PR fixes**:
Fixes #5772

**Feature/Issue validation/testing**:

No behavior change — this removes an option that is a no-op for a cluster-scoped resource (`InNamespace("")` == no namespace filter) and adds a clarifying comment. The existing `clusterServingRuntimeFunc` specs in `pkg/controller/v1beta1/inferenceservice/pod_watch_test.go` continue to exercise the mapper.

**Special notes for your reviewer**:

Pure readability/clarity change. Happy to add a dedicated cross-namespace test case for `clusterServingRuntimeFunc` (the existing specs only exercise a single namespace) if you'd prefer the cluster-wide behavior locked in with a regression test.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
NONE
```
