### PR TITLE
refactor(llmisvc): consolidate model-routing rules

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -1759,33 +1759,6 @@ spec:
               name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
               port: 8000
               weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/completions
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/completions/
-            name: v1-completions-model-routing
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
             filters:
             - type: URLRewrite
               urlRewrite:
@@ -1806,33 +1779,6 @@ spec:
               name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
               port: 8000
               weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/chat/completions
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/chat/completions/
-            name: v1-chat-completions-model-routing
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
             filters:
             - type: URLRewrite
               urlRewrite:
@@ -1844,33 +1790,6 @@ spec:
                 type: PathPrefix
                 value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
             name: v1-responses-path
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/responses
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/responses/
-            name: v1-responses-model-routing
             timeouts:
               backendRequest: 0s
               request: 0s
@@ -1908,6 +1827,54 @@ spec:
                   }}
               path:
                 type: Exact
+                value: /v1/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
                 value: /v1/messages
             - headers:
               - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
@@ -1917,7 +1884,7 @@ spec:
               path:
                 type: Exact
                 value: /v1/messages/
-            name: v1-messages-model-routing
+            name: v1-model-routing
             timeouts:
               backendRequest: 0s
               request: 0s

--- a/config/llmisvcconfig/config-llm-router-route.yaml
+++ b/config/llmisvcconfig/config-llm-router-route.yaml
@@ -1,16 +1,17 @@
 # HTTPRoute template for LLMInferenceService routing.
 #
-# Each endpoint (completions, chat/completions, responses, messages) is split into two
-# rules because Gateway API requires exactly one PathPrefix match per rule
-# when using URLRewrite with replacePrefixMatch:
+# Each inference endpoint (completions, chat/completions, responses, messages)
+# has a PathPrefix rule that matches /{namespace}/{name}/v1/... and rewrites
+# to /v1/... through the InferencePool. Each PathPrefix rule carries a
+# URLRewrite filter and must have exactly one match (Gateway API requirement
+# for ReplacePrefixMatch).
 #
-#   1. PathPrefix rule  — matches /{namespace}/{name}/v1/... and rewrites to
-#      /v1/..., routing through the InferencePool. Carries the URLRewrite filter.
-#
-#   2. Header-based rule — matches the exact path /v1/... with the model-routing
-#      header (ModelBasedRoutingHeaderName), enabling shared-gateway deployments
-#      where a single gateway dispatches to multiple models by header value.
-#      No URLRewrite is needed since the path is already the target path.
+# A single consolidated model-routing rule contains all header-based matches
+# for every inference endpoint. These matches use exact paths (/v1/...) with
+# the model-routing header (ModelBasedRoutingHeaderName), enabling shared-
+# gateway deployments where a single gateway dispatches to multiple models by
+# header value. No URLRewrite is needed since the path is already the target
+# path. Because the rule has no filters, multiple matches can be ORed safely.
 #
 # The catch-all Service rules follow the same split: a PathPrefix rule with
 # URLRewrite for path-based access, and a header-only rule for model-based routing.
@@ -53,32 +54,6 @@ spec:
               timeouts:
                 backendRequest: 0s
                 request: 0s
-            - name: v1-completions-model-routing
-              backendRefs:
-                - group: inference.networking.k8s.io
-                  kind: InferencePool
-                  name: |-
-                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
-                  port: 8000
-                  weight: 1
-              matches:
-                - path:
-                    type: Exact
-                    value: /v1/completions
-                  headers:
-                    - type: Exact
-                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
-                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
-                - path:
-                    type: Exact
-                    value: /v1/completions/
-                  headers:
-                    - type: Exact
-                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
-                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
-              timeouts:
-                backendRequest: 0s
-                request: 0s
             - name: v1-chat-completions-path
               backendRefs:
                 - group: inference.networking.k8s.io
@@ -98,32 +73,6 @@ spec:
                     path:
                       type: ReplacePrefixMatch
                       replacePrefixMatch: /v1/chat/completions
-              timeouts:
-                backendRequest: 0s
-                request: 0s
-            - name: v1-chat-completions-model-routing
-              backendRefs:
-                - group: inference.networking.k8s.io
-                  kind: InferencePool
-                  name: |-
-                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
-                  port: 8000
-                  weight: 1
-              matches:
-                - path:
-                    type: Exact
-                    value: /v1/chat/completions
-                  headers:
-                    - type: Exact
-                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
-                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
-                - path:
-                    type: Exact
-                    value: /v1/chat/completions/
-                  headers:
-                    - type: Exact
-                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
-                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
               timeouts:
                 backendRequest: 0s
                 request: 0s
@@ -149,32 +98,6 @@ spec:
               timeouts:
                 backendRequest: 0s
                 request: 0s
