### PR TITLE
feat(llmisvc): add group routing machinery for traffic splitting

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -202,9 +203,17 @@ func (r *LLMISVCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		// Resource is being deleted, perform cleanup
 		logger.Info("Marked for deletion, finalizing resources")
 		if controllerutil.ContainsFinalizer(original, finalizerName) {
-			if cleanupErr := r.finalize(ctx, original); cleanupErr != nil {
+			done, cleanupErr := r.finalize(ctx, original)
+			if cleanupErr != nil {
 				logger.Error(cleanupErr, "Finalization failed")
 				return ctrl.Result{}, cleanupErr
+			}
+			if !done {
+				logger.Info("Finalization incomplete, requeueing")
+				if statusErr := r.updateStatus(ctx, original); statusErr != nil {
+					logger.Error(statusErr, "Failed to persist finalization status")
+				}
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 			}
 
 			// Cleanup successful, remove finalizer to allow deletion
@@ -288,13 +297,23 @@ func (r *LLMISVCReconciler) reconcile(ctx context.Context, llmSvc *v1alpha2.LLMI
 	return nil
 }
 
-// finalize performs cleanup operations when the LLMInferenceService is being deleted
-func (r *LLMISVCReconciler) finalize(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
-	if err := r.reconcileSchedulerServiceAccount(ctx, llmSvc); err != nil {
-		return fmt.Errorf("failed to finalize scheduler service account: %w", err)
+// finalize performs cleanup operations when the LLMInferenceService is being deleted.
+// Returns (done, err): done=false signals that cleanup is still in progress and the
+// caller should requeue.
+func (r *LLMISVCReconciler) finalize(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) (bool, error) {
+	done, err := r.finalizeGroupMembership(ctx, llmSvc)
+	if err != nil {
+		return false, err
+	}
+	if !done {
+		return false, nil
 	}
 
-	return nil
+	if err := r.reconcileSchedulerServiceAccount(ctx, llmSvc); err != nil {
+		return false, fmt.Errorf("failed to finalize scheduler service account: %w", err)
+	}
+
+	return true, nil
 }
 
 // updateStatus updates the status of the LLMInferenceService with retry on conflict.
@@ -376,6 +395,10 @@ func GetFailConditions(svc *v1alpha2.LLMInferenceService) string {
 func (r *LLMISVCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	logger := mgr.GetLogger().WithName("LLMInferenceService.SetupWithManager")
 
+	if err := setupGroupFieldIndex(context.Background(), mgr.GetFieldIndexer()); err != nil {
+		return fmt.Errorf("failed to set up field indexer for routing group: %w", err)
+	}
+
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha2.LLMInferenceService{}).
 		Watches(&v1alpha2.LLMInferenceServiceConfig{}, r.enqueueOnLLMInferenceServiceConfigChange(logger)).
@@ -389,6 +412,12 @@ func (r *LLMISVCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.EnqueueOnLLMInferenceServicePods),
 			builder.WithPredicates(PodStatusPredicate()))
+
+	b = b.Watches(
+		&v1alpha2.LLMInferenceService{},
+		&groupMemberEventHandler{reconciler: r},
+		builder.WithPredicates(groupMemberChangePredicate()),
+	)
 
 	if err := r.extendControllerSetup(mgr, b); err != nil {
 		return fmt.Errorf("failed to extend controller setup: %w", err)

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_router_group_test.go
@@ -1,0 +1,949 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+var _ = Describe("LLMInferenceService Group Routing", func() {
+	Context("Group formation", func() {
+		It("should form a group with weighted backendRefs when two members share the same group", func(ctx SpecContext) {
+			// given
+			groupName := "my-group"
+			svcNameA := "test-group-a"
+			svcNameB := "test-group-b"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(80),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(20),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+
+			// then - both members should have the routing-group label
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentA := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), currentA)).To(Succeed())
+				g.Expect(currentA.Labels).To(HaveKeyWithValue(constants.LLMRoutingGroupLabelKey, groupName))
+
+				currentB := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcB), currentB)).To(Succeed())
+				g.Expect(currentB.Labels).To(HaveKeyWithValue(constants.LLMRoutingGroupLabelKey, groupName))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - HTTPRoute for member A should have weighted backendRefs for both members
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcA)
+				g.Expect(backendRefs).To(HaveLen(2), "should have backendRefs for both group members")
+
+				g.Expect(backendRefs).To(ContainElement(
+					SatisfyAll(
+						HaveBackendName(svcNameA),
+						HaveBackendWeight(int32(80)),
+					),
+				))
+				g.Expect(backendRefs).To(ContainElement(
+					SatisfyAll(
+						HaveBackendName(svcNameB),
+						HaveBackendWeight(int32(20)),
+					),
+				))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - group status should be populated on both members
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentA := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), currentA)).To(Succeed())
+
+				g.Expect(currentA.Status.Router).ToNot(BeNil())
+				g.Expect(currentA.Status.Router.Group).ToNot(BeNil())
+				g.Expect(currentA.Status.Router.Group.Name).To(Equal(groupName))
+				g.Expect(currentA.Status.Router.Group.Members).To(HaveLen(2))
+
+				cond := currentA.Status.GetCondition(v1alpha2.GroupReady)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.IsTrue()).To(BeTrue())
+			}).WithContext(ctx).Should(Succeed())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentB := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcB), currentB)).To(Succeed())
+
+				g.Expect(currentB.Status.Router).ToNot(BeNil())
+				g.Expect(currentB.Status.Router.Group).ToNot(BeNil())
+				g.Expect(currentB.Status.Router.Group.Name).To(Equal(groupName))
+				g.Expect(currentB.Status.Router.Group.Members).To(HaveLen(2))
+
+				cond := currentB.Status.GetCondition(v1alpha2.GroupReady)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.IsTrue()).To(BeTrue())
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Weight change", func() {
+		It("should update HTTPRoute backendRefs when a member's weight changes", func(ctx SpecContext) {
+			// given
+			groupName := "weight-group"
+			svcNameA := "test-weight-a"
+			svcNameB := "test-weight-b"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(50),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(50),
+			)
+
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+
+			// Verify initial equal weights
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcA)
+				g.Expect(backendRefs).To(HaveLen(2))
+				g.Expect(backendRefs).To(ContainElement(HaveBackendWeight(int32(50))))
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - change weight on member A
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvcA, func() error {
+					llmSvcA.Spec.Router.Route.Weight = ptr.To[int32](90)
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - backendRefs should reflect the updated weights
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcA)
+				g.Expect(backendRefs).To(HaveLen(2))
+				g.Expect(backendRefs).To(ContainElement(
+					SatisfyAll(
+						HaveBackendName(svcNameA),
+						HaveBackendWeight(int32(90)),
+					),
+				))
+				g.Expect(backendRefs).To(ContainElement(
+					SatisfyAll(
+						HaveBackendName(svcNameB),
+						HaveBackendWeight(int32(50)),
+					),
+				))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Model name divergence", func() {
+		It("should form independent sub-groups and mark GroupDegraded when members have different model names", func(ctx SpecContext) {
+			// given
+			groupName := "diverge-group"
+			svcNameA := "test-div-a"
+			svcNameB := "test-div-b"
+			svcNameC := "test-div-c"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			// A and B share model name
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(50),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(30),
+			)
+
+			// C has a different model name - forms its own sub-group
+			llmSvcC := LLMInferenceService(svcNameC,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/llama-2-7b"),
+				WithModelName("meta-llama/llama-2-7b"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(20),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcC)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+				testNs.DeleteAndWait(ctx, llmSvcC)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcC)
+
+			// then - all members should be GroupReady=True (each sub-group works)
+			for _, svc := range []*v1alpha2.LLMInferenceService{llmSvcA, llmSvcB, llmSvcC} {
+				Eventually(func(g Gomega, ctx context.Context) {
+					current := &v1alpha2.LLMInferenceService{}
+					g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(svc), current)).To(Succeed())
+
+					cond := current.Status.GetCondition(v1alpha2.GroupReady)
+					g.Expect(cond).ToNot(BeNil())
+					g.Expect(cond.IsTrue()).To(BeTrue())
+
+					degraded := current.Status.GetCondition(v1alpha2.GroupDegraded)
+					g.Expect(degraded).ToNot(BeNil())
+					g.Expect(degraded.IsTrue()).To(BeTrue())
+					g.Expect(degraded.Reason).To(Equal("MemberDivergence"))
+				}).WithContext(ctx).Should(Succeed())
+			}
+
+			// then - backendRefs on member A should contain only A and B (same model name)
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcA)
+				g.Expect(backendRefs).To(HaveLen(2), "A's sub-group should have A and B")
+
+				backendNames := backendRefNames(backendRefs)
+				g.Expect(backendNames).To(ContainElements(
+					ContainSubstring(svcNameA),
+					ContainSubstring(svcNameB),
+				))
+				g.Expect(backendNames).ToNot(ContainElement(ContainSubstring(svcNameC)))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - backendRefs on member C should contain only C
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcC)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcC)
+				g.Expect(backendRefs).To(HaveLen(1), "C's sub-group should have only C")
+				g.Expect(backendRefs[0]).To(HaveBackendName(svcNameC))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Even split divergence (no majority needed)", func() {
+		It("should form independent sub-groups with GroupReady=True and GroupDegraded without blocking Ready", func(ctx SpecContext) {
+			// given - two members with different model names (1-1 split)
+			groupName := "even-split-group"
+			svcNameA := "test-even-a"
+			svcNameB := "test-even-b"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("model-alpha"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(50),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("model-beta"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(50),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+
+			// then - both members should be GroupReady=True (each forms its own sub-group)
+			// and GroupDegraded=True/MemberDivergence
+			for _, svc := range []*v1alpha2.LLMInferenceService{llmSvcA, llmSvcB} {
+				Eventually(func(g Gomega, ctx context.Context) {
+					current := &v1alpha2.LLMInferenceService{}
+					g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(svc), current)).To(Succeed())
+
+					cond := current.Status.GetCondition(v1alpha2.GroupReady)
+					g.Expect(cond).ToNot(BeNil())
+					g.Expect(cond.IsTrue()).To(BeTrue(), "each sub-group should be ready")
+
+					degraded := current.Status.GetCondition(v1alpha2.GroupDegraded)
+					g.Expect(degraded).ToNot(BeNil())
+					g.Expect(degraded.IsTrue()).To(BeTrue())
+					g.Expect(degraded.Reason).To(Equal("MemberDivergence"))
+
+					routerCond := current.Status.GetCondition(v1alpha2.RouterReady)
+					g.Expect(routerCond).ToNot(BeNil())
+					g.Expect(routerCond.IsTrue()).To(BeTrue(), "RouterReady should stay True - group divergence does not block readiness")
+				}).WithContext(ctx).Should(Succeed())
+			}
+
+			// then - each member's route should have only its own backendRef
+			for _, svc := range []*v1alpha2.LLMInferenceService{llmSvcA, llmSvcB} {
+				Eventually(func(g Gomega, ctx context.Context) {
+					routes, err := managedRoutes(ctx, svc)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(routes).To(HaveLen(1))
+
+					backendRefs := groupRoutingBackendRefs(&routes[0], svc)
+					g.Expect(backendRefs).To(HaveLen(1), "each sub-group should have only its own backendRef")
+					g.Expect(backendRefs[0]).To(HaveBackendName(svc.Name))
+				}).WithContext(ctx).Should(Succeed())
+			}
+		})
+	})
+
+	Context("Member deletion", func() {
+		It("should update remaining member's HTTPRoute when a group member is deleted", func(ctx SpecContext) {
+			// given
+			groupName := "del-group"
+			svcNameA := "test-del-a"
+			svcNameB := "test-del-b"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(60),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(40),
+			)
+
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+
+			// Wait for group to be formed with both members
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(groupRoutingBackendRefs(&routes[0], llmSvcA)).To(HaveLen(2))
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - delete member B
+			testNs.DeleteAndWait(ctx, llmSvcB)
+
+			// then - remaining member A should have only its own backendRef
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcA)
+				g.Expect(backendRefs).To(HaveLen(1), "should have only one backendRef after member deletion")
+				g.Expect(backendRefs[0]).To(HaveBackendName(svcNameA))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - group status should show only one member
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentA := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), currentA)).To(Succeed())
+				g.Expect(currentA.Status.Router).ToNot(BeNil())
+				g.Expect(currentA.Status.Router.Group).ToNot(BeNil())
+				g.Expect(currentA.Status.Router.Group.Members).To(HaveLen(1))
+				g.Expect(currentA.Status.Router.Group.Members[0].Name).To(Equal(svcNameA))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Leave group", func() {
+		It("should remove routing-group label and update peer when a member leaves the group", func(ctx SpecContext) {
+			// given
+			groupName := "leave-group"
+			svcNameA := "test-leave-a"
+			svcNameB := "test-leave-b"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(70),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(30),
+			)
+
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+
+			// Wait for group to be formed
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(groupRoutingBackendRefs(&routes[0], llmSvcA)).To(HaveLen(2))
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - remove group/weight from member B (leaving the group)
+			// Also remove the routing-group label since the defaulting webhook
+			// is not installed in envtest (in a real cluster the webhook does this).
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvcB, func() error {
+					llmSvcB.Spec.Router.Route.Group = nil
+					llmSvcB.Spec.Router.Route.Weight = nil
+					delete(llmSvcB.Labels, constants.LLMRoutingGroupLabelKey)
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - remaining member A should have only its own backendRef
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcA)
+				g.Expect(backendRefs).To(HaveLen(1))
+				g.Expect(backendRefs[0]).To(HaveBackendName(svcNameA))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - remaining member A's group status should show only itself
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentA := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), currentA)).To(Succeed())
+				g.Expect(currentA.Status.Router).ToNot(BeNil())
+				g.Expect(currentA.Status.Router.Group).ToNot(BeNil())
+				g.Expect(currentA.Status.Router.Group.Members).To(HaveLen(1))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Force-stop grouped member", func() {
+		It("should set weight to 0 for a force-stopped member in peer group status", func(ctx SpecContext) {
+			// given
+			groupName := "stop-group"
+			svcNameA := "test-stop-grp-a"
+			svcNameB := "test-stop-grp-b"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(60),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(40),
+			)
+
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+
+			// Wait for group to be formed
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(groupRoutingBackendRefs(&routes[0], llmSvcA)).To(HaveLen(2))
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - force-stop member A
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvcA, func() error {
+					if llmSvcA.Annotations == nil {
+						llmSvcA.Annotations = make(map[string]string)
+					}
+					llmSvcA.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - on the remaining member B's HTTPRoute, member A should have weight 0
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcB)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcB)
+				g.Expect(backendRefs).To(HaveLen(2), "stopped member should still appear in backendRefs")
+
+				g.Expect(backendRefs).To(ContainElement(
+					SatisfyAll(
+						HaveBackendName(svcNameA),
+						HaveBackendWeight(int32(0)),
+					),
+				))
+				g.Expect(backendRefs).To(ContainElement(
+					SatisfyAll(
+						HaveBackendName(svcNameB),
+						HaveBackendWeight(int32(40)),
+					),
+				))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - group status on member B should show member A with weight 0
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentB := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcB), currentB)).To(Succeed())
+				g.Expect(currentB.Status.Router).ToNot(BeNil())
+				g.Expect(currentB.Status.Router.Group).ToNot(BeNil(), "group status should be preserved")
+				g.Expect(currentB.Status.Router.Group.Name).To(Equal(groupName))
+				g.Expect(currentB.Status.Router.Group.Members).To(HaveLen(2))
+
+				for _, member := range currentB.Status.Router.Group.Members {
+					if member.Name == svcNameA {
+						g.Expect(member.Weight).To(Equal(int32(60)), "stopped member should show declared weight in group status")
+						g.Expect(member.Stopped).To(BeTrue(), "stopped member should be marked as stopped")
+					}
+					if member.Name == svcNameB {
+						g.Expect(member.Weight).To(Equal(int32(40)), "non-stopped member weight should be preserved")
+					}
+				}
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Group switch", func() {
+		It("should move a member from one group to another, updating both groups' routes", func(ctx SpecContext) {
+			// given - A and B in group-a, C in group-b
+			svcNameA := "test-switch-a"
+			svcNameB := "test-switch-b"
+			svcNameC := "test-switch-c"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup("group-a"),
+				WithWeight(80),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup("group-a"),
+				WithWeight(20),
+			)
+
+			llmSvcC := LLMInferenceService(svcNameC,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup("group-b"),
+				WithWeight(100),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcC)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+				testNs.DeleteAndWait(ctx, llmSvcC)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcC)
+
+			// Verify initial state: A's route has backendRefs for A and B
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(groupRoutingBackendRefs(&routes[0], llmSvcA)).To(HaveLen(2))
+			}).WithContext(ctx).Should(Succeed())
+
+			// Verify initial state: C's route has backendRef for C only
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcC)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(groupRoutingBackendRefs(&routes[0], llmSvcC)).To(HaveLen(1))
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - move B from group-a to group-b
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvcB, func() error {
+					llmSvcB.Spec.Router.Route.Group = ptr.To("group-b")
+					llmSvcB.Labels[constants.LLMRoutingGroupLabelKey] = "group-b"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - A's route should drop B (1 backendRef: only A)
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcA)
+				g.Expect(backendRefs).To(HaveLen(1), "group-a should have only member A after B switched")
+				g.Expect(backendRefs[0]).To(HaveBackendName(svcNameA))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - C's route should gain B (2 backendRefs: B and C)
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcC)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcC)
+				g.Expect(backendRefs).To(HaveLen(2), "group-b should have members B and C after switch")
+				g.Expect(backendRefs).To(ContainElement(HaveBackendName(svcNameB)))
+				g.Expect(backendRefs).To(ContainElement(HaveBackendName(svcNameC)))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - A's group status should show 1 member
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentA := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), currentA)).To(Succeed())
+				g.Expect(currentA.Status.Router).ToNot(BeNil())
+				g.Expect(currentA.Status.Router.Group).ToNot(BeNil())
+				g.Expect(currentA.Status.Router.Group.Members).To(HaveLen(1))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - C's group status should show 2 members
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentC := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcC), currentC)).To(Succeed())
+				g.Expect(currentC.Status.Router).ToNot(BeNil())
+				g.Expect(currentC.Status.Router.Group).ToNot(BeNil())
+				g.Expect(currentC.Status.Router.Group.Members).To(HaveLen(2))
+			}).WithContext(ctx).Should(Succeed())
+		}, SpecTimeout(60*time.Second))
+	})
+
+	Context("Concurrent deletion", func() {
+		It("should not deadlock when two group members are deleted simultaneously", func(ctx SpecContext) {
+			// given - three members in a group; we will delete A and B at the same time
+			groupName := "concurrent-group"
+			svcNameA := "test-conc-a"
+			svcNameB := "test-conc-b"
+			svcNameC := "test-conc-c"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(50),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(30),
+			)
+
+			llmSvcC := LLMInferenceService(svcNameC,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(20),
+			)
+
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcC)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcC)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcC)
+
+			// Verify initial state: A's route has 3 backendRefs
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(groupRoutingBackendRefs(&routes[0], llmSvcA)).To(HaveLen(3))
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - delete A and B simultaneously.
+			// DeleteAndWait blocks until the object is fully gone (finalizer removed, GC complete).
+			// If both complete without timeout, the finalizer deadlock is avoided.
+			testNs.DeleteAndWait(ctx, llmSvcA)
+			testNs.DeleteAndWait(ctx, llmSvcB)
+
+			// then - C's route should have only its own backendRef
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcC)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcC)
+				g.Expect(backendRefs).To(HaveLen(1), "should have only C's backendRef after A and B are deleted")
+				g.Expect(backendRefs[0]).To(HaveBackendName(svcNameC))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - C's group status should show 1 member
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentC := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcC), currentC)).To(Succeed())
+				g.Expect(currentC.Status.Router).ToNot(BeNil())
+				g.Expect(currentC.Status.Router.Group).ToNot(BeNil())
+				g.Expect(currentC.Status.Router.Group.Members).To(HaveLen(1))
+				g.Expect(currentC.Status.Router.Group.Members[0].Name).To(Equal(svcNameC))
+			}).WithContext(ctx).Should(Succeed())
+
+			// then - A and B should be fully gone
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), &v1alpha2.LLMInferenceService{})).
+					To(MatchError(ContainSubstring("not found")))
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcB), &v1alpha2.LLMInferenceService{})).
+					To(MatchError(ContainSubstring("not found")))
+			}).WithContext(ctx).Should(Succeed())
+		}, SpecTimeout(60*time.Second))
+	})
+})
+
+// groupRoutingBackendRefs returns backendRefs from the first group-rewritten rule
+// in an HTTPRoute. Group routing (rewriteRulesForGroup) only rewrites rules that
+// are NOT per-participant - per-participant rules (PathPrefix matching
+// /{namespace}/{name}/...) retain their solo backendRef.
+func groupRoutingBackendRefs(route *gwapiv1.HTTPRoute, owner *v1alpha2.LLMInferenceService) []gwapiv1.HTTPBackendRef {
+	if len(route.Spec.Rules) == 0 {
+		return nil
+	}
+	prefix := "/" + owner.Namespace + "/" + owner.Name
+	for _, rule := range route.Spec.Rules {
+		scoped := false
+		for _, match := range rule.Matches {
+			if match.Path != nil && match.Path.Value != nil {
+				path := *match.Path.Value
+				if path == prefix || strings.HasPrefix(path, prefix+"/") {
+					scoped = true
+					break
+				}
+			}
+		}
+		if !scoped {
+			return rule.BackendRefs
+		}
+	}
+	return nil
+}
+
+// backendRefNames extracts the backend names from a slice of HTTPBackendRef.
+func backendRefNames(refs []gwapiv1.HTTPBackendRef) []string {
+	names := make([]string, len(refs))
+	for i, ref := range refs {
+		names[i] = string(ref.Name)
+	}
+	return names
+}
+
+// HaveBackendName matches an HTTPBackendRef whose Name starts with the given prefix.
+// Backend names include suffixes like "-inference-pool" or "-kserve-workload-svc".
+func HaveBackendName(namePrefix string) OmegaMatcher {
+	return WithTransform(func(ref gwapiv1.HTTPBackendRef) string {
+		return string(ref.Name)
+	}, HavePrefix(namePrefix))
+}
+
+// HaveBackendWeight matches an HTTPBackendRef with the given weight.
+func HaveBackendWeight(weight int32) OmegaMatcher {
+	return WithTransform(func(ref gwapiv1.HTTPBackendRef) *int32 {
+		return ref.Weight
+	}, Equal(ptr.To(weight)))
+}

