### PR TITLE
fix(autogluon): prevent path traversal in model loading

### DIFF
--- a/python/autogluonserver/autogluonserver/autogluon_model_repository.py
+++ b/python/autogluonserver/autogluonserver/autogluon_model_repository.py
@@ -26,8 +26,31 @@ class AutoGluonModelRepository(ModelRepository):
     async def load(self, name: str) -> bool:
         return self.load_model(name)
 
+    def _validate_model_path(self, name: str) -> str:
+        """Validate model name to prevent path traversal attacks."""
+        if not name or not name.strip():
+            raise ValueError("Model name cannot be empty")
+
+        if os.path.isabs(name):
+            raise ValueError(f"Model name cannot be an absolute path: {name}")
+
+        models_dir_real = os.path.realpath(self.models_dir)
+        candidate_path = os.path.join(models_dir_real, name)
+        candidate_path_real = os.path.realpath(candidate_path)
+
+        try:
+            common_path = os.path.commonpath([models_dir_real, candidate_path_real])
+        except ValueError:
+            raise ValueError(f"Model path traversal detected: {name}")
+
+        if common_path != models_dir_real:
+            raise ValueError(f"Model path traversal detected: {name}")
+
+        return candidate_path_real
+
     def load_model(self, name: str) -> bool:
-        model = create_autogluon_model(name, os.path.join(self.models_dir, name))
+        model_path = self._validate_model_path(name)
+        model = create_autogluon_model(name, model_path)
         if model.load():
             self.update(model)
         return model.ready

--- a/python/autogluonserver/tests/test_autogluon_model_repository.py
+++ b/python/autogluonserver/tests/test_autogluon_model_repository.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pytest
 
 from autogluonserver import AutoGluonModelRepository
