### PR TITLE
feat: improve storage-initializer/modelcare configuration

### DIFF
--- a/charts/_common/common-patches/storagecontainer-patch.yaml
+++ b/charts/_common/common-patches/storagecontainer-patch.yaml
@@ -13,3 +13,16 @@ spec:
       {{- with .Values.kserve.storage.containerSecurityContext}}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- $caCM := .Values.kserve.storage.caBundleConfigMapName }}
+    {{- $caPath := .Values.kserve.storage.caBundleVolumeMountPath }}
+    {{- if or $caCM $caPath }}
+    env:
+      {{- if $caCM }}
+      - name: CA_BUNDLE_CONFIGMAP_NAME
+        value: "{{ $caCM }}"
+      {{- end }}
+      {{- if $caPath }}
+      - name: CA_BUNDLE_VOLUME_MOUNT_POINT
+        value: "{{ $caPath }}"
+      {{- end }}
+    {{- end }}

--- a/charts/kserve-llmisvc-resources/files/common/storagecontainer-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/storagecontainer-patch.yaml
@@ -13,3 +13,16 @@ spec:
       {{- with .Values.kserve.storage.containerSecurityContext}}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- $caCM := .Values.kserve.storage.caBundleConfigMapName }}
+    {{- $caPath := .Values.kserve.storage.caBundleVolumeMountPath }}
+    {{- if or $caCM $caPath }}
+    env:
+      {{- if $caCM }}
+      - name: CA_BUNDLE_CONFIGMAP_NAME
+        value: "{{ $caCM }}"
+      {{- end }}
+      {{- if $caPath }}
+      - name: CA_BUNDLE_VOLUME_MOUNT_POINT
+        value: "{{ $caPath }}"
+      {{- end }}
+    {{- end }}

--- a/charts/kserve-llmisvc-resources/templates/common/clusterstoragecontainer.yaml
+++ b/charts/kserve-llmisvc-resources/templates/common/clusterstoragecontainer.yaml
@@ -4,4 +4,28 @@
   "patchFile" "files/common/storagecontainer-patch.yaml"
   "replaceNamespace" false
   "context" .) -}}
+{{- if .Values.kserve.storage.enableModelcar }}
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterStorageContainer
+metadata:
+  name: modelcar
+spec:
+  container:
+    name: modelcar
+    resources:
+      requests:
+        cpu: "{{ .Values.kserve.storage.cpuModelcar }}"
+        memory: "{{ .Values.kserve.storage.memoryModelcar }}"
+      limits:
+        cpu: "{{ .Values.kserve.storage.cpuModelcar }}"
+        memory: "{{ .Values.kserve.storage.memoryModelcar }}"
+    {{- if .Values.kserve.storage.uidModelcar }}
+    securityContext:
+      runAsUser: {{ .Values.kserve.storage.uidModelcar }}
+    {{- end }}
+  supportedUriFormats:
+    - prefix: oci://
+  workloadType: initContainer
+{{- end }}
 {{- end }}

--- a/charts/kserve-resources/files/common/storagecontainer-patch.yaml
+++ b/charts/kserve-resources/files/common/storagecontainer-patch.yaml
@@ -13,3 +13,16 @@ spec:
       {{- with .Values.kserve.storage.containerSecurityContext}}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- $caCM := .Values.kserve.storage.caBundleConfigMapName }}
+    {{- $caPath := .Values.kserve.storage.caBundleVolumeMountPath }}
+    {{- if or $caCM $caPath }}
+    env:
+      {{- if $caCM }}
+      - name: CA_BUNDLE_CONFIGMAP_NAME
+        value: "{{ $caCM }}"
+      {{- end }}
+      {{- if $caPath }}
+      - name: CA_BUNDLE_VOLUME_MOUNT_POINT
+        value: "{{ $caPath }}"
+      {{- end }}
+    {{- end }}

--- a/charts/kserve-resources/templates/common/clusterstoragecontainer.yaml
+++ b/charts/kserve-resources/templates/common/clusterstoragecontainer.yaml
@@ -4,4 +4,28 @@
   "patchFile" "files/common/storagecontainer-patch.yaml"
   "replaceNamespace" false
   "context" .) -}}
+{{- if .Values.kserve.storage.enableModelcar }}
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterStorageContainer
+metadata:
+  name: modelcar
+spec:
+  container:
+    name: modelcar
+    resources:
+      requests:
+        cpu: "{{ .Values.kserve.storage.cpuModelcar }}"
+        memory: "{{ .Values.kserve.storage.memoryModelcar }}"
+      limits:
+        cpu: "{{ .Values.kserve.storage.cpuModelcar }}"
+        memory: "{{ .Values.kserve.storage.memoryModelcar }}"
+    {{- if .Values.kserve.storage.uidModelcar }}
+    securityContext:
+      runAsUser: {{ .Values.kserve.storage.uidModelcar }}
+    {{- end }}
+  supportedUriFormats:
+    - prefix: oci://
+  workloadType: initContainer
+{{- end }}
 {{- end }}

--- a/pkg/controller/v1alpha2/llmisvc/config_loader.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/credentials"
-	"github.com/kserve/kserve/pkg/types"
 )
 
 const (
@@ -101,11 +100,10 @@ type Config struct {
 	// nil when the "autoscaling-wva-controller-config" key is not present in inferenceservice-config.
 	WVAAutoscalingConfig *WVAAutoscalingConfig `json:"-"`
 
-	// Storage and credential configs are excluded from JSON serialization
-	// as they contain sensitive information
-	StorageConfig    *types.StorageInitializerConfig `json:"-"`
-	CredentialConfig *credentials.CredentialConfig   `json:"-"`
-	SchedulerConfig  *SchedulerConfig                `json:"-"`
+	// Credential and scheduler configs are excluded from JSON serialization
+	// as they contain sensitive information.
+	CredentialConfig *credentials.CredentialConfig `json:"-"`
+	SchedulerConfig  *SchedulerConfig              `json:"-"`
 
 	// ResolvedLoRAAdapters holds the resolved LoRA adapter list derived from the final merged spec.
 	// Populated inside combineBaseRefsConfig (after all spec overlays and variable substitution)
@@ -153,7 +151,7 @@ const autoscalingConfigName = "autoscaling-wva-controller-config"
 
 // NewConfig creates an instance of llm-specific config based on predefined values
 // in IngressConfig struct
-func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *types.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig, schedulerConfig *SchedulerConfig) *Config {
+func NewConfig(ingressConfig *v1beta1.IngressConfig, credentialConfig *credentials.CredentialConfig, schedulerConfig *SchedulerConfig) *Config {
 	igwNs := constants.KServeNamespace
 	igwName := ingressConfig.KserveIngressGateway
 	// Parse gateway name to extract namespace and name components
@@ -172,7 +170,6 @@ func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *types.Storag
 		EnableTLS:                   ingressConfig.EnableLLMInferenceServiceTLS,
 		ModelBasedRoutingHeaderName: ingressConfig.ModelBasedRoutingHeaderName,
 		ModelBasedRoutingMode:       parseModelBasedRoutingMode(ingressConfig.ModelBasedRoutingMode),
-		StorageConfig:               storageConfig,
 		CredentialConfig:            credentialConfig,
 		SchedulerConfig:             schedulerConfig,
 	}
@@ -211,11 +208,6 @@ func toConfig(isvcConfigMap *corev1.ConfigMap) (*Config, error) {
 		return nil, fmt.Errorf("failed to convert InferenceServiceConfigMap to IngressConfig: %w", errConvert)
 	}
 
-	storageInitializerConfig, errConvert := v1beta1.GetStorageInitializerConfigs(isvcConfigMap)
-	if errConvert != nil {
-		return nil, fmt.Errorf("failed to convert InferenceServiceConfigMap to StorageInitializerConfig: %w", errConvert)
-	}
-
 	credentialConfig, errConvert := credentials.GetCredentialConfig(isvcConfigMap)
 	if errConvert != nil {
 		return nil, fmt.Errorf("failed to convert InferenceServiceConfigMap to CredentialConfig: %w", errConvert)
@@ -226,7 +218,7 @@ func toConfig(isvcConfigMap *corev1.ConfigMap) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse scheduler config: %w", errConvert)
 	}
 
-	config := NewConfig(ingressConfig, storageInitializerConfig, &credentialConfig, schedulerConfig)
+	config := NewConfig(ingressConfig, &credentialConfig, schedulerConfig)
 
 	if autoscalingData, ok := isvcConfigMap.Data[autoscalingConfigName]; ok {
 		asCfg := &WVAAutoscalingConfig{}

--- a/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader_test.go
@@ -115,9 +115,6 @@ func TestLoadConfig(t *testing.T) {
 	if got.IngressGatewayName != "kserve-ingress-gateway" {
 		t.Fatalf("IngressGatewayName = %q, want %q", got.IngressGatewayName, "kserve-ingress-gateway")
 	}
-	if got.StorageConfig == nil {
-		t.Fatal("StorageConfig = nil, want populated config")
-	}
 	if got.CredentialConfig == nil {
 		t.Fatal("CredentialConfig = nil, want populated config")
 	}

--- a/pkg/controller/v1alpha2/llmisvc/controller_workload_storage_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_workload_storage_int_test.go
@@ -355,9 +355,14 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 				Expect(envTest.Client.Delete(ctx, globalS3CaBundleconfigMap)).To(Succeed())
 			}()
 
-			// patch the infernceservice-config configmap
-			patchInferenceServiceConfig(ctx, "storageInitializer", isvcConfigPatchStorageInit)
-			defer restoreInferenceServiceConfig(ctx)
+			// Advertise the CA bundle expectation via env vars on the default
+			// ClusterStorageContainer so the storage-initializer mounts the
+			// copied ConfigMap and the CA bundle reconciler is triggered.
+			patchClusterStorageContainerEnv(ctx,
+				corev1.EnvVar{Name: constants.CaBundleConfigMapNameEnvVarKey, Value: "global-s3-custom-certs"},
+				corev1.EnvVar{Name: constants.CaBundleVolumeMountPathEnvVarKey, Value: "/path/to/globalcerts"},
+			)
+			defer restoreClusterStorageContainer(ctx)
 
 			// setup test dependencies
 			svcName := "test-llm-storage-s3"
@@ -636,10 +641,6 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 				Expect(envTest.Client.Delete(ctx, globalS3CaBundleconfigMap)).To(Succeed())
 			}()
 
-			// patch the infernceservice-config configmap
-			patchInferenceServiceConfig(ctx, "storageInitializer", isvcConfigPatchStorageInit)
-			defer restoreInferenceServiceConfig(ctx)
-
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-with-credentials"
 			testNs := NewTestNamespace(ctx, envTest)
@@ -810,10 +811,6 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 			defer func() {
 				Expect(envTest.Client.Delete(ctx, globalS3CaBundleconfigMap)).To(Succeed())
 			}()
-
-			// patch the infernceservice-config configmap
-			patchInferenceServiceConfig(ctx, "storageInitializer", isvcConfigPatchStorageInit)
-			defer restoreInferenceServiceConfig(ctx)
 
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-with-iam-credentials"
@@ -1627,9 +1624,14 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 				Expect(envTest.Client.Delete(ctx, globalS3CaBundleconfigMap)).To(Succeed())
 			}()
 
-			// patch the infernceservice-config configmap
-			patchInferenceServiceConfig(ctx, "storageInitializer", isvcConfigPatchStorageInit)
-			defer restoreInferenceServiceConfig(ctx)
+			// Advertise the CA bundle expectation via env vars on the default
+			// ClusterStorageContainer so the storage-initializer mounts the
+			// copied ConfigMap and the CA bundle reconciler is triggered.
+			patchClusterStorageContainerEnv(ctx,
+				corev1.EnvVar{Name: constants.CaBundleConfigMapNameEnvVarKey, Value: "global-s3-custom-certs"},
+				corev1.EnvVar{Name: constants.CaBundleVolumeMountPathEnvVarKey, Value: "/path/to/globalcerts"},
+			)
+			defer restoreClusterStorageContainer(ctx)
 
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-mn"
@@ -1936,10 +1938,6 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 				Expect(envTest.Client.Delete(ctx, globalS3CaBundleconfigMap)).To(Succeed())
 			}()
 
