### PR TITLE
fix(webhook): apply the 1-100 target range only to the CPU HPA metric

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -537,7 +537,7 @@ func validateScalingHPACompExtension(compExtSpec *ComponentExtensionSpec) error 
 
 	if compExtSpec.ScaleTarget != nil {
 		target := *compExtSpec.ScaleTarget
-		if metric == MetricCPU && target < 1 || target > 100 {
+		if metric == MetricCPU && (target < 1 || target > 100) {
 			return errors.New("the target utilization percentage should be a [1-100] integer")
 		}
 

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -334,6 +334,33 @@ func TestAutoscalerClassHPA(t *testing.T) {
 			},
 			errMatcher: gomega.BeNil(),
 		},
+		"Valid HPA Memory metrics with ScaleTarget above 100": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":  "Standard",
+						"serving.kserve.io/autoscalerClass": "hpa",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							ScaleMetric: ptr.To(MetricMemory),
+							ScaleTarget: ptr.To(int32(200)),
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.BeNil(),
+		},
 		"Invalid autoscaler class": {
 			isvc: &InferenceService{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

Go evaluates the existing HPA target guard as `(metric == MetricCPU && target < 1) || target > 100`, so it incorrectly rejects memory targets above 100 with a CPU-specific validation error.

This PR scopes the `[1-100]` range to CPU targets while retaining the existing minimum of 1 MiB for memory targets.

**Which issue(s) this PR fixes**:

None. Latent operator-precedence bug, no tracked issue.

**Feature/Issue validation/testing**:

Added a table-driven validation case for a 200 MiB memory target. Existing CPU validation still covers targets above 100.

- [x] `go test ./pkg/apis/serving/v1beta1/ -run TestAutoscalerClassHPA -count=1`
- [x] `go test ./pkg/apis/serving/v1beta1/...`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/apis/serving/v1beta1/...`

**Special notes for your reviewer**:

The code change only adds parentheses to correct operator precedence, plus one regression test.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas? Not applicable, the corrected expression is self-contained.
- [ ] Have you made corresponding changes to the documentation? Not applicable, this fixes validation to match existing memory-target semantics.

**Release note**:

```release-note
Fix HPA scale-target validation so the [1-100] range applies only to CPU targets and valid memory targets above 100 MiB are accepted.
```