--- a/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 type LLMInferenceServiceOption ObjectOption[*v1alpha2.LLMInferenceService]
@@ -143,6 +144,41 @@ func WithManagedRoute() LLMInferenceServiceOption {
 		if llmSvc.Spec.Router.Route == nil {
 			llmSvc.Spec.Router.Route = &v1alpha2.GatewayRoutesSpec{}
 		}
+	}
+}
+
+func WithGroup(group string) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		if llmSvc.Spec.Router == nil {
+			llmSvc.Spec.Router = &v1alpha2.RouterSpec{}
+		}
+		if llmSvc.Spec.Router.Route == nil {
+			llmSvc.Spec.Router.Route = &v1alpha2.GatewayRoutesSpec{}
+		}
+		// Group routing requires managed HTTP routes (route.http must be non-nil).
+		if llmSvc.Spec.Router.Route.HTTP == nil {
+			llmSvc.Spec.Router.Route.HTTP = &v1alpha2.HTTPRouteSpec{}
+		}
+		llmSvc.Spec.Router.Route.Group = &group
+		// Mirror what the defaulting webhook does: sync the routing-group label
+		// so field indexers and label selectors work correctly in envtest
+		// (where the defaulting webhook is not installed).
+		if llmSvc.Labels == nil {
+			llmSvc.Labels = make(map[string]string)
+		}
+		llmSvc.Labels[constants.LLMRoutingGroupLabelKey] = group
+	}
+}
+
+func WithWeight(weight int32) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		if llmSvc.Spec.Router == nil {
+			llmSvc.Spec.Router = &v1alpha2.RouterSpec{}
+		}
+		if llmSvc.Spec.Router.Route == nil {
+			llmSvc.Spec.Router.Route = &v1alpha2.GatewayRoutesSpec{}
+		}
+		llmSvc.Spec.Router.Route.Weight = &weight
 	}
 }
 

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -136,12 +136,28 @@ func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1a
 
 	expectedHTTPRoute := r.expectedHTTPRoute(ctx, llmSvc, cfg)
 
