### PR TITLE
fix(llmisvc): render tensor parallelism flags for single-node

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -164,6 +164,7 @@ spec:
           ${ACCESS_LOG_ARGS} \
           ${SHUTDOWN_TIMEOUT_ARGS} \
           ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
@@ -1085,6 +1086,7 @@ spec:
             ${ACCESS_LOG_ARGS} \
             ${SHUTDOWN_TIMEOUT_ARGS} \
             ${KV_TRANSFER_ARGS} \
+            {{- if and .Spec.Prefill .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
@@ -2490,6 +2492,7 @@ spec:
           ${ACCESS_LOG_ARGS} \
           ${SHUTDOWN_TIMEOUT_ARGS} \
           ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -169,6 +169,7 @@ spec:
               ${ACCESS_LOG_ARGS} \
               ${SHUTDOWN_TIMEOUT_ARGS} \
               ${KV_TRANSFER_ARGS} \
+              {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -170,6 +170,7 @@ spec:
                 ${ACCESS_LOG_ARGS} \
                 ${SHUTDOWN_TIMEOUT_ARGS} \
                 ${KV_TRANSFER_ARGS} \
+                {{- if and .Spec.Prefill .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -169,6 +169,7 @@ spec:
               ${ACCESS_LOG_ARGS} \
               ${SHUTDOWN_TIMEOUT_ARGS} \
               ${KV_TRANSFER_ARGS} \
+              {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2768,6 +2768,7 @@ spec:
           ${ACCESS_LOG_ARGS} \
           ${SHUTDOWN_TIMEOUT_ARGS} \
           ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
@@ -3689,6 +3690,7 @@ spec:
             ${ACCESS_LOG_ARGS} \
             ${SHUTDOWN_TIMEOUT_ARGS} \
             ${KV_TRANSFER_ARGS} \
+            {{- if and .Spec.Prefill .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
@@ -5094,6 +5096,7 @@ spec:
           ${ACCESS_LOG_ARGS} \
           ${SHUTDOWN_TIMEOUT_ARGS} \
           ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2354,6 +2354,7 @@ spec:
           ${ACCESS_LOG_ARGS} \
           ${SHUTDOWN_TIMEOUT_ARGS} \
           ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
@@ -3275,6 +3276,7 @@ spec:
             ${ACCESS_LOG_ARGS} \
             ${SHUTDOWN_TIMEOUT_ARGS} \
             ${KV_TRANSFER_ARGS} \
+            {{- if and .Spec.Prefill .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
@@ -4680,6 +4682,7 @@ spec:
           ${ACCESS_LOG_ARGS} \
           ${SHUTDOWN_TIMEOUT_ARGS} \
           ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -629,6 +629,111 @@ func TestPresetFiles(t *testing.T) {
 	}
 }
 
+// TestSingleNodeTensorParallelRendered verifies that spec.parallelism.tensor
+// is rendered into --tensor-parallel-size for single-node (no Worker) templates.
+// Regression test for https://github.com/kserve/kserve/issues/5773
+func TestSingleNodeTensorParallelRendered(t *testing.T) {
+	presetsDir := filepath.Join(kservetesting.ProjectRoot(), "config", "llmisvcconfig")
+
+	tests := []struct {
+		name     string
+		file     string
+		llmSvc   *v1alpha2.LLMInferenceService
+		wantFlag string // substring to find; empty means --tensor-parallel-size must be absent
+	}{
+		{
+			name: "single-node base template",
+			file: "config-llm-template.yaml",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{Name: ptr.To("model")},
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Parallelism: &v1alpha2.ParallelismSpec{Tensor: ptr.To[int32](2)},
+					},
+				},
+			},
+			wantFlag: "--tensor-parallel-size 2",
+		},
+		{
+			name: "single-node decode template (P/D)",
+			file: "config-llm-decode-template.yaml",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{Name: ptr.To("model")},
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Parallelism: &v1alpha2.ParallelismSpec{Tensor: ptr.To[int32](4)},
+					},
+				},
+			},
+			wantFlag: "--tensor-parallel-size 4",
+		},
+		{
+			name: "single-node prefill template (P/D)",
+			file: "config-llm-prefill-template.yaml",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{Name: ptr.To("model")},
+					Prefill: &v1alpha2.WorkloadSpec{
+						Parallelism: &v1alpha2.ParallelismSpec{Tensor: ptr.To[int32](2)},
+					},
+				},
+			},
+			wantFlag: "--tensor-parallel-size 2",
+		},
+		{
+			name: "single-node base template - no parallelism omits flag",
+			file: "config-llm-template.yaml",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{Name: ptr.To("model")},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(presetsDir, tt.file)
+			data, err := os.ReadFile(filepath.Clean(filePath))
+			if err != nil {
+				t.Fatalf("read %s: %v", tt.file, err)
+			}
+			config := loadConfig(t, data, tt.file)
+
+			got, err := llmisvc.ReplaceVariables(tt.llmSvc, config, &llmisvc.Config{})
+			if err != nil {
+				t.Fatalf("ReplaceVariables: %v", err)
+			}
+
+			var containers []corev1.Container
+			switch {
+			case got.Spec.Prefill != nil && got.Spec.Prefill.Template != nil:
+				containers = got.Spec.Prefill.Template.Containers
+			case got.Spec.Template != nil:
+				containers = got.Spec.Template.Containers
+			}
+			if len(containers) == 0 {
+				t.Fatal("expected at least one container")
+			}
+
+			cmd := strings.Join(containers[0].Command, " ")
+			if tt.wantFlag != "" {
+				if !strings.Contains(cmd, tt.wantFlag) {
+					t.Errorf("rendered command does not contain %q:\n%s", tt.wantFlag, cmd)
+				}
+			} else {
+				if strings.Contains(cmd, "--tensor-parallel-size") {
+					t.Errorf("rendered command should not contain --tensor-parallel-size:\n%s", cmd)
+				}
+			}
+		})
+	}
+}
+
 func loadConfig(t *testing.T, data []byte, filePath string) *v1alpha2.LLMInferenceServiceConfig {
 	config := &v1alpha2.LLMInferenceServiceConfig{}
 	if err := yaml.Unmarshal(data, config); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Single-node LLMInferenceService deployments silently drop `spec.parallelism.tensor` - the CRD accepts these fields, the resource reports `Ready=True`, but the rendered `vllm serve` command never includes `--tensor-parallel-size`.

This happens because the single-node config templates (base, decode, prefill) never had these flags - only the multi-node worker templates did. Since tensor is valid on a single multi-GPU node, the single-node templates should render it too.

**Which issue(s) this PR fixes**:
Related to #5773

**Feature/Issue validation/testing**:

- [x] `TestSingleNodeParallelismRendered` - verifies all three single-node templates render `--tensor-parallel-size`  when set
- [x] Negative case confirms flags are omitted when `spec.parallelism` is nil (no panic on nil pointer)
- [x] Existing `TestPresetFiles` suite passes - no regressions in multi-node template rendering

**Special notes for your reviewer**:

Each template uses `and` to nil-guard the `Parallelism` pointer since single-node deployments may not have parallelism set at all. The multi-node worker templates don't need this guard because they're only selected when `Worker != nil`, which implies `Parallelism` is always set.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Renders spec.parallelism.tensor into single-node vllm serve commands, fixing silent field drop on LLMInferenceService without spec.worker.
```