### PR TITLE
test(e2e): add canary deployment lifecycle tests

### DIFF
--- a/test/e2e/predictor/test_canary_deployment.py
+++ b/test/e2e/predictor/test_canary_deployment.py
@@ -90,7 +90,7 @@ def _safe_delete(kserve, service_name):
     try:
         kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
     except Exception:
-        pass
+        logger.exception("Failed to delete %s during cleanup", service_name)
 
 
 def _wait_for_deployment(apps_v1, name, namespace, timeout=120):

--- a/test/e2e/predictor/test_canary_deployment.py
+++ b/test/e2e/predictor/test_canary_deployment.py
@@ -17,10 +17,6 @@ import os
 import time
 
 import pytest
-from kubernetes import client
-from kubernetes.client import V1ResourceRequirements
-from kubernetes.client.rest import ApiException
-
 from kserve import (
     KServeClient,
     V1beta1CanarySpec,
@@ -31,6 +27,9 @@ from kserve import (
     V1beta1PredictorSpec,
     constants,
 )
+from kubernetes import client
+from kubernetes.client import V1ResourceRequirements
+from kubernetes.client.rest import ApiException
 
 from ..common.utils import KSERVE_TEST_NAMESPACE
 
@@ -230,8 +229,8 @@ def test_canary_promote():
         post_promote_uids = _get_pod_uids(
             apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
         )
-        assert canary_pod_uids == post_promote_uids, (
-            f"Pod UIDs changed during promotion: before={canary_pod_uids}, after={post_promote_uids}"
+        assert canary_pod_uids.issubset(post_promote_uids), (
+            f"Canary pods were restarted during promotion: canary={canary_pod_uids}, post_promote={post_promote_uids}"
         )
     finally:
         _safe_delete(kserve, service_name)
@@ -325,7 +324,7 @@ def test_canary_force_stop():
                 name=service_name,
                 namespace=KSERVE_TEST_NAMESPACE,
                 annotations={
-                    "serving.kserve.io/force-stop-canary-v2": "true",
+                    "serving.kserve.io/stop": "true",
                 },
             ),
             spec=isvc.spec,

--- a/test/e2e/predictor/test_canary_deployment.py
+++ b/test/e2e/predictor/test_canary_deployment.py
@@ -119,6 +119,22 @@ def _wait_for_deployment_gone(apps_v1, name, namespace, timeout=120):
     raise TimeoutError(f"Deployment {name} still exists after {timeout}s")
 
 
+def _wait_for_condition(
+    kserve, service_name, condition_type, expected_reason, timeout=60
+):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        got = kserve.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
+        conditions = got.get("status", {}).get("conditions", [])
+        cond = next((c for c in conditions if c["type"] == condition_type), None)
+        if cond is not None and cond.get("reason") == expected_reason:
+            return cond
+        time.sleep(5)
+    raise TimeoutError(
+        f"Condition {condition_type} reason={expected_reason} not seen within {timeout}s"
+    )
+
+
 def _get_pod_uids(apps_v1, deployment_name, namespace):
     core_v1 = client.CoreV1Api()
     dep = apps_v1.read_namespaced_deployment(deployment_name, namespace)
@@ -336,12 +352,6 @@ def test_canary_force_stop():
             apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
         )
 
-        got = kserve.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
-        conditions = got.get("status", {}).get("conditions", [])
-        canary_condition = next(
-            (c for c in conditions if c["type"] == "CanaryPredictorReady"), None
-        )
-        assert canary_condition is not None
-        assert canary_condition["reason"] == "Stopped"
+        _wait_for_condition(kserve, service_name, "CanaryPredictorReady", "Stopped")
     finally:
         _safe_delete(kserve, service_name)

--- a/test/e2e/predictor/test_canary_deployment.py
+++ b/test/e2e/predictor/test_canary_deployment.py
@@ -86,6 +86,13 @@ def _make_isvc(service_name, canaries=None):
     )
 
 