-            - name: v1-responses-model-routing
-              backendRefs:
-                - group: inference.networking.k8s.io
-                  kind: InferencePool
-                  name: |-
-                    {{ ChildName .ObjectMeta.Name `-inference-pool` }}
-                  port: 8000
-                  weight: 1
-              matches:
-                - path:
-                    type: Exact
-                    value: /v1/responses
-                  headers:
-                    - type: Exact
-                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
-                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
-                - path:
-                    type: Exact
-                    value: /v1/responses/
-                  headers:
-                    - type: Exact
-                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
-                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
-              timeouts:
-                backendRequest: 0s
-                request: 0s
             - name: v1-messages-path
               backendRefs:
                 - group: inference.networking.k8s.io
@@ -197,7 +120,7 @@ spec:
               timeouts:
                 backendRequest: 0s
                 request: 0s
-            - name: v1-messages-model-routing
+            - name: v1-model-routing
               backendRefs:
                 - group: inference.networking.k8s.io
                   kind: InferencePool
@@ -206,6 +129,48 @@ spec:
                   port: 8000
                   weight: 1
               matches:
+                - path:
+                    type: Exact
+                    value: /v1/completions
+                  headers:
+                    - type: Exact
+                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
+                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
+                - path:
+                    type: Exact
+                    value: /v1/completions/
+                  headers:
+                    - type: Exact
+                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
+                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
+                - path:
+                    type: Exact
+                    value: /v1/chat/completions
+                  headers:
+                    - type: Exact
+                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
+                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
+                - path:
+                    type: Exact
+                    value: /v1/chat/completions/
+                  headers:
+                    - type: Exact
+                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
+                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
+                - path:
+                    type: Exact
+                    value: /v1/responses
+                  headers:
+                    - type: Exact
+                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
+                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
+                - path:
+                    type: Exact
+                    value: /v1/responses/
+                  headers:
+                    - type: Exact
+                      name: "{{ .GlobalConfig.ModelBasedRoutingHeaderName }}"
+                      value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}
                 - path:
                     type: Exact
                     value: /v1/messages

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -4365,33 +4365,6 @@ spec:
               name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
               port: 8000
               weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/completions
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/completions/
-            name: v1-completions-model-routing
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
             filters:
             - type: URLRewrite
               urlRewrite:
@@ -4412,33 +4385,6 @@ spec:
               name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
               port: 8000
               weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/chat/completions
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/chat/completions/
-            name: v1-chat-completions-model-routing
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
             filters:
             - type: URLRewrite
               urlRewrite:
@@ -4450,33 +4396,6 @@ spec:
                 type: PathPrefix
                 value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
             name: v1-responses-path
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/responses
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/responses/
-            name: v1-responses-model-routing
             timeouts:
               backendRequest: 0s
               request: 0s
@@ -4514,6 +4433,54 @@ spec:
                   }}
               path:
                 type: Exact
+                value: /v1/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
                 value: /v1/messages
             - headers:
               - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
@@ -4523,7 +4490,7 @@ spec:
               path:
                 type: Exact
                 value: /v1/messages/
-            name: v1-messages-model-routing
+            name: v1-model-routing
             timeouts:
               backendRequest: 0s
               request: 0s

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -3951,33 +3951,6 @@ spec:
               name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
               port: 8000
               weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/completions
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/completions/
-            name: v1-completions-model-routing
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
             filters:
             - type: URLRewrite
               urlRewrite:
@@ -3998,33 +3971,6 @@ spec:
               name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
               port: 8000
               weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/chat/completions
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/chat/completions/
-            name: v1-chat-completions-model-routing
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
             filters:
             - type: URLRewrite
               urlRewrite:
@@ -4036,33 +3982,6 @@ spec:
                 type: PathPrefix
                 value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
             name: v1-responses-path
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
-            matches:
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/responses
-            - headers:
-              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
-                type: Exact
-                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
-                  }}
-              path:
-                type: Exact
-                value: /v1/responses/
-            name: v1-responses-model-routing
             timeouts:
               backendRequest: 0s
               request: 0s
@@ -4100,6 +4019,54 @@ spec:
                   }}
               path:
                 type: Exact
+                value: /v1/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
                 value: /v1/messages
             - headers:
               - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
@@ -4109,7 +4076,7 @@ spec:
               path:
                 type: Exact
                 value: /v1/messages/