-			// patch the infernceservice-config configmap
-			patchInferenceServiceConfig(ctx, "storageInitializer", isvcConfigPatchStorageInit)
-			defer restoreInferenceServiceConfig(ctx)
-
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-mn-with-credentials"
 			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
@@ -2127,10 +2125,6 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 			defer func() {
 				Expect(envTest.Client.Delete(ctx, globalS3CaBundleconfigMap)).To(Succeed())
 			}()
-
-			// patch the infernceservice-config configmap
-			patchInferenceServiceConfig(ctx, "storageInitializer", isvcConfigPatchStorageInit)
-			defer restoreInferenceServiceConfig(ctx)
 
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-mn-with-iam-credentials"
@@ -2534,6 +2528,27 @@ func restoreInferenceServiceConfig(ctx context.Context) {
 	restoredIsvcConfigMap := client.MergeFrom(isvcConfigMap.DeepCopy())
 	isvcConfigMap.Data = InferenceServiceCfgMap(constants.KServeNamespace).Data
 	Expect(envTest.Client.Patch(ctx, isvcConfigMap, restoredIsvcConfigMap)).To(Succeed())
+}
+
+// patchClusterStorageContainerEnv appends env vars to the default
+// ClusterStorageContainer's container spec so the storage-initializer
+// receives them. Restore with restoreClusterStorageContainer.
+func patchClusterStorageContainerEnv(ctx context.Context, envs ...corev1.EnvVar) {
+	csc := &v1alpha1.ClusterStorageContainer{}
+	Expect(envTest.Client.Get(ctx, types.NamespacedName{Name: "default"}, csc)).To(Succeed())
+	patch := client.MergeFrom(csc.DeepCopy())
+	csc.Spec.Container.Env = append(csc.Spec.Container.Env, envs...)
+	Expect(envTest.Client.Patch(ctx, csc, patch)).To(Succeed())
+}
+
+// restoreClusterStorageContainer reverts the default ClusterStorageContainer
+// to the fixture baseline (no env vars).
+func restoreClusterStorageContainer(ctx context.Context) {
+	csc := &v1alpha1.ClusterStorageContainer{}
+	Expect(envTest.Client.Get(ctx, types.NamespacedName{Name: "default"}, csc)).To(Succeed())
+	patch := client.MergeFrom(csc.DeepCopy())
+	csc.Spec.Container.Env = nil
+	Expect(envTest.Client.Patch(ctx, csc, patch)).To(Succeed())
 }
 
 //nolint:unparam // keeping params for test flexibility