@@ -75,3 +76,126 @@ async def test_load_failure_does_not_register_model(monkeypatch, tmp_path):
 
     assert repo.get_model(model_name) is None
     assert not await repo.is_model_ready(model_name)
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_blocked_parent_directory(tmp_path):
+    repo = AutoGluonModelRepository(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Model path traversal detected"):
+        await repo.load("../etc/passwd")
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_blocked_double_dot(tmp_path):
+    repo = AutoGluonModelRepository(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Model path traversal detected"):
+        await repo.load("../../tmp/evil")
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_blocked_absolute_path(tmp_path):
+    repo = AutoGluonModelRepository(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Model name cannot be an absolute path"):
+        await repo.load("/etc/passwd")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "nt", reason="Windows-specific path test")
+async def test_path_traversal_blocked_windows_absolute(tmp_path):
+    repo = AutoGluonModelRepository(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Model name cannot be an absolute path"):
+        await repo.load("C:\\Windows\\System32")
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_blocked_symlink_escape(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+
+    repo = AutoGluonModelRepository(str(models_dir))
+
+    with pytest.raises(ValueError, match="Model path traversal detected"):
+        await repo.load("model/../../../etc/passwd")
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_blocked_mixed_separators(tmp_path):
+    repo = AutoGluonModelRepository(str(tmp_path))
+
+    # On Unix, backslashes are literal characters not separators, so this won't traverse
+    # On Windows, this should be caught. Either way, it won't succeed.
+    with pytest.raises((ValueError, Exception)):
+        await repo.load(r"..\..\tmp\evil")
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_blocked_url_encoded(tmp_path):
+    repo = AutoGluonModelRepository(str(tmp_path))
+
+    # URL-encoded paths should still fail validation since realpath resolves them
+    with pytest.raises((ValueError, Exception)):
+        await repo.load("..%2F..%2Ftmp%2Fevil")
+
+
+@pytest.mark.asyncio
+async def test_empty_model_name_rejected(tmp_path):
+    repo = AutoGluonModelRepository(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Model name cannot be empty"):
+        await repo.load("")
+
+
+@pytest.mark.asyncio
+async def test_whitespace_model_name_rejected(tmp_path):
+    repo = AutoGluonModelRepository(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Model name cannot be empty"):
+        await repo.load("   ")
+
+
+@pytest.mark.asyncio
+async def test_valid_model_name_accepted(monkeypatch, tmp_path):
+    model_name = "valid-model-123"
+    (tmp_path / model_name).mkdir()
+
+    class FakeAutoGluonModel:
+        def __init__(self, name, model_dir):
+            self.name = name
+            self.model_dir = model_dir
+            self.ready = False
+
+        def load(self):
+            self.ready = True
+            return True
+
+        async def healthy(self):
+            return self.ready
+
+    monkeypatch.setattr(
+        "autogluonserver.autogluon_model_repository.create_autogluon_model",
+        lambda n, d: FakeAutoGluonModel(n, d),
+    )
+
+    repo = AutoGluonModelRepository(str(tmp_path))
+    await repo.load(model_name)
+    assert repo.get_model(model_name) is not None
+
+
+@pytest.mark.asyncio
+async def test_validate_model_path_returns_real_path(tmp_path):
+    model_name = "test-model"
+    (tmp_path / model_name).mkdir()
+
+    repo = AutoGluonModelRepository.__new__(AutoGluonModelRepository)
+    repo.models_dir = str(tmp_path)
+    repo.models = {}
+
+    validated_path = repo._validate_model_path(model_name)
+
+    assert os.path.isabs(validated_path)
+    assert validated_path == os.path.realpath(os.path.join(str(tmp_path), model_name))
+    assert validated_path.startswith(os.path.realpath(str(tmp_path)))

--- a/python/autogluonserver/tests/test_autogluon_model_repository.py
+++ b/python/autogluonserver/tests/test_autogluon_model_repository.py
@@ -123,25 +123,6 @@ async def test_path_traversal_blocked_symlink_escape(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_path_traversal_blocked_mixed_separators(tmp_path):
-    repo = AutoGluonModelRepository(str(tmp_path))
-
-    # On Unix, backslashes are literal characters not separators, so this won't traverse
-    # On Windows, this should be caught. Either way, it won't succeed.
-    with pytest.raises((ValueError, Exception)):
-        await repo.load(r"..\..\tmp\evil")
-
-
-@pytest.mark.asyncio
-async def test_path_traversal_blocked_url_encoded(tmp_path):
-    repo = AutoGluonModelRepository(str(tmp_path))
-
-    # URL-encoded paths should still fail validation since realpath resolves them
-    with pytest.raises((ValueError, Exception)):
-        await repo.load("..%2F..%2Ftmp%2Fevil")
-
-
-@pytest.mark.asyncio
 async def test_empty_model_name_rejected(tmp_path):
     repo = AutoGluonModelRepository(str(tmp_path))
 


### PR DESCRIPTION
## Summary
- Add `_validate_model_path()` to `AutoGluonModelRepository` to reject empty model names, absolute paths, and resolved paths that escape the configured models directory.
- Use the validated canonical path when loading models via `load_model()`, preventing path traversal attacks (e.g. `../etc/passwd`, nested `..` segments, and symlink-based escapes).
- Add unit tests covering traversal attempts, invalid names, and valid model loading behavior.
## Motivation
Previously, model names were joined directly with `models_dir` without validation. A malicious or malformed model name could resolve outside the intended mount directory and expose arbitrary filesystem paths during model load.
## Test plan
- [ ] Run autogluon server unit tests: `pytest python/autogluonserver/tests/test_autogluon_model_repository.py`
- [ ] Verify valid model names (e.g. `valid-model-123`) still load successfully
- [ ] Verify traversal attempts raise `ValueError` with appropriate messages:
  - `../etc/passwd`, `../../tmp/evil`
  - absolute paths (`/etc/passwd`, Windows drive paths)
  - nested traversal (`model/../../../etc/passwd`)
  - empty and whitespace-only names

Assisted with <Claude Sonnet 4.5>