-            name: v1-messages-model-routing
+            name: v1-model-routing
             timeouts:
               backendRequest: 0s
               request: 0s

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_lora_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_lora_test.go
@@ -193,9 +193,15 @@ func TestExpandLoRAAdapterMatches(t *testing.T) {
 			},
 		},
 		{
-			name: "expands messages model-routing matches for each adapter",
+			name: "expands consolidated model-routing rule with all endpoints",
 			rules: []gwapiv1.HTTPRouteRule{
 				ruleWithMatches(
+					exactPathWithHeaderMatch("/v1/completions", "publishers/ns/models/base-model"),
+					exactPathWithHeaderMatch("/v1/completions/", "publishers/ns/models/base-model"),
+					exactPathWithHeaderMatch("/v1/chat/completions", "publishers/ns/models/base-model"),
+					exactPathWithHeaderMatch("/v1/chat/completions/", "publishers/ns/models/base-model"),
+					exactPathWithHeaderMatch("/v1/responses", "publishers/ns/models/base-model"),
+					exactPathWithHeaderMatch("/v1/responses/", "publishers/ns/models/base-model"),
 					exactPathWithHeaderMatch("/v1/messages", "publishers/ns/models/base-model"),
 					exactPathWithHeaderMatch("/v1/messages/", "publishers/ns/models/base-model"),
 				),
@@ -204,16 +210,23 @@ func TestExpandLoRAAdapterMatches(t *testing.T) {
 			adapters:   adapters,
 			headerName: headerName,
 			wantFn: func(t *testing.T, rules []gwapiv1.HTTPRouteRule) {
-				// 2 base matches + 2 matches × 2 adapters = 6 total
-				assert.Len(t, rules[0].Matches, 6)
-				assert.Equal(t, "publishers/ns/models/adapter-a", rules[0].Matches[2].Headers[0].Value)
-				assert.Equal(t, "/v1/messages", *rules[0].Matches[2].Path.Value)
-				assert.Equal(t, "publishers/ns/models/adapter-b", rules[0].Matches[3].Headers[0].Value)
-				assert.Equal(t, "/v1/messages", *rules[0].Matches[3].Path.Value)
-				assert.Equal(t, "publishers/ns/models/adapter-a", rules[0].Matches[4].Headers[0].Value)
-				assert.Equal(t, "/v1/messages/", *rules[0].Matches[4].Path.Value)
-				assert.Equal(t, "publishers/ns/models/adapter-b", rules[0].Matches[5].Headers[0].Value)
-				assert.Equal(t, "/v1/messages/", *rules[0].Matches[5].Path.Value)
+				// 8 base matches + 8 matches x 2 adapters = 24 total
+				assert.Len(t, rules[0].Matches, 24)
+				for i, adapter := range []string{"adapter-a", "adapter-b"} {
+					for j, path := range []string{
+						"/v1/completions", "/v1/completions/",
+						"/v1/chat/completions", "/v1/chat/completions/",
+						"/v1/responses", "/v1/responses/",
+						"/v1/messages", "/v1/messages/",
+					} {
+						idx := 8 + i + j*2
+						m := rules[0].Matches[idx]
+						assert.Equal(t, "publishers/ns/models/"+adapter, m.Headers[0].Value,
+							"match[%d] adapter header", idx)
+						assert.Equal(t, path, *m.Path.Value,
+							"match[%d] path", idx)
+					}
+				}
 			},
 		},
 		{

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_model_routing_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_model_routing_test.go
@@ -80,12 +80,17 @@ func TestStripModelBasedRoutingRules(t *testing.T) {
 		wantFn     func(t *testing.T, rules []gwapiv1.HTTPRouteRule)
 	}{
 		{
-			name: "strips rules where all matches are model-routing",
+			name: "strips consolidated model-routing rule with all endpoint matches",
 			rules: []gwapiv1.HTTPRouteRule{
 				{Matches: []gwapiv1.HTTPRouteMatch{
 					modelMatch("/v1/completions", "publishers/ns/models/m1"),
+					modelMatch("/v1/completions/", "publishers/ns/models/m1"),
 					modelMatch("/v1/chat/completions", "publishers/ns/models/m1"),
+					modelMatch("/v1/chat/completions/", "publishers/ns/models/m1"),
+					modelMatch("/v1/responses", "publishers/ns/models/m1"),
+					modelMatch("/v1/responses/", "publishers/ns/models/m1"),
 					modelMatch("/v1/messages", "publishers/ns/models/m1"),
+					modelMatch("/v1/messages/", "publishers/ns/models/m1"),
 				}},
 			},
 			headerName: hdr,


### PR DESCRIPTION
**What this PR does / why we need it**:

The HTTPRoute template carried four separate model-routing rules - one per inference endpoint (completions, chat/completions, responses, messages). All four shared identical backendRefs, timeouts, and carried no filters, making them semantically equivalent to a single rule with ORed matches.

This consolidation frees three rule slots under Gateway API's `MaxItems=16` ceiling. The  consolidation is safe because Gateway API only requires exactly one PathPrefix match per rule when ReplacePrefixMatch is present - these rules use Exact path matches with no URL rewrite.

**Which issue(s) this PR fixes**:


**Feature/Issue validation/testing**:

- [x] `TestStripModelBasedRoutingRules` - verifies disabling model-routing strips the consolidated rule with all 8 endpoint matches
- [x] `TestExpandLoRAAdapterMatches` - verifies LoRA expansion produces correct 24-match layout (8 base + 8 x 2 adapters) in the consolidated rule
- [x] Envtest integration tests for model-based-routing pass unchanged

**Special notes for your reviewer**:

Pure template normalization - no Go code changes needed. `stripModelBasedRoutingRules` and `expandLoRAAdapterMatches` already operate per-match within rules, so they handle the consolidated layout without modification.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```