### PR TITLE
fix: stabilize modelcar shell quoting to avoid unnecessary pod restarts

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler_tokenizer_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_tokenizer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package llmisvc
 
 import (
-	"fmt"
 	"path"
 	"testing"
 
@@ -236,9 +235,7 @@ func TestAttachOciModelArtifact_TargetContainer(t *testing.T) {
 			},
 			wantModelcarArgs: []string{
 				"sh", "-c",
-				fmt.Sprintf("mkdir -p '%s' && ln -sf /proc/$$$$/root/models '%s' && sleep infinity",
-					constants.DefaultModelLocalMountPath,
-					path.Join(constants.DefaultModelLocalMountPath, "my-llama")),
+				"mkdir -p /mnt/models && ln -sf /proc/$$$$/root/models /mnt/models/my-llama && sleep infinity",
 			},
 		},
 		{
@@ -252,9 +249,7 @@ func TestAttachOciModelArtifact_TargetContainer(t *testing.T) {
 			},
 			wantModelcarArgs: []string{
 				"sh", "-c",
-				fmt.Sprintf("mkdir -p '%s' && ln -sf /proc/$$$$/root/models '%s' && sleep infinity",
-					path.Join(constants.DefaultModelLocalMountPath, "meta-llama"),
-					path.Join(constants.DefaultModelLocalMountPath, "meta-llama/Llama-2-7b")),
+				"mkdir -p /mnt/models/meta-llama && ln -sf /proc/$$$$/root/models /mnt/models/meta-llama/Llama-2-7b && sleep infinity",
 			},
 		},
 		{
@@ -268,8 +263,7 @@ func TestAttachOciModelArtifact_TargetContainer(t *testing.T) {
 			},
 			wantModelcarArgs: []string{
 				"sh", "-c",
-				fmt.Sprintf("ln -sf /proc/$$$$/root/models '%s' && sleep infinity",
-					constants.DefaultModelLocalMountPath),
+				"ln -sf /proc/$$$$/root/models /mnt/models && sleep infinity",
 			},
 		},
 	}

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -333,12 +333,23 @@ func CreateInitContainerWithConfig(storageConfig *types.StorageInitializerConfig
 	}
 }
 
-// shellQuote wraps s in single quotes for safe interpolation into a sh -c
-// command string. Any embedded single quotes are escaped using the standard
-// POSIX sequence: close the current quote, emit an escaped literal quote,
-// and re-open a new quoted segment ('\\"). This is safe for all byte values.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+// ShellQuote returns s quoted for safe interpolation into a sh -c command
+// string. Strings that consist entirely of shell-safe characters (letters,
+// digits, '/', '.', '_', '-') are returned unchanged to avoid altering
+// previously generated command strings (which would cause unnecessary pod
+// restarts on upgrade). All other strings are wrapped in single quotes with
+// embedded single quotes escaped via the standard POSIX sequence.
+func ShellQuote(s string) string {
+	if len(s) == 0 {
+		return "''"
+	}
+	for _, c := range s {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+			c == '/' || c == '.' || c == '_' || c == '-') {
+			return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+		}
+	}
+	return s
 }
 
 // modelcarCommand returns the shell command for the modelcar container.
@@ -347,16 +358,16 @@ func shellQuote(s string) string {
 // the command is kept identical to the original to avoid unnecessary pod restarts
 // on upgrade.
 //
-// Paths are shell-quoted using shellQuote to prevent metacharacter injection.
+// Paths are shell-quoted using ShellQuote to prevent metacharacter injection.
 // The upstream validation (validateStorageURISpec) ensures paths are absolute
 // and contain no "..", but quoting provides defense-in-depth.
 func modelcarCommand(modelPath string) string {
 	// $$$$ gets escaped by YAML to $$, which is the current PID
 	if modelPath != constants.DefaultModelLocalMountPath {
 		return fmt.Sprintf("mkdir -p %s && ln -sf /proc/$$$$/root/models %s && sleep infinity",
-			shellQuote(path.Dir(modelPath)), shellQuote(modelPath))
+			ShellQuote(path.Dir(modelPath)), ShellQuote(modelPath))
 	}
-	return fmt.Sprintf("ln -sf /proc/$$$$/root/models %s && sleep infinity", shellQuote(modelPath))
+	return fmt.Sprintf("ln -sf /proc/$$$$/root/models %s && sleep infinity", ShellQuote(modelPath))
 }
 
 // CreateModelcarContainer creates the definition of a container holding a model intended to be used as a sidecar (modelcar).

--- a/pkg/utils/storage_test.go
+++ b/pkg/utils/storage_test.go
@@ -26,6 +26,107 @@ import (
 	"github.com/kserve/kserve/pkg/types"
 )
 
