### PR TITLE
feat(llmisvc): add stable and version-independent URLs

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -1922,6 +1922,110 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/completions
+            name: v1-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/chat/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/chat/completions
+            name: v1-chat-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/responses
+            name: v1-responses-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/messages
+            name: v1-messages-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+            name: v1-publisher-path-catch-all
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/config/llmisvcconfig/config-llm-router-route.yaml
+++ b/config/llmisvcconfig/config-llm-router-route.yaml
@@ -223,6 +223,119 @@ spec:
               timeouts:
                 backendRequest: 0s
                 request: 0s
+            # Publisher-qualified model paths provide a stable, version-independent
+            # endpoint using spec.model.name instead of metadata.name.
+            # The /publishers/ path prefix is reserved for this purpose.
+            # These mirror the per-participant endpoint rules above.
+            - name: v1-completions-publisher-path
+              backendRefs:
+                - group: inference.networking.k8s.io
+                  kind: InferencePool
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
+                      /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}/v1/completions
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /v1/completions
+              timeouts:
+                backendRequest: 0s
+                request: 0s
+            - name: v1-chat-completions-publisher-path
+              backendRefs:
+                - group: inference.networking.k8s.io
+                  kind: InferencePool
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
+                      /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}/v1/chat/completions
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /v1/chat/completions
+              timeouts:
+                backendRequest: 0s
+                request: 0s
+            - name: v1-responses-publisher-path
+              backendRefs:
+                - group: inference.networking.k8s.io
+                  kind: InferencePool
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
+                      /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}/v1/responses
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /v1/responses
+              timeouts:
+                backendRequest: 0s
+                request: 0s
+            - name: v1-messages-publisher-path
+              backendRefs:
+                - group: inference.networking.k8s.io
+                  kind: InferencePool
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
+                      /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}/v1/messages
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /v1/messages
+              timeouts:
+                backendRequest: 0s
+                request: 0s
+            - name: v1-publisher-path-catch-all
+              backendRefs:
+                - kind: Service
+                  name: |-
+                    {{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}
+                  port: 8000
+                  weight: 1
+              matches:
+                - path:
+                    type: PathPrefix
+                    value: |-
+                      /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
+              filters:
+                - type: URLRewrite
+                  urlRewrite:
+                    path:
+                      type: ReplacePrefixMatch
+                      replacePrefixMatch: /
+              timeouts:
+                backendRequest: 0s
+                request: 0s
             # Catch-all rules route to the workload Service directly (bypassing
             # InferencePool) for endpoints not handled by the scheduler, such as
             # /v1/models, /health, or custom paths exposed by the runtime.

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4528,6 +4528,110 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/completions
+            name: v1-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/chat/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/chat/completions
+            name: v1-chat-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/responses
+            name: v1-responses-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/messages
+            name: v1-messages-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+            name: v1-publisher-path-catch-all
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -4114,6 +4114,110 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/completions
+            name: v1-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/chat/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/chat/completions
+            name: v1-chat-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/responses
+            name: v1-responses-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/messages
+            name: v1-messages-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+            name: v1-publisher-path-catch-all
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -528,13 +529,20 @@ func expandLoRAAdapterMatches(rules []gwapiv1.HTTPRouteRule, namespace string, a
 	if headerName == "" || len(adapters) == 0 {
 		return
 	}
+
+	sorted := make([]v1alpha2.LLMModelSpec, len(adapters))
+	copy(sorted, adapters)
+	slices.SortFunc(sorted, func(a, b v1alpha2.LLMModelSpec) int {
+		return strings.Compare(ptr.Deref(a.Name, ""), ptr.Deref(b.Name, ""))
+	})
+
 	for i := range rules {
 		var adapterMatches []gwapiv1.HTTPRouteMatch
 		for _, match := range rules[i].Matches {
 			if !isModelBasedRoutingMatch(match, headerName) {
 				continue
 			}
-			for _, adapter := range adapters {
+			for _, adapter := range sorted {
 				if adapter.Name == nil {
 					continue
 				}

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_lora_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_lora_test.go
@@ -230,6 +230,25 @@ func TestExpandLoRAAdapterMatches(t *testing.T) {
 				assert.Equal(t, "publishers/prod/models/lora-1", rules[0].Matches[1].Headers[0].Value)
 			},
 		},
+		{
+			name: "adapter order is stable regardless of input order",
+			rules: []gwapiv1.HTTPRouteRule{
+				ruleWithMatches(
+					exactPathWithHeaderMatch("/v1/completions", "publishers/ns/models/base-model"),
+				),
+			},
+			namespace: "ns",
+			adapters: []v1alpha2.LLMModelSpec{
+				{Name: ptr.To("zebra")},
+				{Name: ptr.To("alpha")},
+			},
+			headerName: headerName,
+			wantFn: func(t *testing.T, rules []gwapiv1.HTTPRouteRule) {
+				assert.Len(t, rules[0].Matches, 3)
+				assert.Equal(t, "publishers/ns/models/alpha", rules[0].Matches[1].Headers[0].Value)
+				assert.Equal(t, "publishers/ns/models/zebra", rules[0].Matches[2].Headers[0].Value)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -177,22 +177,20 @@ func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1a
 	}
 
 	if route.HTTP.HasSpec() {
-		// Intentionally conservative: does not check per-peer enablement since that
-		// can change at any time (annotation flip, gateway config), silently
-		// activating a dormant collision.
-		if r.isModelBasedRoutingEnabled(ctx, llmSvc, cfg) {
-			others := &v1alpha2.LLMInferenceServiceList{}
-			if err := r.List(ctx, others, client.InNamespace(llmSvc.Namespace)); err != nil {
-				logger.Error(err, "failed to list LLMISVCs for model name collision check")
-			} else if collisions := findModelNameCollisions(llmSvc, others.Items); len(collisions) > 0 {
-				r.Eventf(llmSvc, corev1.EventTypeWarning, "ModelNameCollision",
-					"model-routing header values overlap with %s in namespace %s; "+
-						"identical header matches cause the gateway to shadow one service. "+
-						"The service is still reachable at its own address %s/%s "+
-						"and this warning is safe to ignore if you plan to enable traffic splitting later",
-					strings.Join(collisions, ", "), llmSvc.Namespace,
-					llmSvc.Namespace, llmSvc.Name)
-			}
+		// Model name collisions affect publisher paths and model-routing
+		// headers alike - both derive from the same fullyQualifiedModelName.
+		// Run unconditionally because publisher paths are always present.
+		others := &v1alpha2.LLMInferenceServiceList{}
+		if err := r.List(ctx, others, client.InNamespace(llmSvc.Namespace)); err != nil {
+			logger.Error(err, "failed to list LLMISVCs for model name collision check")
+		} else if collisions := findModelNameCollisions(llmSvc, others.Items); len(collisions) > 0 {
+			r.Eventf(llmSvc, corev1.EventTypeWarning, "ModelNameCollision",
+				"model name %q overlaps with %s in namespace %s; "+
+					"shared publisher paths and model-routing headers cause the gateway to shadow one service. "+
+					"Reachable at its own address %s/%s; safe to ignore if traffic splitting is planned",
+				ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.Name),
+				strings.Join(collisions, ", "), llmSvc.Namespace,
+				llmSvc.Namespace, llmSvc.Name)
 		}
 
 		if err := Reconcile(ctx, r, llmSvc, &gwapiv1.HTTPRoute{}, expectedHTTPRoute, semanticHTTPRouteIsEqual); err != nil {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -270,13 +270,10 @@ func extractRoutePaths(route *gwapiv1.HTTPRoute, modelRoutingHeader string) []st
 		servicePaths []string
 		otherPaths   []string
 	}
-	// We keep two separate buckets because the two access methods produce
-	// different "base URL" paths that must both appear in the status:
-	//  - pathBased  → /{namespace}/{name} (the original routing scheme)
-	//  - modelRouting → / (reachable only with the model-routing header)
-	// Mixing them into one list would let the model-routing "/" shadow the
-	// deeper path-based URL, which breaks backward-compatible discovery.
-	var pathBased, modelRouting pathBucket
+	// Three buckets, one per access method. Each produces a different
+	// base URL that lands in status, and mixing them would let the
+	// shallower "/" from model-routing shadow the deeper path-based ones.
+	var pathBased, publisherPath, modelRouting pathBucket
 
 	for _, rule := range route.Spec.Rules {
 		svc := hasServiceBackend(rule)
@@ -287,14 +284,25 @@ func extractRoutePaths(route *gwapiv1.HTTPRoute, modelRoutingHeader string) []st
 			}
 
 			if len(match.Headers) == 0 {
-				// Traditional path-only match — always collected.
-				if svc {
-					pathBased.servicePaths = append(pathBased.servicePaths, p)
+				if strings.HasPrefix(p, "/publishers/") {
+					// Publisher-qualified model path - stable across versions.
+					// The /publishers/ prefix is reserved for controller-managed
+					// model-level routes and must not be used for custom paths.
+					if svc {
+						publisherPath.servicePaths = append(publisherPath.servicePaths, p)
+					} else {
+						publisherPath.otherPaths = append(publisherPath.otherPaths, p)
+					}
 				} else {
-					pathBased.otherPaths = append(pathBased.otherPaths, p)
+					// Traditional path-only match - per-participant.
+					if svc {
+						pathBased.servicePaths = append(pathBased.servicePaths, p)
+					} else {
+						pathBased.otherPaths = append(pathBased.otherPaths, p)
+					}
 				}
 			} else if isModelBasedRoutingMatch(match, modelRoutingHeader) {
-				// Model-based routing match — collected only when the header
+				// Model-based routing match - collected only when the header
 				// is our configured model-routing header so we don't
 				// accidentally promote user-provided header rules to URLs.
 				if svc {
@@ -330,6 +338,9 @@ func extractRoutePaths(route *gwapiv1.HTTPRoute, modelRoutingHeader string) []st
 
 	var result []string
 	if p := shallowest(pathBased); p != "" {
+		result = append(result, p)
+	}
+	if p := shallowest(publisherPath); p != "" {
 		result = append(result, p)
 	}
 	if p := shallowest(modelRouting); p != "" {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_publisher_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_publisher_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The KServe Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestExtractRoutePaths_PublisherPath(t *testing.T) {
+	headerName := "X-Gateway-Model-Name"
+
+	pathRule := func(path string, kind string) gwapiv1.HTTPRouteRule {
+		return gwapiv1.HTTPRouteRule{
+			Matches: []gwapiv1.HTTPRouteMatch{{
+				Path: &gwapiv1.HTTPPathMatch{Value: &path},
+			}},
+			BackendRefs: []gwapiv1.HTTPBackendRef{{
+				BackendRef: gwapiv1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{
+						Kind: ptr.To(gwapiv1.Kind(kind)),
+					},
+				},
+			}},
+		}
+	}
+
+	headerRule := func(path string) gwapiv1.HTTPRouteRule {
+		return gwapiv1.HTTPRouteRule{
+			Matches: []gwapiv1.HTTPRouteMatch{{
+				Path: &gwapiv1.HTTPPathMatch{Value: &path},
+				Headers: []gwapiv1.HTTPHeaderMatch{{
+					Name:  gwapiv1.HTTPHeaderName(headerName),
+					Value: "publishers/ns/models/llama-70b",
+				}},
+			}},
+			BackendRefs: []gwapiv1.HTTPBackendRef{{
+				BackendRef: gwapiv1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{
+						Kind: ptr.To(gwapiv1.Kind("InferencePool")),
+					},
+				},
+			}},
+		}
+	}
+
+	t.Run("publisher path appears alongside per-participant and model-routing paths", func(t *testing.T) {
+		route := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					pathRule("/ns/my-llm/v1/chat/completions", "InferencePool"),
+					headerRule("/v1/chat/completions"),
+					pathRule("/publishers/ns/models/llama-70b", "InferencePool"),
+					pathRule("/ns/my-llm", "Service"),
+				},
+			},
+		}
+
+		paths := extractRoutePaths(route, headerName)
+
+		assert.Contains(t, paths, "/ns/my-llm", "per-participant path")
+		assert.Contains(t, paths, "/publishers/ns/models/llama-70b", "publisher path")
+		assert.Contains(t, paths, "/v1/chat/completions", "model-routing path")
+		assert.Len(t, paths, 3)
+	})
+
+	t.Run("publisher path present without model-routing", func(t *testing.T) {
+		route := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					pathRule("/ns/my-llm", "Service"),
+					pathRule("/publishers/ns/models/llama-70b", "InferencePool"),
+				},
+			},
+		}
+
+		paths := extractRoutePaths(route, headerName)
+
+		assert.Contains(t, paths, "/ns/my-llm")
+		assert.Contains(t, paths, "/publishers/ns/models/llama-70b")
+		assert.Len(t, paths, 2)
+	})
+
+	t.Run("no publisher path - only per-participant and model-routing", func(t *testing.T) {
+		route := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					pathRule("/ns/my-llm", "Service"),
+					headerRule("/v1/chat/completions"),
+				},
+			},
+		}
+
+		paths := extractRoutePaths(route, headerName)
+
+		assert.Contains(t, paths, "/ns/my-llm")
+		assert.Contains(t, paths, "/v1/chat/completions")
+		assert.NotContains(t, paths, "/publishers/ns/models/llama-70b")
+		assert.Len(t, paths, 2)
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a stable, version-independent URL path for LLMInferenceService endpoints using `spec.model.name` instead of `metadata.name`.

Today, every participant's URL includes its `metadata.name` - which changes across versions during controlled deployments. Consumers need a stable endpoint that survives model upgrades. The publisher path (`/publishers/{namespace}/models/{model-name}`) provides exactly that - a single URL that follows the model identity rather than the participant identity, and naturally participates in weighted traffic splitting when multiple grouped members serve the same model. This approach is aligned with header-based routing that we already have in place.

Also lifts the model name collision warning out of the model-routing-only gate. Since publisher paths are always present on managed routes, collisions matter regardless of whether header-based model routing is enabled.

## Publisher path and LoRA adapters

The HTTPRoute exposes one stable publisher-qualified path for the base model. It   does not create a separate path for each LoRA adapter. Clients invoke an adapter through the base model's publisher path and select it using the request body's `model` field:

```http
POST /publishers/ns/models/base-model/v1/chat/completions
{
  "model": "publishers/ns/models/sql-expert"
}
```

Explicit per-adapter publisher paths are intentionally out of scope. Preserving the same behavior as the base publisher path would require five rules per adapter - four inference endpoint rewrites and one Service catch-all. Gateway API requires every rule using ReplacePrefixMatch to contain exactly one PathPrefix match, so these rules cannot be combined. Since the base route already uses 15 of the 16 available rules, even one fully mirrored adapter path would require HTTPRoute sharding. Sharding can be introduced separately if dedicated adapter URLs become a requirement

**Which issue(s) this PR fixes**:

Related to #5725 

**Feature/Issue validation/testing**:

- [x] Unit tests for `extractRoutePaths` covering publisher path bucketing (5 cases: all-three-present, publisher-without-model-routing, no-publisher, publisher-only, service-backed preference)
- [x] Existing `findModelNameCollisions` tests pass unchanged - detection logic is shared

**Special notes for your reviewer**:

The publisher path reuses the same `fullyQualifiedModelName` identity (`publishers/{ns}/models/{name}`) already used by model-routing headers. This means a single collision check covers both routing surfaces.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Add publisher-qualified model path (/publishers/{namespace}/models/{model-name}) providing stable, version-independent URLs for LLMInferenceService endpoints during controlled deployments.
```