+def _safe_delete(kserve, service_name):
+    try:
+        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
+    except Exception:
+        pass
+
+
 def _wait_for_deployment(apps_v1, name, namespace, timeout=120):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -133,7 +140,9 @@ def test_canary_create():
         canaries=[
             V1beta1CanarySpec(
                 traffic_percent=20,
-                predictor=_make_predictor(CANARY_MODEL_URI, name="v2"),
+                predictor=_make_predictor(
+                    CANARY_MODEL_URI, name="v2", min_replicas=None
+                ),
             ),
         ],
     )
@@ -165,7 +174,7 @@ def test_canary_create():
         assert len(canary_status) > 0, "canary status should be populated"
         assert canary_status[0]["name"] == "v2"
     finally:
-        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
+        _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
@@ -179,7 +188,9 @@ def test_canary_promote():
         canaries=[
             V1beta1CanarySpec(
                 traffic_percent=20,
-                predictor=_make_predictor(CANARY_MODEL_URI, name="v2"),
+                predictor=_make_predictor(
+                    CANARY_MODEL_URI, name="v2", min_replicas=None
+                ),
             ),
         ],
     )
@@ -223,7 +234,7 @@ def test_canary_promote():
             f"Pod UIDs changed during promotion: before={canary_pod_uids}, after={post_promote_uids}"
         )
     finally:
-        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
+        _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
@@ -237,7 +248,9 @@ def test_canary_rollback():
         canaries=[
             V1beta1CanarySpec(
                 traffic_percent=20,
-                predictor=_make_predictor(CANARY_MODEL_URI, name="v2"),
+                predictor=_make_predictor(
+                    CANARY_MODEL_URI, name="v2", min_replicas=None
+                ),
             ),
         ],
     )
@@ -276,7 +289,7 @@ def test_canary_rollback():
             "CanaryPredictorReady should be cleared after rollback"
         )
     finally:
-        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
+        _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
@@ -290,7 +303,9 @@ def test_canary_force_stop():
         canaries=[
             V1beta1CanarySpec(
                 traffic_percent=20,
-                predictor=_make_predictor(CANARY_MODEL_URI, name="v2"),
+                predictor=_make_predictor(
+                    CANARY_MODEL_URI, name="v2", min_replicas=None
+                ),
             ),
         ],
     )
@@ -330,4 +345,4 @@ def test_canary_force_stop():
         assert canary_condition is not None
         assert canary_condition["reason"] == "Stopped"
     finally:
-        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
+        _safe_delete(kserve, service_name)

--- a/test/e2e/predictor/test_canary_deployment.py
+++ b/test/e2e/predictor/test_canary_deployment.py
@@ -170,7 +170,7 @@ def test_canary_create():
         assert canary_condition is not None, "CanaryPredictorReady condition missing"
         assert canary_condition["status"] == "True"
 
-        canary_status = got.get("status", {}).get("canary", [])
+        canary_status = got.get("status", {}).get("canaryStatuses", [])
         assert len(canary_status) > 0, "canary status should be populated"
         assert canary_status[0]["name"] == "v2"
     finally:
@@ -209,7 +209,7 @@ def test_canary_promote():
 
         promoted = _make_isvc(service_name)
         promoted.spec.predictor = _make_predictor(CANARY_MODEL_URI, name="v2")
-        promoted.spec.canary = None
+        promoted.spec.canary = []
 
         patch_resp = kserve.patch(
             service_name, promoted, namespace=KSERVE_TEST_NAMESPACE
@@ -264,7 +264,7 @@ def test_canary_rollback():
         )
 
         rolled_back = _make_isvc(service_name)
