### PR TITLE
ci: parallelize predictor-runtime-build with matrix strategy

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -67,18 +67,21 @@ jobs:
             echo 'install_methods=["kustomize"]' >> $GITHUB_OUTPUT
           fi
 
+  kserve-image-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - id: gen
+        run: echo "matrix=$(./test/scripts/gh-actions/build-images.sh --list-json kserve)" >> "$GITHUB_OUTPUT"
+
   kserve-image-build:
+    needs: kserve-image-matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        image:
-          - {name: controller,            image_env: CONTROLLER_IMG}
-          - {name: localmodel-controller, image_env: LOCALMODEL_CONTROLLER_IMG}
-          - {name: localmodel-agent,      image_env: LOCALMODEL_AGENT_IMG}
-          - {name: agent,                 image_env: AGENT_IMG}
-          - {name: storage-initializer,   image_env: STORAGE_INIT_IMG}
-          - {name: router,                image_env: ROUTER_IMG}
+      matrix: ${{ fromJSON(needs.kserve-image-matrix.outputs.matrix) }}
     steps:
       - name: Checkout source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -117,23 +120,21 @@ jobs:
           compression-level: 0
           if-no-files-found: error
 
+  predictor-runtime-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - id: gen
+        run: echo "matrix=$(./test/scripts/gh-actions/build-server-runtimes.sh --list-json predictor,transformer)" >> "$GITHUB_OUTPUT"
+
   predictor-runtime-build:
+    needs: predictor-runtime-matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        image:
-          - {name: sklearn,                 artifact_prefix: pred,  image_env: SKLEARN_IMG}
-          - {name: xgb,                     artifact_prefix: pred,  image_env: XGB_IMG}
-          - {name: lgb,                     artifact_prefix: pred,  image_env: LGB_IMG}
-          - {name: pmml,                    artifact_prefix: pred,  image_env: PMML_IMG}
-          - {name: paddle,                  artifact_prefix: pred,  image_env: PADDLE_IMG}
-          - {name: predictive,              artifact_prefix: pred,  image_env: PREDICTIVE_IMG}
-          - {name: autogluon,               artifact_prefix: pred,  image_env: AUTOGLUON_IMG}
-          - {name: custom-model-grpc,       artifact_prefix: pred,  image_env: CUSTOM_MODEL_GRPC_IMG}
-          - {name: huggingface,             artifact_prefix: "",    image_env: HUGGINGFACE_IMG}
-          - {name: image-transformer,       artifact_prefix: trans, image_env: IMAGE_TRANSFORMER_IMG}
-          - {name: custom-transformer-grpc, artifact_prefix: trans, image_env: CUSTOM_TRANSFORMER_GRPC_IMG}
+      matrix: ${{ fromJSON(needs.predictor-runtime-matrix.outputs.matrix) }}
     steps:
       - name: Checkout source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -151,6 +151,21 @@ jobs:
 
   predictor-runtime-build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - {name: sklearn,                 artifact_prefix: pred,  image_env: SKLEARN_IMG}
+          - {name: xgb,                     artifact_prefix: pred,  image_env: XGB_IMG}
+          - {name: lgb,                     artifact_prefix: pred,  image_env: LGB_IMG}
+          - {name: pmml,                    artifact_prefix: pred,  image_env: PMML_IMG}
+          - {name: paddle,                  artifact_prefix: pred,  image_env: PADDLE_IMG}
+          - {name: predictive,              artifact_prefix: pred,  image_env: PREDICTIVE_IMG}
+          - {name: autogluon,               artifact_prefix: pred,  image_env: AUTOGLUON_IMG}
+          - {name: custom-model-grpc,       artifact_prefix: pred,  image_env: CUSTOM_MODEL_GRPC_IMG}
+          - {name: huggingface,             artifact_prefix: "",    image_env: HUGGINGFACE_IMG}
+          - {name: image-transformer,       artifact_prefix: trans, image_env: IMAGE_TRANSFORMER_IMG}
+          - {name: custom-transformer-grpc, artifact_prefix: trans, image_env: CUSTOM_TRANSFORMER_GRPC_IMG}
     steps:
       - name: Checkout source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -175,99 +190,17 @@ jobs:
         with:
           cache-binary: true
 
