### PR TITLE
feat: add pytest --collect-only for e2e tests to precommit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,11 @@ go-lint: golangci-lint
 	@cd qpext && $(GOLANGCI_LINT) run --fix
 
 py-lint: $(RUFF)
-	$(RUFF) check --config ruff.toml 
+	$(RUFF) check --config ruff.toml
+
+# Verify e2e test files parse and collect without errors (catches import errors, syntax errors, fixture issues).
+e2e-collect:
+	python3 -m pytest --collect-only test/e2e/ -q
 
 pin-actions: pinact
 	GITHUB_TOKEN=$$(gh auth token 2>/dev/null) $(PINACT) run .github/workflows/*.yml .github/workflows/*.yaml
@@ -339,7 +343,7 @@ boilerplate:
 	hack/boilerplate.sh
 
 # This runs all necessary steps to prepare for a commit.
-precommit: ensure-go-version-upgrade sync-deps sync-img-env vet go-lint py-fmt py-lint generate tidy manifests uv-lock generate-quick-install-scripts generate-chart-manifests sync-helm-common-helpers sync-helm-common-resource-helpers sync-helm-multi-resource-helpers verify-pinned-actions verify-minimal-crd-sync boilerplate
+precommit: ensure-go-version-upgrade sync-deps sync-img-env vet go-lint py-fmt py-lint e2e-collect generate tidy manifests uv-lock generate-quick-install-scripts generate-chart-manifests sync-helm-common-helpers sync-helm-common-resource-helpers sync-helm-multi-resource-helpers verify-pinned-actions verify-minimal-crd-sync boilerplate
 
 # This is used by CI to ensure that the precommit checks are met.
 check: precommit

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,10 @@ py-lint: $(RUFF)
 	$(RUFF) check --config ruff.toml
 
 # Verify e2e test files parse and collect without errors (catches import errors, syntax errors, fixture issues).
-e2e-collect:
-	python3 -m pytest --collect-only test/e2e/ -q
+e2e-collect: $(PYTEST)
+	$(UV) pip install --python $(PYTHON_BIN)/python -e ./python/kserve -q
+	$(UV) pip install --python $(PYTHON_BIN)/python --group test --directory ./python/kserve -q
+	$(PYTEST) --collect-only test/e2e/ -q
 
 pin-actions: pinact
 	GITHUB_TOKEN=$$(gh auth token 2>/dev/null) $(PINACT) run .github/workflows/*.yml .github/workflows/*.yaml

--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -15,6 +15,7 @@ HELM_DOCS = $(LOCALBIN)/helm-docs
 PINACT = $(LOCALBIN)/pinact
 UV = $(PYTHON_BIN)/uv
 RUFF = $(PYTHON_BIN)/ruff
+PYTEST = $(PYTHON_BIN)/pytest
 
 ## Tool versions are defined in kserve-deps.env (included in main Makefile)
 
@@ -76,6 +77,9 @@ $(UV): $(PYTHON_VENV) $(DEPS_ENV)
 
 $(RUFF): $(PYTHON_VENV) $(DEPS_ENV)
 	$(PYTHON_BIN)/pip install ruff==$(RUFF_VERSION)
+
+$(PYTEST): $(UV)
+	$(UV) pip install --python $(PYTHON_BIN)/python pytest
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/test/e2e/batcher/test_batcher.py
+++ b/test/e2e/batcher/test_batcher.py
@@ -10,10 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from kubernetes import client
 
-from kserve import KServeClient
 from kserve import constants
 from kserve import V1beta1PredictorSpec
 from kserve import V1beta1Batcher
@@ -25,12 +23,10 @@ from kubernetes.client import V1ResourceRequirements
 import pytest
 from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
-kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_batcher(rest_v1_client, network_layer):
+async def test_batcher(kserve_client, rest_v1_client, network_layer):
     service_name = "isvc-sklearn-batcher"
 
     predictor = V1beta1PredictorSpec(

--- a/test/e2e/batcher/test_batcher_custom_port.py
+++ b/test/e2e/batcher/test_batcher_custom_port.py
@@ -11,10 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from kubernetes import client
 
-from kserve import KServeClient
 from kserve import constants
 from kserve import V1beta1PredictorSpec
 from kserve import V1beta1Batcher
@@ -27,12 +25,10 @@ import pytest
 from ..common.utils import predict_isvc
 from ..common.utils import KSERVE_TEST_NAMESPACE
 
-kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_batcher_custom_port(rest_v1_client, network_layer):
+async def test_batcher_custom_port(kserve_client, rest_v1_client, network_layer):
     service_name = "isvc-sklearn-batcher-custom"
 
     predictor = V1beta1PredictorSpec(

--- a/test/e2e/batcher/test_raw_batcher.py
+++ b/test/e2e/batcher/test_raw_batcher.py
@@ -10,11 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import uuid
 from kubernetes import client
 
-from kserve import KServeClient
 from kserve import constants
 from kserve import V1beta1PredictorSpec
 from kserve import V1beta1Batcher
@@ -27,12 +25,10 @@ import pytest
 from ..common.utils import predict_isvc
 from ..common.utils import KSERVE_TEST_NAMESPACE
 
-kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-
 
 @pytest.mark.raw
 @pytest.mark.asyncio(scope="session")
-async def test_batcher_raw(rest_v1_client, network_layer):
+async def test_batcher_raw(kserve_client, rest_v1_client, network_layer):
     suffix = str(uuid.uuid4())[1:6]
     service_name = "isvc-raw-sklearn-batcher-" + suffix
 

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import os
 
 import pytest
 import pytest_asyncio
@@ -20,7 +21,7 @@ from httpx_retries import Retry, RetryTransport
 import httpx
 
 import kserve
-from kserve import InferenceRESTClient, RESTConfig
+from kserve import KServeClient, InferenceRESTClient, RESTConfig
 from kserve.constants.constants import PredictorProtocol
 from kserve.logging import logger, KSERVE_LOG_CONFIG
 
@@ -103,6 +104,13 @@ async def rest_v2_client():
     )
     yield v2_client
     await v2_client.close()
+
+
+@pytest.fixture(scope="session")
+def kserve_client():
+    return KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
 
 
 def pytest_addoption(parser):

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -108,9 +108,7 @@ async def rest_v2_client():
 
 @pytest.fixture(scope="session")
 def kserve_client():
-    return KServeClient(
-        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
-    )
+    return KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
 
 
 def pytest_addoption(parser):

--- a/test/e2e/explainer/test_art_explainer.py
+++ b/test/e2e/explainer/test_art_explainer.py
@@ -13,14 +13,12 @@
 
 
 import logging
-import os
 import uuid
 
 from kubernetes import client
 from kubernetes.client import V1ResourceRequirements
 import pytest
 
-from kserve import KServeClient
 from kserve import constants
 from kserve import V1beta1PredictorSpec
 from kserve import V1beta1InferenceServiceSpec
@@ -33,12 +31,10 @@ from ..common.utils import predict_isvc
 from ..common.utils import explain_art
 from ..common.utils import KSERVE_TEST_NAMESPACE
 
-kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-
 
 @pytest.mark.explainer
 @pytest.mark.asyncio(scope="session")
-async def test_tabular_explainer(rest_v1_client):
+async def test_tabular_explainer(kserve_client, rest_v1_client):
     suffix = str(uuid.uuid4())[1:6]
     service_name = "art-explainer" + suffix
     isvc = V1beta1InferenceService(
@@ -111,7 +107,7 @@ async def test_tabular_explainer(rest_v1_client):
 
 @pytest.mark.raw
 @pytest.mark.asyncio(scope="session")
-async def test_raw_tabular_explainer(rest_v1_client, network_layer):
+async def test_raw_tabular_explainer(kserve_client, rest_v1_client, network_layer):
     suffix = str(uuid.uuid4())[1:6]
     service_name = "art-explainer-raw-" + suffix
     isvc = V1beta1InferenceService(

--- a/test/e2e/logger/test_logger.py
+++ b/test/e2e/logger/test_logger.py
@@ -12,10 +12,8 @@
 # limitations under the License.
 
 import asyncio
-import os
 from kubernetes import client
 
-from kserve import KServeClient
 from kserve import constants
 from kserve import V1beta1PredictorSpec
 from kserve import V1beta1SKLearnSpec
@@ -28,13 +26,11 @@ import pytest
 from ..common.utils import predict_isvc
 from ..common.utils import KSERVE_TEST_NAMESPACE
 
-kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-
 
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_kserve_logger(rest_v1_client, network_layer):
+async def test_kserve_logger(kserve_client, rest_v1_client, network_layer):
     msg_dumper = "message-dumper"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,

--- a/test/e2e/logger/test_marshaller.py
+++ b/test/e2e/logger/test_marshaller.py
@@ -11,13 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 
 import pytest
 
-from kserve import KServeClient
 from ..common.utils import predict_isvc, KSERVE_TEST_NAMESPACE
+
 from .format_verifiers import (
     verify_json_object,
     verify_csv_object,
@@ -32,15 +31,13 @@ from .s3_utils import (
     wait_for_s3_objects,
 )
 
-kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-
 
 # --- JSON tests ---
 
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_immediate(rest_v1_client, network_layer):
+async def test_json_immediate(kserve_client, rest_v1_client, network_layer):
     """JSON marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -89,7 +86,7 @@ async def test_json_immediate(rest_v1_client, network_layer):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_size_batch(rest_v1_client, network_layer):
+async def test_json_size_batch(kserve_client, rest_v1_client, network_layer):
     """JSON marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -126,7 +123,7 @@ async def test_json_size_batch(rest_v1_client, network_layer):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_timed_batch(rest_v1_client, network_layer):
+async def test_json_timed_batch(kserve_client, rest_v1_client, network_layer):
     """JSON marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 records.
@@ -184,7 +181,7 @@ async def test_json_timed_batch(rest_v1_client, network_layer):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_immediate(rest_v1_client, network_layer):
+async def test_csv_immediate(kserve_client, rest_v1_client, network_layer):
     """CSV marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -227,7 +224,7 @@ async def test_csv_immediate(rest_v1_client, network_layer):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_size_batch(rest_v1_client, network_layer):
+async def test_csv_size_batch(kserve_client, rest_v1_client, network_layer):
     """CSV marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -264,7 +261,7 @@ async def test_csv_size_batch(rest_v1_client, network_layer):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_timed_batch(rest_v1_client, network_layer):
+async def test_csv_timed_batch(kserve_client, rest_v1_client, network_layer):
     """CSV marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 rows.
@@ -320,7 +317,7 @@ async def test_csv_timed_batch(rest_v1_client, network_layer):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_immediate(rest_v1_client, network_layer):
+async def test_parquet_immediate(kserve_client, rest_v1_client, network_layer):
     """Parquet marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -363,7 +360,7 @@ async def test_parquet_immediate(rest_v1_client, network_layer):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_size_batch(rest_v1_client, network_layer):
+async def test_parquet_size_batch(kserve_client, rest_v1_client, network_layer):
     """Parquet marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -400,7 +397,7 @@ async def test_parquet_size_batch(rest_v1_client, network_layer):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_timed_batch(rest_v1_client, network_layer):
+async def test_parquet_timed_batch(kserve_client, rest_v1_client, network_layer):
     """Parquet marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 rows.

--- a/test/e2e/logger/test_raw_logger.py
+++ b/test/e2e/logger/test_raw_logger.py
@@ -12,12 +12,10 @@
 # limitations under the License.
 
 import asyncio
-import os
 import uuid
 from kubernetes import client
 
 from kserve import (
-    KServeClient,
     constants,
     V1beta1PredictorSpec,
     V1beta1SKLearnSpec,
@@ -32,16 +30,15 @@ from ..common.utils import predict_isvc
 from ..common.utils import KSERVE_TEST_NAMESPACE
 
 
-kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
 annotations = {"serving.kserve.io/deploymentMode": "Standard"}
 
 
 @pytest.mark.raw
 @pytest.mark.asyncio(scope="session")
-async def test_kserve_logger(rest_v1_client, network_layer):
+async def test_kserve_logger(kserve_client, rest_v1_client, network_layer):
     suffix = str(uuid.uuid4())[1:6]
     msg_dumper = "message-dumper-raw-" + suffix
-    before(msg_dumper)
+    before(kserve_client, msg_dumper)
 
     service_name = "isvc-logger-raw-" + suffix
     predictor = V1beta1PredictorSpec(
@@ -63,14 +60,14 @@ async def test_kserve_logger(rest_v1_client, network_layer):
             ),
         ),
     )
-    await base_test(msg_dumper, service_name, predictor, rest_v1_client, network_layer)
+    await base_test(kserve_client, msg_dumper, service_name, predictor, rest_v1_client, network_layer)
 
 
 @pytest.mark.asyncio(scope="session")
 @pytest.mark.rawcipn
-async def test_kserve_logger_cipn(rest_v1_client, network_layer):
+async def test_kserve_logger_cipn(kserve_client, rest_v1_client, network_layer):
     msg_dumper = "message-dumper-raw-cipn"
-    before(msg_dumper)
+    before(kserve_client, msg_dumper)
 
     # Verify msg_dumper's status.address.url includes :8080 for headless mode
     isvc_status = kserve_client.get(
@@ -104,10 +101,10 @@ async def test_kserve_logger_cipn(rest_v1_client, network_layer):
             ),
         ),
     )
-    await base_test(msg_dumper, service_name, predictor, rest_v1_client, network_layer)
+    await base_test(kserve_client, msg_dumper, service_name, predictor, rest_v1_client, network_layer)
 
 
-def before(msg_dumper):
+def before(kserve_client, msg_dumper):
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         containers=[
@@ -135,7 +132,7 @@ def before(msg_dumper):
     kserve_client.wait_isvc_ready(msg_dumper, namespace=KSERVE_TEST_NAMESPACE)
 
 
-async def base_test(msg_dumper, service_name, predictor, rest_v1_client, network_layer):
+async def base_test(kserve_client, msg_dumper, service_name, predictor, rest_v1_client, network_layer):
     isvc = V1beta1InferenceService(
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,

--- a/test/e2e/logger/test_raw_logger.py
+++ b/test/e2e/logger/test_raw_logger.py
@@ -60,7 +60,14 @@ async def test_kserve_logger(kserve_client, rest_v1_client, network_layer):
             ),
         ),
     )
-    await base_test(kserve_client, msg_dumper, service_name, predictor, rest_v1_client, network_layer)
+    await base_test(
+        kserve_client,
+        msg_dumper,
+        service_name,
+        predictor,
+        rest_v1_client,
+        network_layer,
+    )
 
 
 @pytest.mark.asyncio(scope="session")
@@ -101,7 +108,14 @@ async def test_kserve_logger_cipn(kserve_client, rest_v1_client, network_layer):
             ),
         ),
     )
-    await base_test(kserve_client, msg_dumper, service_name, predictor, rest_v1_client, network_layer)
+    await base_test(
+        kserve_client,
+        msg_dumper,
+        service_name,
+        predictor,
+        rest_v1_client,
+        network_layer,
+    )
 
 
 def before(kserve_client, msg_dumper):
@@ -132,7 +146,9 @@ def before(kserve_client, msg_dumper):
     kserve_client.wait_isvc_ready(msg_dumper, namespace=KSERVE_TEST_NAMESPACE)
 
 
-async def base_test(kserve_client, msg_dumper, service_name, predictor, rest_v1_client, network_layer):
+async def base_test(
+    kserve_client, msg_dumper, service_name, predictor, rest_v1_client, network_layer
+):
     isvc = V1beta1InferenceService(
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,

--- a/test/e2e/predictor/test_canary.py
+++ b/test/e2e/predictor/test_canary.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from kubernetes import client
 
-from kserve import KServeClient
 from kserve import constants
 from kserve import V1beta1PredictorSpec
 from kserve import V1beta1TFServingSpec
@@ -28,12 +26,9 @@ import pytest
 from ..common.utils import KSERVE_TEST_NAMESPACE
 
 
-kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
-
-
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
-def test_canary_rollout():
+def test_canary_rollout(kserve_client):
     service_name = "isvc-canary"
     default_endpoint_spec = V1beta1InferenceServiceSpec(
         predictor=V1beta1PredictorSpec(
@@ -102,7 +97,7 @@ def test_canary_rollout():
 
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
-def test_canary_rollout_runtime():
+def test_canary_rollout_runtime(kserve_client):
     service_name = "isvc-canary-runtime"
     default_endpoint_spec = V1beta1InferenceServiceSpec(
         predictor=V1beta1PredictorSpec(


### PR DESCRIPTION
## Summary
- Adds `e2e-collect` make target that runs `pytest --collect-only test/e2e/ -q`
- Adds `e2e-collect` to the `precommit` target (after `py-lint`, before `generate`)
- Catches import errors, syntax errors, and fixture issues in e2e test files before they reach CI
- Moves `KServeClient` from module-level global to a session-scoped pytest fixture so that `--collect-only` can import test files without requiring a kubeconfig

Runs in ~0.5s, produces no output on success, fails fast on collection errors.

## Test plan
- [x] `python3 -m pytest --collect-only test/e2e/ -q` collects 210 tests in 0.48s
- [ ] `make precommit` completes with the new target included

🤖 Generated with [Claude Code](https://claude.com/claude-code)