### PR TITLE
fix(llmisvc): retry finalizer on transient peer route read errors

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router_group.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"slices"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	kmeta "knative.dev/pkg/kmeta"
@@ -228,7 +229,10 @@ func (r *LLMISVCReconciler) finalizeGroupMembership(ctx context.Context, llmSvc 
 			Namespace: peers[i].GetNamespace(),
 		}
 		if err := r.Get(ctx, routeKey, route); err != nil {
-			continue
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, fmt.Errorf("checking peer route %s for stale backendRefs: %w", routeKey.Name, err)
 		}
 		if routeReferencesBackend(route, poolName) || routeReferencesBackend(route, svcName) {
 			logger.Info("Waiting for peer to remove backendRef before deletion",


### PR DESCRIPTION
**What this PR does / why we need it**:

Group member deletion finalizer treated all peer HTTPRoute read errors as "route not found", allowing premature finalizer removal on transient failures (cache timeout, API server hiccup). This could leave dangling backendRefs in peer routes until their next reconcile.

Only `NotFound` errors now skip the peer; all other errors return for retry with exponential backoff, preserving the deletion-safety guarantee.

**Which issue(s) this PR fixes**:


**Feature/Issue validation/testing**:

- [x] Unit tests pass (839 tests)
- [x] `go vet` clean
- [x] Reviewed by dev-k8s-ctrl agent for controller correctness

**Special notes for your reviewer**:

Before this fix, a persistent non-NotFound error (e.g. RBAC misconfiguration) would silently skip the peer and remove the finalizer - allowing deletion while a peer's route still has a stale backendRef. With this change, the stuck finalizer becomes an operator-visible signal that something is wrong, which is preferable to silently proceeding with incomplete cleanup.

**Checklist**: