### PR TITLE
fix(webhook): allow first-reconcile update when DeploymentMode is empty

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -589,15 +589,20 @@ func validateCollocationStorageURI(predictorSpec PredictorSpec) error {
 	return nil
 }
 
-// validates if the deploymentMode specified in the annotation is not different from the one recorded in the status
+// validates if the deploymentMode specified in the annotation is not different from the one recorded in the status.
+//
+// An empty oldIsvc.Status.DeploymentMode means the controller has not yet run its first updateStatus
+// (e.g. the finalizer patch on first reconcile). In that case there is no prior state to protect, so
+// the update is allowed. Passing "" through ParseDeploymentMode would fold to DefaultDeployment
+// ("Standard") and reject any non-Standard annotation, breaking first-reconcile on Knative installs.
 func validateDeploymentMode(newIsvc *InferenceService, oldIsvc *InferenceService) error {
+	if oldIsvc.Status.DeploymentMode == "" {
+		return nil
+	}
 	statusDeploymentMode := string(constants.ParseDeploymentMode(oldIsvc.Status.DeploymentMode))
-	if len(statusDeploymentMode) != 0 {
-		annotations := newIsvc.Annotations
-		annotationDeploymentMode, ok := annotations[constants.DeploymentMode]
-		if ok && annotationDeploymentMode != statusDeploymentMode {
-			return fmt.Errorf("update rejected: deploymentMode cannot be changed from '%s' to '%s'", statusDeploymentMode, annotationDeploymentMode)
-		}
+	annotationDeploymentMode, ok := newIsvc.Annotations[constants.DeploymentMode]
+	if ok && annotationDeploymentMode != statusDeploymentMode {
+		return fmt.Errorf("update rejected: deploymentMode cannot be changed from '%s' to '%s'", statusDeploymentMode, annotationDeploymentMode)
 	}
 	return nil
 }

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1471,6 +1471,48 @@ func TestDeploymentModeUpdate(t *testing.T) {
 	// During deletion, deploymentMode mismatch should be allowed
 	g.Expect(warnings).Should(gomega.BeEmpty())
 	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Empty Status.DeploymentMode with a non-Standard annotation should be accepted.
+	// This is the first-reconcile finalizer patch case: the controller adds a finalizer via
+	// r.Patch(...) before updateStatus runs, so oldIsvc.Status.DeploymentMode is "". The
+	// validator must treat that as "no prior state" and not synthesize "Standard" from it.
+	// Regression test for issue #5793.
+	oldIsvcEmptyStatus := makeTestInferenceService()
+	oldIsvcEmptyStatus.Status = InferenceServiceStatus{
+		DeploymentMode: "",
+	}
+	updatedIsvcKnativeAnnotation := oldIsvcEmptyStatus.DeepCopy()
+	updatedIsvcKnativeAnnotation.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.Knative),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcEmptyStatus, updatedIsvcKnativeAnnotation)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Empty Status.DeploymentMode with a legacy Serverless annotation should also be accepted.
+	updatedIsvcLegacySlAnnotation := oldIsvcEmptyStatus.DeepCopy()
+	updatedIsvcLegacySlAnnotation.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.LegacyServerless),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcEmptyStatus, updatedIsvcLegacySlAnnotation)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Empty Status.DeploymentMode with a Standard annotation should also be accepted.
+	updatedIsvcStandardAnnotation := oldIsvcEmptyStatus.DeepCopy()
+	updatedIsvcStandardAnnotation.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.Standard),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcEmptyStatus, updatedIsvcStandardAnnotation)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Empty Status.DeploymentMode with no deploymentMode annotation should be accepted.
+	updatedIsvcNoAnnotation := oldIsvcEmptyStatus.DeepCopy()
+	updatedIsvcNoAnnotation.Annotations = map[string]string{}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcEmptyStatus, updatedIsvcNoAnnotation)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
 }
 
 func TestValidateUpdateDuringDeletion(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes #5793: `validateDeploymentMode` was rejecting the finalizer patch on the very first reconcile of an `InferenceService` whenever its `serving.kserve.io/deploymentMode` annotation was anything other than `Standard` (e.g. `Knative`).
- Root cause: the validator normalized `oldIsvc.Status.DeploymentMode` through `constants.ParseDeploymentMode`, which folds `""` to `DefaultDeployment` (`Standard`). The `len(...) != 0` guard therefore never fired on a freshly-created ISVC, and the annotation was compared against a synthesized `Standard`.
- The fix short-circuits when `oldIsvc.Status.DeploymentMode == ""`: an unpopulated status has no prior state to protect, so the update is allowed. This restores the pre-#5025 behavior for the empty-status case while keeping legacy-value normalization intact for the populated case.
- Regression tests added covering empty status crossed with `Knative`, `LegacyServerless`, `Standard`, and no annotation — the `Knative` case reproduces the reported failure without the fix.

## Test plan

- [x] `go test ./pkg/apis/serving/v1beta1/... -run TestDeploymentModeUpdate` fails before the fix with the exact reported error, passes after
- [x] `go test ./pkg/apis/serving/v1beta1/...` (full package) passes
- [x] `make test`
- [x] `make test-qpext`
- [x] `make py-lint`
- [x] `make vet` / `make go-lint`
- [x] E2E smoke on `kind-kserve` (k8s 1.33.1, Knative-mode install):
  - Bug reproduced against **released** webhook: `admission webhook "inferenceservice.kserve-webhook-server.validator" denied the request: update rejected: deploymentMode cannot be changed from 'Standard' to 'Knative'` on every reconcile of a fresh ISVC annotated `serving.kserve.io/deploymentMode: Knative`.
  - Controller re-rolled from a `ko`-built image with this patch applied, same ISVC recreated: zero admission rejections, `status.deploymentMode=Knative` populated, finalizer added, ISVC progresses normally through Knative Revision creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)