+func TestShellQuote(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	scenarios := map[string]struct {
+		input    string
+		expected string
+	}{
+		"SafeAbsolutePath": {
+			input:    "/mnt/models",
+			expected: "/mnt/models",
+		},
+		"SafeNestedPath": {
+			input:    "/mnt/models/base",
+			expected: "/mnt/models/base",
+		},
+		"SafePathWithDash": {
+			input:    "/mnt/my-models/v1.0",
+			expected: "/mnt/my-models/v1.0",
+		},
+		"SafePathWithUnderscore": {
+			input:    "/mnt/my_models",
+			expected: "/mnt/my_models",
+		},
+		"PathWithSpace": {
+			input:    "/mnt/my models",
+			expected: "'/mnt/my models'",
+		},
+		"PathWithSingleQuote": {
+			input:    "/mnt/it's",
+			expected: "'/mnt/it'\\''s'",
+		},
+		"PathWithSemicolon": {
+			input:    "/mnt/models;rm -rf /",
+			expected: "'/mnt/models;rm -rf /'",
+		},
+		"PathWithPlus": {
+			input:    "/mnt/models/llama-3.1+quant",
+			expected: "'/mnt/models/llama-3.1+quant'",
+		},
+		"PathWithTilde": {
+			input:    "~/models",
+			expected: "'~/models'",
+		},
+		"EmptyString": {
+			input:    "",
+			expected: "''",
+		},
+		"PathWithDollarParens": {
+			input:    "/mnt/$(rm -rf /)",
+			expected: "'/mnt/$(rm -rf /)'",
+		},
+		"PathWithBackticks": {
+			input:    "/mnt/`id`",
+			expected: "'/mnt/`id`'",
+		},
+		"PathWithPipe": {
+			input:    "/mnt/models|cat /etc/passwd",
+			expected: "'/mnt/models|cat /etc/passwd'",
+		},
+		"PathWithAmpersand": {
+			input:    "/mnt/models&rm -rf /",
+			expected: "'/mnt/models&rm -rf /'",
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			result := ShellQuote(scenario.input)
+			g.Expect(result).To(gomega.Equal(scenario.expected))
+		})
+	}
+}
+
+func TestModelcarCommand(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("DefaultPath produces unquoted command", func(t *testing.T) {
+		cmd := modelcarCommand(constants.DefaultModelLocalMountPath)
+		g.Expect(cmd).To(gomega.Equal(
+			"ln -sf /proc/$$$$/root/models /mnt/models && sleep infinity"))
+	})
+
+	t.Run("NonDefaultSafePath produces mkdir with unquoted paths", func(t *testing.T) {
+		cmd := modelcarCommand("/mnt/models/base")
+		g.Expect(cmd).To(gomega.Equal(
+			"mkdir -p /mnt/models && ln -sf /proc/$$$$/root/models /mnt/models/base && sleep infinity"))
+	})
+
+	t.Run("NonDefaultUnsafePath produces mkdir with quoted paths", func(t *testing.T) {
+		cmd := modelcarCommand("/mnt/my models/base")
+		g.Expect(cmd).To(gomega.Equal(
+			"mkdir -p '/mnt/my models' && ln -sf /proc/$$$$/root/models '/mnt/my models/base' && sleep infinity"))
+	})
+
+	t.Run("NonDefaultPathWithSingleQuote produces correctly escaped command", func(t *testing.T) {
+		cmd := modelcarCommand("/mnt/it's/model")
+		g.Expect(cmd).To(gomega.Equal(
+			"mkdir -p '/mnt/it'\\''s' && ln -sf /proc/$$$$/root/models '/mnt/it'\\''s/model' && sleep infinity"))
+	})
+}
+
 func TestFindCommonParentPath(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 


### PR DESCRIPTION
## Summary

- `ShellQuote` conditionally quotes paths for `sh -c` command strings: shell-safe characters (`[a-zA-Z0-9/._-]`) pass through unchanged, all others get POSIX single-quoted with `'\''` escaping
- Prevents unnecessary pod restarts on upgrade caused by unconditional quoting changing the command string (e.g. `/mnt/models` → `'/mnt/models'`)
- Empty string input returns `''` instead of empty to prevent silent bugs

## Test plan

- [x] Unit tests for `ShellQuote`: safe paths, spaces, single quotes, semicolons, `+`, `~`, empty string, `$()`, backticks, `|`, `&`
- [x] Unit tests for `modelcarCommand`: default path, non-default safe path, non-default unsafe path, single-quote path
- [x] Integration tests in `scheduler_tokenizer_test.go` use hardcoded expected command strings (not computed via `ShellQuote`) to catch regressions independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)