-        rolled_back.spec.canary = None
+        rolled_back.spec.canary = []
 
         patch_resp = kserve.patch(
             service_name, rolled_back, namespace=KSERVE_TEST_NAMESPACE

--- a/test/e2e/predictor/test_canary_deployment.py
+++ b/test/e2e/predictor/test_canary_deployment.py
@@ -1,0 +1,333 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import time
+
+import pytest
+from kubernetes import client
+from kubernetes.client import V1ResourceRequirements
+from kubernetes.client.rest import ApiException
+
+from kserve import (
+    KServeClient,
+    V1beta1CanarySpec,
+    V1beta1InferenceService,
+    V1beta1InferenceServiceSpec,
+    V1beta1ModelFormat,
+    V1beta1ModelSpec,
+    V1beta1PredictorSpec,
+    constants,
+)
+
+from ..common.utils import KSERVE_TEST_NAMESPACE
+
+logger = logging.getLogger(__name__)
+
+STABLE_MODEL_URI = "gs://kfserving-examples/models/sklearn/1.0/model"
+CANARY_MODEL_URI = "gs://kfserving-examples/models/sklearn/1.3/mixedtype"
+
+RESOURCES = V1ResourceRequirements(
+    requests={"cpu": "50m", "memory": "128Mi"},
+    limits={"cpu": "100m", "memory": "256Mi"},
+)
+
+
+def _kserve_client():
+    return KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
+
+
+def _apps_v1():
+    return client.AppsV1Api()
+
+
+def _make_predictor(storage_uri, name=None, min_replicas=2):
+    spec = V1beta1PredictorSpec(
+        min_replicas=min_replicas,
+        model=V1beta1ModelSpec(
+            model_format=V1beta1ModelFormat(name="sklearn"),
+            storage_uri=storage_uri,
+            resources=RESOURCES,
+        ),
+    )
+    if name:
+        spec.name = name
+    return spec
+
+
+def _make_isvc(service_name, canaries=None):
+    return V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+            annotations={
+                "serving.kserve.io/deploymentMode": "Standard",
+                "serving.kserve.io/autoscalerClass": "none",
+            },
+        ),
+        spec=V1beta1InferenceServiceSpec(
+            predictor=_make_predictor(STABLE_MODEL_URI),
+            canary=canaries,
+        ),
+    )
+
+
+def _wait_for_deployment(apps_v1, name, namespace, timeout=120):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            dep = apps_v1.read_namespaced_deployment(name, namespace)
+            if dep.status.available_replicas and dep.status.available_replicas > 0:
+                return dep
+        except ApiException as e:
+            if e.status != 404:
+                raise
+        time.sleep(5)
+    raise TimeoutError(f"Deployment {name} not ready within {timeout}s")
+
+
+def _wait_for_deployment_gone(apps_v1, name, namespace, timeout=120):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            apps_v1.read_namespaced_deployment(name, namespace)
+        except ApiException as e:
+            if e.status == 404:
+                return
+            raise
+        time.sleep(5)
+    raise TimeoutError(f"Deployment {name} still exists after {timeout}s")
+
+
+def _get_pod_uids(apps_v1, deployment_name, namespace):
+    core_v1 = client.CoreV1Api()
+    dep = apps_v1.read_namespaced_deployment(deployment_name, namespace)
+    selector = dep.spec.selector.match_labels
+    label_selector = ",".join(f"{k}={v}" for k, v in selector.items())
+    pods = core_v1.list_namespaced_pod(namespace, label_selector=label_selector)
+    return {pod.metadata.uid for pod in pods.items}
+
+
+@pytest.mark.predictor
+def test_canary_create():
+    service_name = "isvc-canary-create"
+    kserve = _kserve_client()
+    apps = _apps_v1()
+
+    isvc = _make_isvc(
+        service_name,
+        canaries=[
+            V1beta1CanarySpec(
+                traffic_percent=20,
+                predictor=_make_predictor(CANARY_MODEL_URI, name="v2"),
+            ),
+        ],
+    )
+
+    try:
+        kserve.create(isvc)
+        kserve.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+        stable_dep = _wait_for_deployment(
+            apps, f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+        )
+        canary_dep = _wait_for_deployment(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+
+        assert stable_dep is not None
+        assert canary_dep is not None
+
+        got = kserve.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+        conditions = got.get("status", {}).get("conditions", [])
+        canary_condition = next(
+            (c for c in conditions if c["type"] == "CanaryPredictorReady"), None
+        )
+        assert canary_condition is not None, "CanaryPredictorReady condition missing"
+        assert canary_condition["status"] == "True"
+
+        canary_status = got.get("status", {}).get("canary", [])
+        assert len(canary_status) > 0, "canary status should be populated"
+        assert canary_status[0]["name"] == "v2"
+    finally:
+        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+
+@pytest.mark.predictor
+def test_canary_promote():
+    service_name = "isvc-canary-promote"
+    kserve = _kserve_client()
+    apps = _apps_v1()
+
+    isvc = _make_isvc(
+        service_name,
+        canaries=[
+            V1beta1CanarySpec(
+                traffic_percent=20,
+                predictor=_make_predictor(CANARY_MODEL_URI, name="v2"),
+            ),
+        ],
+    )
+
+    try:
+        kserve.create(isvc)
+        kserve.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+        _wait_for_deployment(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+        canary_pod_uids = _get_pod_uids(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+        assert len(canary_pod_uids) > 0
+
+        promoted = _make_isvc(service_name)
+        promoted.spec.predictor = _make_predictor(CANARY_MODEL_URI, name="v2")
+        promoted.spec.canary = None
+
+        patch_resp = kserve.patch(
+            service_name, promoted, namespace=KSERVE_TEST_NAMESPACE
+        )
+        kserve.wait_isvc_ready(
+            service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+            expected_generation=patch_resp["metadata"]["generation"],
+        )
+
+        _wait_for_deployment(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+        _wait_for_deployment_gone(
+            apps, f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+        )
+
+        post_promote_uids = _get_pod_uids(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+        assert canary_pod_uids == post_promote_uids, (
+            f"Pod UIDs changed during promotion: before={canary_pod_uids}, after={post_promote_uids}"
+        )
+    finally:
+        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+
+@pytest.mark.predictor
+def test_canary_rollback():
+    service_name = "isvc-canary-rollback"
+    kserve = _kserve_client()
+    apps = _apps_v1()
+
+    isvc = _make_isvc(
+        service_name,
+        canaries=[
+            V1beta1CanarySpec(
+                traffic_percent=20,
+                predictor=_make_predictor(CANARY_MODEL_URI, name="v2"),
+            ),
+        ],
+    )
+
+    try:
+        kserve.create(isvc)
+        kserve.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+        _wait_for_deployment(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+
+        rolled_back = _make_isvc(service_name)
+        rolled_back.spec.canary = None
+
+        patch_resp = kserve.patch(
+            service_name, rolled_back, namespace=KSERVE_TEST_NAMESPACE
+        )
+        kserve.wait_isvc_ready(
+            service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+            expected_generation=patch_resp["metadata"]["generation"],
+        )
+
+        _wait_for_deployment_gone(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+        _wait_for_deployment(apps, f"{service_name}-predictor", KSERVE_TEST_NAMESPACE)
+
+        got = kserve.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
+        conditions = got.get("status", {}).get("conditions", [])
+        canary_condition = next(
+            (c for c in conditions if c["type"] == "CanaryPredictorReady"), None
+        )
+        assert canary_condition is None, (
+            "CanaryPredictorReady should be cleared after rollback"
+        )
+    finally:
+        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+
+@pytest.mark.predictor
+def test_canary_force_stop():
+    service_name = "isvc-canary-stop"
+    kserve = _kserve_client()
+    apps = _apps_v1()
+
+    isvc = _make_isvc(
+        service_name,
+        canaries=[
+            V1beta1CanarySpec(
+                traffic_percent=20,
+                predictor=_make_predictor(CANARY_MODEL_URI, name="v2"),
+            ),
+        ],
+    )
+
+    try:
+        kserve.create(isvc)
+        kserve.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+        _wait_for_deployment(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+
+        stop_patch = V1beta1InferenceService(
+            api_version=constants.KSERVE_V1BETA1,
+            kind=constants.KSERVE_KIND_INFERENCESERVICE,
+            metadata=client.V1ObjectMeta(
+                name=service_name,
+                namespace=KSERVE_TEST_NAMESPACE,
+                annotations={
+                    "serving.kserve.io/force-stop-canary-v2": "true",
+                },
+            ),
+            spec=isvc.spec,
+        )
+
+        kserve.patch(service_name, stop_patch, namespace=KSERVE_TEST_NAMESPACE)
+
+        _wait_for_deployment_gone(
+            apps, f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+
+        got = kserve.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
+        conditions = got.get("status", {}).get("conditions", [])
+        canary_condition = next(
+            (c for c in conditions if c["type"] == "CanaryPredictorReady"), None
+        )
+        assert canary_condition is not None
+        assert canary_condition["reason"] == "Stopped"
+    finally:
+        kserve.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_canary_raw_deployment.py
+++ b/test/e2e/predictor/test_canary_raw_deployment.py
@@ -145,6 +145,8 @@ def _get_pod_uids(apps_v1, deployment_name, namespace):
 
 
 @pytest.mark.predictor
+@pytest.mark.raw
+@pytest.mark.asyncio(scope="session")
 def test_canary_create():
     service_name = "isvc-canary-create"
     kserve = _kserve_client()
@@ -193,6 +195,8 @@ def test_canary_create():
 
 
 @pytest.mark.predictor
+@pytest.mark.raw
+@pytest.mark.asyncio(scope="session")
 def test_canary_promote():
     service_name = "isvc-canary-promote"
     kserve = _kserve_client()
@@ -253,6 +257,8 @@ def test_canary_promote():
 
 
 @pytest.mark.predictor
+@pytest.mark.raw
+@pytest.mark.asyncio(scope="session")
 def test_canary_rollback():
     service_name = "isvc-canary-rollback"
     kserve = _kserve_client()
@@ -308,6 +314,8 @@ def test_canary_rollback():
 
 
 @pytest.mark.predictor
+@pytest.mark.raw
+@pytest.mark.asyncio(scope="session")
 def test_canary_force_stop():
     service_name = "isvc-canary-stop"
     kserve = _kserve_client()
@@ -355,3 +363,6 @@ def test_canary_force_stop():
         _wait_for_condition(kserve, service_name, "CanaryPredictorReady", "Stopped")
     finally:
         _safe_delete(kserve, service_name)
+
+
+# TODO: Add testing for routing after HTTPRoute support is added to the raw deployment mode.


### PR DESCRIPTION
## Summary
Add e2e tests for canary deployment lifecycle in raw deployment mode.

Depends on #5672 (canary API types, validation, and deployment reconciler).

## Test Cases

| Test | What it verifies |
|------|-----------------|
| `test_canary_create` | Stable + canary Deployments created, `CanaryPredictorReady` condition set, canary status populated |
| `test_canary_promote` | Canary becomes stable without pod restart (pod UIDs survive), old stable Deployment deleted |
| `test_canary_rollback` | Canary Deployment deleted, stable restored, `CanaryPredictorReady` condition cleared |
| `test_canary_force_stop` | Force-stop annotation deletes canary Deployment, condition reason set to "Stopped" |

## Notes
- Tests use sklearn models with `autoscalerClass: none` for deterministic replica counts
- No traffic verification (that's handled by omc e2e tests)
- Tests verify deployment lifecycle only: creation, promotion, rollback, force stop

🤖 Generated with [Claude Code](https://claude.ai/code)