### PR TITLE
fix(e2e): update InferenceObjective API group after CRD migration

### DIFF
--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1856,7 +1856,7 @@ def delete_scheduler_configmap():
             raise
 
 
-INFERENCE_OBJECTIVE_GROUP = "inference.networking.x-k8s.io"
+INFERENCE_OBJECTIVE_GROUP = "llm-d.ai"
 INFERENCE_OBJECTIVE_VERSION = "v1alpha2"
 INFERENCE_OBJECTIVE_PLURAL = "inferenceobjectives"
 


### PR DESCRIPTION
## Summary

Fixes failing E2E tests (`test_flow_control_smoke` and LoRA model listing)

- The upstream `InferenceObjective` CRD was migrated from the `inference.networking.x-k8s.io` API group to `llm-d.ai`. The E2E test fixtures still referenced the old group, causing flow control tests to fail with a 404 when creating `InferenceObjective` resources.
- This cascaded into the LoRA `/v1/models` test failure: CI sets `SKIP_DELETION_ON_FAILURE=True`, so the failed flow control services (`fc-smoke-test`, `fc-concurrency-test`) were not cleaned up. Their HTTPRoutes remained active with model-routing headers matching the same model name (`facebook/opt-125m`) as the LoRA test. Envoy Gateway then mis-routed the LoRA test's `/v1/models` request to a stale simulator pod instead of the real vLLM pod, producing a response missing the expected `publishers/`-prefixed model name and LoRA adapters.

## Changes

- Update `INFERENCE_OBJECTIVE_GROUP` in `test/e2e/llmisvc/fixtures.py` from `inference.networking.x-k8s.io` to `llm-d.ai`

## Test plan

- [ ] Flow control E2E tests (`test_flow_control_smoke`) pass without 404 errors
- [ ] LoRA model listing test (`model-fb-opt-125m-with-lora-hf`) passes with correct `/v1/models` response
- [ ] No `ModelNameCollision` interference from stale flow control services