-	// Clean up if router or routes are not configured
 	if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil {
+		llmSvc.MarkGroupReadyUnset()
 		if _, err := r.updateRoutingStatus(ctx, llmSvc); err != nil {
 			return nil, err
 		}
 		return nil, Delete(ctx, r, llmSvc, expectedHTTPRoute)
+	}
+
+	// Inject group members' backendRefs for traffic splitting.
+	// Non-grouped members clear any stale GroupReady condition.
+	var groupMatching, groupDivergent []resolvedMember
+	if llmSvc.Spec.Router.HasGroup() {
+		var err error
+		groupMatching, groupDivergent, err = r.injectGroupBackendRefs(ctx, llmSvc, expectedHTTPRoute)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		llmSvc.MarkGroupReadyUnset()
+		if llmSvc.Status.Router != nil {
+			llmSvc.Status.Router.Group = nil
+		}
 	}
 
 	// Collect any explicitly referenced HTTPRoutes
@@ -164,6 +180,11 @@ func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1a
 			return nil, fmt.Errorf("failed to reconcile HTTPRoute %s/%s: %w", expectedHTTPRoute.GetNamespace(), expectedHTTPRoute.GetName(), err)
 		}
 		referencedRoutes = append(referencedRoutes, expectedHTTPRoute)
+	}
+
+	// Apply group status after the route write so status reflects committed state.
+	if groupMatching != nil {
+		r.applyGroupStatus(llmSvc, groupMatching, groupDivergent)
 	}
 
 	return r.updateRoutingStatus(ctx, llmSvc, referencedRoutes...)
