### PR TITLE
fix(tls): enforce TLS 1.2 minimum on webhook, metrics, and router servers

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -151,9 +151,8 @@ func main() {
 	}
 
 	tlsOpts := []func(*tls.Config){
-		func(c *tls.Config) {
-			c.NextProtos = []string{"h2", "http/1.1"}
-		},
+		func(c *tls.Config) { c.MinVersion = tls.VersionTLS12 },
+		func(c *tls.Config) { c.NextProtos = []string{"h2", "http/1.1"} },
 	}
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -83,7 +83,6 @@ type Options struct {
 	enableLeaderElection  bool
 	probeAddr             string
 	metricsSecure         bool
-	enableHTTP2           bool
 	migrationTimeout      time.Duration
 	migrationPollInterval time.Duration
 	zapOpts               zap.Options
@@ -96,7 +95,6 @@ func DefaultOptions() Options {
 		enableLeaderElection:  false,
 		probeAddr:             ":8081",
 		metricsSecure:         true,
-		enableHTTP2:           false,
 		migrationTimeout:      1 * time.Hour,
 		migrationPollInterval: 30 * time.Second,
 		zapOpts:               zap.Options{},
@@ -113,7 +111,6 @@ func GetOptions() Options {
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
 	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metric via HTTPS.")
-	flag.BoolVar(&opts.enableHTTP2, "enable-http2", false, "If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.DurationVar(&opts.migrationTimeout, "storage-migration-timeout", opts.migrationTimeout, "Total retry budget for storage version migration.")
 	flag.DurationVar(&opts.migrationPollInterval, "storage-migration-poll-interval", opts.migrationPollInterval, "Polling interval for storage version migration retries after initial backoff.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
@@ -153,19 +150,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// http/2 should be disabled due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
-
-	var tlsOpts []func(*tls.Config)
-	if !options.enableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
+	tlsOpts := []func(*tls.Config){
+		func(c *tls.Config) {
+			c.NextProtos = []string{"h2", "http/1.1"}
+		},
 	}
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:

--- a/cmd/localmodel/main.go
+++ b/cmd/localmodel/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"os"
 
@@ -101,12 +102,16 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
+	tlsOpts := []func(*tls.Config){func(c *tls.Config) { c.MinVersion = tls.VersionTLS12 }}
+
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/cmd/localmodelnode/main.go
+++ b/cmd/localmodelnode/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"os"
 
@@ -94,12 +95,16 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
+	tlsOpts := []func(*tls.Config){func(c *tls.Config) { c.MinVersion = tls.VersionTLS12 }}
+
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"net/http"
 	"os"
@@ -124,12 +125,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	tlsOpts := []func(*tls.Config){func(c *tls.Config) { c.MinVersion = tls.VersionTLS12 }}
+
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/json"
 	goerrors "errors"
 	"fmt"
@@ -513,6 +514,7 @@ func main() {
 	server := &http.Server{
 		Addr:         ":" + strconv.Itoa(constants.RouterPort),
 		Handler:      nil,                                                      // default server mux
+		TLSConfig:    &tls.Config{MinVersion: tls.VersionTLS12},
 		ReadTimeout:  time.Duration(*routerTimeouts.ServerRead) * time.Second,  // set the maximum duration for reading the entire request, including the body
 		WriteTimeout: time.Duration(*routerTimeouts.ServerWrite) * time.Second, // set the maximum duration before timing out writes of the response
 		IdleTimeout:  time.Duration(*routerTimeouts.ServerIdle) * time.Second,  // set the maximum amount of time to wait for the next request when keep-alives are enabled

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -107,6 +107,7 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 					RootCAs:            clientCertPool,
 					MinVersion:         tls.VersionTLS12,
 					InsecureSkipVerify: logReq.TlsSkipVerify, // #nosec G402
+					NextProtos:         []string{"h2", "http/1.1"},
 				},
 			}
 			t.Client.Transport = tlsTransport


### PR DESCRIPTION
## Summary

- Sets `MinVersion: tls.VersionTLS12` on all controller-runtime webhook and metrics servers (manager, llmisvc, localmodel, localmodelnode) via `TLSOpts`
- Sets `TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}` on the router's `http.Server`

Prior to this change all servers accepted TLS 1.0+, which is below current security baselines. Go's default cipher suite selection for TLS 1.2 is already secure; raising the minimum floor requires no additional configuration.

## Dependencies

This PR is stacked on top of #5743 (NextProtos/ALPN). The diff includes both changesets until #5743 merges, at which point this PR will be rebased to show only the MinVersion changes.

## Changes

- `cmd/manager/main.go`: Add `tlsOpts` with `MinVersion: tls.VersionTLS12`, pass to webhook and metrics servers
- `cmd/llmisvc/main.go`: Add `MinVersion: tls.VersionTLS12` to existing `tlsOpts` (alongside NextProtos from #5743)
- `cmd/localmodel/main.go`: Add `tlsOpts` with `MinVersion: tls.VersionTLS12`, pass to webhook and metrics servers
- `cmd/localmodelnode/main.go`: Add `tlsOpts` with `MinVersion: tls.VersionTLS12`, pass to webhook and metrics servers
- `cmd/router/main.go`: Set `TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}` on the HTTP server