### PR TITLE
feat(llmisvc): add x-served-by response header

### DIFF
--- a/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
@@ -1132,8 +1132,9 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
+  - create
+  - delete
   - get
   - list
   - watch
@@ -1145,6 +1146,14 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -158,6 +158,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
           --port 8001 \
@@ -167,6 +178,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -493,6 +505,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -511,6 +534,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -833,6 +857,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -851,6 +886,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -1079,6 +1115,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" \
             --port 8000 \
@@ -1088,6 +1135,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -1355,6 +1403,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve \
             /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -1373,6 +1432,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -1634,6 +1694,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve \
             /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -1652,6 +1723,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -2588,6 +2660,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
           --port 8000 \
@@ -2597,6 +2680,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -2875,6 +2959,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -2893,6 +2988,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -3154,6 +3250,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -3172,6 +3279,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -163,6 +163,17 @@ spec:
               fi
             fi
 
+            # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+            # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+            MIDDLEWARE_ARGS=""
+            if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+              if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+              else
+                echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+              fi
+            fi
+
             eval "exec vllm serve /mnt/models \
               --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
               --port 8001 \
@@ -172,6 +183,7 @@ spec:
               {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+              ${MIDDLEWARE_ARGS} \
               ${VLLM_ADDITIONAL_ARGS} \
               $@"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -246,6 +246,17 @@ spec:
               fi
             fi
 
+            # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+            # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+            MIDDLEWARE_ARGS=""
+            if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+              if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+              else
+                echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+              fi
+            fi
+
             eval "exec vllm serve \
               /mnt/models \
               --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -264,6 +275,7 @@ spec:
               {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+              ${MIDDLEWARE_ARGS} \
               ${VLLM_ADDITIONAL_ARGS} \
               $@"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
@@ -528,6 +540,17 @@ spec:
               fi
             fi
 
+            # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+            # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+            MIDDLEWARE_ARGS=""
+            if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+              if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+              else
+                echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+              fi
+            fi
+
             eval "exec vllm serve \
               /mnt/models \
               --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -546,6 +569,7 @@ spec:
               {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+              ${MIDDLEWARE_ARGS} \
               ${VLLM_ADDITIONAL_ARGS} \
               $@"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -164,6 +164,17 @@ spec:
                 fi
               fi
 
+              # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+              # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+              MIDDLEWARE_ARGS=""
+              if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+                if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                  MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+                else
+                  echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+                fi
+              fi
+
               eval "exec vllm serve /mnt/models \
                 --served-model-name "{{ .Spec.Model.Name }}" \
                 --port 8000 \
@@ -173,6 +184,7 @@ spec:
                 {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+                ${MIDDLEWARE_ARGS} \
                 ${VLLM_ADDITIONAL_ARGS} \
                 $@"
             # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -186,6 +186,17 @@ spec:
                 fi
               fi
 
+              # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+              # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+              MIDDLEWARE_ARGS=""
+              if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+                if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                  MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+                else
+                  echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+                fi
+              fi
+
               eval "exec vllm serve \
                 /mnt/models \
                 --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -204,6 +215,7 @@ spec:
                 {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+                ${MIDDLEWARE_ARGS} \
                 ${VLLM_ADDITIONAL_ARGS} \
                 $@"
             # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
@@ -468,6 +480,17 @@ spec:
                 fi
               fi
 
+              # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+              # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+              MIDDLEWARE_ARGS=""
+              if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+                if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                  MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+                else
+                  echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+                fi
+              fi
+
               eval "exec vllm serve \
                 /mnt/models \
                 --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -486,6 +509,7 @@ spec:
                 {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
                 {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+                ${MIDDLEWARE_ARGS} \
                 ${VLLM_ADDITIONAL_ARGS} \
                 $@"
             # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -163,6 +163,17 @@ spec:
               fi
             fi
 
+            # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+            # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+            MIDDLEWARE_ARGS=""
+            if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+              if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+              else
+                echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+              fi
+            fi
+
             eval "exec vllm serve /mnt/models \
               --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
               --port 8000 \
@@ -172,6 +183,7 @@ spec:
               {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+              ${MIDDLEWARE_ARGS} \
               ${VLLM_ADDITIONAL_ARGS} \
               $@"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -185,6 +185,17 @@ spec:
               fi
             fi
 
+            # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+            # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+            MIDDLEWARE_ARGS=""
+            if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+              if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+              else
+                echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+              fi
+            fi
+
             eval "exec vllm serve \
               /mnt/models \
               --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -203,6 +214,7 @@ spec:
               {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+              ${MIDDLEWARE_ARGS} \
               ${VLLM_ADDITIONAL_ARGS} \
               $@"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
@@ -467,6 +479,17 @@ spec:
               fi
             fi
 
+            # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+            # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+            MIDDLEWARE_ARGS=""
+            if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+              if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+                MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+              else
+                echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+              fi
+            fi
+
             eval "exec vllm serve \
               /mnt/models \
               --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -485,6 +508,7 @@ spec:
               {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
               {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+              ${MIDDLEWARE_ARGS} \
               ${VLLM_ADDITIONAL_ARGS} \
               $@"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve

--- a/config/rbac/llmisvc/role.yaml
+++ b/config/rbac/llmisvc/role.yaml
@@ -12,8 +12,9 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
+  - create
+  - delete
   - get
   - list
   - watch
@@ -25,6 +26,14 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2764,6 +2764,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
           --port 8001 \
@@ -2773,6 +2784,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -3099,6 +3111,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -3117,6 +3140,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -3439,6 +3463,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -3457,6 +3492,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -3685,6 +3721,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" \
             --port 8000 \
@@ -3694,6 +3741,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -3961,6 +4009,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve \
             /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -3979,6 +4038,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -4240,6 +4300,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve \
             /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -4258,6 +4329,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -5194,6 +5266,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
           --port 8000 \
@@ -5203,6 +5286,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -5481,6 +5565,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -5499,6 +5594,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -5760,6 +5856,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -5778,6 +5885,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2350,6 +2350,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
           --port 8001 \
@@ -2359,6 +2370,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -2685,6 +2697,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -2703,6 +2726,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -3025,6 +3049,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -3043,6 +3078,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -3271,6 +3307,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" \
             --port 8000 \
@@ -3280,6 +3327,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -3547,6 +3595,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve \
             /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -3565,6 +3624,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -3826,6 +3886,17 @@ spec:
             fi
           fi
 
+          # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+          # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+          MIDDLEWARE_ARGS=""
+          if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+            if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+              MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+            else
+              echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+            fi
+          fi
+
           eval "exec vllm serve \
             /mnt/models \
             --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -3844,6 +3915,7 @@ spec:
             {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
             {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${MIDDLEWARE_ARGS} \
             ${VLLM_ADDITIONAL_ARGS} \
             $@"
         - --
@@ -4780,6 +4852,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
           --port 8000 \
@@ -4789,6 +4872,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -5067,6 +5151,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -5085,6 +5180,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --
@@ -5346,6 +5442,17 @@ spec:
           fi
         fi
 
+        # x-served-by middleware requires Python ASGI support (vLLM Python frontend).
+        # Rust frontend does not support --middleware yet (vllm-project/vllm#44280).
+        MIDDLEWARE_ARGS=""
+        if [ -n "$KSERVE_MIDDLEWARE_CLASS" ]; then
+          if [ "${VLLM_USE_RUST_FRONTEND:-0}" != "1" ]; then
+            MIDDLEWARE_ARGS="--middleware=$KSERVE_MIDDLEWARE_CLASS"
+          else
+            echo "WARN: x-served-by middleware not supported with Rust frontend, skipping" >&2
+          fi
+        fi
+
         eval "exec vllm serve \
           /mnt/models \
           --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
@@ -5364,6 +5471,7 @@ spec:
           {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
           {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${MIDDLEWARE_ARGS} \
           ${VLLM_ADDITIONAL_ARGS} \
           $@"
       - --

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_lifecycle.go
@@ -120,6 +120,11 @@ const (
 	// continues with available members. False (or unset) when fully healthy.
 	// Only present when traffic splitting is configured (group + weight set).
 	GroupDegraded apis.ConditionType = "GroupDegraded"
+
+	// RequestAttributionReady is True when the x-served-by response header
+	// middleware is injected. Independent of Ready - does not gate workload health.
+	// Only present when the served-by annotation is set.
+	RequestAttributionReady apis.ConditionType = "RequestAttributionReady"
 )
 
 var llmInferenceServiceCondSet = apis.NewLivingConditionSet(
@@ -313,6 +318,18 @@ func (in *LLMInferenceService) MarkGroupDegraded(reason, messageFormat string, m
 
 func (in *LLMInferenceService) MarkGroupNotDegraded() {
 	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(GroupDegraded)
+}
+
+func (in *LLMInferenceService) MarkRequestAttributionReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(RequestAttributionReady)
+}
+
+func (in *LLMInferenceService) MarkRequestAttributionNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(RequestAttributionReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkRequestAttributionReadyUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(RequestAttributionReady)
 }
 
 func (in *LLMInferenceService) DetermineRouterReadiness() {

--- a/pkg/controller/v1alpha2/llmisvc/container_mutations.go
+++ b/pkg/controller/v1alpha2/llmisvc/container_mutations.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
+)
+
+// ContainerMutation modifies a container in-place.
+type ContainerMutation func(*corev1.Container)
+
+// withArg appends an arg if not already present.
+func withArg(arg string) ContainerMutation {
+	return func(c *corev1.Container) {
+		if !slices.Contains(c.Args, arg) {
+			c.Args = append(c.Args, arg)
+		}
+	}
+}
+
+// withEnvVar sets an env var to a literal value. If the env var already exists,
+// the entire EnvVar struct is replaced - this intentionally clears ValueFrom
+// to prevent an invalid state where both Value and ValueFrom are set
+// (which Kubernetes rejects).
+func withEnvVar(name, value string) ContainerMutation {
+	return func(c *corev1.Container) {
+		idx := slices.IndexFunc(c.Env, func(e corev1.EnvVar) bool { return e.Name == name })
+		if idx >= 0 {
+			c.Env[idx] = corev1.EnvVar{Name: name, Value: value}
+		} else {
+			c.Env = append(c.Env, corev1.EnvVar{Name: name, Value: value})
+		}
+	}
+}
+
+// withVolumeMount adds a VolumeMount if not already present (by mount path).
+func withVolumeMount(vm corev1.VolumeMount) ContainerMutation {
+	return func(c *corev1.Container) {
+		for _, existing := range c.VolumeMounts {
+			if existing.MountPath == vm.MountPath {
+				return
+			}
+		}
+		c.VolumeMounts = append(c.VolumeMounts, vm)
+	}
+}
+
+const (
+	servedByEnvVar             = "KSERVE_SERVED_BY"
+	servedByMiddlewareClassVar = "KSERVE_MIDDLEWARE_CLASS"
+	servedByMiddlewareClass    = "kserve.served_by.ServedByMiddleware"
+	servedByContainerName      = "main"
+	servedByConfigMapName      = "kserve-served-by-middleware"
+	servedByVolumeName         = "kserve-middleware"
+	servedByMountPath          = "/opt/kserve-middleware/kserve"
+	servedByPythonPath         = "/opt/kserve-middleware"
+	servedByPythonPathVar      = "PYTHONPATH"
+)
+
+// servedByMiddlewareSource is the Python ASGI middleware that adds x-served-by
+// response headers. Embedded here so the controller can deploy it via ConfigMap
+// to any vLLM image without requiring the kserve SDK to be installed.
+const servedByMiddlewareSource = `import os
+import re
+
+_HEADER_NAME = b"x-served-by"
+_ENV_VAR = "KSERVE_SERVED_BY"
+_DNS_SAFE = re.compile(r"^[a-z0-9]([a-z0-9.\-]*[a-z0-9])?$")
+
+
+def _validate(raw):
+    if not raw:
+        return None
+    value = raw.strip().lower()
+    if not value or len(value) > 128 or not _DNS_SAFE.match(value):
+        return None
+    return value.encode("ascii")
+
+
+class ServedByMiddleware:
+    def __init__(self, app):
+        self.app = app
+        self._value = _validate(os.environ.get(_ENV_VAR))
+
+    def __call__(self, scope, receive, send):
+        if scope.get("type") != "http" or self._value is None:
+            return self.app(scope, receive, send)
+        value = self._value
+
+        async def send_with_header(message):
+            if message.get("type") == "http.response.start":
+                headers = [
+                    (k, v) for k, v in message.get("headers", [])
+                    if k.lower() != _HEADER_NAME
+                ]
+                headers.append((_HEADER_NAME, value))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        return self.app(scope, receive, send_with_header)
+`
+
+// injectServedByMiddleware adds the x-served-by response header middleware
+// when opted in via the serving.kserve.io/enable-served-by-header annotation.
+//
+// It ensures a ConfigMap with the middleware Python code exists in the namespace,
+// mounts it into the container, and sets env vars so the bash entrypoint template
+// can conditionally add --middleware at startup.
+//
+// When the annotation is absent or "false", none of the above is injected.
+// The deployment spec is rebuilt from template on every reconcile, so removal
+// is implicit - the volume, mount, and env vars simply aren't added.
+// The ConfigMap is left in the namespace (inert when not mounted).
+func (r *LLMISVCReconciler) injectServedByMiddleware(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, podSpec *corev1.PodSpec) error {
+	if llmSvc.Annotations[constants.LLMServedByAnnotationKey] != "true" {
+		llmSvc.MarkRequestAttributionReadyUnset()
+		return nil
+	}
+
+	container := utils.GetContainerWithName(podSpec, servedByContainerName)
+	if container == nil {
+		return nil
+	}
+
+	// Proactive Rust frontend detection. The controller can only see literal env
+	// vars in the pod spec - ValueFrom, Dockerfile ENV, and entrypoint-set values
+	// are invisible here. The bash template guards those cases at startup by
+	// checking VLLM_USE_RUST_FRONTEND before adding --middleware.
+	for _, env := range container.Env {
+		if env.Name == "VLLM_USE_RUST_FRONTEND" && env.Value == "1" {
+			llmSvc.MarkRequestAttributionNotReady("UnsupportedRuntime",
+				"Rust frontend does not support --middleware; x-served-by header will not be added")
+			return nil
+		}
+	}
+
+	ensured, err := r.ensureServedByConfigMap(ctx, llmSvc.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to ensure served-by middleware ConfigMap: %w", err)
+	}
+	if !ensured {
+		return nil
+	}
+
+	addVolume(podSpec, corev1.Volume{
+		Name: servedByVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: servedByConfigMapName},
+			},
+		},
+	})
+
+	mutations := []ContainerMutation{
+		withEnvVar(servedByEnvVar, llmSvc.Name),
+		withEnvVar(servedByMiddlewareClassVar, servedByMiddlewareClass),
+		withEnvVar(servedByPythonPathVar, servedByPythonPath+":$("+servedByPythonPathVar+")"),
+		withVolumeMount(corev1.VolumeMount{
+			Name:      servedByVolumeName,
+			MountPath: servedByMountPath,
+			ReadOnly:  true,
+		}),
+	}
+	for _, m := range mutations {
+		m(container)
+	}
+
+	llmSvc.MarkRequestAttributionReady()
+	return nil
+}
+
+const servedByManagedByValue = "kserve-llmisvc-controller"
+
+// ensureServedByConfigMap creates the middleware ConfigMap as immutable.
+// If the content is stale (controller upgrade), the old ConfigMap is deleted
+// and recreated. Immutability prevents namespace actors with ConfigMap write
+// access from replacing the middleware with arbitrary code.
+// Returns (true, nil) when the ConfigMap is ready, (false, nil) when creation
+// was skipped (namespace terminating or name conflict), or (false, err) on failure.
+func (r *LLMISVCReconciler) ensureServedByConfigMap(ctx context.Context, namespace string) (bool, error) {
+	immutable := true
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      servedByConfigMapName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": servedByManagedByValue,
+			},
+		},
+		Immutable: &immutable,
+		Data: map[string]string{
+			"__init__.py":  "",
+			"served_by.py": servedByMiddlewareSource,
+		},
+	}
+
+	existing := &corev1.ConfigMap{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(desired), existing); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return false, fmt.Errorf("failed to get served-by middleware ConfigMap: %w", err)
+		}
+		if err := r.Create(ctx, desired); err != nil {
+			if apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
+				return false, nil
+			}
+			if createErr := client.IgnoreAlreadyExists(err); createErr != nil {
+				return false, fmt.Errorf("failed to create served-by middleware ConfigMap: %w", createErr)
+			}
+			return true, nil
+		}
+		return true, nil
+	}
+
+	if existing.Data["served_by.py"] == servedByMiddlewareSource {
+		return true, nil
+	}
+
+	if existing.Labels["app.kubernetes.io/managed-by"] != servedByManagedByValue {
+		log.FromContext(ctx).Info("served-by ConfigMap exists but is not controller-managed, skipping injection",
+			"configmap", servedByConfigMapName, "namespace", namespace)
+		return false, nil
+	}
+
+	// Content mismatch (controller upgrade) - delete and recreate since
+	// immutable ConfigMaps can't be updated.
+	if err := r.Delete(ctx, existing); err != nil {
+		return false, fmt.Errorf("failed to delete stale served-by middleware ConfigMap: %w", err)
+	}
+	if err := r.Create(ctx, desired); err != nil {
+		if apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
+			return false, nil
+		}
+		if createErr := client.IgnoreAlreadyExists(err); createErr != nil {
+			return false, fmt.Errorf("failed to recreate served-by middleware ConfigMap: %w", createErr)
+		}
+	}
+	return true, nil
+}
+
+// addVolume adds a volume to the pod spec if not already present (by name).
+func addVolume(podSpec *corev1.PodSpec, vol corev1.Volume) {
+	for _, existing := range podSpec.Volumes {
+		if existing.Name == vol.Name {
+			return
+		}
+	}
+	podSpec.Volumes = append(podSpec.Volumes, vol)
+}

--- a/pkg/controller/v1alpha2/llmisvc/container_mutations_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/container_mutations_test.go
@@ -1,0 +1,367 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+const testNamespace = "default"
+
+func testReconcilerWithNamespace(t *testing.T) *LLMISVCReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	return &LLMISVCReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build(),
+	}
+}
+
+func findEnvVar(envs []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range envs {
+		if envs[i].Name == name {
+			return &envs[i]
+		}
+	}
+	return nil
+}
+
+func TestInjectServedByMiddleware(t *testing.T) {
+	t.Run("injects when annotation is true", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "llama-70b-v1",
+				Namespace:   testNamespace,
+				Annotations: map[string]string{constants.LLMServedByAnnotationKey: "true"},
+			},
+		}
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Args: []string{"--model", "llama-70b"}},
+			},
+		}
+
+		err := testReconcilerWithNamespace(t).injectServedByMiddleware(t.Context(), llmSvc, podSpec)
+		require.NoError(t, err)
+
+		env := findEnvVar(podSpec.Containers[0].Env, servedByEnvVar)
+		require.NotNil(t, env, "KSERVE_SERVED_BY should be set")
+		assert.Equal(t, "llama-70b-v1", env.Value)
+
+		env = findEnvVar(podSpec.Containers[0].Env, servedByMiddlewareClassVar)
+		require.NotNil(t, env, "KSERVE_MIDDLEWARE_CLASS should be set")
+		assert.Equal(t, servedByMiddlewareClass, env.Value)
+
+		env = findEnvVar(podSpec.Containers[0].Env, servedByPythonPathVar)
+		require.NotNil(t, env, "PYTHONPATH should be set")
+		assert.Equal(t, servedByPythonPath+":$("+servedByPythonPathVar+")", env.Value)
+
+		assert.Len(t, podSpec.Volumes, 1)
+		assert.Len(t, podSpec.Containers[0].VolumeMounts, 1)
+
+		cond := llmSvc.GetStatus().GetCondition(v1alpha2.RequestAttributionReady)
+		require.NotNil(t, cond, "RequestAttributionReady should be set")
+		assert.Equal(t, "True", string(cond.Status))
+	})
+
+	t.Run("skips when annotation absent", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "solo", Namespace: testNamespace},
+		}
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "main", Args: []string{"--model", "llama-70b"}},
+			},
+		}
+
+		err := testReconcilerWithNamespace(t).injectServedByMiddleware(t.Context(), llmSvc, podSpec)
+		require.NoError(t, err)
+
+		assert.Nil(t, findEnvVar(podSpec.Containers[0].Env, servedByMiddlewareClassVar))
+		assert.Empty(t, podSpec.Volumes)
+	})
+
+	t.Run("skips when annotation is false", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "v1",
+				Namespace:   testNamespace,
+				Annotations: map[string]string{constants.LLMServedByAnnotationKey: "false"},
+			},
+		}
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main"}},
+		}
+
+		err := testReconcilerWithNamespace(t).injectServedByMiddleware(t.Context(), llmSvc, podSpec)
+		require.NoError(t, err)
+
+		assert.Nil(t, findEnvVar(podSpec.Containers[0].Env, servedByMiddlewareClassVar))
+	})
+
+	t.Run("does not duplicate env vars if already present", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "v1",
+				Namespace:   testNamespace,
+				Annotations: map[string]string{constants.LLMServedByAnnotationKey: "true"},
+			},
+		}
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Env: []corev1.EnvVar{
+						{Name: servedByMiddlewareClassVar, Value: servedByMiddlewareClass},
+					},
+				},
+			},
+		}
+
+		err := testReconcilerWithNamespace(t).injectServedByMiddleware(t.Context(), llmSvc, podSpec)
+		require.NoError(t, err)
+
+		count := 0
+		for _, env := range podSpec.Containers[0].Env {
+			if env.Name == servedByMiddlewareClassVar {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "should not duplicate KSERVE_MIDDLEWARE_CLASS")
+	})
+
+	t.Run("overwrites existing env var including ValueFrom", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "v2",
+				Namespace:   testNamespace,
+				Annotations: map[string]string{constants.LLMServedByAnnotationKey: "true"},
+			},
+		}
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Env: []corev1.EnvVar{
+						{
+							Name:      servedByEnvVar,
+							ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+						},
+					},
+				},
+			},
+		}
+
+		err := testReconcilerWithNamespace(t).injectServedByMiddleware(t.Context(), llmSvc, podSpec)
+		require.NoError(t, err)
+
+		env := findEnvVar(podSpec.Containers[0].Env, servedByEnvVar)
+		require.NotNil(t, env)
+		assert.Equal(t, "v2", env.Value)
+		assert.Nil(t, env.ValueFrom, "ValueFrom should be cleared when overwriting with literal value")
+	})
+
+	t.Run("no-op if container not found - no volume added", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "v1",
+				Namespace:   testNamespace,
+				Annotations: map[string]string{constants.LLMServedByAnnotationKey: "true"},
+			},
+		}
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "other-container"},
+			},
+		}
+
+		err := testReconcilerWithNamespace(t).injectServedByMiddleware(t.Context(), llmSvc, podSpec)
+		require.NoError(t, err)
+
+		assert.Empty(t, podSpec.Containers[0].Args)
+		assert.Empty(t, podSpec.Containers[0].Env)
+		assert.Empty(t, podSpec.Volumes, "volume should not be added when container is missing")
+	})
+
+	t.Run("skips injection when Rust frontend is enabled", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "v1",
+				Namespace:   testNamespace,
+				Annotations: map[string]string{constants.LLMServedByAnnotationKey: "true"},
+			},
+		}
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Env: []corev1.EnvVar{
+						{Name: "VLLM_USE_RUST_FRONTEND", Value: "1"},
+					},
+				},
+			},
+		}
+
+		err := testReconcilerWithNamespace(t).injectServedByMiddleware(t.Context(), llmSvc, podSpec)
+		require.NoError(t, err)
+
+		assert.Nil(t, findEnvVar(podSpec.Containers[0].Env, servedByMiddlewareClassVar),
+			"should not inject middleware class when Rust frontend is active")
+		assert.Empty(t, podSpec.Volumes, "should not add volume when Rust frontend is active")
+
+		cond := llmSvc.GetStatus().GetCondition(v1alpha2.RequestAttributionReady)
+		require.NotNil(t, cond, "RequestAttributionReady should be set")
+		assert.Equal(t, "False", string(cond.Status))
+		assert.Equal(t, "UnsupportedRuntime", cond.Reason)
+	})
+
+	t.Run("ignores Rust frontend when value is not 1", func(t *testing.T) {
+		llmSvc := &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "v1",
+				Namespace:   testNamespace,
+				Annotations: map[string]string{constants.LLMServedByAnnotationKey: "true"},
+			},
+		}
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Env: []corev1.EnvVar{
+						{Name: "VLLM_USE_RUST_FRONTEND", Value: "0"},
+					},
+				},
+			},
+		}
+
+		err := testReconcilerWithNamespace(t).injectServedByMiddleware(t.Context(), llmSvc, podSpec)
+		require.NoError(t, err)
+
+		assert.NotNil(t, findEnvVar(podSpec.Containers[0].Env, servedByMiddlewareClassVar),
+			"should inject when Rust frontend is explicitly disabled")
+	})
+}
+
+func TestEnsureServedByConfigMap(t *testing.T) {
+	t.Run("creates ConfigMap when not present", func(t *testing.T) {
+		r := testReconcilerWithNamespace(t)
+
+		ensured, err := r.ensureServedByConfigMap(t.Context(), testNamespace)
+		require.NoError(t, err)
+		assert.True(t, ensured)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(t.Context(), clientKeyForConfigMap(), cm)
+		require.NoError(t, err)
+		assert.Equal(t, servedByMiddlewareSource, cm.Data["served_by.py"])
+		assert.Equal(t, servedByManagedByValue, cm.Labels["app.kubernetes.io/managed-by"])
+		require.NotNil(t, cm.Immutable, "ConfigMap should be immutable")
+		assert.True(t, *cm.Immutable)
+	})
+
+	t.Run("no-op when content matches", func(t *testing.T) {
+		r := testReconcilerWithNamespace(t)
+
+		ensured, err := r.ensureServedByConfigMap(t.Context(), testNamespace)
+		require.NoError(t, err)
+		assert.True(t, ensured)
+
+		ensured, err = r.ensureServedByConfigMap(t.Context(), testNamespace)
+		require.NoError(t, err)
+		assert.True(t, ensured)
+	})
+
+	t.Run("deletes and recreates when content differs and label is present", func(t *testing.T) {
+		r := testReconcilerWithNamespace(t)
+
+		stale := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      servedByConfigMapName,
+				Namespace: testNamespace,
+				Labels:    map[string]string{"app.kubernetes.io/managed-by": servedByManagedByValue},
+			},
+			Data: map[string]string{
+				"__init__.py":  "",
+				"served_by.py": "old content",
+			},
+		}
+		require.NoError(t, r.Create(t.Context(), stale))
+
+		ensured, err := r.ensureServedByConfigMap(t.Context(), testNamespace)
+		require.NoError(t, err)
+		assert.True(t, ensured)
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, r.Get(t.Context(), clientKeyForConfigMap(), cm))
+		assert.Equal(t, servedByMiddlewareSource, cm.Data["served_by.py"])
+		assert.NotNil(t, cm.Immutable, "recreated ConfigMap should be immutable")
+		assert.True(t, *cm.Immutable)
+	})
+
+	t.Run("skips update when ConfigMap is not controller-managed", func(t *testing.T) {
+		r := testReconcilerWithNamespace(t)
+
+		tenant := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      servedByConfigMapName,
+				Namespace: testNamespace,
+			},
+			Data: map[string]string{
+				"served_by.py": "tenant data",
+			},
+		}
+		require.NoError(t, r.Create(t.Context(), tenant))
+
+		ensured, err := r.ensureServedByConfigMap(t.Context(), testNamespace)
+		require.NoError(t, err)
+		assert.False(t, ensured, "should return false to skip injection for unmanaged ConfigMap")
+
+		cm := &corev1.ConfigMap{}
+		require.NoError(t, r.Get(t.Context(), clientKeyForConfigMap(), cm))
+		assert.Equal(t, "tenant data", cm.Data["served_by.py"], "tenant data should be preserved")
+	})
+
+	t.Run("creates ConfigMap in a different namespace", func(t *testing.T) {
+		scheme := runtime.NewScheme()
+		require.NoError(t, corev1.AddToScheme(scheme))
+		require.NoError(t, v1alpha2.AddToScheme(scheme))
+		r := &LLMISVCReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		}
+
+		ensured, err := r.ensureServedByConfigMap(t.Context(), "other-ns")
+		require.NoError(t, err)
+		assert.True(t, ensured)
+	})
+}
+
+func clientKeyForConfigMap() types.NamespacedName {
+	return types.NamespacedName{Name: servedByConfigMapName, Namespace: testNamespace}
+}

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -165,7 +165,7 @@ type LLMISVCReconciler struct {
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews;subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:urls=/metrics,verbs=get
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;delete
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,resourceNames=llminferenceservices.serving.kserve.io;llminferenceserviceconfigs.serving.kserve.io,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,resourceNames=llminferenceservices.serving.kserve.io;llminferenceserviceconfigs.serving.kserve.io,verbs=update;patch
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -217,6 +217,10 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 			attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, llmSvc.Spec.KVCacheOffloading.Secondary, "main")
 		}
 
