### PR TITLE
feat(llmisvc): warn when model-routing names collide across LLMISVCs

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -541,7 +541,7 @@ func expandLoRAAdapterMatches(rules []gwapiv1.HTTPRouteRule, namespace string, a
 				am := *match.DeepCopy()
 				for h := range am.Headers {
 					if string(am.Headers[h].Name) == headerName {
-						am.Headers[h].Value = fmt.Sprintf("publishers/%s/models/%s", namespace, *adapter.Name)
+						am.Headers[h].Value = fullyQualifiedModelName(namespace, *adapter.Name)
 					}
 				}
 				adapterMatches = append(adapterMatches, am)

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"knative.dev/pkg/apis"
@@ -176,6 +177,24 @@ func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1a
 	}
 
 	if route.HTTP.HasSpec() {
+		// Intentionally conservative: does not check per-peer enablement since that
+		// can change at any time (annotation flip, gateway config), silently
+		// activating a dormant collision.
+		if r.isModelBasedRoutingEnabled(ctx, llmSvc, cfg) {
+			others := &v1alpha2.LLMInferenceServiceList{}
+			if err := r.List(ctx, others, client.InNamespace(llmSvc.Namespace)); err != nil {
+				logger.Error(err, "failed to list LLMISVCs for model name collision check")
+			} else if collisions := findModelNameCollisions(llmSvc, others.Items); len(collisions) > 0 {
+				r.Eventf(llmSvc, corev1.EventTypeWarning, "ModelNameCollision",
+					"model-routing header values overlap with %s in namespace %s; "+
+						"identical header matches cause the gateway to shadow one service. "+
+						"The service is still reachable at its own address %s/%s "+
+						"and this warning is safe to ignore if you plan to enable traffic splitting later",
+					strings.Join(collisions, ", "), llmSvc.Namespace,
+					llmSvc.Namespace, llmSvc.Name)
+			}
+		}
+
 		if err := Reconcile(ctx, r, llmSvc, &gwapiv1.HTTPRoute{}, expectedHTTPRoute, semanticHTTPRouteIsEqual); err != nil {
 			return nil, fmt.Errorf("failed to reconcile HTTPRoute %s/%s: %w", expectedHTTPRoute.GetNamespace(), expectedHTTPRoute.GetName(), err)
 		}

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_filter.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_filter.go
@@ -18,7 +18,6 @@ package llmisvc
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"strings"
 
@@ -32,6 +31,10 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/network"
 )
+
+func fullyQualifiedModelName(namespace, modelName string) string {
+	return "publishers/" + namespace + "/models/" + modelName
+}
 
 // IsInternalURL determines if a URL points to an internal/private endpoint
 // This is used to classify URLs as internal vs external for routing decisions
@@ -94,7 +97,6 @@ func SourcedAddress(ctx context.Context, d DiscoveredURL, llmSvc *v1alpha2.LLMIn
 	}
 
 	models := make([]v1alpha2.ModelSourcedAddressStatus, 0, 2)
-	const modelRoutingFmt = "publishers/%s/models/%s"
 
 	// Ensure llmSvc.Spec.Model.Name is set.
 	llmSvc.Spec.Model.Name = ptr.To(ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.GetName()))