@@ -355,9 +376,10 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 	}
 
 	if len(routes) > 0 {
-		llmSvc.Status.Router = &v1alpha2.RouterStatus{
-			Gateways: BuildObservedGateways(routes),
+		if llmSvc.Status.Router == nil {
+			llmSvc.Status.Router = &v1alpha2.RouterStatus{}
 		}
+		llmSvc.Status.Router.Gateways = BuildObservedGateways(routes)
 	}
 
 	additional, err := r.discoverAdditionalURLs(ctx, discovered)
@@ -424,17 +446,57 @@ func preferPathBasedURL(urls []DiscoveredURL, namespace, name, preferredScheme s
 }
 
 func RouterLabels(llmSvc *v1alpha2.LLMInferenceService) map[string]string {
-	return map[string]string{
+	labels := map[string]string{
 		constants.KubernetesComponentLabelKey: constants.LLMComponentRouter,
 		constants.KubernetesAppNameLabelKey:   llmSvc.GetName(),
 		constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
 	}
+	if llmSvc.Spec.Router.HasGroup() {
+		labels[constants.LLMRoutingGroupLabelKey] = *llmSvc.Spec.Router.Route.Group
+	}
+	return labels
 }
 
 func semanticHTTPRouteIsEqual(e *gwapiv1.HTTPRoute, c *gwapiv1.HTTPRoute) bool {
-	return equality.Semantic.DeepDerivative(e.Spec, c.Spec) &&
+	specEqual := equality.Semantic.DeepDerivative(e.Spec, c.Spec)
+	if isGroupRoute(e) {
+		// Grouped routes need exact rule comparison to detect stale backendRefs
+		// from deleted members. DeepDerivative only checks subset membership.
+		specEqual = equality.Semantic.DeepEqual(e.Spec.Rules, c.Spec.Rules) &&
+			equality.Semantic.DeepDerivative(e.Spec.ParentRefs, c.Spec.ParentRefs) &&
+			equality.Semantic.DeepDerivative(e.Spec.Hostnames, c.Spec.Hostnames)
+	}
+	return specEqual &&
 		equality.Semantic.DeepDerivative(e.Labels, c.Labels) &&
+		!hasStaleControllerLabels(e.Labels, c.Labels) &&
 		equality.Semantic.DeepDerivative(e.Annotations, c.Annotations)
+}
+
+func isGroupRoute(route *gwapiv1.HTTPRoute) bool {
+	if route == nil || route.Labels == nil {
+		return false
+	}
+	_, hasGroupLabel := route.Labels[constants.LLMRoutingGroupLabelKey]
+	return hasGroupLabel
+}
+
+// hasStaleControllerLabels returns true when the current object carries a
+// controller-managed label that the expected object does not. DeepDerivative
+// alone misses this case because it only checks that expected is a subset of
+// current - it never flags removals.
+func hasStaleControllerLabels(expected, current map[string]string) bool {
+	for _, key := range controllerManagedLabelKeys {
+		_, inCurrent := current[key]
+		_, inExpected := expected[key]
+		if inCurrent && !inExpected {
+			return true
+		}
+	}
+	return false
+}
+
+var controllerManagedLabelKeys = []string{
+	constants.LLMRoutingGroupLabelKey,
 }
 
 // EvaluateGatewayConditions evaluates the readiness of all Gateways referenced by the LLMInferenceService
@@ -615,6 +677,9 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
 		logger.V(2).Info("Scheduler is disabled, clearing InferencePoolReady condition")
 		llmSvc.MarkInferencePoolReadyUnset()
+		if llmSvc.Status.Router != nil {
+			llmSvc.Status.Router.Scheduler = nil
+		}
 		return nil
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/router_comparator_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_comparator_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestSemanticHTTPRouteIsEqual_Labels(t *testing.T) {
+	baseLabels := map[string]string{
+		constants.KubernetesComponentLabelKey: constants.LLMComponentRouter,
+		constants.KubernetesAppNameLabelKey:   "my-llm",
+		constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
+	}
+
+	withGroup := func(labels map[string]string, group string) map[string]string {
+		out := make(map[string]string, len(labels)+1)
+		for k, v := range labels {
+			out[k] = v
+		}
+		out[constants.LLMRoutingGroupLabelKey] = group
+		return out
+	}
+
+	withExtra := func(labels map[string]string, key, val string) map[string]string {
+		out := make(map[string]string, len(labels)+1)
+		for k, v := range labels {
+			out[k] = v
+		}
+		out[key] = val
+		return out
+	}
+
+	route := func(labels map[string]string) *gwapiv1.HTTPRoute {
+		return &gwapiv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		expected *gwapiv1.HTTPRoute
+		current  *gwapiv1.HTTPRoute
+		wantEq   bool
+	}{
+		{
+			name:     "extra non-controller label on current - no update",
+			expected: route(baseLabels),
+			current:  route(withExtra(baseLabels, "app.kubernetes.io/managed-by", "argocd")),
+			wantEq:   true,
+		},
+		{
+			name:     "stale routing-group on current, absent in expected - update",
+			expected: route(baseLabels),
+			current:  route(withGroup(baseLabels, "old-group")),
+			wantEq:   false,
+		},
+		{
+			name:     "routing-group value changed - update",
+			expected: route(withGroup(baseLabels, "new-group")),
+			current:  route(withGroup(baseLabels, "old-group")),
+			wantEq:   false,
+		},
+		{
+			name:     "expected has routing-group, current missing - update",
+			expected: route(withGroup(baseLabels, "llama-70b")),
+			current:  route(baseLabels),
+			wantEq:   false,
+		},
+		{
+			name:     "identical labels - no update",
+			expected: route(withGroup(baseLabels, "llama-70b")),
+			current:  route(withGroup(baseLabels, "llama-70b")),
+			wantEq:   true,
+		},
+		{
+			name:     "no labels on either - no update",
+			expected: route(nil),
+			current:  route(nil),
+			wantEq:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantEq, semanticHTTPRouteIsEqual(tt.expected, tt.current))
+		})
+	}
+}
+
+func TestSemanticHTTPRouteIsEqual_GroupedRouteRules(t *testing.T) {
+	groupLabels := map[string]string{
+		constants.LLMRoutingGroupLabelKey: "llama-70b",
+	}
+
+	makeRule := func(path string, weight int32) gwapiv1.HTTPRouteRule {
+		return gwapiv1.HTTPRouteRule{
+			Matches: []gwapiv1.HTTPRouteMatch{
+				{Path: &gwapiv1.HTTPPathMatch{Value: &path}},
+			},
+			BackendRefs: []gwapiv1.HTTPBackendRef{
+				{BackendRef: gwapiv1.BackendRef{Weight: &weight}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		expected *gwapiv1.HTTPRoute
+		current  *gwapiv1.HTTPRoute
+		wantEq   bool
+	}{
+		{
+			name: "grouped route - identical rules - no update",
+			expected: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Labels: groupLabels},
+				Spec:       gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{makeRule("/v1/chat", 9)}},
+			},
+			current: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Labels: groupLabels},
+				Spec:       gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{makeRule("/v1/chat", 9)}},
+			},
+			wantEq: true,
+		},
+		{
+			name: "grouped route - stale backendRef in current (extra rule) - update",
+			expected: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Labels: groupLabels},
+				Spec:       gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{makeRule("/v1/chat", 9)}},
+			},
+			current: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Labels: groupLabels},
+				Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{
+					makeRule("/v1/chat", 9),
+					makeRule("/v1/chat", 1),
+				}},
+			},
+			wantEq: false,
+		},
+		{
+			name: "grouped route - weight changed - update",
+			expected: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Labels: groupLabels},
+				Spec:       gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{makeRule("/v1/chat", 5)}},
+			},
+			current: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Labels: groupLabels},
+				Spec:       gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{makeRule("/v1/chat", 9)}},
+			},
+			wantEq: false,
+		},
+		{
+			name: "non-grouped route - extra rule tolerated by DeepDerivative - no update",
+			expected: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec:       gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{makeRule("/v1/chat", 9)}},
+			},
+			current: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+				Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{
+					makeRule("/v1/chat", 9),
+					makeRule("/v1/chat", 1),
+				}},
+			},
+			wantEq: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantEq, semanticHTTPRouteIsEqual(tt.expected, tt.current))
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	kmeta "knative.dev/pkg/kmeta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
+)
+
+const reasonFinalizationPending = "FinalizationPending"
+
+const groupFieldIndex = ".spec.router.route.group"
+
+// resolvedMember holds the effective weight and backend for a single group member.
+type resolvedMember struct {
+	name       string
+	modelNames []string
+	weight     int32
+	stopped    bool
+	backendRef gwapiv1.BackendObjectReference
+}
+
+// setupGroupFieldIndex registers a field indexer on spec.router.route.group
+// for efficient group member discovery without listing all LLMISVCs in a namespace.
+func setupGroupFieldIndex(ctx context.Context, mgr client.FieldIndexer) error {
+	return mgr.IndexField(
+		ctx,
+		&v1alpha2.LLMInferenceService{},
+		groupFieldIndex,
+		func(obj client.Object) []string {
+			llmSvc := obj.(*v1alpha2.LLMInferenceService)
+			if g := llmSvc.Spec.Router.Group(); g != nil {
+				return []string{llmSvc.Namespace + "/" + *g}
+			}
+			return nil
+		},
+	)
+}
+
+// injectGroupBackendRefs post-processes the template-rendered HTTPRoute to add
+// weighted backendRefs for all group members. Each member's route carries
+// backendRefs for ALL members so the gateway can distribute traffic proportionally.
+//
+// Returns a groupResult for the caller to apply status after the route write.
+func (r *LLMISVCReconciler) injectGroupBackendRefs(
+	ctx context.Context,
+	llmSvc *v1alpha2.LLMInferenceService,
+	route *gwapiv1.HTTPRoute,
+) (matching, divergent []resolvedMember, err error) {
+	members, err := r.listGroupMembers(ctx, llmSvc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("injecting group backends: %w", err)
+	}
+
+	resolved, err := r.resolveGroupMembers(filterActiveMembers(members))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	selfModels := resolvedModelNames(llmSvc)
+
+	for _, m := range resolved {
+		if slices.Equal(m.modelNames, selfModels) {
+			matching = append(matching, m)
+		} else {
+			divergent = append(divergent, m)
+		}
+	}
+
+	rewriteRulesForGroup(route, llmSvc, matching)
+
+	return matching, divergent, nil
+}
+
+// resolveGroupMembers reads each member's backendRef from their status.
+// Members without scheduler status use the workload Service as their backend.
+func (r *LLMISVCReconciler) resolveGroupMembers(
+	members []v1alpha2.LLMInferenceService,
+) ([]resolvedMember, error) {
+	resolved := make([]resolvedMember, 0, len(members))
+	for i := range members {
+		m := &members[i]
+		stopped := utils.GetForceStopRuntime(m)
+		w := ptr.Deref(m.Spec.Router.Weight(), 0)
+
+		backendRef, err := resolveMemberBackendRef(m)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve backend for member %s: %w", m.Name, err)
+		}
+
+		resolved = append(resolved, resolvedMember{
+			name:       m.Name,
+			modelNames: resolvedModelNames(m),
+			weight:     w,
+			stopped:    stopped,
+			backendRef: backendRef,
+		})
+	}
+
+	slices.SortFunc(resolved, func(a, b resolvedMember) int {
+		return cmp.Compare(a.name, b.name)
+	})
+
+	return resolved, nil
+}
+
+// resolvedModelNames returns the deduplicated, sorted set of model names
+// served by a member. Prefers status.Addresses (which reflects baseRef merges)
+// over raw spec.
+func resolvedModelNames(m *v1alpha2.LLMInferenceService) []string {
+	var names []string
+	for _, addr := range m.Status.Addresses {
+		for _, model := range addr.Models {
+			names = append(names, model.Name)
+		}
+	}
+
+	if len(names) > 0 {
+		slices.Sort(names)
+		return slices.Compact(names)
+	}
+
+	names = append(names, ptr.Deref(m.Spec.Model.Name, m.Name))
+	if m.Spec.Model.LoRA != nil {
+		for _, a := range m.Spec.Model.LoRA.Adapters {
+			if a.Name != nil {
+				names = append(names, *a.Name)
+			}
+		}
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}
+
+// resolveMemberBackendRef reads the member's backend from its status or spec.
+func resolveMemberBackendRef(
+	member *v1alpha2.LLMInferenceService,
+) (gwapiv1.BackendObjectReference, error) {
+	if member.Spec.Router != nil &&
+		member.Spec.Router.Scheduler != nil &&
+		member.Spec.Router.Scheduler.Pool.HasRef() {
+		return gwapiv1.BackendObjectReference{
+			Group: ptr.To(gwapiv1.Group(constants.InferencePoolV1Alpha2APIGroupName)),
+			Kind:  ptr.To(gwapiv1.Kind("InferencePool")),
+			Name:  gwapiv1.ObjectName(member.Spec.Router.Scheduler.Pool.Ref.Name),
+			Port:  ptr.To(gwapiv1.PortNumber(8000)),
+		}, nil
+	}
+
+	if member.Status.Router != nil &&
+		member.Status.Router.Scheduler != nil &&
+		member.Status.Router.Scheduler.InferencePool != nil {
+		pool := member.Status.Router.Scheduler.InferencePool
+		return gwapiv1.BackendObjectReference{
+			Group: ptr.To(pool.Group),
+			Kind:  ptr.To(pool.Kind),
+			Name:  pool.Name,
+			Port:  ptr.To(gwapiv1.PortNumber(8000)),
+		}, nil
+	}
+
+	svcName := workloadServiceName(member)
+	if svcName != "" {
+		return gwapiv1.BackendObjectReference{
+			Kind: ptr.To(gwapiv1.Kind("Service")),
+			Name: gwapiv1.ObjectName(svcName),
+			Port: ptr.To(gwapiv1.PortNumber(8000)),
+		}, nil
+	}
+
+	return gwapiv1.BackendObjectReference{}, fmt.Errorf(
+		"member %s/%s has no scheduler status and no workload service",
+		member.Namespace, member.Name)
+}
+
+// finalizeGroupMembership ensures peer routes no longer reference this member's
+// backend before allowing deletion to proceed. Returns true when all peers have
+// converged (no backendRefs pointing to this member), false when still waiting.
+func (r *LLMISVCReconciler) finalizeGroupMembership(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) (bool, error) {
+	if !llmSvc.Spec.Router.HasGroup() {
+		return true, nil
+	}
+
+	logger := log.FromContext(ctx)
+
+	peers, err := r.listGroupMembers(ctx, llmSvc)
+	if err != nil {
+		return false, fmt.Errorf("finalizing group membership: %w", err)
+	}
+
+	poolName := (&v1alpha2.SchedulerSpec{}).InferencePoolName(llmSvc)
+	svcName := workloadServiceName(llmSvc)
+
+	for i := range peers {
+		if peers[i].Name == llmSvc.Name || peers[i].DeletionTimestamp != nil {
+			continue
+		}
+		route := &gwapiv1.HTTPRoute{}
+		routeKey := types.NamespacedName{
+			Name:      kmeta.ChildName(peers[i].GetName(), "-kserve-route"),
+			Namespace: peers[i].GetNamespace(),
+		}
+		if err := r.Get(ctx, routeKey, route); err != nil {
+			continue
+		}
+		if routeReferencesBackend(route, poolName) || routeReferencesBackend(route, svcName) {
+			logger.Info("Waiting for peer to remove backendRef before deletion",
+				"peer", peers[i].Name, "pool", poolName)
+			llmSvc.MarkGroupNotReady(reasonFinalizationPending,
+				"waiting for peer %s to remove backendRef before deletion", peers[i].Name)
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func routeReferencesBackend(route *gwapiv1.HTTPRoute, backendName string) bool {
+	for _, rule := range route.Spec.Rules {
+		for _, ref := range rule.BackendRefs {
+			if string(ref.Name) == backendName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// listGroupMembers returns all LLMISVCs in the same namespace with the same group.
+func (r *LLMISVCReconciler) listGroupMembers(
+	ctx context.Context,
+	llmSvc *v1alpha2.LLMInferenceService,
+) ([]v1alpha2.LLMInferenceService, error) {
+	group := llmSvc.Spec.Router.Group()
+	if group == nil {
+		return nil, nil
+	}
+	list := &v1alpha2.LLMInferenceServiceList{}
+	if err := r.List(ctx, list,
+		client.InNamespace(llmSvc.Namespace),
+		client.MatchingFields{groupFieldIndex: llmSvc.Namespace + "/" + *group},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list group members for group %q: %w", *group, err)
+	}
+	return list.Items, nil
+}
+
+func filterActiveMembers(members []v1alpha2.LLMInferenceService) []v1alpha2.LLMInferenceService {
+	active := make([]v1alpha2.LLMInferenceService, 0, len(members))
+	for i := range members {
+		if members[i].DeletionTimestamp == nil {
+			active = append(active, members[i])
+		}
+	}
+	return active
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_handler.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_handler.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
+)
+
+var _ handler.EventHandler = &groupMemberEventHandler{}
+
+// groupMemberEventHandler implements handler.EventHandler to enqueue group
+// siblings when a grouped LLMISVC changes. Using a typed handler (instead of
+// EnqueueRequestsFromMapFunc) gives access to both old and new objects on
+// updates - needed for old-group cleanup since the defaulting webhook
+// synchronizes label and spec before the controller sees the new object.
+type groupMemberEventHandler struct {
+	reconciler *LLMISVCReconciler
+}
+
+func (h *groupMemberEventHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.enqueueCurrentGroupMembers(ctx, e.Object, q)
+}
+
+func (h *groupMemberEventHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	oldSvc := e.ObjectOld.(*v1alpha2.LLMInferenceService)
+	newSvc := e.ObjectNew.(*v1alpha2.LLMInferenceService)
+
+	h.enqueueCurrentGroupMembers(ctx, newSvc, q)
+
+	// When group changes, also enqueue OLD group members so they remove the
+	// departed member's backendRef. The old object carries the previous group
+	// value (informer cache snapshot before the update).
+	oldGroup := oldSvc.Spec.Router.Group()
+	newGroup := newSvc.Spec.Router.Group()
+	if oldGroup != nil && !ptr.Equal(oldGroup, newGroup) {
+		h.enqueueOldGroupMembers(ctx, oldSvc, newSvc.Name, q)
+	}
+}
+
+func (h *groupMemberEventHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.enqueueCurrentGroupMembers(ctx, e.Object, q)
+}
+
+func (h *groupMemberEventHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *groupMemberEventHandler) enqueueCurrentGroupMembers(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	llmSvc := obj.(*v1alpha2.LLMInferenceService)
+	if !llmSvc.Spec.Router.HasGroup() {
+		return
+	}
+
+	members, err := h.reconciler.listGroupMembers(ctx, llmSvc)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to list group members for enqueue")
+		return
+	}
+
+	for i := range members {
+		if members[i].Name == llmSvc.Name {
+			continue
+		}
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: members[i].Namespace,
+				Name:      members[i].Name,
+			},
+		})
+	}
+}
+
+func (h *groupMemberEventHandler) enqueueOldGroupMembers(
+	ctx context.Context,
+	oldSvc *v1alpha2.LLMInferenceService,
+	selfName string,
+	q workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
+	oldGroup := *oldSvc.Spec.Router.Group()
+	list := &v1alpha2.LLMInferenceServiceList{}
+	if err := h.reconciler.List(ctx, list,
+		client.InNamespace(oldSvc.Namespace),
+		client.MatchingLabels{constants.LLMRoutingGroupLabelKey: oldGroup},
+	); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list old group members for enqueue",
+			"oldGroup", oldGroup)
+		return
+	}
+
+	for i := range list.Items {
+		if list.Items[i].Name == selfName {
+			continue
+		}
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: list.Items[i].Namespace,
+				Name:      list.Items[i].Name,
+			},
+		})
+	}
+}
+
+// groupMemberChangePredicate limits fan-out to traffic-relevant changes only.
+// Without this, any spec change to a grouped LLMISVC triggers reconciliation
+// of all group members.
+func groupMemberChangePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.(*v1alpha2.LLMInferenceService).Spec.Router.HasGroup()
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSvc := e.ObjectOld.(*v1alpha2.LLMInferenceService)
+			newSvc := e.ObjectNew.(*v1alpha2.LLMInferenceService)
+			return trafficFieldsChanged(oldSvc, newSvc)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.(*v1alpha2.LLMInferenceService).Spec.Router.HasGroup()
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func trafficFieldsChanged(old, new *v1alpha2.LLMInferenceService) bool {
+	if old.DeletionTimestamp.IsZero() != new.DeletionTimestamp.IsZero() {
+		return true
+	}
+
+	if utils.GetForceStopRuntime(old) != utils.GetForceStopRuntime(new) {
+		return true
+	}
+
+	if !equality.Semantic.DeepEqual(old.Spec.Router, new.Spec.Router) {
+		return true
+	}
+
+	if !equality.Semantic.DeepEqual(old.Spec.Model, new.Spec.Model) {
+		return true
+	}
+
+	if !slices.Equal(old.Spec.BaseRefs, new.Spec.BaseRefs) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_handler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_handler_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestGroupMemberEventHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		objects         []client.Object
+		event           func(*groupMemberEventHandler, workqueue.TypedRateLimitingInterface[reconcile.Request])
+		wantEnqueued    []string
+		wantNotEnqueued []string
+	}{
+		{
+			name: "update: old group members enqueued when member switches groups",
+			objects: objList(
+				groupedSvc("v1", "group-a"),
+				groupedSvc("v2", "group-a"),
+				groupedSvc("v3", "group-b"),
+			),
+			event: updateEvent(
+				groupedSvc("v3", "group-a"),
+				groupedSvc("v3", "group-b"),
+			),
+			wantEnqueued:    []string{"v1", "v2"},
+			wantNotEnqueued: []string{"v3"},
+		},
+		{
+			name: "update: old group members enqueued when member leaves group",
+			objects: objList(
+				groupedSvc("v1", "group-a"),
+				ungroupedSvc("v2"),
+			),
+			event: updateEvent(
+				groupedSvc("v2", "group-a"),
+				ungroupedSvc("v2"),
+			),
+			wantEnqueued: []string{"v1"},
+		},
+		{
+			name: "update: peers enqueued on weight change",
+			objects: objList(
+				groupedSvc("v1", "group-a"),
+				groupedSvcWithWeight("v2", "group-a", 5),
+			),
+			event: updateEvent(
+				groupedSvc("v2", "group-a"),
+				groupedSvcWithWeight("v2", "group-a", 5),
+			),
+			wantEnqueued:    []string{"v1"},
+			wantNotEnqueued: []string{"v2"},
+		},
+		{
+			name: "delete: peers enqueued on member deletion",
+			objects: objList(
+				groupedSvc("v1", "group-a"),
+				groupedSvc("v2", "group-a"),
+			),
+			event:           deleteEvent(groupedSvc("v2", "group-a")),
+			wantEnqueued:    []string{"v1"},
+			wantNotEnqueued: []string{"v2"},
+		},
+		{
+			name:    "create: non-grouped member enqueues nothing",
+			objects: objList(ungroupedSvc("solo")),
+			event:   createEvent(ungroupedSvc("solo")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &groupMemberEventHandler{
+				reconciler: &LLMISVCReconciler{Client: fakeClientWithIndex(t, tt.objects...)},
+			}
+			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			defer q.ShutDown()
+
+			tt.event(h, q)
+
+			names := requestNames(drainQueue(q))
+			for _, want := range tt.wantEnqueued {
+				assert.Contains(t, names, want)
+			}
+			for _, notWant := range tt.wantNotEnqueued {
+				assert.NotContains(t, names, notWant)
+			}
+			if tt.wantEnqueued == nil && tt.wantNotEnqueued == nil {
+				assert.Empty(t, names)
+			}
+		})
+	}
+}
+
+// --- Test helpers ---
+
+func groupedSvc(name, group string) v1alpha2.LLMInferenceService {
+	return groupedSvcWithWeight(name, group, 1)
+}
+
+func groupedSvcWithWeight(name, group string, weight int32) v1alpha2.LLMInferenceService {
+	return v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{constants.LLMRoutingGroupLabelKey: group},
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{
+				Route: &v1alpha2.GatewayRoutesSpec{
+					Group:  ptr.To(group),
+					Weight: ptr.To(weight),
+				},
+			},
+		},
+	}
+}
+
+func ungroupedSvc(name string) v1alpha2.LLMInferenceService {
+	return v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{},
+	}
+}
+
+func objList(svcs ...v1alpha2.LLMInferenceService) []client.Object {
+	objs := make([]client.Object, len(svcs))
+	for i := range svcs {
+		objs[i] = &svcs[i]
+	}
+	return objs
+}
+
+func updateEvent(oldSvc, newSvc v1alpha2.LLMInferenceService) func(*groupMemberEventHandler, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	return func(h *groupMemberEventHandler, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		h.Update(context.Background(), event.UpdateEvent{ObjectOld: &oldSvc, ObjectNew: &newSvc}, q)
+	}
+}
+
+func deleteEvent(svc v1alpha2.LLMInferenceService) func(*groupMemberEventHandler, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	return func(h *groupMemberEventHandler, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		h.Delete(context.Background(), event.DeleteEvent{Object: &svc}, q)
+	}
+}
+
+func createEvent(svc v1alpha2.LLMInferenceService) func(*groupMemberEventHandler, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	return func(h *groupMemberEventHandler, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		h.Create(context.Background(), event.CreateEvent{Object: &svc}, q)
+	}
+}
+
+func fakeClientWithIndex(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithIndex(&v1alpha2.LLMInferenceService{}, groupFieldIndex, func(obj client.Object) []string {
+			llmSvc := obj.(*v1alpha2.LLMInferenceService)
+			if g := llmSvc.Spec.Router.Group(); g != nil {
+				return []string{llmSvc.GetNamespace() + "/" + *g}
+			}
+			return nil
+		}).
+		Build()
+}
+
+func drainQueue(q workqueue.TypedRateLimitingInterface[reconcile.Request]) []reconcile.Request {
+	reqs := make([]reconcile.Request, 0, q.Len())
+	for q.Len() > 0 {
+		req, shutdown := q.Get()
+		if shutdown {
+			break
+		}
+		reqs = append(reqs, req)
+		q.Done(req)
+		q.Forget(req)
+	}
+	return reqs
+}
+
+func requestNames(reqs []reconcile.Request) []string {
+	names := make([]string, len(reqs))
+	for i, r := range reqs {
+		names[i] = r.Name
+	}
+	return names
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_routing.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_routing.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"slices"
+	"strings"
+
+	"k8s.io/utils/ptr"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+// rewriteRulesForGroup replaces backendRefs on rules that have a controller-managed
+// backend with the full set of weighted group member backends. Rules with only
+// user-managed custom backendRefs are left untouched.
+func rewriteRulesForGroup(route *gwapiv1.HTTPRoute, llmSvc *v1alpha2.LLMInferenceService, members []resolvedMember) {
+	allBackendRefs := make([]gwapiv1.HTTPBackendRef, 0, len(members))
+	for _, m := range members {
+		w := m.weight
+		if m.stopped {
+			w = 0
+		}
+		allBackendRefs = append(allBackendRefs, gwapiv1.HTTPBackendRef{
+			BackendRef: gwapiv1.BackendRef{
+				BackendObjectReference: m.backendRef,
+				Weight:                 ptr.To(w),
+			},
+		})
+	}
+
+	perParticipantPrefix := "/" + llmSvc.Namespace + "/" + llmSvc.Name
+
+	for i := range route.Spec.Rules {
+		if isPerParticipantRule(route.Spec.Rules[i], perParticipantPrefix) {
+			continue
+		}
+		if !hasControllerManagedBackendRef(route.Spec.Rules[i], llmSvc) {
+			continue
+		}
+		route.Spec.Rules[i].BackendRefs = slices.Clone(allBackendRefs)
+	}
+}
+
+// isPerParticipantRule returns true for rules whose path matches the
+// per-participant pattern (/{namespace}/{name}/...). These are direct-access
+// routes unique to this member and should not get weighted group backendRefs.
+func isPerParticipantRule(rule gwapiv1.HTTPRouteRule, perParticipantPrefix string) bool {
+	for _, match := range rule.Matches {
+		if match.Path == nil || match.Path.Value == nil {
+			continue
+		}
+		path := *match.Path.Value
+		if path == perParticipantPrefix ||
+			strings.HasPrefix(path, perParticipantPrefix+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasControllerManagedBackendRef returns true if any backendRef in the rule is
+// a controller-managed backend: default InferencePool, custom pool ref, or
+// workload Service.
+func hasControllerManagedBackendRef(rule gwapiv1.HTTPRouteRule, llmSvc *v1alpha2.LLMInferenceService) bool {
+	for _, ref := range rule.BackendRefs {
+		if isExpectedBackendRef(llmSvc, ref.BackendRef) {
+			return true
+		}
+	}
+	return false
+}
+
+// isExpectedBackendRef checks whether a backendRef matches the backend that
+// the controller would produce for this LLMISVC: default InferencePool,
+// scheduler pool ref, or workload Service.
+func isExpectedBackendRef(llmSvc *v1alpha2.LLMInferenceService, ref gwapiv1.BackendRef) bool {
+	if isDefaultBackendRef(llmSvc, ref) {
+		return true
+	}
+	if ptr.Deref(ref.Kind, "Service") == "Service" &&
+		string(ref.Name) == workloadServiceName(llmSvc) {
+		return true
+	}
+	// User-provided InferencePool via scheduler.pool.ref
+	if llmSvc.Spec.Router != nil &&
+		llmSvc.Spec.Router.Scheduler != nil &&
+		llmSvc.Spec.Router.Scheduler.Pool.HasRef() &&
+		ptr.Deref(ref.Kind, "") == "InferencePool" &&
+		string(ref.Name) == llmSvc.Spec.Router.Scheduler.Pool.Ref.Name {
+		return true
+	}
+	return false
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_routing_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_routing_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestIsPerParticipantRule(t *testing.T) {
+	prefix := "/default/my-svc"
+
+	tests := []struct {
+		name string
+		rule gwapiv1.HTTPRouteRule
+		want bool
+	}{
+		{
+			name: "exact prefix match",
+			rule: gwapiv1.HTTPRouteRule{
+				Matches: []gwapiv1.HTTPRouteMatch{{
+					Path: &gwapiv1.HTTPPathMatch{Value: ptr.To(prefix)},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "prefix with trailing path",
+			rule: gwapiv1.HTTPRouteRule{
+				Matches: []gwapiv1.HTTPRouteMatch{{
+					Path: &gwapiv1.HTTPPathMatch{Value: ptr.To(prefix + "/v1/completions")},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "non-matching path",
+			rule: gwapiv1.HTTPRouteRule{
+				Matches: []gwapiv1.HTTPRouteMatch{{
+					Path: &gwapiv1.HTTPPathMatch{Value: ptr.To("/v1/chat/completions")},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "nil path value",
+			rule: gwapiv1.HTTPRouteRule{
+				Matches: []gwapiv1.HTTPRouteMatch{{
+					Path: &gwapiv1.HTTPPathMatch{Value: nil},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "empty matches",
+			rule: gwapiv1.HTTPRouteRule{
+				Matches: []gwapiv1.HTTPRouteMatch{},
+			},
+			want: false,
+		},
+		{
+			name: "partial name collision - segment boundary guard",
+			rule: gwapiv1.HTTPRouteRule{
+				Matches: []gwapiv1.HTTPRouteMatch{{
+					Path: &gwapiv1.HTTPPathMatch{Value: ptr.To("/default/my-svc-v2")},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "header-only match no path",
+			rule: gwapiv1.HTTPRouteRule{
+				Matches: []gwapiv1.HTTPRouteMatch{{
+					Headers: []gwapiv1.HTTPHeaderMatch{{
+						Name:  "x-model",
+						Value: "test",
+					}},
+				}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPerParticipantRule(tt.rule, prefix))
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_status.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_status.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+const reasonMemberDivergence = "MemberDivergence"
+
+// applyGroupStatus sets group conditions and status on the LLMISVC.
+// Call after the HTTPRoute write succeeds so status reflects committed state.
+func (r *LLMISVCReconciler) applyGroupStatus(llmSvc *v1alpha2.LLMInferenceService, matching, divergent []resolvedMember) {
+	updateGroupStatus(llmSvc, matching)
+	llmSvc.MarkGroupReady()
+
+	if len(divergent) > 0 {
+		msg := divergenceMessage(divergent)
+		llmSvc.MarkGroupDegraded(reasonMemberDivergence, msg)
+		r.Eventf(llmSvc, corev1.EventTypeWarning, reasonMemberDivergence,
+			"Group %q has members with divergent model.name or LoRA adapter sets",
+			*llmSvc.Spec.Router.Route.Group)
+	} else {
+		llmSvc.MarkGroupNotDegraded()
+	}
+}
+
+// updateGroupStatus populates the group topology in the LLMISVC status.
+func updateGroupStatus(llmSvc *v1alpha2.LLMInferenceService, resolved []resolvedMember) {
+	groupStatus := &v1alpha2.GroupStatus{
+		Name: *llmSvc.Spec.Router.Route.Group,
+	}
+
+	for _, m := range resolved {
+		ref := m.backendRef
+		groupStatus.Members = append(groupStatus.Members, v1alpha2.GroupMemberStatus{
+			Name:       m.name,
+			Weight:     m.weight,
+			Stopped:    m.stopped,
+			BackendRef: &ref,
+		})
+	}
+
+	if llmSvc.Status.Router == nil {
+		llmSvc.Status.Router = &v1alpha2.RouterStatus{}
+	}
+	llmSvc.Status.Router.Group = groupStatus
+}
+
+func divergenceMessage(divergent []resolvedMember) string {
+	models := make([]string, 0, len(divergent))
+	for _, m := range divergent {
+		models = append(models, strings.Join(m.modelNames, "+"))
+	}
+	slices.Sort(models)
+	return "group has members with different model sets: " + strings.Join(slices.Compact(models), ", ")
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_test.go
@@ -1,0 +1,641 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestRouterSpecHasGroup(t *testing.T) {
+	tests := []struct {
+		name   string
+		llmSvc *v1alpha2.LLMInferenceService
+		want   bool
+	}{
+		{
+			name:   "nil router",
+			llmSvc: &v1alpha2.LLMInferenceService{},
+			want:   false,
+		},
+		{
+			name: "nil route",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Router: &v1alpha2.RouterSpec{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no group",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Router: &v1alpha2.RouterSpec{
+						Route: &v1alpha2.GatewayRoutesSpec{
+							Weight: ptr.To(int32(1)),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "group set",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Router: &v1alpha2.RouterSpec{
+						Route: &v1alpha2.GatewayRoutesSpec{
+							Group:  ptr.To("llama-70b"),
+							Weight: ptr.To(int32(9)),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.llmSvc.Spec.Router.HasGroup())
+		})
+	}
+}
+
+func TestFilterActiveMembers(t *testing.T) {
+	now := metav1.Now()
+
+	t.Run("excludes terminating members", func(t *testing.T) {
+		m := memberSvc("v1", "llama-70b", 9, false, now)
+		m.DeletionTimestamp = &now
+		members := []v1alpha2.LLMInferenceService{
+			m,
+			memberSvc("v2", "llama-70b", 1, false, now),
+		}
+		active := filterActiveMembers(members)
+		require.Len(t, active, 1)
+		assert.Equal(t, "v2", active[0].Name)
+	})
+
+	t.Run("keeps all active members", func(t *testing.T) {
+		members := []v1alpha2.LLMInferenceService{
+			memberSvc("v1", "llama-70b", 9, false, now),
+			memberSvc("v2", "llama-70b", 1, false, now),
+		}
+		active := filterActiveMembers(members)
+		assert.Len(t, active, 2)
+	})
+}
+
+func TestIsGroupRoute(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *gwapiv1.HTTPRoute
+		want  bool
+	}{
+		{
+			name:  "nil route",
+			route: nil,
+			want:  false,
+		},
+		{
+			name:  "no labels",
+			route: &gwapiv1.HTTPRoute{},
+			want:  false,
+		},
+		{
+			name: "no group label",
+			route: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"other": "label"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "has group label",
+			route: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						constants.LLMRoutingGroupLabelKey: "llama-70b",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isGroupRoute(tt.route))
+		})
+	}
+}
+
+func TestUpdateGroupStatus(t *testing.T) {
+	t.Run("populates group status from resolved members", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			Spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Route: &v1alpha2.GatewayRoutesSpec{
+						Group: ptr.To("llama-70b"),
+					},
+				},
+			},
+		}
+
+		resolved := []resolvedMember{
+			{name: "v1", weight: 9, backendRef: gwapiv1.BackendObjectReference{Name: "v1-pool"}},
+			{name: "v2", weight: 1, backendRef: gwapiv1.BackendObjectReference{Name: "v2-pool"}},
+		}
+
+		updateGroupStatus(llmSvc, resolved)
+
+		require.NotNil(t, llmSvc.Status.Router)
+		require.NotNil(t, llmSvc.Status.Router.Group)
+		assert.Equal(t, "llama-70b", llmSvc.Status.Router.Group.Name)
+		require.Len(t, llmSvc.Status.Router.Group.Members, 2)
+		assert.Equal(t, "v1", llmSvc.Status.Router.Group.Members[0].Name)
+		assert.Equal(t, int32(9), llmSvc.Status.Router.Group.Members[0].Weight)
+		assert.Equal(t, "v2", llmSvc.Status.Router.Group.Members[1].Name)
+		assert.Equal(t, int32(1), llmSvc.Status.Router.Group.Members[1].Weight)
+	})
+
+	t.Run("creates RouterStatus if nil", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			Spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Route: &v1alpha2.GatewayRoutesSpec{
+						Group: ptr.To("g"),
+					},
+				},
+			},
+		}
+
+		updateGroupStatus(llmSvc, []resolvedMember{{name: "v1", weight: 1}})
+
+		require.NotNil(t, llmSvc.Status.Router)
+		assert.Equal(t, "g", llmSvc.Status.Router.Group.Name)
+	})
+}
+
+func TestRewriteRulesForGroup(t *testing.T) {
+	t.Run("replaces controller-managed backendRefs with group members", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc"},
+		}
+		route := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{BackendRef: gwapiv1.BackendRef{
+								BackendObjectReference: gwapiv1.BackendObjectReference{
+									Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+									Name: "my-svc-inference-pool",
+								},
+							}},
+						},
+					},
+				},
+			},
+		}
+
+		members := []resolvedMember{
+			{name: "v1", weight: 9, backendRef: gwapiv1.BackendObjectReference{Name: "v1-pool"}},
+			{name: "v2", weight: 1, backendRef: gwapiv1.BackendObjectReference{Name: "v2-pool"}},
+		}
+
+		rewriteRulesForGroup(route, llmSvc, members)
+
+		require.Len(t, route.Spec.Rules[0].BackendRefs, 2)
+		assert.Equal(t, gwapiv1.ObjectName("v1-pool"), route.Spec.Rules[0].BackendRefs[0].Name)
+		assert.Equal(t, int32(9), *route.Spec.Rules[0].BackendRefs[0].Weight)
+		assert.Equal(t, gwapiv1.ObjectName("v2-pool"), route.Spec.Rules[0].BackendRefs[1].Name)
+		assert.Equal(t, int32(1), *route.Spec.Rules[0].BackendRefs[1].Weight)
+	})
+
+	t.Run("skips rules with only custom backendRefs", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc"},
+		}
+		route := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{
+							Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+							Name: "my-svc-inference-pool",
+						},
+					}}}},
+					{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{
+							Kind: ptr.To(gwapiv1.Kind("Service")),
+							Name: "user-custom-svc",
+						},
+					}}}},
+				},
+			},
+		}
+
+		members := []resolvedMember{
+			{name: "v1", weight: 5, backendRef: gwapiv1.BackendObjectReference{Name: "v1-pool"}},
+		}
+
+		rewriteRulesForGroup(route, llmSvc, members)
+
+		require.Len(t, route.Spec.Rules[0].BackendRefs, 1, "controller-managed rule should be rewritten")
+		assert.Equal(t, gwapiv1.ObjectName("v1-pool"), route.Spec.Rules[0].BackendRefs[0].Name)
+
+		require.Len(t, route.Spec.Rules[1].BackendRefs, 1, "custom rule should be untouched")
+		assert.Equal(t, gwapiv1.ObjectName("user-custom-svc"), route.Spec.Rules[1].BackendRefs[0].Name)
+	})
+}
+
+func TestIsExpectedBackendRef(t *testing.T) {
+	svc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-svc"},
+	}
+	svcWithScheduler := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-svc"},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{
+				Scheduler: &v1alpha2.SchedulerSpec{
+					Pool: &v1alpha2.InferencePoolSpec{
+						Ref: &corev1.LocalObjectReference{Name: "custom-pool"},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		svc  *v1alpha2.LLMInferenceService
+		ref  gwapiv1.BackendRef
+		want bool
+	}{
+		{
+			name: "default InferencePool matches",
+			svc:  svc,
+			ref:  gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Kind: ptr.To(gwapiv1.Kind("InferencePool")), Name: "my-svc-inference-pool"}},
+			want: true,
+		},
+		{
+			name: "workload Service matches",
+			svc:  svc,
+			ref:  gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Kind: ptr.To(gwapiv1.Kind("Service")), Name: gwapiv1.ObjectName(workloadServiceName(svc))}},
+			want: true,
+		},
+		{
+			name: "custom pool ref matches",
+			svc:  svcWithScheduler,
+			ref:  gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Kind: ptr.To(gwapiv1.Kind("InferencePool")), Name: "custom-pool"}},
+			want: true,
+		},
+		{
+			name: "user InferencePool does not match",
+			svc:  svc,
+			ref:  gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Kind: ptr.To(gwapiv1.Kind("InferencePool")), Name: "user-custom-pool"}},
+			want: false,
+		},
+		{
+			name: "user Service does not match",
+			svc:  svc,
+			ref:  gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Kind: ptr.To(gwapiv1.Kind("Service")), Name: "user-custom-svc"}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isExpectedBackendRef(tt.svc, tt.ref))
+		})
+	}
+}
+
+func TestTrafficFieldsChanged(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		name string
+		old  *v1alpha2.LLMInferenceService
+		new  *v1alpha2.LLMInferenceService
+		want bool
+	}{
+		{
+			name: "no traffic fields on either",
+			old:  &v1alpha2.LLMInferenceService{},
+			new:  &v1alpha2.LLMInferenceService{},
+			want: false,
+		},
+		{
+			name: "group added",
+			old:  &v1alpha2.LLMInferenceService{},
+			new:  &v1alpha2.LLMInferenceService{Spec: v1alpha2.LLMInferenceServiceSpec{Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To("g")}}}},
+			want: true,
+		},
+		{
+			name: "group removed",
+			old:  &v1alpha2.LLMInferenceService{Spec: v1alpha2.LLMInferenceServiceSpec{Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To("g")}}}},
+			new:  &v1alpha2.LLMInferenceService{},
+			want: true,
+		},
+		{
+			name: "weight changed",
+			old:  &v1alpha2.LLMInferenceService{Spec: v1alpha2.LLMInferenceServiceSpec{Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To("g"), Weight: ptr.To(int32(9))}}}},
+			new:  &v1alpha2.LLMInferenceService{Spec: v1alpha2.LLMInferenceServiceSpec{Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To("g"), Weight: ptr.To(int32(5))}}}},
+			want: true,
+		},
+		{
+			name: "force-stop changed",
+			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			new:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, true, now); return &s }(),
+			want: true,
+		},
+		{
+			name: "model name changed on grouped member",
+			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Spec.Model.Name = ptr.To("different")
+				return &s
+			}(),
+			want: true,
+		},
+		{
+			name: "LoRA adapters changed on grouped member",
+			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Spec.Model.LoRA = &v1alpha2.LoRASpec{
+					Adapters: []v1alpha2.LLMModelSpec{{Name: ptr.To("new-adapter")}},
+				}
+				return &s
+			}(),
+			want: true,
+		},
+		{
+			name: "baseRefs changed on grouped member",
+			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Spec.BaseRefs = []corev1.LocalObjectReference{{Name: "new-config"}}
+				return &s
+			}(),
+			want: true,
+		},
+		{
+			name: "scheduler added on grouped member",
+			old: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Spec.Router.Scheduler = nil
+				return &s
+			}(),
+			new:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			want: true,
+		},
+		{
+			name: "scheduler removed on grouped member",
+			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Spec.Router.Scheduler = nil
+				return &s
+			}(),
+			want: true,
+		},
+		{
+			name: "scheduler pool ref changed on grouped member",
+			old: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Spec.Router.Scheduler.Pool = &v1alpha2.InferencePoolSpec{
+					Ref: &corev1.LocalObjectReference{Name: "old-pool"},
+				}
+				return &s
+			}(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Spec.Router.Scheduler.Pool = &v1alpha2.InferencePoolSpec{
+					Ref: &corev1.LocalObjectReference{Name: "new-pool"},
+				}
+				return &s
+			}(),
+			want: true,
+		},
+		{
+			name: "scheduler pool ref added on grouped member",
+			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Spec.Router.Scheduler.Pool = &v1alpha2.InferencePoolSpec{
+					Ref: &corev1.LocalObjectReference{Name: "custom-pool"},
+				}
+				return &s
+			}(),
+			want: true,
+		},
+		{
+			name: "non-traffic change on grouped member",
+			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			new:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, trafficFieldsChanged(tt.old, tt.new))
+		})
+	}
+}
+
+func TestResolveMemberBackendRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		member  *v1alpha2.LLMInferenceService
+		want    gwapiv1.BackendObjectReference
+		wantErr bool
+	}{
+		{
+			name: "custom pool ref from spec uses well-known API group",
+			member: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "v1", Namespace: "default"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Router: &v1alpha2.RouterSpec{
+						Scheduler: &v1alpha2.SchedulerSpec{
+							Pool: &v1alpha2.InferencePoolSpec{
+								Ref: &corev1.LocalObjectReference{Name: "my-custom-pool"},
+							},
+						},
+					},
+				},
+			},
+			want: gwapiv1.BackendObjectReference{
+				Group: ptr.To(gwapiv1.Group(constants.InferencePoolV1Alpha2APIGroupName)),
+				Kind:  ptr.To(gwapiv1.Kind("InferencePool")),
+				Name:  "my-custom-pool",
+				Port:  ptr.To(gwapiv1.PortNumber(8000)),
+			},
+		},
+		{
+			name: "managed pool from status uses pool's own API group",
+			member: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "v1", Namespace: "default"},
+				Status: v1alpha2.LLMInferenceServiceStatus{
+					Router: &v1alpha2.RouterStatus{
+						Scheduler: &v1alpha2.ObservedSchedulerStatus{
+							InferencePool: &gwapiv1.ObjectReference{
+								Group: gwapiv1.Group(constants.InferencePoolV1APIGroupName),
+								Kind:  "InferencePool",
+								Name:  "v1-inference-pool",
+							},
+						},
+					},
+				},
+			},
+			want: gwapiv1.BackendObjectReference{
+				Group: ptr.To(gwapiv1.Group(constants.InferencePoolV1APIGroupName)),
+				Kind:  ptr.To(gwapiv1.Kind("InferencePool")),
+				Name:  "v1-inference-pool",
+				Port:  ptr.To(gwapiv1.PortNumber(8000)),
+			},
+		},
+		{
+			name: "workload service fallback",
+			member: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+			},
+			want: gwapiv1.BackendObjectReference{
+				Kind: ptr.To(gwapiv1.Kind("Service")),
+				Name: gwapiv1.ObjectName(workloadServiceName(&v1alpha2.LLMInferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-svc"},
+				})),
+				Port: ptr.To(gwapiv1.PortNumber(8000)),
+			},
+		},
+		{
+			// The error branch in resolveMemberBackendRef is defensive: kmeta.ChildName
+			// always returns non-empty for the "-kserve-workload-svc" suffix, so it
+			// falls through to the workload service path even with an empty name.
+			name: "empty name still resolves via workload service",
+			member: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "default"},
+			},
+			want: gwapiv1.BackendObjectReference{
+				Kind: ptr.To(gwapiv1.Kind("Service")),
+				Name: gwapiv1.ObjectName(workloadServiceName(&v1alpha2.LLMInferenceService{})),
+				Port: ptr.To(gwapiv1.PortNumber(8000)),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveMemberBackendRef(tt.member)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRouteReferencesBackend(t *testing.T) {
+	tests := []struct {
+		name    string
+		route   *gwapiv1.HTTPRoute
+		backend string
+		want    bool
+	}{
+		{
+			name: "match in first rule",
+			route: &gwapiv1.HTTPRoute{Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{
+				{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "pool-a"}}}}},
+			}}},
+			backend: "pool-a",
+			want:    true,
+		},
+		{
+			name: "no match",
+			route: &gwapiv1.HTTPRoute{Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{
+				{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "pool-a"}}}}},
+			}}},
+			backend: "pool-b",
+			want:    false,
+		},
+		{
+			name:    "empty rules",
+			route:   &gwapiv1.HTTPRoute{},
+			backend: "pool-a",
+			want:    false,
+		},
+		{
+			name: "match in second rule",
+			route: &gwapiv1.HTTPRoute{Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{
+				{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "pool-a"}}}}},
+				{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "pool-b"}}}}},
+			}}},
+			backend: "pool-b",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, routeReferencesBackend(tt.route, tt.backend))
+		})
+	}
+}
+
+// memberSvc creates a minimal LLMInferenceService for group testing.
+func memberSvc(name, group string, weight int32, stopped bool, ts metav1.Time) v1alpha2.LLMInferenceService {
+	svc := v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			CreationTimestamp: ts,
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Model: v1alpha2.LLMModelSpec{
+				Name: ptr.To("llama-70b"),
+			},
+			Router: &v1alpha2.RouterSpec{
+				Route: &v1alpha2.GatewayRoutesSpec{
+					Group:  ptr.To(group),
+					Weight: ptr.To(weight),
+				},
+				Scheduler: &v1alpha2.SchedulerSpec{},
+			},
+		},
+	}
+	if stopped {
+		svc.Annotations = map[string]string{
+			constants.StopAnnotationKey: "true",
+		}
+	}
+	return svc
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements the controller logic that translates per-member `group` + `weight` fields into Gateway API HTTPRoute weighted `backendRef` entries. This is the core machinery that makes traffic splitting work - group discovery, backend resolution, weight injection, and lifecycle management.