+		if err := r.injectServedByMiddleware(ctx, llmSvc, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec); err != nil {
+			return nil, fmt.Errorf("failed to inject served-by middleware: %w", err)
+		}
+
 		if hasRoutingSidecar(expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec) {
 			log.FromContext(ctx).V(2).Info("Main container has a routing sidecar")
 
@@ -243,6 +247,10 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 		}
 		if llmSvc.Spec.KVCacheOffloading != nil {
 			attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, llmSvc.Spec.KVCacheOffloading.Secondary, "main")
+		}
+
+		if err := r.injectServedByMiddleware(ctx, llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec); err != nil {
+			return nil, fmt.Errorf("failed to inject served-by middleware: %w", err)
 		}
 
 		if hasRoutingSidecar(expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec) {
@@ -359,6 +367,10 @@ func (r *LLMISVCReconciler) expectedPrefillMultiNodeLWS(ctx context.Context, llm
 			if llmSvc.Spec.Prefill.KVCacheOffloading != nil {
 				attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, llmSvc.Spec.Prefill.KVCacheOffloading.Secondary, "main")
 			}
+
+			if err := r.injectServedByMiddleware(ctx, llmSvc, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec); err != nil {
+				return nil, fmt.Errorf("failed to inject served-by middleware: %w", err)
+			}
 		}
 		if llmSvc.Spec.Prefill.Worker != nil {
 			expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec = *llmSvc.Spec.Prefill.Worker.DeepCopy()
@@ -370,6 +382,10 @@ func (r *LLMISVCReconciler) expectedPrefillMultiNodeLWS(ctx context.Context, llm
 			}
 			if llmSvc.Spec.Prefill.KVCacheOffloading != nil {
 				attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, llmSvc.Spec.Prefill.KVCacheOffloading.Secondary, "main")
+			}
+
+			if err := r.injectServedByMiddleware(ctx, llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec); err != nil {
+				return nil, fmt.Errorf("failed to inject served-by middleware: %w", err)
 			}
 		}
 

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -172,6 +172,10 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 		if llmSvc.Spec.KVCacheOffloading != nil {
 			attachKVCacheSecondaryTiers(&d.Spec.Template.Spec, llmSvc.Spec.KVCacheOffloading.Secondary, "main")
 		}
