### PR TITLE
docs: update llmisvc samples from v1alpha1 to v1alpha2

### DIFF
--- a/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-gpu-deepep-ht.yaml
+++ b/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-gpu-deepep-ht.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: deepseek-r1-0528

--- a/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-gpu-naive.yaml
+++ b/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-gpu-naive.yaml
@@ -1,5 +1,5 @@
 # GCP a3-highgpu-8g: No SR-IOV/RDMA, uses gVNIC with TCP-optimized NCCL
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: deepseek-coder-v2

--- a/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-pd-gpu-p-deepep-ht-d-deepep-ht.yaml
+++ b/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-pd-gpu-p-deepep-ht-d-deepep-ht.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: deepseek-r1-0528-pd

--- a/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-pd-gpu-p-deepep-ht-d-pplx.yaml
+++ b/docs/samples/llmisvc/dp-ep/deepseek-r1-gpu-rdma-roce/llm-inference-service-dp-ep-deepseek-r1-pd-gpu-p-deepep-ht-d-pplx.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: deepseek-r1-0528-pd

--- a/docs/samples/llmisvc/kv-cache-offloading/llm-inference-service-kv-cache-offloading.yaml
+++ b/docs/samples/llmisvc/kv-cache-offloading/llm-inference-service-kv-cache-offloading.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: qwen2-7b-kv-cache-offloading

--- a/docs/samples/llmisvc/lora-adapters/test-examples/01-lora-hf-cpu.yaml
+++ b/docs/samples/llmisvc/lora-adapters/test-examples/01-lora-hf-cpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: lora-hf-test

--- a/docs/samples/llmisvc/lora-adapters/test-examples/02-lora-multi-hf-cpu.yaml
+++ b/docs/samples/llmisvc/lora-adapters/test-examples/02-lora-multi-hf-cpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: lora-multi-hf-test

--- a/docs/samples/llmisvc/lora-adapters/test-examples/04-lora-pvc-cpu.yaml
+++ b/docs/samples/llmisvc/lora-adapters/test-examples/04-lora-pvc-cpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: lora-pvc-test

--- a/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
+++ b/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: qwen2-7b-instruct-amd

--- a/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-nvidia-with-scheduler.yaml
+++ b/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-nvidia-with-scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: qwen2-7b-instruct-nvidia

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: facebook-opt-125m-single

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: facebook-opt-125m-single

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: facebook-opt-125m-pd

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/README.md
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/README.md
@@ -34,7 +34,6 @@ This example demonstrates precise prefix cache routing with cache block tracking
 - **Queue Scorer**: Balances load across endpoints based on queue depth (weight: 2)
 - **Active Request Scorer**: Prefers idle pods to spread prefix caches during cold starts, preventing all requests with a shared prefix from piling onto one endpoint (weight: 3)
 - **Cache Tracking Mode**: Real-time tracking of KV cache blocks using ZMQ events
-- **KV Transfer**: Enabled via NixlConnector for cache sharing between instances
 - **Block Size**: 64 tokens (configurable, must match between vLLM and scheduler)
 - **Hash Seed**: PYTHONHASHSEED=42 (must match across all components)
 
@@ -71,7 +70,6 @@ Key vLLM settings for cache routing:
 VLLM_ADDITIONAL_ARGS:
   - --prefix-caching-hash-algo sha256_cbor
   - --block-size 64
-  - --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
   - --kv-events-config '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://...:5557","topic":"kv@${POD_IP}@..."}'
 
 PYTHONHASHSEED: "42"

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
@@ -1,5 +1,5 @@
 # kv-cache
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: qwen2-7b-kv-cache-routing
@@ -56,7 +56,7 @@ spec:
         env:
           # Configure vLLM for prefix caching with KV cache event publishing
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--prefix-caching-hash-algo sha256_cbor --block-size 64 --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --kv-events-config '{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://{{ ChildName .ObjectMeta.Name `-epp-service` }}:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen2.5-7B-Instruct\"}'"
+            value: "--prefix-caching-hash-algo sha256_cbor --block-size 64 --kv-events-config '{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://{{ ChildName .ObjectMeta.Name `-epp-service` }}:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen2.5-7B-Instruct\"}'"
           # Pod IP used in KV cache event topic
           - name: POD_IP
             valueFrom:

--- a/docs/samples/llmisvc/single-node-gpu/llm-inference-service-pd-qwen2-7b-gpu.yaml
+++ b/docs/samples/llmisvc/single-node-gpu/llm-inference-service-pd-qwen2-7b-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: qwen2-7b-instruct-pd

--- a/docs/samples/llmisvc/single-node-gpu/llm-inference-service-qwen2-7b-gpu-no-scheduler.yaml
+++ b/docs/samples/llmisvc/single-node-gpu/llm-inference-service-qwen2-7b-gpu-no-scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: qwen2-7b-instruct-single-no-scheduler

--- a/docs/samples/llmisvc/single-node-gpu/llm-inference-service-qwen2-7b-gpu.yaml
+++ b/docs/samples/llmisvc/single-node-gpu/llm-inference-service-qwen2-7b-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha1
+apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
 metadata:
   name: qwen2-7b-instruct-single


### PR DESCRIPTION
  What this PR does / why we need it:                                                                                                                                                                                                                                                     
                                     
  Updates all LLMInferenceService sample manifests under docs/samples/llmisvc/ from serving.kserve.io/v1alpha1 to serving.kserve.io/v1alpha2. v1alpha2 is the storage version of the CRD (storage: true). No spec fields, resource values, env vars, or plugin configs were changed — with one exception: llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml also removes --kv_transfer_config NixlConnector from VLLM_ADDITIONAL_ARGS as it is not required for prefix cache routing (no KV transfer between pods occurs).
                                                                                                                                                                                                                                                                                          
  Which issue(s) this PR fixes:                                                                                                                                                                                                                                                                          
  N/A                     
                                                                                                                                                                                                                                                                                          
  Feature/Issue validation/testing:                                                                                                                                                                                                                                                                                 
  All 17 files validated with server-side dry-run against a live Kubernetes cluster (v1.34.8) with the LLMInferenceService CRD installed:
                                                                                                                                                                                                                                                                                          
  kubectl apply --dry-run=server -f <file>                                                                                                                                                                                                                                                                                  - Server-side dry-run passed for all 17 files
                                                                                                                                                                                                                                                                                          
  Special notes for your reviewer:                                                                                                                                                                                                                                                                                
  17 files changed. 16 are pure apiVersion bumps (one line each). The kv-cache routing GPU file additionally removes NixlConnector from VLLM_ADDITIONAL_ARGS — prefix cache routing works by routing requests to pods that already have the blocks cached, no KV transfer is needed.
                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                      

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [X ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
NONE

