### PR TITLE
ci: wait for llmisvc controller rollout to fully complete before proceeding

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -20,6 +20,8 @@ on:
       - "hack/setup/infra/manage.prometheus-adapter-helm.sh"
       - "hack/setup/infra/manage.wva-helm.sh"
       - "hack/setup/infra/manage.jaeger-helm.sh"
+      - "hack/setup/infra/manage.kserve-helm.sh"
+      - "hack/setup/quick-install/*-helm.sh"
   merge_group:
     types: [ checks_requested ]
 

--- a/hack/setup/infra/manage.kserve-helm.sh
+++ b/hack/setup/infra/manage.kserve-helm.sh
@@ -378,6 +378,25 @@ install() {
 
         log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
         kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+
+        # Wait for the NEW ReplicaSet to be fully rolled out. The wait_for_deployment
+        # helper below uses --for=condition=Available, which is satisfied by the OLD
+        # ReplicaSet's Ready pod during the rolling restart: it returns instantly but
+        # does not guarantee the new pod is serving the webhook. The subsequent
+        # kserve-runtime-configs install then applies LLMInferenceServiceConfig presets
+        # whose validating webhook must authorize each, and can hit the webhook Service
+        # before the new pod is a ready endpoint (dial ...:443: connect: connection refused).
+        log_info "Waiting for llmisvc-controller-manager rollout to complete..."
+        kubectl rollout status deployment/llmisvc-controller-manager \
+            -n "${KSERVE_NAMESPACE}" --timeout=300s
+
+        # Additionally wait for the webhook Service to have ready endpoints, covering the
+        # window between pod-ready and kube-proxy programming the Service endpoints.
+        log_info "Waiting for llmisvc webhook Service endpoints..."
+        kubectl wait --for=jsonpath='{.subsets[0].addresses}' \
+            endpoints/llmisvc-webhook-server-service \
+            -n "${KSERVE_NAMESPACE}" --timeout=60s
+        log_info "llmisvc webhook is ready."
     fi
 
     # Wait for all controller managers to be ready

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-helm.sh
@@ -1516,6 +1516,25 @@ install_kserve_helm() {
 
         log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
         kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+
+        # Wait for the NEW ReplicaSet to be fully rolled out. The wait_for_deployment
+        # helper below uses --for=condition=Available, which is satisfied by the OLD
+        # ReplicaSet's Ready pod during the rolling restart: it returns instantly but
+        # does not guarantee the new pod is serving the webhook. The subsequent
+        # kserve-runtime-configs install then applies LLMInferenceServiceConfig presets
+        # whose validating webhook must authorize each, and can hit the webhook Service
+        # before the new pod is a ready endpoint (dial ...:443: connect: connection refused).
+        log_info "Waiting for llmisvc-controller-manager rollout to complete..."
+        kubectl rollout status deployment/llmisvc-controller-manager \
+            -n "${KSERVE_NAMESPACE}" --timeout=300s
+
+        # Additionally wait for the webhook Service to have ready endpoints, covering the
+        # window between pod-ready and kube-proxy programming the Service endpoints.
+        log_info "Waiting for llmisvc webhook Service endpoints..."
+        kubectl wait --for=jsonpath='{.subsets[0].addresses}' \
+            endpoints/llmisvc-webhook-server-service \
+            -n "${KSERVE_NAMESPACE}" --timeout=60s
+        log_info "llmisvc webhook is ready."
     fi
 
     # Wait for all controller managers to be ready

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-helm.sh
@@ -1107,6 +1107,25 @@ install_kserve_helm() {
 
         log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
         kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+
+        # Wait for the NEW ReplicaSet to be fully rolled out. The wait_for_deployment
+        # helper below uses --for=condition=Available, which is satisfied by the OLD
+        # ReplicaSet's Ready pod during the rolling restart: it returns instantly but
+        # does not guarantee the new pod is serving the webhook. The subsequent
+        # kserve-runtime-configs install then applies LLMInferenceServiceConfig presets
+        # whose validating webhook must authorize each, and can hit the webhook Service
+        # before the new pod is a ready endpoint (dial ...:443: connect: connection refused).
+        log_info "Waiting for llmisvc-controller-manager rollout to complete..."
+        kubectl rollout status deployment/llmisvc-controller-manager \
+            -n "${KSERVE_NAMESPACE}" --timeout=300s
+
+        # Additionally wait for the webhook Service to have ready endpoints, covering the
+        # window between pod-ready and kube-proxy programming the Service endpoints.
+        log_info "Waiting for llmisvc webhook Service endpoints..."
+        kubectl wait --for=jsonpath='{.subsets[0].addresses}' \
+            endpoints/llmisvc-webhook-server-service \
+            -n "${KSERVE_NAMESPACE}" --timeout=60s
+        log_info "llmisvc webhook is ready."
     fi
 
     # Wait for all controller managers to be ready

--- a/hack/setup/quick-install/llmisvc-full-install-helm.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-helm.sh
@@ -1486,6 +1486,25 @@ install_kserve_helm() {
 
         log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
         kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+
+        # Wait for the NEW ReplicaSet to be fully rolled out. The wait_for_deployment
+        # helper below uses --for=condition=Available, which is satisfied by the OLD
+        # ReplicaSet's Ready pod during the rolling restart: it returns instantly but
+        # does not guarantee the new pod is serving the webhook. The subsequent
+        # kserve-runtime-configs install then applies LLMInferenceServiceConfig presets
+        # whose validating webhook must authorize each, and can hit the webhook Service
+        # before the new pod is a ready endpoint (dial ...:443: connect: connection refused).
+        log_info "Waiting for llmisvc-controller-manager rollout to complete..."
+        kubectl rollout status deployment/llmisvc-controller-manager \
+            -n "${KSERVE_NAMESPACE}" --timeout=300s
+
+        # Additionally wait for the webhook Service to have ready endpoints, covering the
+        # window between pod-ready and kube-proxy programming the Service endpoints.
+        log_info "Waiting for llmisvc webhook Service endpoints..."
+        kubectl wait --for=jsonpath='{.subsets[0].addresses}' \
+            endpoints/llmisvc-webhook-server-service \
+            -n "${KSERVE_NAMESPACE}" --timeout=60s
+        log_info "llmisvc webhook is ready."
     fi
 
     # Wait for all controller managers to be ready


### PR DESCRIPTION
Follow-up to #5770 (cert-mount race fix). After the rollout restart introduced by that PR, the subsequent `kubectl wait --for=condition=Available` returns instantly because the OLD ReplicaSet's Ready pod satisfies the condition — the NEW pod is not yet serving. The subsequent `kserve-runtime-configs` Helm install then applies 10 LLMInferenceServiceConfig presets, and the validating webhook must authorize each. The webhook Service has no ready endpoint during this window, producing 10 identical `Internal error occurred: failed calling webhook ... connect: connection refused`.

Immediately after the restart, add `kubectl rollout status` (which waits for the new ReplicaSet to fully roll out) plus an explicit wait for the webhook Service Endpoints to have at least one ready address (covering the window between pod-ready and kube-proxy programming). The existing `--for=condition=Available` readiness loop is kept, so the kserve controller wait is unaffected.

### Diagnosis

- Failing job: `test-llmisvc (helm)` — 10x `... connect: connection refused` during the Install KServe step, before any pytest runs.
- Independently reproduced on unrelated PRs: #5558 (rebased HEAD 82ba722cb) and #5773, with byte-identical signature and count on the same post-#5770 master.
- Other helm llmisvc jobs (`tracing`, `wva-hpa`, `wva-keda`) pass because they don't hit the runtime-configs install-time admission call in this narrow window.
- Diff scope: `hack/setup/infra/manage.kserve-helm.sh` (+~10 lines of logic), the three regenerated `hack/setup/quick-install/*-helm.sh` scripts, and a 2-line addition to this workflow's path triggers. No product code, no chart-lifecycle changes.

### Self-verification

This PR extends the LLMISVC E2E workflow's path triggers to include `hack/setup/infra/manage.kserve-helm.sh` and `hack/setup/quick-install/*-helm.sh`, so this PR's own CI runs `test-llmisvc (helm)` against the fix. Previously these files were outside the workflow's trigger paths — the same class of gap that let the underlying issue reach master without being exercised.

The race is structurally non-reproducible on fast local kind clusters: it depends on GHA-runner cert-issuance timing widening the window between OLD pod endpoint removal and NEW pod ready. The mechanism is proven from CI logs (0.14s false-positive `Available` + a two-pod snapshot showing OLD `1/1` leader + NEW `0/1` mid-rollout), and `test-llmisvc (helm)` on this PR is the faithful-environment check.
