### PR TITLE
fix(e2e): thread network_layer through autogluon tests

### DIFF
--- a/test/e2e/predictor/autogluon_helpers.py
+++ b/test/e2e/predictor/autogluon_helpers.py
@@ -91,6 +91,9 @@ async def deploy_and_predict(
     rest_client,
     input_path: str,
     timeout_seconds: int = AUTOGLUON_ISVC_WAIT_TIMEOUT,
+    network_layer: str = "istio",
 ):
     async with autogluon_isvc(service_name, predictor, timeout_seconds):
-        return await predict_isvc(rest_client, service_name, input_path)
+        return await predict_isvc(
+            rest_client, service_name, input_path, network_layer=network_layer
+        )

--- a/test/e2e/predictor/test_autogluon.py
+++ b/test/e2e/predictor/test_autogluon.py
@@ -58,7 +58,7 @@ def _create_predictor(
 @pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v1(rest_v1_client):
+async def test_autogluon_runtime_kserve_v1(rest_v1_client, network_layer):
     service_name = "isvc-autogluon-v1"
     predictor = _create_predictor(service_name)
     response = await deploy_and_predict(
@@ -66,6 +66,7 @@ async def test_autogluon_runtime_kserve_v1(rest_v1_client):
         predictor,
         rest_v1_client,
         "./data/autogluon_titanic_input.json",
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0
@@ -74,7 +75,7 @@ async def test_autogluon_runtime_kserve_v1(rest_v1_client):
 @pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v2(rest_v2_client):
+async def test_autogluon_runtime_kserve_v2(rest_v2_client, network_layer):
     service_name = "isvc-autogluon-v2"
     predictor = _create_predictor(service_name, protocol_version="v2")
     response = await deploy_and_predict(
@@ -82,6 +83,7 @@ async def test_autogluon_runtime_kserve_v2(rest_v2_client):
         predictor,
         rest_v2_client,
         "./data/autogluon_titanic_input_v2.json",
+        network_layer=network_layer,
     )
     assert len(response.outputs) > 0
     assert len(response.outputs[0].data) > 0
@@ -90,7 +92,9 @@ async def test_autogluon_runtime_kserve_v2(rest_v2_client):
 @pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
+async def test_autogluon_runtime_kserve_v2_input_variants(
+    rest_v2_client, network_layer
+):
     service_name = "isvc-autogluon-v2-variants"
     predictor = _create_predictor(service_name, protocol_version="v2")
     async with autogluon_isvc(service_name, predictor):
@@ -99,7 +103,9 @@ async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
             "./data/autogluon_titanic_input_v2_binary.json",
             "./data/autogluon_titanic_input_v2_all_binary.json",
         ]:
-            response = await predict_isvc(rest_v2_client, service_name, input_path)
+            response = await predict_isvc(
+                rest_v2_client, service_name, input_path, network_layer=network_layer
+            )
             assert len(response.outputs) > 0
             assert len(response.outputs[0].data) > 0
 
@@ -109,6 +115,7 @@ async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_runtime_kserve_v2_storage_uri_without_trailing_slash(
     rest_v2_client,
+    network_layer,
 ):
     service_name = "isvc-autogluon-v2-noslash"
     storage_uri = AUTOGLUON_STORAGE_URI.rstrip("/")
@@ -120,6 +127,7 @@ async def test_autogluon_runtime_kserve_v2_storage_uri_without_trailing_slash(
         predictor,
         rest_v2_client,
         "./data/autogluon_titanic_input_v2.json",
+        network_layer=network_layer,
     )
     assert len(response.outputs) > 0
     assert len(response.outputs[0].data) > 0

--- a/test/e2e/predictor/test_autogluon_timeseries.py
+++ b/test/e2e/predictor/test_autogluon_timeseries.py
@@ -60,21 +60,32 @@ def _create_ts_predictor(service_name: str, storage_uri: str = None):
 
 
 async def _deploy_and_predict_v1(
-    service_name: str, rest_v1_client, input_path: str, storage_uri: str = None
+    service_name: str,
+    rest_v1_client,
+    input_path: str,
+    storage_uri: str = None,
+    network_layer: str = "istio",
 ):
     predictor = _create_ts_predictor(service_name, storage_uri=storage_uri)
-    return await deploy_and_predict(service_name, predictor, rest_v1_client, input_path)
+    return await deploy_and_predict(
+        service_name,
+        predictor,
+        rest_v1_client,
+        input_path,
+        network_layer=network_layer,
+    )
 
 
 @pytest.mark.autogluon
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client):
+async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client, network_layer):
     service_name = "isvc-autogluon-ts-v1"
     response = await _deploy_and_predict_v1(
         service_name,
         rest_v1_client,
         "./data/autogluon_timeseries_input.json",
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0
@@ -85,6 +96,7 @@ async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client):
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_timeseries_runtime_kserve_v1_storage_uri_without_trailing_slash(
     rest_v1_client,
+    network_layer,
 ):
     service_name = "isvc-autogluon-ts-v1-noslash"
     response = await _deploy_and_predict_v1(
@@ -92,6 +104,7 @@ async def test_autogluon_timeseries_runtime_kserve_v1_storage_uri_without_traili
         rest_v1_client,
         "./data/autogluon_timeseries_input_long.json",
         storage_uri=AUTOGLUON_TS_STORAGE_URI.rstrip("/"),
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0


### PR DESCRIPTION
## Summary
Thread `network_layer` pytest fixture through all autogluon e2e tests and helpers.

## Problem
The autogluon e2e tests are the only predictor tests that don't accept the `network_layer` fixture. `predict_isvc()` defaults to `network_layer="istio"`, so on clusters using different networking (e.g. `openshift-route`, `gateway-api`), the tests fail with:

```
RuntimeError: No service found with labels: {'app': 'istio-ingressgateway', 'istio': 'ingressgateway'}
```

Every other predictor test (lightgbm, sklearn, tensorflow, etc.) correctly threads the `network_layer` fixture. The autogluon tests were added in #5269 and #5749 without it.

## Fix
- Add `network_layer` parameter to `deploy_and_predict` in `autogluon_helpers.py`
- Add `network_layer` fixture to all 4 test functions in `test_autogluon.py`
- Add `network_layer` fixture to both test functions and `_deploy_and_predict_v1` in `test_autogluon_timeseries.py`

## Test plan
- [x] Verified on OpenShift CI with `openshift-route` network layer (e2e-predictor, e2e-raw both pass)
- [ ] Upstream CI passes (no behavior change — istio is the default)

🤖 Generated with [Claude Code](https://claude.ai/code)