-      - name: Build runtime server images
+      - name: Build ${{ matrix.image.name }} image
         run: |
           sudo mkdir -p ${DOCKER_IMAGES_PATH}
           sudo chown -R $USER ${DOCKER_IMAGES_PATH}
-          ./test/scripts/gh-actions/build-server-runtimes.sh predictor,transformer
-          docker image ls
-          sudo ls -lh ${DOCKER_IMAGES_PATH}
+          ./test/scripts/gh-actions/build-server-runtimes.sh ${{ matrix.image.name }}
 
-      - name: Upload sklearn artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ${{ env.PREDICTOR_ARTIFACT_PREFIX }}-${{ env.SKLEARN_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.SKLEARN_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload xgb server image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.PREDICTOR_ARTIFACT_PREFIX }}-${{ env.XGB_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.XGB_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload lgb server image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.PREDICTOR_ARTIFACT_PREFIX }}-${{ env.LGB_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.LGB_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload pmml server image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.PREDICTOR_ARTIFACT_PREFIX }}-${{ env.PMML_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.PMML_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload paddle image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.PREDICTOR_ARTIFACT_PREFIX }}-${{ env.PADDLE_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.PADDLE_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload predictiveserver image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.PREDICTOR_ARTIFACT_PREFIX }}-${{ env.PREDICTIVE_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.PREDICTIVE_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload autogluon image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.PREDICTOR_ARTIFACT_PREFIX }}-${{ env.AUTOGLUON_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.AUTOGLUON_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload image transformer image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.TRANSFORMER_ARTIFACT_PREFIX }}-${{ env.IMAGE_TRANSFORMER_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.IMAGE_TRANSFORMER_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload custom model grpc image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.PREDICTOR_ARTIFACT_PREFIX }}-${{ env.CUSTOM_MODEL_GRPC_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.CUSTOM_MODEL_GRPC_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload custom model transformer grpc image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.TRANSFORMER_ARTIFACT_PREFIX }}-${{ env.CUSTOM_TRANSFORMER_GRPC_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.CUSTOM_TRANSFORMER_GRPC_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload huggingface image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.HUGGINGFACE_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.HUGGINGFACE_IMG }}-${{ env.TAG }}
+          name: ${{ matrix.image.artifact_prefix && format('{0}-', matrix.image.artifact_prefix) || '' }}${{ env[matrix.image.image_env] }}-${{ env.TAG }}
+          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env[matrix.image.image_env] }}-${{ env.TAG }}
           compression-level: 0
           if-no-files-found: error
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -69,6 +69,16 @@ jobs:
 
   kserve-image-build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - {name: controller,            image_env: CONTROLLER_IMG}
+          - {name: localmodel-controller, image_env: LOCALMODEL_CONTROLLER_IMG}
+          - {name: localmodel-agent,      image_env: LOCALMODEL_AGENT_IMG}
+          - {name: agent,                 image_env: AGENT_IMG}
+          - {name: storage-initializer,   image_env: STORAGE_INIT_IMG}
+          - {name: router,                image_env: ROUTER_IMG}
     steps:
       - name: Checkout source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -93,59 +103,17 @@ jobs:
         with:
           cache-binary: true
 
-      - name: Build KServe images
+      - name: Build ${{ matrix.image.name }} image
         run: |
           sudo mkdir -p ${DOCKER_IMAGES_PATH}
           sudo chown -R $USER ${DOCKER_IMAGES_PATH}
-          ./test/scripts/gh-actions/build-images.sh
-          docker image ls
-          sudo ls -lh ${DOCKER_IMAGES_PATH}
+          ./test/scripts/gh-actions/build-images.sh ${{ matrix.image.name }}
 
