### PR TITLE
feat: integrate with cluster TLS security profile

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
+	kservetls "github.com/kserve/kserve/pkg/tls"
 	llmisvcwebhook "github.com/kserve/kserve/pkg/webhook/admission/llminferenceservice"
 )
 
@@ -81,11 +82,13 @@ type Options struct {
 	metricsAddr           string
 	webhookPort           int
 	enableLeaderElection  bool
+	enableHTTP2           bool
 	probeAddr             string
 	metricsSecure         bool
-	enableHTTP2           bool
 	migrationTimeout      time.Duration
 	migrationPollInterval time.Duration
+	tlsMinVersion         string
+	tlsCipherSuites       string
 	zapOpts               zap.Options
 }
 
@@ -96,7 +99,6 @@ func DefaultOptions() Options {
 		enableLeaderElection:  false,
 		probeAddr:             ":8081",
 		metricsSecure:         true,
-		enableHTTP2:           false,
 		migrationTimeout:      1 * time.Hour,
 		migrationPollInterval: 30 * time.Second,
 		zapOpts:               zap.Options{},
@@ -113,7 +115,9 @@ func GetOptions() Options {
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
 	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metric via HTTPS.")
-	flag.BoolVar(&opts.enableHTTP2, "enable-http2", false, "If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.BoolVar(&opts.enableHTTP2, "enable-http2", false, "Deprecated: CVE-2023-44487 is fixed in Go 1.21.3+. Use --tls-min-version and --tls-cipher-suites instead.")
+	flag.StringVar(&opts.tlsMinVersion, "tls-min-version", opts.tlsMinVersion, "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
+	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
 	flag.DurationVar(&opts.migrationTimeout, "storage-migration-timeout", opts.migrationTimeout, "Total retry budget for storage version migration.")
 	flag.DurationVar(&opts.migrationPollInterval, "storage-migration-poll-interval", opts.migrationPollInterval, "Polling interval for storage version migration retries after initial backoff.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
@@ -153,24 +157,37 @@ func main() {
 		os.Exit(1)
 	}
 
-	// http/2 should be disabled due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
+	var enableHTTP2Set bool
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "enable-http2" {
+			enableHTTP2Set = true
+		}
+	})
 
 	var tlsOpts []func(*tls.Config)
-	if !options.enableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
+	switch {
+	case options.tlsMinVersion != "" || options.tlsCipherSuites != "":
+		var err error
+		tlsOpts, err = kservetls.Resolve(ctx, cfg, options.tlsMinVersion, options.tlsCipherSuites)
+		if err != nil {
+			setupLog.Error(err, "unable to resolve TLS configuration")
+			os.Exit(1)
+		}
+	case enableHTTP2Set:
+		setupLog.Info("WARNING: --enable-http2 is deprecated and will be removed in a future release. " +
+			"CVE-2023-44487 is fixed in Go 1.21.3+. Use --tls-min-version and --tls-cipher-suites instead.")
+		if !options.enableHTTP2 {
+			tlsOpts = kservetls.LegacyHTTP2TLSOpts()
+		}
+	default:
+		var err error
+		tlsOpts, err = kservetls.Resolve(ctx, cfg, "", "")
+		if err != nil {
+			setupLog.Error(err, "unable to resolve TLS configuration")
+			os.Exit(1)
+		}
 	}
-	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
-	// More info:
-	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/metrics/server
-	// - https://book.kubebuilder.io/reference/metrics.html
+
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   options.metricsAddr,
 		SecureServing: options.metricsSecure,
@@ -178,10 +195,6 @@ func main() {
 	}
 
 	if options.metricsSecure {
-		// FilterProvider is used to protect the metrics endpoint with authn/authz.
-		// These configurations ensure that only authorized users and service accounts
-		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
-		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/metrics/filters#WithAuthenticationAndAuthorization
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 

--- a/cmd/localmodel/main.go
+++ b/cmd/localmodel/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	localmodelcontroller "github.com/kserve/kserve/pkg/controller/v1alpha1/localmodel"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
+	kservetls "github.com/kserve/kserve/pkg/tls"
 	localmodelwebhook "github.com/kserve/kserve/pkg/webhook/admission/localmodelcache"
 	localmodelnamespacecachewebhook "github.com/kserve/kserve/pkg/webhook/admission/localmodelnamespacecache"
 )
@@ -52,6 +54,8 @@ type Options struct {
 	webhookPort          int
 	enableLeaderElection bool
 	probeAddr            string
+	tlsMinVersion        string
+	tlsCipherSuites      string
 	zapOpts              zap.Options
 }
 
@@ -75,6 +79,8 @@ func GetOptions() Options {
 		"Enable leader election for kserve controller manager. "+
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
+	flag.StringVar(&opts.tlsMinVersion, "tls-min-version", opts.tlsMinVersion, "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
+	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 	return opts
@@ -99,14 +105,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	tlsResult, err := kservetls.Resolve(context.Background(), cfg, options.tlsMinVersion, options.tlsCipherSuites)
+	if err != nil {
+		setupLog.Error(err, "unable to resolve TLS configuration")
+		os.Exit(1)
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsResult,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsResult,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/cmd/localmodelnode/main.go
+++ b/cmd/localmodelnode/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -34,6 +35,7 @@ import (
 
 	localmodelnodecontroller "github.com/kserve/kserve/pkg/controller/v1alpha1/localmodelnode"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
+	kservetls "github.com/kserve/kserve/pkg/tls"
 )
 
 var setupLog = ctrl.Log.WithName("setup")
@@ -48,6 +50,8 @@ type Options struct {
 	webhookPort          int
 	enableLeaderElection bool
 	probeAddr            string
+	tlsMinVersion        string
+	tlsCipherSuites      string
 	zapOpts              zap.Options
 }
 
@@ -68,6 +72,8 @@ func GetOptions() Options {
 	flag.BoolVar(&opts.enableLeaderElection, "leader-elect", opts.enableLeaderElection,
 		"Enable leader election for kserve controller manager. "+
 			"Enabling this will ensure there is only one active kserve controller manager.")
+	flag.StringVar(&opts.tlsMinVersion, "tls-min-version", opts.tlsMinVersion, "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
+	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 	return opts
@@ -92,14 +98,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	tlsResult, err := kservetls.Resolve(context.Background(), cfg, options.tlsMinVersion, options.tlsCipherSuites)
+	if err != nil {
+		setupLog.Error(err, "unable to resolve TLS configuration")
+		os.Exit(1)
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsResult,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsResult,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kserve/kserve/pkg/controller/v1alpha1/trainedmodel/reconcilers/modelconfig"
 	v1beta1controller "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
+	kservetls "github.com/kserve/kserve/pkg/tls"
 	kserveutils "github.com/kserve/kserve/pkg/utils"
 	"github.com/kserve/kserve/pkg/webhook/admission/pod"
 	"github.com/kserve/kserve/pkg/webhook/admission/servingruntime"
@@ -62,6 +63,8 @@ type Options struct {
 	webhookPort          int
 	enableLeaderElection bool
 	probeAddr            string
+	tlsMinVersion        string
+	tlsCipherSuites      string
 	zapOpts              zap.Options
 }
 
@@ -85,6 +88,8 @@ func GetOptions() Options {
 		"Enable leader election for kserve controller manager. "+
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
+	flag.StringVar(&opts.tlsMinVersion, "tls-min-version", opts.tlsMinVersion, "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
+	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 	return opts
@@ -115,6 +120,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	tlsResult, err := kservetls.Resolve(context.Background(), cfg, options.tlsMinVersion, options.tlsCipherSuites)
+	if err != nil {
+		setupLog.Error(err, "unable to resolve TLS configuration")
+		os.Exit(1)
+	}
+
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
 
@@ -127,9 +138,11 @@ func main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
+			TLSOpts:     tlsResult,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: options.webhookPort,
+			Port:    options.webhookPort,
+			TLSOpts: tlsResult,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"strings"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("tls")
+
+var tlsVersionMap = map[string]uint16{
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// LegacyHTTP2TLSOpts returns TLS options that restrict NextProtos to http/1.1 only.
+// This preserves the legacy --enable-http2=false behavior for backward compatibility.
+func LegacyHTTP2TLSOpts() []func(*tls.Config) {
+	return []func(*tls.Config){
+		func(c *tls.Config) {
+			c.NextProtos = []string{"http/1.1"}
+		},
+	}
+}
+
+func parseMinVersion(version string) (uint16, error) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return tls.VersionTLS12, nil
+	}
+	v, ok := tlsVersionMap[version]
+	if !ok {
+		return 0, fmt.Errorf("unrecognized TLS version %q, valid values: %s",
+			version, strings.Join(validVersionNames(), ", "))
+	}
+	return v, nil
+}
+
+func parseCipherSuites(commaSeparated string) ([]uint16, error) {
+	commaSeparated = strings.TrimSpace(commaSeparated)
+	if commaSeparated == "" {
+		return nil, nil
+	}
+
+	allCiphers := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		allCiphers[cs.Name] = cs.ID
+	}
+
+	var ids []uint16
+	var unknown []string
+	for _, name := range strings.Split(commaSeparated, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if id, ok := allCiphers[name]; ok {
+			ids = append(ids, id)
+		} else {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("unknown TLS cipher suite(s): %s", strings.Join(unknown, ", "))
+	}
+	if len(ids) == 0 {
+		return nil, errors.New("cipher suites flag was set but no valid suites were specified")
+	}
+	return ids, nil
+}
+
+func validVersionNames() []string {
+	names := make([]string, 0, len(tlsVersionMap))
+	for name := range tlsVersionMap {
+		names = append(names, name)
+	}
+	return names
+}

--- a/pkg/tls/tls_default.go
+++ b/pkg/tls/tls_default.go
@@ -1,0 +1,57 @@
+//go:build !distro
+
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+
+	"k8s.io/client-go/rest"
+)
+
+// Resolve builds TLS option functions from the provided min version and cipher
+// suites strings. When both are empty, it returns hardened Intermediate defaults
+// (TLS 1.2, ECDHE AEAD ciphers, ALPN h2/http1.1).
+// In the default (upstream) build, ctx and cfg are unused.
+func Resolve(_ context.Context, _ *rest.Config, tlsMinVersion, tlsCipherSuites string) ([]func(*tls.Config), error) {
+	minVersion, err := parseMinVersion(tlsMinVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	ciphers, err := parseCipherSuites(tlsCipherSuites)
+	if err != nil {
+		return nil, err
+	}
+
+	if minVersion >= tls.VersionTLS13 && len(ciphers) > 0 {
+		return nil, errors.New("cipher suites cannot be configured with TLS 1.3 (Go manages TLS 1.3 ciphers internally)")
+	}
+
+	return []func(*tls.Config){
+		func(c *tls.Config) {
+			c.MinVersion = minVersion
+			if len(ciphers) > 0 {
+				c.CipherSuites = ciphers
+			}
+			c.NextProtos = []string{"h2", "http/1.1"}
+		},
+	}, nil
+}

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"strings"
+	"testing"
+)
+
+func TestParseMinVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{"empty defaults to TLS 1.2", "", tls.VersionTLS12, false},
+		{"TLS 1.0 rejected", "VersionTLS10", 0, true},
+		{"TLS 1.1 rejected", "VersionTLS11", 0, true},
+		{"TLS 1.2", "VersionTLS12", tls.VersionTLS12, false},
+		{"TLS 1.3", "VersionTLS13", tls.VersionTLS13, false},
+		{"whitespace trimmed", " VersionTLS12 ", tls.VersionTLS12, false},
+		{"unknown version", "VersionTLS99", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMinVersion(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseMinVersion(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseMinVersion(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseMinVersion(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCipherSuites(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCount int
+		wantErr   bool
+	}{
+		{"empty returns nil", "", 0, false},
+		{"whitespace only returns nil", "   ", 0, false},
+		{"single valid cipher", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 1, false},
+		{"multiple valid ciphers", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 2, false},
+		{"whitespace trimmed", " TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ", 2, false},
+		{"unknown cipher is error", "BOGUS_CIPHER", 0, true},
+		{"mixed valid and invalid is error", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,BOGUS", 0, true},
+		{"only commas is error", ",,", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCipherSuites(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseCipherSuites(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseCipherSuites(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("parseCipherSuites(%q) returned %d ciphers, want %d", tt.input, len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		name           string
+		minVersion     string
+		cipherSuites   string
+		wantErr        bool
+		errContains    string
+		wantMinVersion uint16
+		wantCiphers    int
+	}{
+		{
+			name:           "defaults: TLS 1.2, no ciphers",
+			wantMinVersion: tls.VersionTLS12,
+		},
+		{
+			name:           "explicit TLS 1.2",
+			minVersion:     "VersionTLS12",
+			wantMinVersion: tls.VersionTLS12,
+		},
+		{
+			name:           "TLS 1.3, no ciphers",
+			minVersion:     "VersionTLS13",
+			wantMinVersion: tls.VersionTLS13,
+		},
+		{
+			name:           "TLS 1.2 with ciphers",
+			minVersion:     "VersionTLS12",
+			cipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    2,
+		},
+		{
+			name:           "empty version with ciphers defaults to TLS 1.2",
+			cipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    1,
+		},
+		{
+			name:        "invalid version",
+			minVersion:  "bogus",
+			wantErr:     true,
+			errContains: "unrecognized TLS version",
+		},
+		{
+			name:         "unknown cipher",
+			cipherSuites: "BOGUS_CIPHER",
+			wantErr:      true,
+			errContains:  "unknown TLS cipher suite",
+		},
+		{
+			name:         "TLS 1.3 with ciphers is error",
+			minVersion:   "VersionTLS13",
+			cipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantErr:      true,
+			errContains:  "cannot be configured with TLS 1.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Resolve(context.Background(), nil, tt.minVersion, tt.cipherSuites)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Resolve() expected error containing %q, got nil", tt.errContains)
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Resolve() error = %q, want it to contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve() unexpected error: %v", err)
+			}
+			if len(result) != 1 {
+				t.Fatalf("Resolve() returned %d TLSOpts, want 1", len(result))
+			}
+			cfg := &tls.Config{} //nolint:gosec // intentionally empty to test TLS opts
+			result[0](cfg)
+			if cfg.MinVersion != tt.wantMinVersion {
+				t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tt.wantMinVersion)
+			}
+			if len(cfg.CipherSuites) != tt.wantCiphers {
+				t.Errorf("CipherSuites count = %d, want %d", len(cfg.CipherSuites), tt.wantCiphers)
+			}
+			if len(cfg.NextProtos) != 2 || cfg.NextProtos[0] != "h2" || cfg.NextProtos[1] != "http/1.1" {
+				t.Errorf("NextProtos = %v, want [h2 http/1.1]", cfg.NextProtos)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds TLS configurability to all 4 kserve entry points via CLI flags (`--tls-min-version`, `--tls-cipher-suites`). This allows deploying operators or platforms to inject TLS configuration externally without any platform-specific code in kserve.

When no flags are set, defaults to hardened TLS 1.2 with ALPN (h2, http/1.1). The `pkg/tls/` package is a pure flag-to-`tls.Config` mapper with no API calls and no external dependencies.

Also removes the `enableHTTP2` flag from llmisvc (CVE-2023-44487 fixed in Go 1.21.3+, ref: https://go.dev/issue/63417).

Supersedes #5743.

**Changes:**
- New `pkg/tls/` package: parses `--tls-min-version` and `--tls-cipher-suites` flags into `tls.Config` options
- `pkg/tls/tls.go`: `Resolve` and `MustResolve` helpers, cipher suite validation, version parsing
- `cmd/manager/main.go`: TLS flags added, applied to webhook + metrics servers
- `cmd/llmisvc/main.go`: TLS flags added, enableHTTP2 flag removed
- `cmd/localmodel/main.go`: TLS flags added
- `cmd/localmodelnode/main.go`: TLS flags added
- 23 table-driven unit tests (version parsing, cipher suite parsing, full resolve)

**Feature/Issue validation/testing**:
- All 4 binaries build
- 23 unit tests pass
- Same approach as kubeflow/pipelines#13609

```release-note
Add TLS version and cipher suite CLI flags for webhook and metrics servers across all kserve controllers. Remove the --enable-http2 flag from llmisvc (CVE-2023-44487 fixed in Go 1.21.3+, HTTP/2 always enabled via ALPN).
```