### PR TITLE
fix(llmisvc): skip scheduler for custom backendRefs

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_bypass_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_bypass_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+var _ = Describe("LLMInferenceService Controller", func() {
+	Context("Scheduler bypass when backendRefs do not reference InferencePool", func() {
+		It("should reach RouterReady without InferencePool when no scheduler is configured and route uses a custom backendRef kind", func(ctx SpecContext) {
+			svcName := "test-no-sched-custom-ref"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithHTTPRouteSpec(&gwapiv1.HTTPRouteSpec{
+					Rules: []gwapiv1.HTTPRouteRule{
+						HTTPRouteRule(
+							WithBackendRefs(gwapiv1.HTTPBackendRef{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Group: ptr.To(gwapiv1.Group("agentgateway.dev")),
+										Kind:  ptr.To(gwapiv1.Kind("AgentgatewayBackend")),
+										Name:  gwapiv1.ObjectName(svcName + "-backend"),
+									},
+								},
+							}),
+							WithMatches(PathPrefixMatch("/v1/chat/completions")),
+						),
+					},
+				}),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// Wait for the controller to reconcile and set at least one condition
+			Eventually(func(g Gomega, ctx SpecContext) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status.Conditions).ToNot(BeEmpty(), "controller should have set at least one condition")
+			}).WithContext(ctx).Should(Succeed())
+
+			// Mark the controller-created HTTPRoute as ready
+			Eventually(func(g Gomega, ctx SpecContext) {
+				routes := &gwapiv1.HTTPRouteList{}
+				g.Expect(envTest.Client.List(ctx, routes,
+					client.InNamespace(testNs.Name),
+					client.MatchingLabels(llmisvc.RouterLabels(llmSvc)),
+				)).To(Succeed())
+				g.Expect(routes.Items).To(HaveLen(1))
+
+				updatedRoute := routes.Items[0].DeepCopy()
+				WithHTTPRouteReadyStatus(DefaultGatewayControllerName)(updatedRoute)
+				g.Expect(envTest.Client.Status().Update(ctx, updatedRoute)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// RouterReady should become True - no InferencePool needed
+			Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha2.LLMInferenceService) {
+				poolCond := current.GetStatus().GetCondition(v1alpha2.InferencePoolReady)
+				g.Expect(poolCond).To(BeNil(), "InferencePoolReady should be cleared when no scheduler is set")
+
+				schedulerCond := current.GetStatus().GetCondition(v1alpha2.SchedulerWorkloadReady)
+				g.Expect(schedulerCond).To(BeNil(), "SchedulerWorkloadReady should be cleared when no scheduler is set")
+			})).WithContext(ctx).Should(Succeed())
+
+			// No InferencePool should exist
+			pools := &igwapi.InferencePoolList{}
+			Expect(envTest.Client.List(ctx, pools, client.InNamespace(testNs.Name))).To(Succeed())
+			Expect(pools.Items).To(BeEmpty(), "No InferencePool should be created")
+
+			// No scheduler deployment should exist
+			deps := &appsv1.DeploymentList{}
+			Expect(envTest.Client.List(ctx, deps,
+				client.InNamespace(testNs.Name),
+				client.MatchingLabels(llmisvc.SchedulerLabels(llmSvc)),
+			)).To(Succeed())
+			Expect(deps.Items).To(BeEmpty(), "No scheduler deployment should be created")
+		})
+
+		It("should create scheduler and InferencePool when using default route with InferencePool backendRef", func(ctx SpecContext) {
+			svcName := "test-default-pool-ref"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// InferencePool and scheduler deployment should be created
+			Eventually(func(g Gomega, ctx SpecContext) {
+				pools := &igwapi.InferencePoolList{}
+				g.Expect(envTest.Client.List(ctx, pools, client.InNamespace(testNs.Name))).To(Succeed())
+				g.Expect(pools.Items).ToNot(BeEmpty(), "InferencePool should be created for default backendRef")
+			}).WithContext(ctx).Should(Succeed())
+
+			Eventually(func(g Gomega, ctx SpecContext) {
+				deps := &appsv1.DeploymentList{}
+				g.Expect(envTest.Client.List(ctx, deps,
+					client.InNamespace(testNs.Name),
+					client.MatchingLabels(llmisvc.SchedulerLabels(llmSvc)),
+				)).To(Succeed())
+				g.Expect(deps.Items).ToNot(BeEmpty(), "Scheduler deployment should be created for default backendRef")
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+})

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -89,7 +89,6 @@ func (r *LLMISVCReconciler) reconcileRouter(ctx context.Context, llmSvc *v1alpha
 		return err
 	}
 
-	// Reconcile the scheduler component that manages inference pools
 	if err := r.reconcileScheduler(ctx, llmSvc); err != nil {
 		llmSvc.MarkSchedulerWorkloadNotReady("SchedulerReconcileError", "Failed to reconcile scheduler: %v", err.Error())
 		return fmt.Errorf("failed to reconcile scheduler: %w", err)

--- a/pkg/controller/v1alpha2/llmisvc/router_export_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_export_test.go
@@ -27,3 +27,7 @@ import (
 func UpdateRoutingStatusForTest(ctx context.Context, r *LLMISVCReconciler, llmSvc *v1alpha2.LLMInferenceService, routes ...*gwapiv1.HTTPRoute) ([]ResolvedGateway, error) {
 	return r.updateRoutingStatus(ctx, llmSvc, routes...)
 }
+
+func ValidateSchedulerBackendRefConsistencyForTest(r *LLMISVCReconciler, llmSvc *v1alpha2.LLMInferenceService) error {
+	return r.validateSchedulerBackendRefConsistency(llmSvc)
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_scheduler_bypass_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_scheduler_bypass_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+func backendRefAgentgateway(name string) gwapiv1.HTTPBackendRef {
+	return gwapiv1.HTTPBackendRef{
+		BackendRef: gwapiv1.BackendRef{
+			BackendObjectReference: gwapiv1.BackendObjectReference{
+				Group: ptr.To(gwapiv1.Group("agentgateway.dev")),
+				Kind:  ptr.To(gwapiv1.Kind("AgentgatewayBackend")),
+				Name:  gwapiv1.ObjectName(name),
+			},
+		},
+	}
+}
+
+func TestValidateSchedulerBackendRefConsistency(t *testing.T) {
+	tests := []struct {
+		name        string
+		llmSvc      *v1alpha2.LLMInferenceService
+		expectError bool
+		errorSubstr string
+	}{
+		{
+			name: "no scheduler - no error",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteSpec(&gwapiv1.HTTPRouteSpec{
+					Rules: []gwapiv1.HTTPRouteRule{
+						HTTPRouteRule(
+							WithBackendRefs(backendRefAgentgateway("no-sched-backend")),
+						),
+					},
+				}),
+			),
+			expectError: false,
+		},
+		{
+			name: "scheduler with InferencePool backendRef - no error",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithManagedScheduler(),
+				WithHTTPRouteSpec(&gwapiv1.HTTPRouteSpec{
+					Rules: []gwapiv1.HTTPRouteRule{
+						HTTPRouteRule(
+							WithBackendRefs(BackendRefInferencePool("test-llm-inference-pool")),
+							WithMatches(PathPrefixMatch("/v1/completions")),
+						),
+					},
+				}),
+			),
+			expectError: false,
+		},
+		{
+			name: "scheduler with custom backendRef bypassing InferencePool - validation error",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithManagedScheduler(),
+				WithHTTPRouteSpec(&gwapiv1.HTTPRouteSpec{
+					Rules: []gwapiv1.HTTPRouteRule{
+						HTTPRouteRule(
+							WithBackendRefs(backendRefAgentgateway("mismatched-backend")),
+							WithMatches(PathPrefixMatch("/v1/chat/completions")),
+						),
+					},
+				}),
+			),
+			expectError: true,
+			errorSubstr: "spec.router.scheduler is configured but no HTTPRoute backendRef references the managed InferencePool",
+		},
+		{
+			name: "external pool ref with matching backendRef - no error",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithInferencePoolRef("custom-pool"),
+				WithHTTPRouteSpec(&gwapiv1.HTTPRouteSpec{
+					Rules: []gwapiv1.HTTPRouteRule{
+						HTTPRouteRule(
+							WithBackendRefs(BackendRefInferencePool("custom-pool")),
+							WithMatches(PathPrefixMatch("/v1/completions")),
+						),
+					},
+				}),
+			),
+			expectError: false,
+		},
+		{
+			name: "scheduler without route spec - no error (defaults to InferencePool)",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithManagedScheduler(),
+			),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			reconciler := &llmisvc.LLMISVCReconciler{}
+			err := llmisvc.ValidateSchedulerBackendRefConsistencyForTest(reconciler, tt.llmSvc)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(llmisvc.IsValidationError(err)).To(BeTrue(), "error should be a ValidationError")
+				g.Expect(err.Error()).To(ContainSubstring(tt.errorSubstr))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_validation.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_validation.go
@@ -24,6 +24,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -31,7 +32,8 @@ import (
 )
 
 const (
-	RefsInvalidReason = "RefsInvalid"
+	RefsInvalidReason                 = "RefsInvalid"
+	SchedulerBackendRefMismatchReason = "SchedulerBackendRefMismatch"
 )
 
 // ValidationError represents a validation failure that should be reported via conditions
@@ -91,6 +93,12 @@ func (r *LLMISVCReconciler) validateRouterReferences(ctx context.Context, llmSvc
 			return err
 		}
 		return fmt.Errorf("managed HTTPRoute spec validation failed: %w", err)
+	}
+
+	if err := r.validateSchedulerBackendRefConsistency(llmSvc); err != nil {
+		llmSvc.MarkSchedulerWorkloadNotReady(SchedulerBackendRefMismatchReason, err.Error())
+		logger.Info("Scheduler/backendRef consistency validation failed", "error", err)
+		return nil
 	}
 
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Route != nil && llmSvc.Spec.Router.Route.HTTP.HasRefs() {
@@ -266,4 +274,52 @@ func (r *LLMISVCReconciler) validateManagedHTTPRouteSpec(ctx context.Context, ll
 	}
 
 	return nil
+}
+
+// httpRouteReferencesInferencePool reports whether the effective HTTPRoute spec
+// has at least one backendRef targeting the managed InferencePool. Returns true
+// when there is no route spec (controller-generated defaults always target the pool).
+// Callers must check Scheduler != nil before calling - the pool name is derived from it.
+func (r *LLMISVCReconciler) httpRouteReferencesInferencePool(llmSvc *v1alpha2.LLMInferenceService) bool {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil || !llmSvc.Spec.Router.Route.HTTP.HasSpec() {
+		return true
+	}
+	return rulesReferencePool(llmSvc.Spec.Router.Route.HTTP.Spec.Rules, llmSvc.Spec.Router.Scheduler.InferencePoolName(llmSvc))
+}
+
+// rulesReferencePool returns true when at least one backendRef across all rules
+// targets an InferencePool with the given name. Group is ignored because the pool
+// can be v1 or v1alpha2 during migration.
+func rulesReferencePool(rules []gwapiv1.HTTPRouteRule, poolName string) bool {
+	for _, rule := range rules {
+		for _, ref := range rule.BackendRefs {
+			if ptr.Deref(ref.Kind, "") == "InferencePool" && string(ref.Name) == poolName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// validateSchedulerBackendRefConsistency rejects specs where a scheduler is configured
+// but the effective HTTPRoute backendRefs do not reference the managed InferencePool.
+// This runs after preset merging, so the spec reflects the combined configuration.
+func (r *LLMISVCReconciler) validateSchedulerBackendRefConsistency(llmSvc *v1alpha2.LLMInferenceService) error {
+	// Nothing to validate when scheduler is absent or the combined route spec has no rules.
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil ||
+		llmSvc.Spec.Router.Route == nil || !llmSvc.Spec.Router.Route.HTTP.HasSpec() {
+		return nil
+	}
+
+	poolName := llmSvc.Spec.Router.Scheduler.InferencePoolName(llmSvc)
+	if rulesReferencePool(llmSvc.Spec.Router.Route.HTTP.Spec.Rules, poolName) {
+		return nil
+	}
+
+	return NewValidationError(
+		fmt.Sprintf("spec.router.scheduler is configured but no HTTPRoute backendRef references "+
+			"the managed InferencePool %q; the scheduler (EPP deployment and InferencePool) would not "+
+			"be in the data path - either remove spec.router.scheduler or update backendRefs to "+
+			"reference the InferencePool", poolName),
+	)
 }

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -69,6 +69,11 @@ const (
 func (r *LLMISVCReconciler) reconcileScheduler(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
 	log.FromContext(ctx).Info("Reconciling Scheduler")
 
+	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil &&
+		!r.httpRouteReferencesInferencePool(llmSvc) {
+		llmSvc.MarkSchedulerWorkloadUnset()
+	}
+
 	if err := r.reconcileSchedulerServiceAccount(ctx, llmSvc); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When an LLMInferenceService overrides HTTPRoute `backendRefs` to a non-InferencePool kind (e.g. `AgentgatewayBackend`), the controller still creates the full scheduler subsystem (EPP deployment, service, InferencePool) and gates `Ready` on InferencePool acceptance. Gateways that don't implement the GIE InferencePool resource - like AgentGateway - never accept the pool, blocking `Ready` indefinitely.

This change detects when the effective (post-merge) HTTPRoute backendRefs don't target the managed InferencePool and:

- Clears `SchedulerWorkloadReady` so the scheduler doesn't block readiness
- Surfaces a `SchedulerBackendRefMismatch` condition when scheduler is configured but no backendRef references the pool, giving the user a clear signal to remove `spec.router.scheduler`
- Always calls `reconcileScheduler` so its internal guards clean up stale resources on transition (e.g. switching from InferencePool to a custom backend)

The validation runs post-merge (in `validateRouterReferences`, not the webhook) because `baseRefs` are not resolved at admission time - the backendRefs may come entirely from an `LLMInferenceServiceConfig` preset.

**Which issue(s) this PR fixes**:
Ref https://github.com/kserve/kserve/issues/5729

**Feature/Issue validation/testing**:

- [x] Unit tests for `validateSchedulerBackendRefConsistency` covering: no scheduler, matching InferencePool, custom backendRef bypass, external pool ref, no route spec
- [x] Envtest integration tests: custom backendRef reaches `RouterReady` without InferencePool; default InferencePool path creates scheduler resources as before

**Special notes for your reviewer**:

Discovered while validating the [LLMInferenceService + AgentGateway integration guide](https://github.com/kserve/website/pull/697) on a kind cluster. AgentGateway doesn't watch InferencePool resources unless `inferenceExtension.enabled=true` is set, and even then only writes parent status for pools directly referenced by an HTTPRoute - not through an `AgentgatewayBackend` chain.

**Checklist**:
- [x] Tests added
- [x] Existing tests pass