--- a/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
@@ -24,10 +24,12 @@ import (
 
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/kmeta"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 
@@ -59,6 +61,75 @@ func RequiredResources(ctx context.Context, c client.Client, ns string) {
 
 	gomega.Expect(c.Create(ctx, DefaultGateway(ns))).To(gomega.Succeed())
 	gomega.Expect(c.Create(ctx, DefaultGatewayClass())).To(gomega.Succeed())
+	gomega.Expect(c.Create(ctx, DefaultClusterStorageContainer())).To(gomega.Succeed())
+	gomega.Expect(c.Create(ctx, DefaultModelcarClusterStorageContainer())).To(gomega.Succeed())
+}
+
+// DefaultClusterStorageContainer returns a cluster-scoped CSC covering the
+// download-based URI schemes (s3://, hf://, https://, …) exercised by the
+// storage integration tests.
+func DefaultClusterStorageContainer() *v1alpha1.ClusterStorageContainer {
+	return &v1alpha1.ClusterStorageContainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: v1alpha1.StorageContainerSpec{
+			Container: corev1.Container{
+				Name:  "storage-initializer",
+				Image: "kserve/storage-initializer:latest",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			SupportedUriFormats: []v1alpha1.SupportedUriFormat{
+				{Prefix: "s3://"},
+				{Prefix: "gs://"},
+				{Prefix: "hf://"},
+				{Prefix: "https://"},
+				{Prefix: "http://"},
+			},
+			WorkloadType:               v1alpha1.InitContainer,
+			SupportsMultiModelDownload: ptr.To(true),
+		},
+	}
+}
+
+// DefaultModelcarClusterStorageContainer returns a cluster-scoped CSC that
+// matches oci:// URIs. The container spec supplies modelcar-sized resources;
+// the image and args are overridden at pod-injection time (image from the
+// oci:// URI, args to the shared-namespace symlink command).
+func DefaultModelcarClusterStorageContainer() *v1alpha1.ClusterStorageContainer {
+	return &v1alpha1.ClusterStorageContainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "modelcar",
+		},
+		Spec: v1alpha1.StorageContainerSpec{
+			Container: corev1.Container{
+				Name: "modelcar",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("15Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("15Mi"),
+					},
+				},
+			},
+			SupportedUriFormats: []v1alpha1.SupportedUriFormat{
+				{Prefix: "oci://"},
+			},
+			WorkloadType: v1alpha1.InitContainer,
+		},
+	}
 }
 
 func IstioShadowService(name, ns string) *corev1.Service {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_tokenizer_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_tokenizer_test.go
@@ -22,21 +22,32 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
-	kserveTypes "github.com/kserve/kserve/pkg/types"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
-func testStorageConfig() *kserveTypes.StorageInitializerConfig {
-	return &kserveTypes.StorageInitializerConfig{
-		CpuRequest:     "100m",
-		CpuLimit:       "1",
-		MemoryRequest:  "100Mi",
-		MemoryLimit:    "1Gi",
-		CpuModelcar:    "10m",
-		MemoryModelcar: "15Mi",
+// testCSC returns a minimal ClusterStorageContainer spec with reasonable
+// resource defaults, shared by tests that only need "a CSC" without caring
+// about its exact contents.
+func testCSC() *v1alpha1.StorageContainerSpec {
+	return &v1alpha1.StorageContainerSpec{
+		Container: corev1.Container{
+			Name: "storage-initializer",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
 	}
 }
 
@@ -96,7 +107,7 @@ func TestAttachStorageInitializer_TargetContainer(t *testing.T) {
 				"hf://meta-llama/Llama-2-7b",
 				corev1.PodSpec{}, // empty curr
 				podSpec,
-				testStorageConfig(),
+				testCSC(),
 				nil, // no confidential
 				tc.containerName,
 				tc.modelPath,
@@ -283,7 +294,7 @@ func TestAttachOciModelArtifact_TargetContainer(t *testing.T) {
 				},
 			}
 
-			err := r.attachOciModelArtifact("oci://ghcr.io/test/model:v1", podSpec, testStorageConfig(), tc.containerName, tc.modelPath)
+			err := r.attachOciModelArtifact("oci://ghcr.io/test/model:v1", podSpec, testCSC(), tc.containerName, tc.modelPath)
 			if err != nil {
 				t.Fatalf("attachOciModelArtifact returned error: %v", err)
 			}

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage.go
@@ -25,20 +25,112 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap"
 	"github.com/kserve/kserve/pkg/credentials"
 	"github.com/kserve/kserve/pkg/credentials/s3"
-	kserveTypes "github.com/kserve/kserve/pkg/types"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
 const CaBundleVolumeName = "cabundle-cert"
+
+// resolveStorageContainerSpec finds a ClusterStorageContainer whose
+// supportedUriFormats match modelUri. If explicitName is non-empty the lookup
+// is by-name (with eligibility checks); otherwise the first eligible CSC
+// matching the URI is returned. Returns (nil, nil) when no CSC is found so
+// callers can fall through to defaults.
+func resolveStorageContainerSpec(ctx context.Context, c client.Client, modelUri, explicitName string) (*v1alpha1.StorageContainerSpec, error) {
+	if explicitName != "" {
+		sc := &v1alpha1.ClusterStorageContainer{}
+		if err := c.Get(ctx, types.NamespacedName{Name: explicitName}, sc); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("ClusterStorageContainer %q not found", explicitName)
+			}
+			return nil, fmt.Errorf("failed to fetch ClusterStorageContainer %q: %w", explicitName, err)
+		}
+		if sc.IsDisabled() {
+			return nil, fmt.Errorf("ClusterStorageContainer %q is disabled", explicitName)
+		}
+		if sc.Spec.WorkloadType != v1alpha1.InitContainer {
+			return nil, fmt.Errorf("ClusterStorageContainer %q has workloadType %q; explicit selection requires %q", explicitName, sc.Spec.WorkloadType, v1alpha1.InitContainer)
+		}
+		supported, err := sc.Spec.IsStorageUriSupported(modelUri)
+		if err != nil {
+			return nil, fmt.Errorf("ClusterStorageContainer %q URI check failed for %q: %w", explicitName, modelUri, err)
+		}
+		if !supported {
+			return nil, fmt.Errorf("ClusterStorageContainer %q does not support storageUri %q", explicitName, modelUri)
+		}
+		return &sc.Spec, nil
+	}
+
+	list := &v1alpha1.ClusterStorageContainerList{}
+	if err := c.List(ctx, list); err != nil {
+		return nil, err
+	}
+	for _, sc := range list.Items {
+		if sc.IsDisabled() || sc.Spec.WorkloadType != v1alpha1.InitContainer {
+			continue
+		}
+		ok, err := sc.Spec.IsStorageUriSupported(modelUri)
+		if err != nil {
+			return nil, fmt.Errorf("error checking ClusterStorageContainer %s: %w", sc.Name, err)
+		}
+		if ok {
+			return &sc.Spec, nil
+		}
+	}
+	return nil, nil
+}
+
+// initContainerFromCSC builds the storage-initializer init container from a
+// ClusterStorageContainer's container spec, merged over a minimal default that
+// carries the supplied args. When csc is nil, only the default image/args are
+// used. If the current pod already has a storage-initializer container, its
+// image is preserved to avoid unnecessary pod restarts on reconcile.
+func initContainerFromCSC(csc *v1alpha1.StorageContainerSpec, containerArgs []string, currentInitContainers []corev1.Container) (*corev1.Container, error) {
+	preservedImage := ""
+	for _, ic := range currentInitContainers {
+		if ic.Name == constants.StorageInitializerContainerName {
+			preservedImage = ic.Image
+			break
+		}
+	}
+	base := &corev1.Container{
+		Name:                     constants.StorageInitializerContainerName,
+		Image:                    preservedImage,
+		Args:                     containerArgs,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+	}
+	if csc == nil {
+		if base.Image == "" {
+			base.Image = constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion
+		}
+		return base, nil
+	}
+	crd := csc.Container.DeepCopy()
+	// If the current pod already carries a storage-initializer image, keep
+	// it; otherwise let the CSC's image win via strategic merge.
+	if preservedImage != "" {
+		crd.Image = preservedImage
+	}
+	if err := utils.MergeContainerSpecs(base, crd); err != nil {
+		return nil, err
+	}
+	// Args on the merged container come from strategic merge (crd.Args replaces
+	// base.Args). We always want the caller's containerArgs to win, since they
+	// encode the source-uri/dest-path pairs.
+	base.Args = containerArgs
+	return base, nil
+}
 
 // storageDownloadPair is one uri→path pair for the storage-initializer (multi-arg entrypoint).
 type storageDownloadPair struct {
@@ -124,6 +216,19 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 		loraPairs = collectLoRADownloadPairs(config.ResolvedLoRAAdapters)
 	}
 
+	// Resolve a ClusterStorageContainer for this URI. PVC URIs are mounted
+	// directly so they don't need a CSC. An operator can pin a specific CSC via
+	// the well-known annotation; otherwise we auto-match by URI prefix.
+	var csc *v1alpha1.StorageContainerSpec
+	if schema+"://" != constants.PvcURIPrefix {
+		explicit := llmSvc.Annotations[constants.StorageContainerNameAnnotationKey]
+		found, err := resolveStorageContainerSpec(ctx, r.Client, modelUri, explicit)
+		if err != nil {
+			return fmt.Errorf("failed to resolve ClusterStorageContainer for %q: %w", modelUri, err)
+		}
+		csc = found
+	}
+
 	// Handle model artifact downloads based on URI scheme
 	switch schema + "://" {
 	case constants.PvcURIPrefix:
@@ -131,46 +236,45 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 			return err
 		}
 		if len(loraPairs) > 0 {
-			if err := r.attachMultiStorageDownloads(ctx, serviceAccount, llmSvc, curr, podSpec, config.StorageConfig, config.CredentialConfig, containerName, loraPairs); err != nil {
+			if err := r.attachMultiStorageDownloads(ctx, serviceAccount, llmSvc, curr, podSpec, csc, config.CredentialConfig, containerName, loraPairs); err != nil {
 				return err
 			}
 		}
 
 	case constants.OciURIPrefix:
-		// Check of OCI is enabled
-		if !config.StorageConfig.EnableOciImageSource {
-			return errors.New("OCI modelcars is not enabled")
+		// OCI (modelcar) requires a matching ClusterStorageContainer.
+		if csc == nil {
+			return errors.New("no ClusterStorageContainer found for oci:// URI; deploy a ClusterStorageContainer whose supportedUriFormats matches oci:// to enable modelcar")
 		}
-
-		if err := r.attachOciModelArtifact(modelUri, podSpec, config.StorageConfig, containerName, modelPath); err != nil {
+		if err := r.attachOciModelArtifact(modelUri, podSpec, csc, containerName, modelPath); err != nil {
 			return err
 		}
 		if len(loraPairs) > 0 {
-			if err := r.attachMultiStorageDownloads(ctx, serviceAccount, llmSvc, curr, podSpec, config.StorageConfig, config.CredentialConfig, containerName, loraPairs); err != nil {
+			if err := r.attachMultiStorageDownloads(ctx, serviceAccount, llmSvc, curr, podSpec, csc, config.CredentialConfig, containerName, loraPairs); err != nil {
 				return err
 			}
 		}
 
 	case constants.HfURIPrefix:
 		if len(loraPairs) == 0 {
-			if err := r.attachHfModelArtifact(ctx, serviceAccount, llmSvc, modelUri, curr, podSpec, config.StorageConfig, config.CredentialConfig, containerName, modelPath); err != nil {
+			if err := r.attachHfModelArtifact(ctx, serviceAccount, llmSvc, modelUri, curr, podSpec, csc, config.CredentialConfig, containerName, modelPath); err != nil {
 				return err
 			}
 		} else {
 			pairs := append([]storageDownloadPair{{uri: modelUri, path: constants.DefaultModelLocalMountPath}}, loraPairs...)
-			if err := r.attachMultiStorageDownloads(ctx, serviceAccount, llmSvc, curr, podSpec, config.StorageConfig, config.CredentialConfig, containerName, pairs); err != nil {
+			if err := r.attachMultiStorageDownloads(ctx, serviceAccount, llmSvc, curr, podSpec, csc, config.CredentialConfig, containerName, pairs); err != nil {
 				return err
 			}
 		}
 
 	case constants.S3URIPrefix:
 		if len(loraPairs) == 0 {
-			if err := r.attachS3ModelArtifact(ctx, serviceAccount, llmSvc, modelUri, curr, podSpec, config.StorageConfig, config.CredentialConfig, containerName, modelPath); err != nil {
+			if err := r.attachS3ModelArtifact(ctx, serviceAccount, llmSvc, modelUri, curr, podSpec, csc, config.CredentialConfig, containerName, modelPath); err != nil {
 				return err
 			}
 		} else {
 			pairs := append([]storageDownloadPair{{uri: modelUri, path: constants.DefaultModelLocalMountPath}}, loraPairs...)
-			if err := r.attachMultiStorageDownloads(ctx, serviceAccount, llmSvc, curr, podSpec, config.StorageConfig, config.CredentialConfig, containerName, pairs); err != nil {
+			if err := r.attachMultiStorageDownloads(ctx, serviceAccount, llmSvc, curr, podSpec, csc, config.CredentialConfig, containerName, pairs); err != nil {
 				return err
 			}
 		}
@@ -189,24 +293,16 @@ func (r *LLMISVCReconciler) attachModelArtifacts(ctx context.Context, serviceAcc
 	return nil
 }
 
-// attachOciModelArtifact configures a PodSpec to use a model stored in an OCI registry.
-// It updates the "main" container in the PodSpec to use the model from OCI image. The
-// required supporting volumes and volume mounts are added to the PodSpec.
-//
-// Parameters:
-//   - modelUri: The URI of the model in the OCI registry.
-//   - podSpec: The PodSpec to which the OCI model should be attached.
-//   - storageConfig: The storage initializer configuration.
-//
-// Returns:
-//
-//	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachOciModelArtifact(modelUri string, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, containerName string, modelPath string) error {
-	if err := utils.ConfigureModelcarToContainer(modelUri, podSpec, containerName, modelPath, storageConfig, 0); err != nil {
-		return err
+// attachOciModelArtifact configures a PodSpec to use a model stored in an OCI
+// registry. The modelcar sidecar and its init container inherit resources,
+// security context, env, and any extra fields from the ClusterStorageContainer's
+// container spec.
+func (r *LLMISVCReconciler) attachOciModelArtifact(modelUri string, podSpec *corev1.PodSpec, csc *v1alpha1.StorageContainerSpec, containerName string, modelPath string) error {
+	var cscContainer *corev1.Container
+	if csc != nil {
+		cscContainer = &csc.Container
 	}
-
-	return nil
+	return utils.ConfigureModelcarToContainerFromCSC(modelUri, podSpec, containerName, modelPath, cscContainer, 0)
 }
 
 // attachPVCModelArtifact mounts a model artifact from a PersistentVolumeClaim (PVC) to the specified PodSpec.
@@ -243,23 +339,11 @@ func (r *LLMISVCReconciler) attachPVCModelArtifact(modelUri string, podSpec *cor
 	return nil
 }
 
-// attachS3ModelArtifact configures a PodSpec to use a model stored in an S3-compatible object store.
-// Model downloading is delegated to vLLM by passing the S3 URI and other required arguments.
-//
-// Parameters:
-//   - ctx: The context for API calls and logging.
-//   - serviceAccount: service account associated with the LLMInferenceService.
-//   - llmSvc: The LLMInferenceService resource containing the model specification.
-//   - modelUri: The URI of the model in the S3-compatible object store.
-//   - podSpec: The PodSpec to which the S3 model should be attached.
-//   - storageConfig: The storage initializer configuration.
-//   - credentialConfig: The credential configuration used for model downloads.
-//
-// Returns:
-//
-//	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig, containerName string, modelPath string) error {
-	if err := r.attachStorageInitializer(modelUri, curr, podSpec, storageConfig, llmSvc.Spec.Model.Confidential, containerName, modelPath); err != nil {
+// attachS3ModelArtifact configures a PodSpec to use a model stored in an
+// S3-compatible object store. The storage-initializer init container is built
+// from the resolved ClusterStorageContainer.
+func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, csc *v1alpha1.StorageContainerSpec, credentialConfig *credentials.CredentialConfig, containerName string, modelPath string) error {
+	if err := r.attachStorageInitializer(modelUri, curr, podSpec, csc, llmSvc.Spec.Model.Confidential, containerName, modelPath); err != nil {
 		return err
 	}
 	if initContainer := utils.GetInitContainerWithName(podSpec, constants.StorageInitializerContainerName); initContainer != nil {
@@ -269,7 +353,9 @@ func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAc
 			err := r.Get(ctx, types.NamespacedName{Name: constants.LLMISVCDefaultServiceAccountName, Namespace: llmSvc.Namespace}, serviceAccount)
 			if err != nil {
 				log.FromContext(ctx).Error(err, "Failed to find default service account", "namespace", llmSvc.Namespace)
-				injectCaBundle(llmSvc.Namespace, podSpec, initContainer, storageConfig)
+				if err := r.materializeCaBundle(ctx, llmSvc.Namespace, podSpec, initContainer); err != nil {
+					return err
+				}
 				return nil
 			}
 		}
@@ -284,7 +370,9 @@ func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAc
 		); err != nil {
 			return err
 		}
-		injectCaBundle(llmSvc.Namespace, podSpec, initContainer, storageConfig)
+		if err := r.materializeCaBundle(ctx, llmSvc.Namespace, podSpec, initContainer); err != nil {
+			return err
+		}
 
 		if containerName == tokenizerContainerName {
 			utils.AddEnvVars(initContainer, []corev1.EnvVar{*tokenizerOnlyDownload.DeepCopy()})
@@ -294,23 +382,11 @@ func (r *LLMISVCReconciler) attachS3ModelArtifact(ctx context.Context, serviceAc
 	return nil
 }
 
-// attachHfModelArtifact configures a PodSpec to use a model stored in the hugging face hub.
-// Model downloading is delegated to vLLM by passing the HF URI and other required arguments.
-//
-// Parameters:
-//   - ctx: The context for API calls and logging.
-//   - serviceAccount: service account associated with the LLMInferenceService.
-//   - llmSvc: The LLMInferenceService resource containing the model specification.
-//   - modelUri: The URI of the model in the S3-compatible object store.
-//   - podSpec: The PodSpec to which the S3 model should be attached.
-//   - storageConfig: The storage initializer configuration.
-//   - credentialConfig: The credential configuration used for model downloads.
-//
-// Returns:
-//
-//	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, credentialConfig *credentials.CredentialConfig, containerName string, modelPath string) error {
-	if err := r.attachStorageInitializer(modelUri, curr, podSpec, storageConfig, llmSvc.Spec.Model.Confidential, containerName, modelPath); err != nil {
+// attachHfModelArtifact configures a PodSpec to fetch a model from the Hugging
+// Face hub. The storage-initializer init container is built from the resolved
+// ClusterStorageContainer.
+func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, serviceAccount *corev1.ServiceAccount, llmSvc *v1alpha2.LLMInferenceService, modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, csc *v1alpha1.StorageContainerSpec, credentialConfig *credentials.CredentialConfig, containerName string, modelPath string) error {
+	if err := r.attachStorageInitializer(modelUri, curr, podSpec, csc, llmSvc.Spec.Model.Confidential, containerName, modelPath); err != nil {
 		return err
 	}
 	if initContainer := utils.GetInitContainerWithName(podSpec, constants.StorageInitializerContainerName); initContainer != nil {
@@ -354,18 +430,12 @@ func (r *LLMISVCReconciler) attachHfModelArtifact(ctx context.Context, serviceAc
 	return nil
 }
 
-// attachStorageInitializer configures a PodSpec to use KServe storage-initializer for
-// downloading a model from compatible storage.
-//
-// Parameters:
-//   - modelUri: The URI of the model in compatible object store.
-//   - podSpec: The PodSpec to which the storage-initializer container should be attached.
-//   - storageConfig: The storage initializer configuration.
-//
-// Returns:
-//
-//	An error if the configuration fails, otherwise nil.
-func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, storageConfig *kserveTypes.StorageInitializerConfig, confidential *v1alpha2.ConfidentialSpec, containerName string, modelPath string) error {
+// attachStorageInitializer configures a PodSpec to use the KServe storage
+// initializer for downloading a model from a compatible storage backend. The
+// init container's image, resources, env vars, and other pod-spec fields are
+// sourced from the provided ClusterStorageContainer (CSC-wins semantics; see
+// initContainerFromCSC).
+func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, curr corev1.PodSpec, podSpec *corev1.PodSpec, csc *v1alpha1.StorageContainerSpec, confidential *v1alpha2.ConfidentialSpec, containerName string, modelPath string) error {
 	stripPriorControllerStorageInitializer(podSpec)
 
 	containerArgs := []string{
@@ -378,18 +448,10 @@ func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, curr corev
 		ReadOnly:   false,
 	}
 
-	copied := *storageConfig
-
-	// Preserve the existing storage-initializer image from the current deployment
-	// to avoid unnecessary pod restarts during operator upgrades when the model
-	// hasn't changed.
-	for _, initContainer := range curr.InitContainers {
-		if initContainer.Name == constants.StorageInitializerContainerName {
-			copied.Image = initContainer.Image
-		}
+	initContainer, err := initContainerFromCSC(csc, containerArgs, curr.InitContainers)
+	if err != nil {
+		return err
 	}
-
-	initContainer := utils.CreateInitContainerWithConfig(&copied, containerArgs)
 
 	// Inject confidential env vars before appending to the pod spec
 	if confidential != nil && confidential.Enabled {
@@ -415,22 +477,27 @@ func (r *LLMISVCReconciler) attachStorageInitializer(modelUri string, curr corev
 	return nil
 }
 
-// attachMultiStorageDownloads adds one storage-initializer init container with multiple
-// src_uri dest_path pairs (see storage-initializer entrypoint) and mounts the shared
-// emptyDir at the common parent of all destination paths.
+// attachMultiStorageDownloads adds one storage-initializer init container with
+// multiple src_uri dest_path pairs (see storage-initializer entrypoint) and
+// mounts the shared emptyDir at the common parent of all destination paths.
+// The init container is built from the provided ClusterStorageContainer, which
+// must have SupportsMultiModelDownload=true when non-nil.
 func (r *LLMISVCReconciler) attachMultiStorageDownloads(
 	ctx context.Context,
 	serviceAccount *corev1.ServiceAccount,
 	llmSvc *v1alpha2.LLMInferenceService,
 	curr corev1.PodSpec,
 	podSpec *corev1.PodSpec,
-	storageConfig *kserveTypes.StorageInitializerConfig,
+	csc *v1alpha1.StorageContainerSpec,
 	credentialConfig *credentials.CredentialConfig,
 	containerName string,
 	pairs []storageDownloadPair,
 ) error {
 	if len(pairs) == 0 {
 		return nil
+	}
+	if csc != nil && (csc.SupportsMultiModelDownload == nil || !*csc.SupportsMultiModelDownload) {
+		return fmt.Errorf("ClusterStorageContainer %q does not support multi-model download; enable supportsMultiModelDownload or use a compatible ClusterStorageContainer", csc.Container.Name)
 	}
 	stripPriorControllerStorageInitializer(podSpec)
 
@@ -448,15 +515,10 @@ func (r *LLMISVCReconciler) attachMultiStorageDownloads(
 		args = append(args, p.uri, p.path)
 	}
 
-	copied := *storageConfig
-	for _, ic := range curr.InitContainers {
-		if ic.Name == constants.StorageInitializerContainerName {
-			copied.Image = ic.Image
-			break
-		}
+	initC, err := initContainerFromCSC(csc, args, curr.InitContainers)
+	if err != nil {
+		return err
 	}
-
-	initC := utils.CreateInitContainerWithConfig(&copied, args)
 	podSpec.InitContainers = append(podSpec.InitContainers, *initC)
 	iname := initC.Name
 
@@ -485,7 +547,9 @@ func (r *LLMISVCReconciler) attachMultiStorageDownloads(
 		err := r.Get(ctx, types.NamespacedName{Name: constants.LLMISVCDefaultServiceAccountName, Namespace: llmSvc.Namespace}, serviceAccount)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "Failed to find default service account", "namespace", llmSvc.Namespace)
-			injectCaBundle(llmSvc.Namespace, podSpec, initPtr, storageConfig)
+			if err := r.materializeCaBundle(ctx, llmSvc.Namespace, podSpec, initPtr); err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -515,72 +579,131 @@ func (r *LLMISVCReconciler) attachMultiStorageDownloads(
 		utils.AddEnvVars(initPtr, []corev1.EnvVar{*tokenizerOnlyDownload.DeepCopy()})
 	}
 
-	injectCaBundle(llmSvc.Namespace, podSpec, initPtr, storageConfig)
+	if err := r.materializeCaBundle(ctx, llmSvc.Namespace, podSpec, initPtr); err != nil {
+		return err
+	}
 	return nil
 }
 
-// caBundleConfig holds the configuration for CA bundle injection
-type caBundleConfig struct {
-	configMapName   string
-	volumeMountPath string
-	envVarExists    bool
-	mountPathExists bool
+// materializeCaBundle mounts the CA bundle ConfigMap on the init container
+// (via injectCaBundle) and, when the mount points at a copy of a source
+// ConfigMap in the kserve namespace, invokes the CA bundle reconciler to
+// ensure that copy exists in the user namespace before the pod is scheduled.
+func (r *LLMISVCReconciler) materializeCaBundle(ctx context.Context, namespace string, podSpec *corev1.PodSpec, initContainer *corev1.Container) error {
+	sourceConfigMapName := injectCaBundle(namespace, podSpec, initContainer)
+	if sourceConfigMapName == "" {
+		return nil
+	}
+	reconciler := cabundleconfigmap.NewCaBundleConfigMapReconciler(r.Client, r.Clientset)
+	if err := reconciler.ReconcileForSource(ctx, namespace, sourceConfigMapName); err != nil {
+		return fmt.Errorf("failed to reconcile CA bundle ConfigMap %q into namespace %q: %w", sourceConfigMapName, namespace, err)
+	}
+	return nil
 }
 
-// extractCaBundleConfig extracts and processes CA bundle configuration from environment variables in a single pass
-func extractCaBundleConfig(initContainer *corev1.Container, storageConfig *kserveTypes.StorageInitializerConfig, namespace string) *caBundleConfig {
-	config := &caBundleConfig{
-		configMapName:   storageConfig.CaBundleConfigMapName,
-		volumeMountPath: storageConfig.CaBundleVolumeMountPath,
-	}
+// caBundleConfig holds the configuration for CA bundle injection derived from
+// the storage-initializer init container's environment.
+type caBundleConfig struct {
+	// configMapName is the ConfigMap the init container should mount. In user
+	// namespaces this is always the local copy (global-ca-bundle) that the CA
+	// bundle reconciler produces. In the kserve system namespace it's the
+	// source name directly.
+	configMapName string
+	// sourceConfigMapName is the ConfigMap in the kserve system namespace that
+	// the CA bundle reconciler should copy into the user namespace. Empty if
+	// no CA bundle reconciliation is needed (e.g. when the caller runs in the
+	// kserve namespace already).
+	sourceConfigMapName string
+	volumeMountPath     string
+}
 
-	// Set defaults
-	if namespace != constants.KServeNamespace {
-		config.configMapName = constants.DefaultGlobalCaBundleConfigMapName
-	}
-	if config.volumeMountPath == "" {
-		config.volumeMountPath = constants.DefaultCaBundleVolumeMountPath
-	}
+// extractCaBundleConfig reads CA bundle configuration exclusively from the
+// init container's environment variables. Values may come from:
+//
+//   - CSC-set CA_BUNDLE_CONFIGMAP_NAME: names a ConfigMap in the kserve
+//     system namespace; the CA bundle reconciler copies it into the user
+//     namespace as constants.DefaultGlobalCaBundleConfigMapName before the
+//     init container mounts it.
+//
+//   - Credential-builder-set AWS_CA_BUNDLE_CONFIG_MAP / AWS_CA_BUNDLE: names
+//     a ConfigMap already present in the *same* namespace as the pod (via an
+//     S3 secret annotation). No cross-namespace copy is needed — the init
+//     container mounts that ConfigMap directly.
+//
+// When neither is set the returned config has an empty configMapName and the
+// caller should skip CA bundle injection.
+func extractCaBundleConfig(initContainer *corev1.Container, namespace string) *caBundleConfig {
+	config := &caBundleConfig{}
+	var (
+		crossNsSource     string // from CSC-set CA_BUNDLE_CONFIGMAP_NAME
+		crossNsMountPath  string // from CSC-set CA_BUNDLE_VOLUME_MOUNT_POINT
+		sameNsSource      string // from credential-builder-set AWS_CA_BUNDLE_CONFIG_MAP
+		sameNsMountPath   string // from credential-builder-set AWS_CA_BUNDLE
+	)
 
-	// Single pass through environment variables to extract values and check existence
 	for _, envVar := range initContainer.Env {
 		switch envVar.Name {
-		case s3.AWSCABundleConfigMap:
-			config.configMapName = envVar.Value
-		case s3.AWSCABundle:
-			config.volumeMountPath = filepath.Dir(envVar.Value)
 		case constants.CaBundleConfigMapNameEnvVarKey:
-			config.envVarExists = true
+			crossNsSource = envVar.Value
 		case constants.CaBundleVolumeMountPathEnvVarKey:
-			config.mountPathExists = true
+			crossNsMountPath = envVar.Value
+		case s3.AWSCABundleConfigMap:
+			sameNsSource = envVar.Value
+		case s3.AWSCABundle:
+			sameNsMountPath = filepath.Dir(envVar.Value)
 		}
+	}
+
+	switch {
+	case sameNsSource != "":
+		// Credential-builder path — same-namespace ConfigMap, mount directly.
+		// Its own mount-path env pins the mount location; CSC-declared mount
+		// paths are ignored on this branch.
+		config.configMapName = sameNsSource
+		config.volumeMountPath = sameNsMountPath
+	case crossNsSource != "":
+		// CSC path — cross-namespace source needs copying by the CA bundle
+		// reconciler. In the kserve namespace itself no copy is needed.
+		if namespace == constants.KServeNamespace {
+			config.configMapName = crossNsSource
+		} else {
+			config.sourceConfigMapName = crossNsSource
+			config.configMapName = constants.DefaultGlobalCaBundleConfigMapName
+		}
+		config.volumeMountPath = crossNsMountPath
+	}
+
+	if config.volumeMountPath == "" {
+		config.volumeMountPath = constants.DefaultCaBundleVolumeMountPath
 	}
 
 	return config
 }
 
-func injectCaBundle(namespace string, podSpec *corev1.PodSpec, initContainer *corev1.Container, storageConfig *kserveTypes.StorageInitializerConfig) bool { //nolint:unparam
-	// Inject CA bundle configMap if caBundleConfigMapName or constants.DefaultGlobalCaBundleConfigMapName annotation is set
-	if !needCaBundleMount(storageConfig.CaBundleConfigMapName, initContainer) {
-		return false
+// injectCaBundle mounts the CA bundle ConfigMap onto the init container when
+// the container's environment indicates that a CA bundle is expected. The
+// ConfigMap name and mount path are sourced from the init container's env
+// vars (populated by the ClusterStorageContainer or the AWS credential
+// builder), not from any global operator config. Returns the name of the
+// source ConfigMap in the kserve namespace that the CA bundle reconciler must
+// copy into the user namespace before the pod can mount it; empty when no
+// cross-namespace copy is needed (pod runs in kserve namespace, or no CA
+// bundle is expected).
+func injectCaBundle(namespace string, podSpec *corev1.PodSpec, initContainer *corev1.Container) string {
+	if !needCaBundleMount(initContainer) {
+		return ""
 	}
 
-	config := extractCaBundleConfig(initContainer, storageConfig, namespace)
-
-	// Add CA bundle env vars only if they don't already exist (could be customized by user)
-	if !config.envVarExists {
-		initContainer.Env = append(initContainer.Env, corev1.EnvVar{
-			Name:  constants.CaBundleConfigMapNameEnvVarKey,
-			Value: config.configMapName,
-		})
+	config := extractCaBundleConfig(initContainer, namespace)
+	if config.configMapName == "" {
+		return ""
 	}
 
-	if !config.mountPathExists {
-		initContainer.Env = append(initContainer.Env, corev1.EnvVar{
-			Name:  constants.CaBundleVolumeMountPathEnvVarKey,
-			Value: config.volumeMountPath,
-		})
-	}
+	// Overwrite existing CA bundle env vars: the CSC-set value may reference a
+	// source ConfigMap in the kserve namespace, but the pod always mounts the
+	// user-namespace copy under constants.DefaultGlobalCaBundleConfigMapName.
+	utils.AddOrReplaceEnv(initContainer, constants.CaBundleConfigMapNameEnvVarKey, config.configMapName)
+	utils.AddOrReplaceEnv(initContainer, constants.CaBundleVolumeMountPathEnvVarKey, config.volumeMountPath)
 
 	caBundleVolume := corev1.Volume{
 		Name: CaBundleVolumeName,
@@ -602,17 +725,23 @@ func injectCaBundle(namespace string, podSpec *corev1.PodSpec, initContainer *co
 	podSpec.Volumes = append(podSpec.Volumes, caBundleVolume)
 	initContainer.VolumeMounts = append(initContainer.VolumeMounts, caBundleVolumeMount)
 
-	return true
+	return config.sourceConfigMapName
 }
 
-func needCaBundleMount(caBundleConfigMapName string, initContainer *corev1.Container) bool {
-	result := caBundleConfigMapName != ""
-
+// needCaBundleMount reports whether the init container's environment indicates
+// that a CA bundle should be mounted. Any of CA_BUNDLE_CONFIGMAP_NAME,
+// CA_BUNDLE_VOLUME_MOUNT_POINT, or the AWS credential builder's
+// AWS_CA_BUNDLE_CONFIG_MAP env var triggers the mount.
+func needCaBundleMount(initContainer *corev1.Container) bool {
 	for _, envVar := range initContainer.Env {
-		if envVar.Name == s3.AWSCABundleConfigMap {
-			result = true
-			break
+		switch envVar.Name {
+		case constants.CaBundleConfigMapNameEnvVarKey,
+			constants.CaBundleVolumeMountPathEnvVarKey,
+			s3.AWSCABundleConfigMap:
+			if envVar.Value != "" {
+				return true
+			}
 		}
 	}
-	return result
+	return false
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage_confidential_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage_confidential_test.go
@@ -22,20 +22,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
-	kserveTypes "github.com/kserve/kserve/pkg/types"
 )
 
 func TestAttachStorageInitializerConfidential(t *testing.T) {
-	baseConfig := &kserveTypes.StorageInitializerConfig{
-		Image:         "kserve/storage-initializer:latest",
-		CpuRequest:    "100m",
-		CpuLimit:      "1",
-		MemoryRequest: "256Mi",
-		MemoryLimit:   "1Gi",
+	baseConfig := &v1alpha1.StorageContainerSpec{
+		Container: corev1.Container{
+			Name:  "storage-initializer",
+			Image: "kserve/storage-initializer:latest",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
 	}
 
 	tests := []struct {

--- a/pkg/controller/v1alpha2/llmisvc/workload_storage_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_storage_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/credentials/s3"
+)
+
+// fakeCSCClient builds a controller-runtime fake client seeded with the given
+// ClusterStorageContainers.
+func fakeCSCClient(t *testing.T, cscs ...*v1alpha1.ClusterStorageContainer) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	builder := fakeclient.NewClientBuilder().WithScheme(scheme)
+	for _, csc := range cscs {
+		builder = builder.WithObjects(csc)
+	}
+	return builder.Build()
+}
+
+func csc(name string, disabled *bool, workloadType v1alpha1.WorkloadType, prefixes ...string) *v1alpha1.ClusterStorageContainer {
+	supported := make([]v1alpha1.SupportedUriFormat, 0, len(prefixes))
+	for _, p := range prefixes {
+		supported = append(supported, v1alpha1.SupportedUriFormat{Prefix: p})
+	}
+	return &v1alpha1.ClusterStorageContainer{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Disabled:   disabled,
+		Spec: v1alpha1.StorageContainerSpec{
+			Container:           corev1.Container{Name: "storage-initializer"},
+			SupportedUriFormats: supported,
+			WorkloadType:        workloadType,
+		},
+	}
+}
+
+func TestResolveStorageContainerSpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		cscs         []*v1alpha1.ClusterStorageContainer
+		modelURI     string
+		explicitName string
+		wantNil      bool
+		wantErr      string
+	}{
+		{
+			name:     "auto-match by URI prefix",
+			cscs:     []*v1alpha1.ClusterStorageContainer{csc("default", nil, v1alpha1.InitContainer, "s3://")},
+			modelURI: "s3://bucket/model",
+		},
+		{
+			name:     "no match returns nil, nil",
+			cscs:     []*v1alpha1.ClusterStorageContainer{csc("default", nil, v1alpha1.InitContainer, "s3://")},
+			modelURI: "hf://user/model",
+			wantNil:  true,
+		},
+		{
+			name:     "disabled CSC is skipped on auto-match",
+			cscs:     []*v1alpha1.ClusterStorageContainer{csc("default", ptr.To(true), v1alpha1.InitContainer, "s3://")},
+			modelURI: "s3://bucket/model",
+			wantNil:  true,
+		},
+		{
+			name:     "wrong workload type is skipped on auto-match",
+			cscs:     []*v1alpha1.ClusterStorageContainer{csc("default", nil, v1alpha1.LocalModelDownloadJob, "s3://")},
+			modelURI: "s3://bucket/model",
+			wantNil:  true,
+		},
+		{
+			name:         "explicit by-name selection succeeds",
+			cscs:         []*v1alpha1.ClusterStorageContainer{csc("chosen", nil, v1alpha1.InitContainer, "s3://")},
+			modelURI:     "s3://bucket/model",
+			explicitName: "chosen",
+		},
+		{
+			name:         "explicit by-name for missing CSC returns error",
+			cscs:         nil,
+			modelURI:     "s3://bucket/model",
+			explicitName: "chosen",
+			wantErr:      `ClusterStorageContainer "chosen" not found`,
+		},
+		{
+			name:         "explicit by-name for disabled CSC returns error",
+			cscs:         []*v1alpha1.ClusterStorageContainer{csc("chosen", ptr.To(true), v1alpha1.InitContainer, "s3://")},
+			modelURI:     "s3://bucket/model",
+			explicitName: "chosen",
+			wantErr:      `ClusterStorageContainer "chosen" is disabled`,
+		},
+		{
+			name:         "explicit by-name with wrong workload type returns error",
+			cscs:         []*v1alpha1.ClusterStorageContainer{csc("chosen", nil, v1alpha1.LocalModelDownloadJob, "s3://")},
+			modelURI:     "s3://bucket/model",
+			explicitName: "chosen",
+			wantErr:      "workloadType",
+		},
+		{
+			name:         "explicit by-name for CSC that does not support the URI returns error",
+			cscs:         []*v1alpha1.ClusterStorageContainer{csc("chosen", nil, v1alpha1.InitContainer, "hf://")},
+			modelURI:     "s3://bucket/model",
+			explicitName: "chosen",
+			wantErr:      `does not support storageUri "s3://bucket/model"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fakeCSCClient(t, tc.cscs...)
+			spec, err := resolveStorageContainerSpec(context.Background(), c, tc.modelURI, tc.explicitName)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Nil(t, spec)
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantNil {
+				assert.Nil(t, spec)
+			} else {
+				assert.NotNil(t, spec)
+			}
+		})
+	}
+}
+
+func TestExtractCaBundleConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		env           []corev1.EnvVar
+		namespace     string
+		wantCmName    string // configMapName the init container should mount
+		wantSourceCm  string // sourceConfigMapName the CA bundle reconciler must copy
+		wantMountPath string
+	}{
+		{
+			name:          "no CA env at all → nothing to mount",
+			env:           nil,
+			namespace:     "user-ns",
+			wantMountPath: constants.DefaultCaBundleVolumeMountPath,
+		},
+		{
+			name: "CSC-set CA_BUNDLE_CONFIGMAP_NAME in user namespace → mount local copy, trigger reconciler",
+			env: []corev1.EnvVar{
+				{Name: constants.CaBundleConfigMapNameEnvVarKey, Value: "src"},
+				{Name: constants.CaBundleVolumeMountPathEnvVarKey, Value: "/etc/ca"},
+			},
+			namespace:     "user-ns",
+			wantCmName:    constants.DefaultGlobalCaBundleConfigMapName,
+			wantSourceCm:  "src",
+			wantMountPath: "/etc/ca",
+		},
+		{
+			name: "CSC-set CA_BUNDLE_CONFIGMAP_NAME in kserve namespace → mount source directly, no copy",
+			env: []corev1.EnvVar{
+				{Name: constants.CaBundleConfigMapNameEnvVarKey, Value: "src"},
+			},
+			namespace:     constants.KServeNamespace,
+			wantCmName:    "src",
+			wantMountPath: constants.DefaultCaBundleVolumeMountPath,
+		},
+		{
+			name: "credential-builder AWS_CA_BUNDLE_CONFIG_MAP wins over CSC source",
+			env: []corev1.EnvVar{
+				{Name: constants.CaBundleConfigMapNameEnvVarKey, Value: "cross-src"},
+				{Name: constants.CaBundleVolumeMountPathEnvVarKey, Value: "/etc/ca/cross"},
+				{Name: s3.AWSCABundleConfigMap, Value: "same-ns"},
+				{Name: s3.AWSCABundle, Value: "/etc/ca/same/tls.crt"},
+			},
+			namespace:     "user-ns",
+			wantCmName:    "same-ns",
+			wantMountPath: "/etc/ca/same",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			container := &corev1.Container{Env: tc.env}
+			cfg := extractCaBundleConfig(container, tc.namespace)
+			assert.Equal(t, tc.wantCmName, cfg.configMapName, "configMapName")
+			assert.Equal(t, tc.wantSourceCm, cfg.sourceConfigMapName, "sourceConfigMapName")
+			assert.Equal(t, tc.wantMountPath, cfg.volumeMountPath, "volumeMountPath")
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler.go
@@ -66,14 +66,16 @@ func (c *CaBundleConfigMapReconciler) Reconcile(ctx context.Context, namespace s
 		}
 	}
 
-	var newCaBundleConfigMap *corev1.ConfigMap
-	if storageInitializerConfig.CaBundleConfigMapName == "" {
+	return c.ReconcileForSource(ctx, namespace, storageInitializerConfig.CaBundleConfigMapName)
+}
+
+func (c *CaBundleConfigMapReconciler) ReconcileForSource(ctx context.Context, namespace, sourceConfigMapName string) error {
+	if sourceConfigMapName == "" {
 		return nil
-	} else {
-		newCaBundleConfigMap, err = c.getCabundleConfigMapForUserNS(ctx, storageInitializerConfig.CaBundleConfigMapName, constants.KServeNamespace, namespace)
-		if err != nil {
-			return fmt.Errorf("fails to get cabundle configmap for creating to user namespace: %w", err)
-		}
+	}
+	newCaBundleConfigMap, err := c.getCabundleConfigMapForUserNS(ctx, sourceConfigMapName, constants.KServeNamespace, namespace)
+	if err != nil {
+		return fmt.Errorf("fails to get cabundle configmap for creating to user namespace: %w", err)
 	}
 
 	if err := c.ReconcileCaBundleConfigMap(ctx, newCaBundleConfigMap); err != nil {

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -17,12 +17,15 @@ limitations under the License.
 package utils
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/utils/ptr"
 
 	"github.com/kserve/kserve/pkg/constants"
@@ -359,6 +362,12 @@ func modelcarCommand(modelPath string) string {
 	return fmt.Sprintf("ln -sf /proc/$$$$/root/models %s && sleep infinity", shellQuote(modelPath))
 }
 
+// modelcarInitCommand returns the shell command for the modelcar init
+// container: fail-fast when the OCI image doesn't carry a /models directory.
+func modelcarInitCommand(image string) string {
+	return "echo 'Pre-fetching modelcar " + image + ": ' && [ -d /models ] && [ \"$$(ls -A /models)\" ] && echo 'OK ... Prefetched and valid (/models exists)' || (echo 'NOK ... Prefetched but modelcar is invalid (/models does not exist or is empty)' && exit 1)"
+}
+
 // CreateModelcarContainer creates the definition of a container holding a model intended to be used as a sidecar (modelcar).
 // The container is configured with CPU, memory, and UID settings from the storage initializer configuration.
 //
@@ -445,8 +454,7 @@ func CreateModelcarInitContainer(containerName string, image string, storageConf
 		Args: []string{
 			"sh",
 			"-c",
-			// Check that the expected models directory exists
-			"echo 'Pre-fetching modelcar " + image + ": ' && [ -d /models ] && [ \"$$(ls -A /models)\" ] && echo 'OK ... Prefetched and valid (/models exists)' || (echo 'NOK ... Prefetched but modelcar is invalid (/models does not exist or is empty)' && exit 1)",
+			modelcarInitCommand(image),
 		},
 		Resources: corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
@@ -580,5 +588,142 @@ func ConfigureModelcarToContainer(modelUri string, podSpec *corev1.PodSpec, targ
 	// can be reached by the user container
 	podSpec.ShareProcessNamespace = ptr.To(true)
 
+	return nil
+}
+
+// MergeContainerSpecs strategic-merge-patches crdContainer onto targetContainer.
+// The container name from targetContainer is preserved. When strategic merge
+// leaves a field-wise merged env entry with both Value and ValueFrom populated
+// (a state Kubernetes rejects), the entry is reconciled by deferring to the
+// intent of crdContainer.
+func MergeContainerSpecs(targetContainer *corev1.Container, crdContainer *corev1.Container) error {
+	if targetContainer == nil {
+		return errors.New("targetContainer is nil")
+	}
+	if crdContainer == nil {
+		return nil
+	}
+
+	containerName := targetContainer.Name
+
+	defaultContainerJson, err := json.Marshal(*targetContainer)
+	if err != nil {
+		return err
+	}
+
+	overrides, err := json.Marshal(*crdContainer)
+	if err != nil {
+		return err
+	}
+
+	jsonResult, err := strategicpatch.StrategicMergePatch(defaultContainerJson, overrides, corev1.Container{})
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal into a fresh Container rather than reusing targetContainer:
+	// json.Unmarshal does not clear struct fields absent from the JSON, so reusing
+	// existing EnvVar slice elements lets stale Value/ValueFrom fields bleed into
+	// merged-in entries (issue #5516).
+	merged := corev1.Container{}
+	if err := json.Unmarshal(jsonResult, &merged); err != nil {
+		return err
+	}
+
+	crdEnvByName := make(map[string]corev1.EnvVar, len(crdContainer.Env))
+	for _, e := range crdContainer.Env {
+		crdEnvByName[e.Name] = e
+	}
+	for i := range merged.Env {
+		e := &merged.Env[i]
+		if e.Value == "" || e.ValueFrom == nil {
+			continue
+		}
+		crdEntry, ok := crdEnvByName[e.Name]
+		if !ok {
+			continue
+		}
+		if crdEntry.ValueFrom != nil {
+			e.Value = ""
+		} else if crdEntry.Value != "" {
+			e.ValueFrom = nil
+		}
+	}
+
+	*targetContainer = merged
+	if targetContainer.Name == "" {
+		targetContainer.Name = containerName
+	}
+	return nil
+}
+
+// modelcarFromCSC returns a copy of the CSC's container spec with the
+// modelcar-owned fields (name, image, args) hard-set. The caller is
+// responsible for prepending any mandatory volume mount.
+func modelcarFromCSC(csc *corev1.Container, name, image string, args []string) *corev1.Container {
+	var c corev1.Container
+	if csc != nil {
+		c = *csc.DeepCopy()
+	}
+	c.Name = name
+	c.Image = image
+	c.Args = args
+	if c.TerminationMessagePolicy == "" {
+		c.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
+	}
+	return &c
+}
+
+// CreateModelcarContainerFromCSC builds the modelcar sidecar. The CSC's whole
+// container spec is used verbatim; the code only owns name, image (from the
+// oci:// URI), args (the shared-namespace symlink command), and the mandatory
+// volume mount for reaching the model through /proc/PID/root.
+func CreateModelcarContainerFromCSC(containerName, image, modelPath, volumeName string, csc *corev1.Container) *corev1.Container {
+	c := modelcarFromCSC(csc, containerName, image, []string{"sh", "-c", modelcarCommand(modelPath)})
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: GetParentDirectory(modelPath),
+		ReadOnly:  false,
+	})
+	return c
+}
+
+// CreateModelcarInitContainerFromCSC builds the modelcar init container. Its
+// only job is to fail-fast if the OCI image doesn't carry a /models directory.
+func CreateModelcarInitContainerFromCSC(containerName, image string, csc *corev1.Container) *corev1.Container {
+	return modelcarFromCSC(csc, containerName, image, []string{"sh", "-c", modelcarInitCommand(image)})
+}
+
+// ConfigureModelcarToContainerFromCSC configures the OCI image specified in
+// modelUri as a modelcar for targetContainerName on podSpec. See
+// ConfigureModelcarToContainer for behavior details.
+func ConfigureModelcarToContainerFromCSC(modelUri string, podSpec *corev1.PodSpec, targetContainerName string, modelPath string, csc *corev1.Container, ociIndex int) error {
+	targetContainer := GetContainerWithName(podSpec, targetContainerName)
+	if targetContainer == nil {
+		return fmt.Errorf("no container found with name %s", targetContainerName)
+	}
+
+	sidecarName, initName, volumeName := ModelcarNames(ociIndex)
+
+	AddOrReplaceEnv(targetContainer, constants.ModelInitModeEnvVarKey, "async")
+
+	modelParentDir := GetParentDirectory(modelPath)
+	AddEmptyDirVolumeIfNotPresent(podSpec, volumeName)
+	AddVolumeMountIfNotPresent(targetContainer, volumeName, modelParentDir, false)
+
+	if csc != nil && csc.SecurityContext != nil && csc.SecurityContext.RunAsUser != nil {
+		if targetContainer.SecurityContext == nil {
+			targetContainer.SecurityContext = &corev1.SecurityContext{}
+		}
+		targetContainer.SecurityContext.RunAsUser = csc.SecurityContext.RunAsUser
+	}
+
+	if GetContainerWithName(podSpec, sidecarName) == nil {
+		image := strings.TrimPrefix(modelUri, constants.OciURIPrefix)
+		podSpec.Containers = append(podSpec.Containers, *CreateModelcarContainerFromCSC(sidecarName, image, modelPath, volumeName, csc))
+		podSpec.InitContainers = append(podSpec.InitContainers, *CreateModelcarInitContainerFromCSC(initName, image, csc))
+	}
+
+	podSpec.ShareProcessNamespace = ptr.To(true)
 	return nil
 }

--- a/pkg/utils/storage_test.go
+++ b/pkg/utils/storage_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/types"
@@ -500,4 +501,112 @@ func TestMaxOCISourcesPerPod(t *testing.T) {
 	// Ensure the constant is reasonable and matches documented limit
 	g.Expect(MaxOCISourcesPerPod).To(gomega.Equal(10),
 		"MaxOCISourcesPerPod should be 10 — each URI adds 2 containers + 1 volume")
+}
+
+// TestCreateModelcarContainerFromCSC verifies that the CSC-derived modelcar
+// helper copies operator-supplied container fields (env, envFrom, resources,
+// securityContext, imagePullPolicy, lifecycle) verbatim while hard-setting
+// the modelcar-owned fields (name, image, args) and prepending the mandatory
+// sidecar volume mount.
+func TestCreateModelcarContainerFromCSC(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	cscUID := int64(1234)
+	csc := &corev1.Container{
+		Name:            "cluster-storage-container-name", // must be overridden
+		Image:           "cluster-storage-container-image", // must be overridden
+		Command:         []string{"ignored"},
+		Args:            []string{"csc-arg-must-be-overridden"},
+		ImagePullPolicy: corev1.PullAlways,
+		Env: []corev1.EnvVar{
+			{Name: "FOO", Value: "bar"},
+			{Name: "SECRET", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "secret"},
+				Key:                  "key",
+			}}},
+		},
+		EnvFrom: []corev1.EnvFromSource{
+			{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "cm"}}},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+		},
+		SecurityContext: &corev1.SecurityContext{RunAsUser: &cscUID},
+		Lifecycle: &corev1.Lifecycle{
+			PostStart: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{Command: []string{"echo", "started"}}},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "extra-mount", MountPath: "/extra"},
+		},
+	}
+
+	sidecarName := "modelcar"
+	image := "ghcr.io/example/llama:v1"
+	modelPath := constants.DefaultModelLocalMountPath
+	volumeName := constants.StorageInitializerVolumeName
+
+	c := CreateModelcarContainerFromCSC(sidecarName, image, modelPath, volumeName, csc)
+
+	// Modelcar-owned fields — always overridden by code.
+	g.Expect(c.Name).To(gomega.Equal(sidecarName))
+	g.Expect(c.Image).To(gomega.Equal(image))
+	g.Expect(c.Args).To(gomega.Equal([]string{"sh", "-c", modelcarCommand(modelPath)}))
+
+	// The sidecar's mandatory volume mount is appended alongside any CSC-supplied mounts.
+	g.Expect(c.VolumeMounts).To(gomega.ContainElements(
+		corev1.VolumeMount{Name: "extra-mount", MountPath: "/extra"},
+		corev1.VolumeMount{Name: volumeName, MountPath: GetParentDirectory(modelPath), ReadOnly: false},
+	))
+
+	// Everything else must flow through from the CSC.
+	g.Expect(c.ImagePullPolicy).To(gomega.Equal(corev1.PullAlways))
+	g.Expect(c.Env).To(gomega.Equal(csc.Env))
+	g.Expect(c.EnvFrom).To(gomega.Equal(csc.EnvFrom))
+	g.Expect(c.Resources).To(gomega.Equal(csc.Resources))
+	g.Expect(c.SecurityContext).To(gomega.Equal(csc.SecurityContext))
+	g.Expect(c.Lifecycle).To(gomega.Equal(csc.Lifecycle))
+	g.Expect(c.TerminationMessagePolicy).To(gomega.Equal(corev1.TerminationMessageFallbackToLogsOnError))
+}
+
+// TestCreateModelcarContainerFromCSC_NilCSC verifies that the helper is
+// nil-safe: callers that reach the modelcar path without a matching CSC still
+// get a functional sidecar with modelcar-owned fields set.
+func TestCreateModelcarContainerFromCSC_NilCSC(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	c := CreateModelcarContainerFromCSC("modelcar", "img", constants.DefaultModelLocalMountPath, "vol", nil)
+
+	g.Expect(c.Name).To(gomega.Equal("modelcar"))
+	g.Expect(c.Image).To(gomega.Equal("img"))
+	g.Expect(c.Args).To(gomega.Equal([]string{"sh", "-c", modelcarCommand(constants.DefaultModelLocalMountPath)}))
+	g.Expect(c.VolumeMounts).To(gomega.HaveLen(1))
+	g.Expect(c.VolumeMounts[0].Name).To(gomega.Equal("vol"))
+	g.Expect(c.TerminationMessagePolicy).To(gomega.Equal(corev1.TerminationMessageFallbackToLogsOnError))
+}
+
+// TestCreateModelcarInitContainerFromCSC verifies the init-container variant
+// applies the same CSC-verbatim + modelcar-owned override policy.
+func TestCreateModelcarInitContainerFromCSC(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	csc := &corev1.Container{
+		Name:  "cluster-storage-container-name",
+		Image: "cluster-storage-container-image",
+		Env:   []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m")},
+		},
+	}
+
+	image := "ghcr.io/example/llama:v1"
+	c := CreateModelcarInitContainerFromCSC("modelcar-init", image, csc)
+
+	g.Expect(c.Name).To(gomega.Equal("modelcar-init"))
+	g.Expect(c.Image).To(gomega.Equal(image))
+	g.Expect(c.Args).To(gomega.Equal([]string{"sh", "-c", modelcarInitCommand(image)}))
+	g.Expect(c.Env).To(gomega.Equal(csc.Env))
+	g.Expect(c.Resources).To(gomega.Equal(csc.Resources))
+	// No sidecar volume mount on the init container.
+	g.Expect(c.VolumeMounts).To(gomega.BeEmpty())
 }


### PR DESCRIPTION
> PR description was drafted with AI assistance.

**What this PR does / why we need it**:

Every new operator-facing knob on the LLMISVC storage-initializer used to require a three-layer change: Helm value → `inferenceservice-config` ConfigMap → Go parsing. Anything not already in the ConfigMap schema (envFrom, imagePullPolicy, lifecycle, extra volume mounts, custom securityContext, …) meant a KServe code change. Meanwhile the `ClusterStorageContainer` CRD,  the documented way to configure the storage-initializer, was silently ignored by the LLMISVC controller.

This PR routes the LLMISVC storage flow through `ClusterStorageContainer` end-to-end. Everything on `spec.container` is used verbatim; adding a new knob is now zero code changes.

Helm values are unchanged. The chart now also renders them into two CSCs — `default` (for `s3://`, `hf://`, `https://`, …) and `modelcar` (for `oci://`, gated on `enableModelcar: true`). Modelcar sidecars keep four code-owned fields (name, image from the URI, the `ln -sf /proc/$$/root/models` args, the mandatory shared volume mount); everything else on the CSC container flows through.

Scoped to LLMISVC. The classic v1beta1 InferenceService controller, the pod-mutating webhook, and the local-model reconciler still consume the ConfigMap-based path and are unchanged. Chart additions ship on both charts so a follow-up migration doesn't need to touch operator-facing config.

**Which issue(s) this PR fixes**:

Fixes #5769

**Feature/Issue validation/testing**:

- [x] Unit tests for the CSC-verbatim modelcar helpers (`go test ./pkg/utils/...`) — asserts env / envFrom / resources / securityContext / lifecycle / imagePullPolicy flow verbatim; name / image / args are code-owned; nil-CSC nil-safety.
- [x] Unit tests for `resolveStorageContainerSpec` (auto-match, no-match, disabled, wrong workload type, 5 by-name error paths) and `extractCaBundleConfig` (CSC vs credential-builder precedence, kserve-ns vs user-ns).
- [x] All 241 existing Ginkgo integration specs still pass under envtest (`make setup-envtest && KUBEBUILDER_ASSETS=... go test ./pkg/controller/v1alpha2/llmisvc/...`).
- [x] `helm lint` clean on both charts; `helm template` renders 2 CSCs by default, 1 when `enableModelcar=false`, and omits the CA env block when both CA values are empty.
- [x] `hack/setup/scripts/generate_chart_manifests.sh` re-run is a no-op — `_common` source and per-chart mirrors stay in sync.

**Special notes for your reviewer**:

CA bundle env vars (`CA_BUNDLE_CONFIGMAP_NAME`, `CA_BUNDLE_VOLUME_MOUNT_POINT`) on the CSC drive `cabundleconfigmap.ReconcileForSource` — a new source-name-explicit form of the existing reconciler so llmisvc-only clusters get the cross-namespace CA-bundle copy without depending on the v1beta1 controller running. The existing `Reconcile(ctx, ns)` signature is unchanged.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
LLMInferenceService: storage-initializer configuration is now sourced from a matching `ClusterStorageContainer` end-to-end. Operators can customize every field of the init container (env, envFrom, imagePullPolicy, securityContext, lifecycle, volumeMounts, …) via the CSC without KServe code changes. Modelcar (`oci://`) is gated on a `ClusterStorageContainer` matching `oci://`; the Helm chart now renders a `modelcar` CSC when `enableModelcar` is set. Classic InferenceService, the pod-mutating webhook, and localmodel-node continue to use the existing ConfigMap-based configuration.
```