@@ -103,7 +105,7 @@ func SourcedAddress(ctx context.Context, d DiscoveredURL, llmSvc *v1alpha2.LLMIn
 		typeName += "-model-routing"
 
 		models = append(models, v1alpha2.ModelSourcedAddressStatus{
-			Name: fmt.Sprintf(modelRoutingFmt, llmSvc.GetNamespace(), *llmSvc.Spec.Model.Name),
+			Name: fullyQualifiedModelName(llmSvc.GetNamespace(), *llmSvc.Spec.Model.Name),
 		})
 		if llmSvc.Spec.Model.LoRA != nil {
 			for _, m := range llmSvc.Spec.Model.LoRA.Adapters {
@@ -111,14 +113,14 @@ func SourcedAddress(ctx context.Context, d DiscoveredURL, llmSvc *v1alpha2.LLMIn
 					continue
 				}
 				models = append(models, v1alpha2.ModelSourcedAddressStatus{
-					Name: fmt.Sprintf(modelRoutingFmt, llmSvc.GetNamespace(), *m.Name),
+					Name: fullyQualifiedModelName(llmSvc.GetNamespace(), *m.Name),
 				})
 			}
 		}
 	} else {
 		models = append(models,
 			v1alpha2.ModelSourcedAddressStatus{
-				Name: fmt.Sprintf(modelRoutingFmt, llmSvc.GetNamespace(), *llmSvc.Spec.Model.Name),
+				Name: fullyQualifiedModelName(llmSvc.GetNamespace(), *llmSvc.Spec.Model.Name),
 			},
 			v1alpha2.ModelSourcedAddressStatus{
 				Name: *llmSvc.Spec.Model.Name,
@@ -132,7 +134,7 @@ func SourcedAddress(ctx context.Context, d DiscoveredURL, llmSvc *v1alpha2.LLMIn
 
 				models = append(models,
 					v1alpha2.ModelSourcedAddressStatus{
-						Name: fmt.Sprintf(modelRoutingFmt, llmSvc.GetNamespace(), *m.Name),
+						Name: fullyQualifiedModelName(llmSvc.GetNamespace(), *m.Name),
 					},
 					v1alpha2.ModelSourcedAddressStatus{
 						Name: *m.Name,

--- a/pkg/controller/v1alpha2/llmisvc/router_validation.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_validation.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -266,4 +268,74 @@ func (r *LLMISVCReconciler) validateManagedHTTPRouteSpec(ctx context.Context, ll
 	}
 
 	return nil
+}
+
+// findModelNameCollisions returns the names of LLMISVCs whose model-routing
+// header values overlap with self's. Compares self's effective model names
+// (from post-merge spec) against each peer's status.addresses[].models[].name
+// which reflects the peer's resolved state including baseRef overrides.
+// Falls back to spec.model.name for peers not yet reconciled (empty status).
+func findModelNameCollisions(self *v1alpha2.LLMInferenceService, others []v1alpha2.LLMInferenceService) []string {
+	selfModels := modelRoutingNames(self)
+	if len(selfModels) == 0 {
+		return nil
+	}
+
+	var collisions []string
+	for i := range others {
+		other := &others[i]
+		if other.Name == self.Name ||
+			other.DeletionTimestamp != nil ||
+			sameRoutingGroup(self, other) {
+			continue
+		}
+		if otherModelNamesOverlap(selfModels, other) {
+			collisions = append(collisions, other.Name)
+		}
+	}
+
+	slices.Sort(collisions)
+
+	return collisions
+}
+
+func otherModelNamesOverlap(selfModels map[string]struct{}, other *v1alpha2.LLMInferenceService) bool {
+	for _, addr := range other.Status.Addresses {
+		for _, m := range addr.Models {
+			if _, ok := selfModels[m.Name]; ok {
+				return true
+			}
+		}
+	}
+	// Fallback: peer not yet reconciled (empty status) - check spec directly.
+	if len(other.Status.Addresses) == 0 {
+		for name := range modelRoutingNames(other) {
+			if _, ok := selfModels[name]; ok {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func modelRoutingNames(svc *v1alpha2.LLMInferenceService) map[string]struct{} {
+	baseName := ptr.Deref(svc.Spec.Model.Name, svc.Name)
+	names := map[string]struct{}{
+		fullyQualifiedModelName(svc.Namespace, baseName): {},
+	}
+	if svc.Spec.Model.LoRA != nil {
+		for _, adapter := range svc.Spec.Model.LoRA.Adapters {
+			if adapter.Name != nil {
+				names[fullyQualifiedModelName(svc.Namespace, *adapter.Name)] = struct{}{}
+			}
+		}
+	}
+
+	return names
+}
+
+func sameRoutingGroup(a, b *v1alpha2.LLMInferenceService) bool {
+	return a.Spec.Router.HasGroup() && b.Spec.Router.HasGroup() &&
+		*a.Spec.Router.Group() == *b.Spec.Router.Group()
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_validation_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_validation_internal_test.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+func newLLMISVC(name string, opts ...func(*v1alpha2.LLMInferenceService)) v1alpha2.LLMInferenceService {
+	svc := v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+	}
+	for _, o := range opts {
+		o(&svc)
+	}
+
+	return svc
+}
+
+func withModelName(name string) func(*v1alpha2.LLMInferenceService) {
+	return func(svc *v1alpha2.LLMInferenceService) {
+		svc.Spec.Model.Name = ptr.To(name)
+	}
+}
+
+func withLoRAAdapter(names ...string) func(*v1alpha2.LLMInferenceService) {
+	return func(svc *v1alpha2.LLMInferenceService) {
+		if svc.Spec.Model.LoRA == nil {
+			svc.Spec.Model.LoRA = &v1alpha2.LoRASpec{}
+		}
+		for _, n := range names {
+			svc.Spec.Model.LoRA.Adapters = append(svc.Spec.Model.LoRA.Adapters,
+				v1alpha2.LLMModelSpec{Name: ptr.To(n)})
+		}
+	}
+}
+
+func withGroup(group string) func(*v1alpha2.LLMInferenceService) {
+	return func(svc *v1alpha2.LLMInferenceService) {
+		if svc.Spec.Router == nil {
+			svc.Spec.Router = &v1alpha2.RouterSpec{}
+		}
+		if svc.Spec.Router.Route == nil {
+			svc.Spec.Router.Route = &v1alpha2.GatewayRoutesSpec{}
+		}
+		svc.Spec.Router.Route.Group = ptr.To(group)
+	}
+}
+
+// withStatusModels sets status.addresses with the given model routing names.
+// This is what peers look like after their own reconciliation.
+func withStatusModels(models ...string) func(*v1alpha2.LLMInferenceService) {
+	return func(svc *v1alpha2.LLMInferenceService) {
+		ms := make([]v1alpha2.ModelSourcedAddressStatus, len(models))
+		for i, m := range models {
+			ms[i] = v1alpha2.ModelSourcedAddressStatus{Name: m}
+		}
+		svc.Status.Addresses = []v1alpha2.SourcedAddress{{Models: ms}}
+	}
+}
+
+func withDeleting() func(*v1alpha2.LLMInferenceService) {
+	return func(svc *v1alpha2.LLMInferenceService) {
+		now := metav1.Now()
+		svc.DeletionTimestamp = &now
+	}
+}
+
+func TestFindModelNameCollisions(t *testing.T) {
+	tests := []struct {
+		name   string
+		self   v1alpha2.LLMInferenceService
+		others []v1alpha2.LLMInferenceService
+		want   []string
+	}{
+		{
+			name:   "no others",
+			self:   newLLMISVC("a", withModelName("gpt-4o")),
+			others: nil,
+		},
+		{
+			name: "no collision - different model names",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withStatusModels("publishers/default/models/llama")),
+			},
+		},
+		{
+			name: "base model collision",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withStatusModels("publishers/default/models/gpt-4o")),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "multiple collisions sorted",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("c", withStatusModels("publishers/default/models/gpt-4o")),
+				newLLMISVC("b", withStatusModels("publishers/default/models/gpt-4o")),
+			},
+			want: []string{"b", "c"},
+		},
+		{
+			name: "same group excluded",
+			self: newLLMISVC("a", withModelName("gpt-4o"), withGroup("my-group")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withGroup("my-group"),
+					withStatusModels("publishers/default/models/gpt-4o")),
+			},
+		},
+		{
+			name: "different groups collide",
+			self: newLLMISVC("a", withModelName("gpt-4o"), withGroup("g1")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withGroup("g2"),
+					withStatusModels("publishers/default/models/gpt-4o")),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "self grouped other standalone - collision",
+			self: newLLMISVC("a", withModelName("gpt-4o"), withGroup("g1")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withStatusModels("publishers/default/models/gpt-4o")),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "self standalone other grouped - collision",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withGroup("g1"),
+					withStatusModels("publishers/default/models/gpt-4o")),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "nil model.name defaults to metadata.name",
+			self: newLLMISVC("shared-name"),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withStatusModels("publishers/default/models/shared-name")),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "self excluded from results",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("a", withStatusModels("publishers/default/models/gpt-4o")),
+			},
+		},
+		{
+			name: "peer being deleted skipped",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withDeleting(),
+					withStatusModels("publishers/default/models/gpt-4o")),
+			},
+		},
+		{
+			name: "peer with empty status falls back to spec.model.name",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withModelName("gpt-4o")),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "peer with empty status and different model.name - no collision",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withModelName("llama")),
+			},
+		},
+		{
+			name: "lora adapter on self collides with base model on peer",
+			self: newLLMISVC("a", withModelName("base"), withLoRAAdapter("shared-adapter")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withStatusModels("publishers/default/models/shared-adapter")),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "lora adapter on peer collides with base model on self",
+			self: newLLMISVC("a", withModelName("gpt-4o")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withStatusModels(
+					"publishers/default/models/other-base",
+					"publishers/default/models/gpt-4o",
+				)),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "no collision when peer model-routing names differ",
+			self: newLLMISVC("a", withModelName("gpt-4o"), withLoRAAdapter("adapter-a")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withStatusModels(
+					"publishers/default/models/llama",
+					"publishers/default/models/adapter-b",
+				)),
+			},
+		},
+		{
+			name: "peer with empty status - lora adapter fallback catches collision",
+			self: newLLMISVC("a", withModelName("base")),
+			others: []v1alpha2.LLMInferenceService{
+				newLLMISVC("b", withModelName("other"), withLoRAAdapter("base")),
+			},
+			want: []string{"b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findModelNameCollisions(&tt.self, tt.others)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("findModelNameCollisions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora.go
@@ -164,7 +164,7 @@ func (r *LLMISVCReconciler) attachLoRAAdapters(
 		}
 		for _, mod := range []loraModuleJSON{
 			{Name: a.name, Path: a.mountPath},
-			{Name: fmt.Sprintf("publishers/%s/models/%s", llmSvc.Namespace, a.name), Path: a.mountPath},
+			{Name: fullyQualifiedModelName(llmSvc.Namespace, a.name), Path: a.mountPath},
 		} {
 			m, err := json.Marshal(mod)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

If two LLMISVCs in the same namespace produce identical model-routing header values (`publishers/{ns}/models/{name}`), Gateway API picks the oldest route and the other one just stops getting traffic silently.

This PR adds a collision check at reconcile time that emits a `ModelNameCollision` warning event when overlapping model-routing names are detected. Compares self's effective model names (base model + LoRA adapters) from post-merge spec against each peer's `status.addresses[].models` - the resolved state that already includes baseRef overrides. Catches both base-model and LoRA adapter collisions.

Does not check whether the peer has model-based routing enabled - that state can flip at any time (annotation, gateway config), but a conservative warning beats is still helpful.

Follow-up from the discussion in #5521.

**Which issue(s) this PR fixes**:


**Feature/Issue validation/testing**:

- [x] Unit tests for `findModelNameCollisions` covering: no collision, single/multiple collisions, same group excluded, asymmetric group membership, nil model.name defaulting, deleted peer filtering, empty status (not yet reconciled), LoRA adapter vs base model collision (both directions), conservative warning when peer lacks model-routing annotation
- [x] All existing tests pass (`go test ./pkg/controller/v1alpha2/llmisvc/...`)
- [x] `make precommit` passes (lint, vet, codegen)

**Special notes for your reviewer**:

The check is intentionally conservative - warns based on model-routing name overlap without verifying per-peer enablement. Peers that haven't been reconciled yet (empty status) are silently skipped and caught on the next reconcile.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Emit a warning event when LLMInferenceService resources in the same namespace produce overlapping model-routing header values (base model or LoRA adapters), which causes the gateway to silently shadow one service.
```