### PR TITLE
ci: replace enforce-all-checks with lewagon/wait-on-check-action

### DIFF
--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -16,10 +16,12 @@ jobs:
       checks: read
     steps:
       - name: job status check
-        uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0
+        uses: lewagon/wait-on-check-action@1d57e2c51a58d812d2765e036a028b6bdb5a6154 # v1.8.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          interval: 60s
-          # seconds to wait before first poll.
-          delay: 300s
-          timeout: 10800s # 3 hour (based on the highest avg runtime of a job https://github.com/kserve/kserve/actions/metrics/performance?tab=jobs)
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          running-workflow-name: enforce-all-checks
+          allowed-conclusions: success,skipped
+          wait-interval: 60
+          checks-discovery-timeout: 300
+          verbose: false

--- a/test/e2e/predictor/test_sklearn.py
+++ b/test/e2e/predictor/test_sklearn.py
@@ -76,6 +76,7 @@ async def test_sklearn_kserve(rest_v1_client, network_layer):
         network_layer=network_layer,
     )
     assert res["predictions"] == [1, 1]
+
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 


### PR DESCRIPTION
## Summary
Replace `poseidon/wait-for-status-checks` with `lewagon/wait-on-check-action` in the `enforce-all-checks` workflow.

## Problem
The current `enforce-all-checks` job evaluates **all** check runs associated with a commit SHA, including stale results from previous workflow runs. When a workflow is re-triggered (e.g. by pushing a new commit or re-running), the action sees both old and new check runs and fails on the outdated results — even when the latest run passes.

This causes `enforce-all-checks` to fail on nearly every PR that has been re-run, requiring maintainers to manually intervene.

## Fix
[`lewagon/wait-on-check-action`](https://github.com/lewagon/wait-on-check-action) only considers the **most recent run per check name** by default. Stale results from previous workflow executions are ignored.

Other changes:
- `running-workflow-name: enforce-all-checks` prevents the job from waiting on itself
- `checks-discovery-timeout: 300` gives GitHub 5 minutes to register all check runs before polling begins (matches the old `delay: 300s`)
- Pinned to SHA `1d57e2c` (v1.8.1)

## Test plan
- [ ] Open a PR, trigger CI, verify `enforce-all-checks` passes when all current checks pass
- [ ] Re-run a failed job, verify `enforce-all-checks` doesn't fail on stale results from the previous run

🤖 Generated with [Claude Code](https://claude.ai/code)