-      - name: Upload controller image
+      - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.CONTROLLER_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.CONTROLLER_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload localmodel controller image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.LOCALMODEL_CONTROLLER_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.LOCALMODEL_CONTROLLER_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload localmodel agent image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.LOCALMODEL_AGENT_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.LOCALMODEL_AGENT_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload agent image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.AGENT_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.AGENT_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload storage initializer image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.STORAGE_INIT_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.STORAGE_INIT_IMG }}-${{ env.TAG }}
-          compression-level: 0
-          if-no-files-found: error
-
-      - name: Upload router image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.ROUTER_IMG }}-${{ env.TAG }}
-          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.ROUTER_IMG }}-${{ env.TAG }}
+          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env[matrix.image.image_env] }}-${{ env.TAG }}
+          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env[matrix.image.image_env] }}-${{ env.TAG }}
           compression-level: 0
           if-no-files-found: error
 

--- a/test/scripts/gh-actions/build-images.sh
+++ b/test/scripts/gh-actions/build-images.sh
@@ -33,10 +33,6 @@ source "${PROJECT_ROOT}/kserve-images.sh"
 
 KO_DOCKER_REPO="${KO_DOCKER_REPO:-kserve}"
 
-mkdir -p "${DOCKER_IMAGES_PATH}"
-
-echo "Github SHA ${TAG}"
-
 # Image registry: name -> "dockerfile|context_dir|env_var"
 # context_dir is relative to PROJECT_ROOT ("." for repo root, "python" for python/)
 declare -A IMAGE_REGISTRY=(
@@ -75,6 +71,29 @@ build_one() {
   echo "Disk usage after building ${name}:"
   df -hT
 }
+
+if [[ "${1:-}" == "--list-json" ]]; then
+  group="${2:-kserve}"
+  case "$group" in
+    kserve)   names=("${KSERVE_IMAGES[@]}") ;;
+    llmisvc)  names=("${LLMISVC_IMAGES[@]}") ;;
+    *)        echo "Unknown group: $group" >&2; exit 1 ;;
+  esac
+  json='{"image":['
+  first=true
+  for name in "${names[@]}"; do
+    IFS='|' read -r _ _ envvar <<< "${IMAGE_REGISTRY[$name]}"
+    $first || json+=','
+    json+="{\"name\":\"${name}\",\"image_env\":\"${envvar}\"}"
+    first=false
+  done
+  json+=']}'
+  echo "$json"
+  exit 0
+fi
+
+mkdir -p "${DOCKER_IMAGES_PATH}"
+echo "Github SHA ${TAG}"
 
 target="${1:-kserve}"
 

--- a/test/scripts/gh-actions/build-images.sh
+++ b/test/scripts/gh-actions/build-images.sh
@@ -14,9 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The script is used to build all the KServe images.
-
-# TODO: Implement selective building and tag replacement based on modified code.
+# Build KServe core images.
+#
+# Usage:
+#   build-images.sh              # build all kserve images (default)
+#   build-images.sh kserve       # build all kserve images (explicit)
+#   build-images.sh llmisvc      # build llmisvc controller only
+#   build-images.sh controller   # build a single image by name
 
 set -o errexit
 set -o nounset
@@ -27,58 +31,63 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 source "${PROJECT_ROOT}/kserve-images.sh"
 
-if [ -d "${DOCKER_IMAGES_PATH}" ]; then
-  mkdir -p "${DOCKER_IMAGES_PATH}"  
-fi
+KO_DOCKER_REPO="${KO_DOCKER_REPO:-kserve}"
+
+mkdir -p "${DOCKER_IMAGES_PATH}"
 
 echo "Github SHA ${TAG}"
-CONTROLLER_IMG_TAG=${KO_DOCKER_REPO}/${CONTROLLER_IMG}:${TAG}
-LOCALMODEL_CONTROLLER_IMG_TAG=${KO_DOCKER_REPO}/${LOCALMODEL_CONTROLLER_IMG}:${TAG}
-LOCALMODEL_AGENT_IMG_TAG=${KO_DOCKER_REPO}/${LOCALMODEL_AGENT_IMG}:${TAG}
-STORAGE_INIT_IMG_TAG=${KO_DOCKER_REPO}/${STORAGE_INIT_IMG}:${TAG}
-AGENT_IMG_TAG=${KO_DOCKER_REPO}/${AGENT_IMG}:${TAG}
-ROUTER_IMG_TAG=${KO_DOCKER_REPO}/${ROUTER_IMG}:${TAG}
-LLMISVC_CONTROLLER_IMG_TAG=${KO_DOCKER_REPO}/${LLMISVC_CONTROLLER_IMG}:${TAG}
 
