### PR TITLE
fix: correct swapped args in CustomPredictor invalid-protocol error

### DIFF
--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -54,7 +54,7 @@ func (c *CustomPredictor) validateCustomProtocol() error {
 			if envVar.Value == string(constants.ProtocolV1) || envVar.Value == string(constants.ProtocolV2) {
 				return nil
 			} else {
-				return fmt.Errorf(InvalidProtocol, strings.Join([]string{string(constants.ProtocolV1), string(constants.ProtocolV2)}, ", "), envVar.Value)
+				return fmt.Errorf(InvalidProtocol, envVar.Value, strings.Join([]string{string(constants.ProtocolV1), string(constants.ProtocolV2)}, ", "))
 			}
 		}
 	}

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -98,7 +98,7 @@ func TestCustomPredictorValidation(t *testing.T) {
 					},
 				},
 			},
-			matcher: gomega.Not(gomega.BeNil()),
+			matcher: gomega.MatchError("invalid protocol unknown. Must be one of [v1, v2]"),
 		},
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:

When a custom predictor sets an unsupported `PROTOCOL` env value, KServe rejects
it with a message that reports the wrong values. The message template
(`pkg/apis/serving/v1beta1/component.go`) is:

```
invalid protocol %s. Must be one of [%s]
```

so the first verb is meant to be the offending value and the second the list of
allowed protocols. `CustomPredictor.validateCustomProtocol`
(`pkg/apis/serving/v1beta1/predictor_custom.go`) passed the two arguments in the
reverse order, so a bad value like `PROTOCOL=grpc` produced:

```
invalid protocol v1, v2. Must be one of [grpc]
```

which labels the valid options (`v1, v2`) as invalid and the invalid value
(`grpc`) as the only allowed one, i.e. the opposite of the truth. This PR swaps
the two arguments so the offending value is reported first and the allowed list
second:

```
invalid protocol grpc. Must be one of [v1, v2]
```

It also tightens the existing invalid-protocol unit test to assert the exact
rendered string, so the argument order is now covered by a regression test.
`InvalidProtocol` has exactly one caller, so this is a message-only change with
no other behavior impact.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/apis/serving/v1beta1/... -run TestCustomPredictorValidation -count=1`
  (the `ValidProtocolV1`, `ValidProtocolV2`, and `InvalidValidProtocol` subtests pass)
- [x] `go test ./pkg/apis/serving/v1beta1/... -count=1` (full package green)

- Logs

  ```
  === RUN   TestCustomPredictorValidation/InvalidValidProtocol
  --- PASS: TestCustomPredictorValidation/InvalidValidProtocol (0.00s)
  ok  	github.com/kserve/kserve/pkg/apis/serving/v1beta1	1.624s
  ```

  Reverting only the source line to the old (buggy) argument order makes the
  tightened test fail, rendering `invalid protocol v1, v2. Must be one of [unknown]`,
  which confirms the test guards the fix.

**Special notes for your reviewer**:

Message-only fix; validation semantics (which protocols are accepted) are
unchanged. The regression is covered by strengthening the existing
`InvalidValidProtocol` case from `gomega.Not(gomega.BeNil())` to
`gomega.MatchError(...)` rather than adding a new case, keeping the diff minimal.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas? (N/A - one-line argument reorder)
- [ ] Have you made corresponding changes to the documentation? (N/A - error text only)

**Release note**:
```release-note
Fix the CustomPredictor invalid-protocol validation error so it reports the offending value and the list of allowed protocols in the correct order.
```
