### PR TITLE
fix: say 'input' not 'output' in InferRequest.to_rest missing-data error

### DIFF
--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -731,7 +731,7 @@ class InferRequest:
         for infer_input in self.inputs:
             if infer_input.data is None and infer_input._raw_data is None:
                 raise InvalidInput(
-                    f"'data' field is missing for output '{infer_input.name}' for model '{self.model_name}'"
+                    f"'data' field is missing for input '{infer_input.name}' for model '{self.model_name}'"
                 )
             if isinstance(infer_input.data, np.ndarray):
                 infer_input.set_data_from_numpy(infer_input.data, binary_data=False)

--- a/python/kserve/test/test_infer_type.py
+++ b/python/kserve/test/test_infer_type.py
@@ -424,8 +424,12 @@ class TestInferRequest:
             model_name="test_model",
             infer_inputs=[infer_input],
         )
-        with pytest.raises(InvalidInput):
+        with pytest.raises(InvalidInput) as err:
             infer_request_bytes, json_length = infer_request.to_rest()
+        assert (
+            err.value.reason
+            == "'data' field is missing for input 'input1' for model 'test_model'"
+        )
 
     def test_infer_request_from_bytes_valid_input(self):
         infer_input_1 = InferInput(


### PR DESCRIPTION
**What this PR does / why we need it**:

`InferRequest.to_rest()` validates request inputs, but its missing-data error incorrectly referred to an `output`. This changes that word to `input` and strengthens the existing unit test to assert the exact error message. The response-path wording remains unchanged because it correctly refers to outputs.

**Which issue(s) this PR fixes**:

None. Unclaimed latent bug, no tracked issue.

**Feature/Issue validation/testing**:

- [x] `uv run pytest test/test_infer_type.py -q` (33 passed)
- [x] `uv run pytest test/test_server.py -q -k "to_rest or infer"` (6 passed, 48 deselected)

**Special notes for your reviewer**:

One-word message fix plus a tighter test assertion. InferResponse.to_rest() still says output because that path iterates outputs.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas? (N/A, one-word message fix)
- [ ] Have you made corresponding changes to the documentation? (N/A, no documentation references this message)

**Release note**:
```release-note
Fix the InferRequest.to_rest() error to say the missing data field is for an input, not an output.
```