Handles the full group lifecycle: member join/leave, weight changes, force-stop (GPU reclamation with preserved weights), model name validation via strict majority, and symmetric `GroupReady`/`GroupDegraded` condition reporting across all members. 

A finalizer-based cleanup ensures peer routes converge before a deleted member's resources are garbage-collected, preventing the 5xx window.

Each member's HTTPRoute carries weighted backendRefs for ALL group members so the gateway distributes traffic proportionally when using header-based routing. 

Per-participant rules (`/<ns>/<name>/...`) keep their single `backendRef` for direct version access.

**Which issue(s) this PR fixes**:
Part of #5725

**Feature/Issue validation/testing**:

- [x] Unit tests for group member resolution, model name validation (majority-wins), backend ref matching
- [x] Unit tests for event handler fan-out (create/update/delete, old-group cleanup)  
- [x] Unit tests for `trafficFieldsChanged` predicate (weight, group, force-stop, deletion, baseRefs, scheduler changes)
- [x] Unit tests for HTTPRoute comparator with grouped route rules
- [x] Envtest integration tests: group formation, weight changes, model name ambiguity, force-stop with stopped status, member leaving group, member deletion with finalizer convergence, three-member groups

**Special notes for your reviewer**:

Stacked on #5727 (API surface, merged). The group routing code is split across focused files:
- `group.go` - core reconcile loop, finalization, member resolution
- `group_routing.go` - HTTPRoute rule rewriting (shared vs per-participant)
- `group_handler.go` - event handler for peer fan-out, change predicate
- `group_validation.go` - model name majority validation

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Add group routing machinery for LLMInferenceService traffic splitting - translates per-member weights into Gateway API HTTPRoute weighted backendRefs with full lifecycle management, including force-stop, model name validation, and finalizer-based safe deletion.
```