+
+		if err := r.injectServedByMiddleware(ctx, llmSvc, &d.Spec.Template.Spec); err != nil {
+			return nil, fmt.Errorf("failed to inject served-by middleware: %w", err)
+		}
 	}
 
 	r.propagateDeploymentMetadata(llmSvc, d)
@@ -274,6 +278,10 @@ func (r *LLMISVCReconciler) expectedPrefillMainDeployment(ctx context.Context, l
 		}
 		if llmSvc.Spec.Prefill != nil && llmSvc.Spec.Prefill.KVCacheOffloading != nil {
 			attachKVCacheSecondaryTiers(&d.Spec.Template.Spec, llmSvc.Spec.Prefill.KVCacheOffloading.Secondary, "main")
+		}
+
+		if err := r.injectServedByMiddleware(ctx, llmSvc, &d.Spec.Template.Spec); err != nil {
+			return nil, fmt.Errorf("failed to inject served-by middleware: %w", err)
 		}
 	}
 

--- a/test/e2e/llmisvc/test_x_served_by.py
+++ b/test/e2e/llmisvc/test_x_served_by.py
@@ -1,0 +1,125 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test that the x-served-by response header is emitted when opted in via annotation."""
+
+from __future__ import annotations
+
+import os
+import pytest
+import requests
+from kserve import KServeClient
+from kubernetes import client
+
+from .fixtures import (
+    generate_test_id,
+    inject_k8s_proxy,
+)
+from .logging import log_execution, logger
+from .diagnostic import collect_diagnostics
+from .test_llm_inference_service import (
+    TestCase,
+    create_llmisvc,
+    wait_for_llm_isvc_ready,
+    wait_for_model_response,
+    maybe_delete_llmisvc,
+)
+
+
+def assert_x_served_by(service_name: str):
+    """Create a response assertion that checks for x-served-by header."""
+
+    def assertion(response: requests.Response) -> None:
+        served_by = response.headers.get("x-served-by")
+        assert served_by is not None, (
+            f"Expected x-served-by header, got headers: {dict(response.headers)}"
+        )
+        assert served_by == service_name, (
+            f"Expected x-served-by: {service_name}, got: {served_by}"
+        )
+
+    return assertion
+
+
+@pytest.mark.llminferenceservice
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-single-cpu",
+                    "model-fb-opt-125m",
+                ],
+                prompt="KServe is a",
+                service_name="x-served-by-test",
+            ),
+            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
+        ),
+    ],
+    indirect=["test_case"],
+    ids=generate_test_id,
+)
+@log_execution
+def test_x_served_by_header(test_case: TestCase):
+    """Test that an LLMISVC with enable-served-by-header annotation includes x-served-by response header."""
+    inject_k8s_proxy()
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config"),
+        client_configuration=client.Configuration(),
+    )
+
+    llm_service = test_case.llm_service
+    service_name = llm_service.metadata.name
+    test_failed = False
+
+    # Set the annotation before creating the service so the first deployment
+    # already has the middleware injected - no rollout needed.
+    if not llm_service.metadata.annotations:
+        llm_service.metadata.annotations = {}
+    llm_service.metadata.annotations["serving.kserve.io/enable-served-by-header"] = (
+        "true"
+    )
+
+    try:
+        logger.info(f"Creating LLMInferenceService {service_name}")
+        create_llmisvc(kserve_client, llm_service)
+
+        logger.info(f"Waiting for LLMInferenceService {service_name} to be ready")
+        wait_for_llm_isvc_ready(kserve_client, llm_service, test_case.wait_timeout)
+
+        # Override response assertion to check x-served-by header.
+        # wait_for_model_response retries until 200, then runs the assertion once.
+        test_case.response_assertion = assert_x_served_by(service_name)
+
+        logger.info(
+            f"Waiting for model response with x-served-by header from {service_name}"
+        )
+        wait_for_model_response(kserve_client, test_case)
+
+    except Exception as e:
+        test_failed = True
+        logger.error(f"❌ ERROR: x-served-by test failed for {service_name}: {e}")
+        collect_diagnostics(
+            service_name,
+            llm_service.metadata.namespace,
+            kserve_client=kserve_client,
+            log=logger.info,
+        )
+        raise
+    finally:
+        maybe_delete_llmisvc(kserve_client, llm_service, test_failed)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an `x-served-by` response header identifying which LLMInferenceService member handled each inference request. During controlled deployment (e.g. canary rollouts), operators might need per-request attribution to verify actual traffic distribution against configured weights or debug version-specific behavior.

Gated by `serving.kserve.io/enable-served-by-header: "true"` annotation to not impact on existing deployments.

The middleware is deployed as an immutable ConfigMap with Python ASGI middleware, volume-mounted into vLLM containers. The controller sets intent via env vars, and the bash entrypoint template conditionally adds `--middleware` at startup - keeping the controller runtime-agnostic. Immutability prevents namespace actors with ConfigMap write access from replacing the middleware with arbitrary code.

A `RequestAttributionReady` condition (independent of `Ready`, like `GroupReady`) reports whether attribution is active, with explicit detection of unsupported runtimes.

### Middleware gating

Two layers handle runtime compatibility - particularly the upcoming vLLM Rust frontend ([vllm-project/vllm#44280](https://github.com/vllm-project/vllm/issues/44280)) which does not support `--middleware` (yet?).

**Controller** (reconcile time): scans the pod spec for literal `VLLM_USE_RUST_FRONTEND=1`. If found, skips injection and sets `RequestAttributionReady=False/UnsupportedRuntime`. Cannot see `ValueFrom`, Dockerfile `ENV`, or entrypoint-set values.

**Template** (pod startup): checks the effective `VLLM_USE_RUST_FRONTEND` env var regardless of source. If the Rust frontend is active, skips `--middleware` and logs a warning. The pod starts fine without the header.

| Scenario | Controller | Template | Outcome |
|----------|-----------|----------|---------|
| Python vLLM | Injects, condition True | Adds `--middleware` | Header works |
| Rust via literal env | Skips, condition False | N/A | No header, condition explains why |
| Rust via ValueFrom/Dockerfile | Injects, condition True | Skips, logs WARN | No header, stale condition |
| Future vLLM drops `--middleware` | Injects, condition True | Adds flag, vLLM rejects | Crashloop - operator removes annotation |

Row 3 is a condition accuracy gap, but harmless - visible in pod logs.
Row 4 is the only crashloop path - a speculative scenario where neither layer detects the problem.

**Which issue(s) this PR fixes**:

Part of the controlled deployment feature for LLMInferenceService #5725

**Feature/Issue validation/testing**:

- [x] Go unit tests for middleware injection (annotation gating, Rust detection, env var dedup, ConfigMap lifecycle, ownership check)
- [x] Go unit tests for `RequestAttributionReady` condition lifecycle
- [x] Python unit tests for the ASGI middleware (28 tests - validation, header injection, streaming, edge cases)
- [x] E2e test for x-served-by header presence on responses

**Special notes for your reviewer**:

- The immutable ConfigMap uses delete+create for upgrades (sub-second window, fail-open). Chosen over mutable ConfigMap because anyone with configmap write in the namespace could replace the middleware with arbitrary Python otherwise.
- `PYTHONPATH` is prepended (`/opt/kserve-middleware:$(PYTHONPATH)`) rather than overwritten. A separate PR will add `ValidateBlockedEnvVars` to the LLMISVC webhook for parity with InferenceService/ServingRuntime.
- The `MIDDLEWARE_ARGS` template conditional is applied to all 6 vllm serve templates (main, worker-dp, decode, decode-worker-dp, prefill, prefill-worker-dp).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
feat(llmisvc): add x-served-by response header for per-request traffic attribution during controlled deployment, with Rust frontend detection and RequestAttributionReady condition
```