### PR TITLE
fix(localmodel): handle LocalModelNode race between reconcilers

### DIFF
--- a/pkg/controller/v1alpha1/localmodel/reconcilers/utils.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/utils.go
@@ -715,29 +715,29 @@ func ReconcileLocalModelNode(
 
 		for _, node := range readyNodes.Items {
 			localModelNode := &v1alpha1.LocalModelNode{}
-			err := c.Get(ctx, types.NamespacedName{Name: node.Name}, localModelNode)
-			found := true
-			if err != nil {
-				if apierr.IsNotFound(err) {
-					found = false
-					log.Info("localmodelNode not found")
-				} else {
-					log.Error(err, "Failed to get localmodelnode", "name", node.Name)
-					return err
-				}
+			nn := types.NamespacedName{Name: node.Name}
+			err := c.Get(ctx, nn, localModelNode)
+			found := err == nil
+			if err != nil && !apierr.IsNotFound(err) {
+				return err
 			}
 			if !found {
 				localModelNode = &v1alpha1.LocalModelNode{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: node.Name,
-					},
-					Spec: v1alpha1.LocalModelNodeSpec{LocalModels: []v1alpha1.LocalModelInfo{modelInfo}},
+					ObjectMeta: metav1.ObjectMeta{Name: node.Name},
+					Spec:       v1alpha1.LocalModelNodeSpec{LocalModels: []v1alpha1.LocalModelInfo{modelInfo}},
 				}
-				if err := c.Create(ctx, localModelNode); err != nil {
-					log.Error(err, "Create localmodelnode", "name", node.Name)
+				if err := c.Create(ctx, localModelNode); apierr.IsAlreadyExists(err) {
+					if err := c.Get(ctx, nn, localModelNode); err != nil {
+						return err
+					}
+					found = true
+				} else if err != nil {
 					return err
 				}
-			} else {
+			}
+			// Newly created LocalModelNode already includes modelInfo in Spec.
+			// UpdateLocalModelNode is only needed for pre-existing objects.
+			if found {
 				if err := UpdateLocalModelNode(ctx, c, log, localModelNode, localModelCache, localModelNamespaceCache, nodeGroupName); err != nil {
 					return err
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `LocalModelCache` (cluster-scoped) and `LocalModelNamespaceCache` (namespace-scoped) reconcilers can race to create the same `LocalModelNode` object. When both call `ReconcileLocalModelNode` concurrently, the second `Create` fails with `AlreadyExists` and bails out - preventing its model info from ever being added to the node.

This causes a flaky CI timeout in the "Should track both cluster-scoped and namespace-scoped models on LocalModelNode" test, because the losing reconciler never gets its model registered on the node.

Handles `AlreadyExists` on Create by re-fetching the existing `LocalModelNode` and falling through to `UpdateLocalModelNode`, so both reconcilers converge regardless of creation order.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes flaky CI test in `pkg/controller/v1alpha1/localmodel`

**Feature/Issue validation/testing**:

- [x] Existing test suite passes (`go test ./pkg/controller/v1alpha1/localmodel/... -v -count=1`)
- [x] Ran the test suite twice to confirm the flaky test no longer times out

**Special notes for your reviewer**:

Standard controller pattern - `IsAlreadyExists` guard on Create with re-Get + Update fallback. The `UpdateLocalModelNode` path already handles concurrent modifications via `MergeFrom` patch, so conflicts there are retried by the controller requeue loop.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```