-types=("${1:-kserve}")
+# Image registry: name -> "dockerfile|context_dir|env_var"
+# context_dir is relative to PROJECT_ROOT ("." for repo root, "python" for python/)
+declare -A IMAGE_REGISTRY=(
+  [controller]="Dockerfile|.|CONTROLLER_IMG"
+  [localmodel-controller]="localmodel.Dockerfile|.|LOCALMODEL_CONTROLLER_IMG"
+  [localmodel-agent]="localmodel-agent.Dockerfile|.|LOCALMODEL_AGENT_IMG"
+  [agent]="agent.Dockerfile|.|AGENT_IMG"
+  [router]="router.Dockerfile|.|ROUTER_IMG"
+  [storage-initializer]="storage-initializer.Dockerfile|python|STORAGE_INIT_IMG"
+  [llmisvc-controller]="llmisvc-controller.Dockerfile|.|LLMISVC_CONTROLLER_IMG"
+)
 
+# Group definitions
+KSERVE_IMAGES=(controller localmodel-controller localmodel-agent agent router storage-initializer)
+LLMISVC_IMAGES=(llmisvc-controller)
 
-if [[ " ${types[*]} " =~ "llmisvc" ]]; then
-  echo "Building LLMISvc controller image: ${LLMISVC_CONTROLLER_IMG_TAG}"
-  docker buildx build -f llmisvc-controller.Dockerfile . -t "${LLMISVC_CONTROLLER_IMG_TAG}" \
-    -o type=docker,dest="${DOCKER_IMAGES_PATH}/${LLMISVC_CONTROLLER_IMG}-${TAG}",compression-level=0
-  echo "Disk usage after Building LLMIsvc controller image:"
-      df -hT
-else
-  echo "Building Kserve controller image"
-  docker buildx build . -t "${CONTROLLER_IMG_TAG}" \
-    -o type=docker,dest="${DOCKER_IMAGES_PATH}/${CONTROLLER_IMG}-${TAG}",compression-level=0
+build_one() {
+  local name="$1"
+  local entry="${IMAGE_REGISTRY[$name]:-}"
 
-  echo "Building localmodel controller image"
-  docker buildx build -f localmodel.Dockerfile . -t "${LOCALMODEL_CONTROLLER_IMG_TAG}" \
-    -o type=docker,dest="${DOCKER_IMAGES_PATH}/${LOCALMODEL_CONTROLLER_IMG}-${TAG}",compression-level=0
+  if [[ -z "$entry" ]]; then
+    echo "ERROR: Unknown image name: $name"
+    echo "Available images: ${!IMAGE_REGISTRY[*]}"
+    exit 1
+  fi
 
-  echo "Building localmodel agent image"
-  docker buildx build -f localmodel-agent.Dockerfile . -t "${LOCALMODEL_AGENT_IMG_TAG}" \
-    -o type=docker,dest="${DOCKER_IMAGES_PATH}/${LOCALMODEL_AGENT_IMG}-${TAG}",compression-level=0
+  IFS='|' read -r dockerfile context_dir envvar <<< "$entry"
+  local img_basename="${!envvar}"
+  local img_tag="${KO_DOCKER_REPO}/${img_basename}:${TAG}"
+  local output="${DOCKER_IMAGES_PATH}/${img_basename}-${TAG}"
+  local build_dir="${PROJECT_ROOT}/${context_dir}"
 
-  echo "Building agent image"
-  docker buildx build -f agent.Dockerfile . -t "${AGENT_IMG_TAG}" \
-    -o type=docker,dest="${DOCKER_IMAGES_PATH}/${AGENT_IMG}-${TAG}",compression-level=0
+  echo "Building ${name} image (${dockerfile} in ${context_dir}/ -> ${img_basename})"
+  docker buildx build -f "${dockerfile}" "${build_dir}" -t "${img_tag}" \
+    -o "type=docker,dest=${output},compression-level=0"
+  echo "Disk usage after building ${name}:"
+  df -hT
+}
 
-  echo "Building router image"
-  docker buildx build -f router.Dockerfile . -t "${ROUTER_IMG_TAG}" \
-    -o type=docker,dest="${DOCKER_IMAGES_PATH}/${ROUTER_IMG}-${TAG}",compression-level=0
+target="${1:-kserve}"
 
-  echo "Disk usage before Building storage initializer:"
-          df -hT
-fi
-
-
-pushd python >/dev/null
-  echo "Building storage initializer"
-  docker buildx build -f storage-initializer.Dockerfile . -t "${STORAGE_INIT_IMG_TAG}" \
-    -o type=docker,dest="${DOCKER_IMAGES_PATH}/${STORAGE_INIT_IMG}-${TAG}",compression-level=0
-popd
+case "$target" in
+  kserve)
+    for img in "${KSERVE_IMAGES[@]}"; do build_one "$img"; done
+    ;;
+  llmisvc)
+    for img in "${LLMISVC_IMAGES[@]}"; do build_one "$img"; done
+    ;;
+  *)
+    build_one "$target"
+    ;;
+esac
 
 echo "Done building images"

--- a/test/scripts/gh-actions/build-images.sh
+++ b/test/scripts/gh-actions/build-images.sh
@@ -70,7 +70,7 @@ build_one() {
   local build_dir="${PROJECT_ROOT}/${context_dir}"
 
   echo "Building ${name} image (${dockerfile} in ${context_dir}/ -> ${img_basename})"
-  docker buildx build -f "${dockerfile}" "${build_dir}" -t "${img_tag}" \
+  docker buildx build -f "${build_dir}/${dockerfile}" "${build_dir}" -t "${img_tag}" \
     -o "type=docker,dest=${output},compression-level=0"
   echo "Disk usage after building ${name}:"
   df -hT

--- a/test/scripts/gh-actions/build-server-runtimes.sh
+++ b/test/scripts/gh-actions/build-server-runtimes.sh
@@ -14,112 +14,110 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The script is used to build all the KServe images.
-
-# TODO: Implement selective building and tag replacement based on modified code.
+# Build KServe runtime server images.
+#
+# Usage:
+#   build-server-runtimes.sh predictor,transformer   # build all predictor + transformer images (legacy)
+#   build-server-runtimes.sh sklearn                  # build a single image by name
+#   build-server-runtimes.sh                          # defaults to "predictor"
 
 set -o errexit
 set -o nounset
 set -o pipefail
-IFS=,
 
 # Load image configurations
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 source "${PROJECT_ROOT}/kserve-images.sh"
 
-# Default image basename if kserve-images.sh predates AUTOGLUON_IMG (matches kserve-images.env).
 AUTOGLUON_IMG="${AUTOGLUON_IMG:-autogluonserver}"
+KO_DOCKER_REPO="${KO_DOCKER_REPO:-kserve}"
 
-if [ -d "${DOCKER_IMAGES_PATH}" ]; then
-  mkdir -p "${DOCKER_IMAGES_PATH}"  
-fi
+mkdir -p "${DOCKER_IMAGES_PATH}"
 
 echo "Github SHA ${TAG}"
 
-# Predictor runtime server images
-SKLEARN_IMG_TAG=${KO_DOCKER_REPO}/${SKLEARN_IMG}:${TAG}
-XGB_IMG_TAG=${KO_DOCKER_REPO}/${XGB_IMG}:${TAG}
-LGB_IMG_TAG=${KO_DOCKER_REPO}/${LGB_IMG}:${TAG}
-PMML_IMG_TAG=${KO_DOCKER_REPO}/${PMML_IMG}:${TAG}
-PADDLE_IMG_TAG=${KO_DOCKER_REPO}/${PADDLE_IMG}:${TAG}
-AUTOGLUON_IMG_TAG=${KO_DOCKER_REPO}/${AUTOGLUON_IMG}:${TAG}
-CUSTOM_MODEL_GRPC_IMG_TAG=${KO_DOCKER_REPO}/${CUSTOM_MODEL_GRPC_IMG}:${TAG}
-CUSTOM_TRANSFORMER_GRPC_IMG_TAG=${KO_DOCKER_REPO}/${CUSTOM_TRANSFORMER_GRPC_IMG}:${TAG}
-HUGGINGFACE_CPU_IMG_TAG=${KO_DOCKER_REPO}/${HUGGINGFACE_IMG}:${TAG}
-PREDICTIVE_IMG_TAG=${KO_DOCKER_REPO}/${PREDICTIVE_IMG}:${TAG}
-# Explainer images
-ART_IMG_TAG=${KO_DOCKER_REPO}/${ART_IMG}:${TAG}
-# Transformer images
-IMAGE_TRANSFORMER_IMG_TAG=${KO_DOCKER_REPO}/${IMAGE_TRANSFORMER_IMG}:${TAG}
-types=("${1:-predictor}")
+# Image registry: name -> dockerfile (relative to python/)
+declare -A IMAGE_DOCKERFILE=(
+  [sklearn]="sklearn.Dockerfile"
+  [xgb]="xgb.Dockerfile"
+  [lgb]="lgb.Dockerfile"
+  [pmml]="pmml.Dockerfile"
+  [paddle]="paddle.Dockerfile"
+  [autogluon]="autogluon.Dockerfile"
+  [custom-model-grpc]="custom_model_grpc.Dockerfile"
+  [custom-transformer-grpc]="custom_transformer_grpc.Dockerfile"
+  [huggingface]="huggingface_server_cpu.Dockerfile"
+  [predictive]="predictiveserver.Dockerfile"
+  [art]="artexplainer.Dockerfile"
+  [image-transformer]="custom_transformer.Dockerfile"
+)
+
+# Image registry: name -> env var holding the image basename
+declare -A IMAGE_ENVVAR=(
+  [sklearn]="SKLEARN_IMG"
+  [xgb]="XGB_IMG"
+  [lgb]="LGB_IMG"
+  [pmml]="PMML_IMG"
+  [paddle]="PADDLE_IMG"
+  [autogluon]="AUTOGLUON_IMG"
+  [custom-model-grpc]="CUSTOM_MODEL_GRPC_IMG"
+  [custom-transformer-grpc]="CUSTOM_TRANSFORMER_GRPC_IMG"
+  [huggingface]="HUGGINGFACE_IMG"
+  [predictive]="PREDICTIVE_IMG"
+  [art]="ART_IMG"
+  [image-transformer]="IMAGE_TRANSFORMER_IMG"
+)
+
+# Group definitions for backward compatibility
+PREDICTOR_IMAGES=(sklearn xgb lgb pmml paddle autogluon custom-model-grpc custom-transformer-grpc huggingface predictive)
+EXPLAINER_IMAGES=(art)
+TRANSFORMER_IMAGES=(image-transformer)
+
+build_one() {
+  local name="$1"
+  local dockerfile="${IMAGE_DOCKERFILE[$name]:-}"
+  local envvar="${IMAGE_ENVVAR[$name]:-}"
+
+  if [[ -z "$dockerfile" || -z "$envvar" ]]; then
+    echo "ERROR: Unknown image name: $name"
+    echo "Available images: ${!IMAGE_DOCKERFILE[*]}"
+    exit 1
+  fi
+
+  local img_basename="${!envvar}"
+  local img_tag="${KO_DOCKER_REPO}/${img_basename}:${TAG}"
+  local output="${DOCKER_IMAGES_PATH}/${img_basename}-${TAG}"
+
+  echo "Building ${name} image (${dockerfile} -> ${img_basename})"
+  docker buildx build -t "${img_tag}" -f "${dockerfile}" \
+    -o "type=docker,dest=${output},compression-level=0" .
+  echo "Disk usage after building ${name}:"
+  df -hT
+}
+
+# Parse arguments
+IFS=, read -ra targets <<< "${1:-predictor}"
 
 pushd python >/dev/null
-  if [[ " ${types[*]} " =~ "predictor" ]]; then
-    echo "Building Sklearn image"
-    docker buildx build -t "${SKLEARN_IMG_TAG}" -f sklearn.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${SKLEARN_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building Sklearn image:"
-        df -hT
-    echo "Building XGB image"
-    docker buildx build -t "${XGB_IMG_TAG}" -f xgb.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${XGB_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building XGB image:"
-        df -hT
-    echo "Building LGB image"
-    docker buildx build -t "${LGB_IMG_TAG}" -f lgb.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${LGB_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building LGB image:"
-        df -hT
-    echo "Building PMML image"
-    docker buildx build -t "${PMML_IMG_TAG}" -f pmml.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${PMML_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building PMML image:"
-        df -hT
-    echo "Building Paddle image"
-    docker buildx build -t "${PADDLE_IMG_TAG}" -f paddle.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${PADDLE_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building Paddle image:"
-        df -hT
-    echo "Building Custom model gRPC image"
-    docker buildx build -t "${CUSTOM_MODEL_GRPC_IMG_TAG}" -f custom_model_grpc.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${CUSTOM_MODEL_GRPC_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building Custom model gRPC image:"
-        df -hT
-    echo "Building image transformer gRPC image"
-    docker buildx build -t "${CUSTOM_TRANSFORMER_GRPC_IMG_TAG}" -f custom_transformer_grpc.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${CUSTOM_TRANSFORMER_GRPC_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building image transformer gRPC image:"
-        df -hT
-    echo "Building Huggingface CPU image"
-    docker buildx build -t "${HUGGINGFACE_CPU_IMG_TAG}" -f huggingface_server_cpu.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${HUGGINGFACE_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building Huggingface CPU image:"
-        df -hT
-    echo "Building Predictive server image"
-    docker buildx build -t "${PREDICTIVE_IMG_TAG}" -f predictiveserver.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${PREDICTIVE_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building Predictive server image:"
-        df -hT
-    echo "Building AutoGluon server image"
-    docker buildx build -t "${AUTOGLUON_IMG_TAG}" -f autogluon.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${AUTOGLUON_IMG}-${TAG}",compression-level=0 .
-    echo "Disk usage after Building AutoGluon server image:"
-        df -hT
-  fi
 
-  if [[ " ${types[*]} " =~ "explainer" ]]; then
-    echo "Building ART explainer image"
-    docker buildx build -t "${ART_IMG_TAG}" -f artexplainer.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${ART_IMG}-${TAG}",compression-level=0 .
-  fi
+for target in "${targets[@]}"; do
+  case "$target" in
+    predictor)
+      for img in "${PREDICTOR_IMAGES[@]}"; do build_one "$img"; done
+      ;;
+    explainer)
+      for img in "${EXPLAINER_IMAGES[@]}"; do build_one "$img"; done
+      ;;
+    transformer)
+      for img in "${TRANSFORMER_IMAGES[@]}"; do build_one "$img"; done
+      ;;
+    *)
+      build_one "$target"
+      ;;
+  esac
+done
 
-  if [[ " ${types[*]} " =~ "transformer" ]]; then
-    echo "Building Image transformer image"
-    docker buildx build -t "${IMAGE_TRANSFORMER_IMG_TAG}" -f custom_transformer.Dockerfile \
-      -o type=docker,dest="${DOCKER_IMAGES_PATH}/${IMAGE_TRANSFORMER_IMG}-${TAG}",compression-level=0 .
-  fi
-
-popd
+popd >/dev/null
 
 echo "Done building images"

--- a/test/scripts/gh-actions/build-server-runtimes.sh
+++ b/test/scripts/gh-actions/build-server-runtimes.sh
@@ -33,10 +33,6 @@ source "${PROJECT_ROOT}/kserve-images.sh"
 AUTOGLUON_IMG="${AUTOGLUON_IMG:-autogluonserver}"
 KO_DOCKER_REPO="${KO_DOCKER_REPO:-kserve}"
 
-mkdir -p "${DOCKER_IMAGES_PATH}"
-
-echo "Github SHA ${TAG}"
-
 # Image registry: name -> dockerfile (relative to python/)
 declare -A IMAGE_DOCKERFILE=(
   [sklearn]="sklearn.Dockerfile"
@@ -69,10 +65,44 @@ declare -A IMAGE_ENVVAR=(
   [image-transformer]="IMAGE_TRANSFORMER_IMG"
 )
 
+# Artifact prefix per image (matches workflow upload naming convention)
+declare -A IMAGE_PREFIX=(
+  [sklearn]="pred" [xgb]="pred" [lgb]="pred" [pmml]="pred"
+  [paddle]="pred" [autogluon]="pred" [custom-model-grpc]="pred"
+  [predictive]="pred" [huggingface]=""
+  [custom-transformer-grpc]="trans" [image-transformer]="trans"
+  [art]="exp"
+)
+
 # Group definitions for backward compatibility
 PREDICTOR_IMAGES=(sklearn xgb lgb pmml paddle autogluon custom-model-grpc custom-transformer-grpc huggingface predictive)
 EXPLAINER_IMAGES=(art)
 TRANSFORMER_IMAGES=(image-transformer)
+
+if [[ "${1:-}" == "--list-json" ]]; then
+  IFS=, read -ra groups <<< "${2:-predictor}"
+  names=()
+  for group in "${groups[@]}"; do
+    case "$group" in
+      predictor)    names+=("${PREDICTOR_IMAGES[@]}") ;;
+      explainer)    names+=("${EXPLAINER_IMAGES[@]}") ;;
+      transformer)  names+=("${TRANSFORMER_IMAGES[@]}") ;;
+      *)            echo "Unknown group: $group" >&2; exit 1 ;;
+    esac
+  done
+  json='{"image":['
+  first=true
+  for name in "${names[@]}"; do
+    prefix="${IMAGE_PREFIX[$name]:-}"
+    envvar="${IMAGE_ENVVAR[$name]}"
+    $first || json+=','
+    json+="{\"name\":\"${name}\",\"artifact_prefix\":\"${prefix}\",\"image_env\":\"${envvar}\"}"
+    first=false
+  done
+  json+=']}'
+  echo "$json"
+  exit 0
+fi
 
 build_one() {
   local name="$1"
@@ -95,6 +125,9 @@ build_one() {
   echo "Disk usage after building ${name}:"
   df -hT
 }
+
+mkdir -p "${DOCKER_IMAGES_PATH}"
+echo "Github SHA ${TAG}"
 
 # Parse arguments
 IFS=, read -ra targets <<< "${1:-predictor}"


### PR DESCRIPTION
## Summary
Parallelize the `kserve-image-build` (6 images) and `predictor-runtime-build` (11 images) jobs by building each image on its own runner via matrix strategies.

## Problem
Both jobs sequentially build all their Docker images on a single `ubuntu-latest` runner:
- **Slow**: `predictor-runtime-build` takes 30-55 minutes, `kserve-image-build` takes 15-25 minutes
- **Disk pressure**: ~14GB free on the runner; 11+ uncompressed images frequently exceed this
- **Fragile**: a transient `apt-get` mirror failure on one image wastes the time spent building all prior images

## Fix

### `build-server-runtimes.sh` and `build-images.sh`
Add an image registry (associative array) mapping short names to dockerfiles. Both scripts now accept:
- Group names (`predictor`, `transformer`, `explainer`, `kserve`, `llmisvc`) — builds all images in that group (backward compatible)
- A specific image name like `sklearn` or `controller` — builds just that one

### `e2e-test.yml`
Replace both monolithic jobs with matrix strategies. Each matrix entry builds one image on its own runner and uploads one artifact. `fail-fast: false` ensures other images keep building if one fails.

Artifact names are preserved identically so **no downstream test jobs need changes** — they already use `pattern: base-*` / `pred-*` with `merge-multiple: true`.

## Expected improvement
| | Before | After |
|---|---|---|
| Wall clock (predictor-runtime-build) | ~45 min | ~5 min (longest single image) |
| Wall clock (kserve-image-build) | ~20 min | ~5 min (longest single image) |
| Disk per runner | ~15GB (all images) | ~1-2GB (1 image) |
| Blast radius | 1 failure kills all images | 1 failure affects 1 image |

## Test plan
- [ ] All 17 matrix jobs (6 + 11) complete successfully
- [ ] Downstream test jobs (`test-predictor`, `test-raw`, etc.) download and load all images
- [ ] `./build-server-runtimes.sh predictor,transformer` still works (backward compat)
- [ ] `./build-images.sh kserve` still works (backward compat)

🤖 Generated with [Claude Code](https://claude.ai/code)