### PR TITLE
refactor(e2e): auto-assign llminferenceservice & consolidate markers

### DIFF
--- a/test/e2e/llmisvc/README.md
+++ b/test/e2e/llmisvc/README.md
@@ -23,30 +23,35 @@ via `pytest.param(..., marks=...)`.
 ### Auto-assigned group markers (implicit, from file naming)
 
 `conftest.py` hooks into `pytest_collection_modifyitems` and assigns group
-markers based on the test file name. No `@pytest.mark` decorator is needed on
-individual tests for these — the filename alone decides the group.
+markers based on the test file name. **No `@pytest.mark` decorator is needed on
+individual tests for these** — the filename alone decides the group.
+
+All tests collected from the `llmisvc/` directory automatically receive the
+`llminferenceservice` marker. In addition, each test gets a sub-group marker:
 
 | File pattern | Assigned markers | Example file |
 |---|---|---|
-| `test_llm_autoscaling_<variant>.py` | `llmisvc_autoscaling` + `autoscaling_<variant>` | `test_llm_autoscaling_wva.py` → `llmisvc_autoscaling`, `autoscaling_wva` |
-| Files in `_LLMISVC_CORE_EXCLUDED` | *none* (manually marked) | `test_llm_tracing.py` has its own `tracing` marker |
-| Everything else | `llmisvc_core` | `test_llm_inference_service.py`, `test_pod_watch.py` |
+| `test_llm_autoscaling_<variant>.py` | `llminferenceservice` + `llmisvc_autoscaling` + `autoscaling_<variant>` | `test_llm_autoscaling_wva.py` → `llminferenceservice`, `llmisvc_autoscaling`, `autoscaling_wva` |
+| Files in `_LLMISVC_CORE_EXCLUDED` | `llminferenceservice` only (manually marked for sub-group) | `test_llm_tracing.py` has its own `tracing` marker |
+| Everything else | `llminferenceservice` + `llmisvc_core` | `test_llm_inference_service.py`, `test_pod_watch.py` |
 
 **Key rules:**
 
-1. **Autoscaling variants** — name the file `test_llm_autoscaling_<variant>.py`
+1. **`llminferenceservice` is always automatic** — every test file under
+   `test/e2e/llmisvc/` gets this marker. Do not add it manually.
+2. **Autoscaling variants** — name the file `test_llm_autoscaling_<variant>.py`
    and the variant marker (`autoscaling_<variant>`) is derived automatically.
    Adding `test_llm_autoscaling_keda.py` creates the `autoscaling_keda` marker
    with no further code changes.
-2. **Excluded files** — files in `_LLMISVC_CORE_EXCLUDED` (currently
+3. **Excluded files** — files in `_LLMISVC_CORE_EXCLUDED` (currently
    `test_llm_tracing.py`) opt out of automatic `llmisvc_core` and must carry
-   their own explicit markers.
-3. **Default** — every other `test_*.py` under `test/e2e/llmisvc/` receives
+   their own explicit sub-group markers.
+4. **Default** — every other `test_*.py` under `test/e2e/llmisvc/` receives
    `llmisvc_core` automatically.
 
 When adding a new test file, decide which group it belongs to:
 
-- Core LLMISVC functionality → just name it `test_*.py` (auto-gets `llmisvc_core`).
+- Core LLMISVC functionality → just name it `test_*.py` (auto-gets `llminferenceservice` + `llmisvc_core`).
 - New autoscaling backend → name it `test_llm_autoscaling_<backend>.py`.
 - Completely new category → add the file to `_LLMISVC_CORE_EXCLUDED` and apply
   an explicit marker; register the marker in `pytest_configure` and `pytest.ini`.
@@ -56,7 +61,6 @@ When adding a new test file, decide which group it belongs to:
 These are set on individual `pytest.param(...)` entries and describe what
 hardware or environment the test needs:
 
-- `@pytest.mark.llminferenceservice` - All LLM inference service tests
 - `@pytest.mark.cluster_cpu` - CPU-only tests
 - `@pytest.mark.cluster_amd` - AMD GPU tests
 - `@pytest.mark.cluster_nvidia` - NVIDIA GPU tests

--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -30,14 +30,21 @@ _LLMISVC_CORE_EXCLUDED = {"test_llm_tracing.py"}
 def _auto_assign_group_markers(items):
     """Auto-assign group markers based on file naming convention.
 
+    Every test collected from the ``llmisvc/`` directory automatically receives
+    the ``llminferenceservice`` marker.  Additionally:
+
     * ``test_llm_autoscaling_<variant>.py`` -> ``llmisvc_autoscaling`` +
       ``autoscaling_<variant>`` (e.g. ``autoscaling_wva``, ``autoscaling_keda``).
-    * ``test_llm_tracing.py`` -> skipped (has its own ``tracing`` marker).
+    * ``test_llm_tracing.py`` -> skipped from ``llmisvc_core`` (has its own
+      ``tracing`` marker).
     * Everything else -> ``llmisvc_core``.
     """
     for item in items:
         if not item.path.is_relative_to(_LLMISVC_DIR):
             continue
+
+        item.add_marker(pytest.mark.llminferenceservice)
+
         stem = item.path.stem  # filename without .py
 
         if stem.startswith(_AUTOSCALING_STEM_PREFIX):
@@ -48,8 +55,21 @@ def _auto_assign_group_markers(items):
             item.add_marker(pytest.mark.llmisvc_core)
 
 
-# This hook is used to ensure that the test names are unique and to ensure that
-# the test names are consistent with the cluster marks.
+def pytest_configure(config):
+    """Register dynamic autoscaling variant markers derived from filenames.
+
+    Static markers are declared in pytest.ini. This hook only handles markers
+    that are generated from the filesystem (autoscaling_<variant>) so that
+    --strict-markers works without manual upkeep.
+    """
+    for path in _LLMISVC_DIR.glob(f"{_AUTOSCALING_STEM_PREFIX}*.py"):
+        variant = path.stem[len(_AUTOSCALING_STEM_PREFIX) :]
+        config.addinivalue_line(
+            "markers",
+            f"autoscaling_{variant}: auto-discovered autoscaling variant marker",
+        )
+
+
 def pytest_collection_modifyitems(config, items):
     _auto_assign_group_markers(items)
 
@@ -72,36 +92,6 @@ def pytest_collection_modifyitems(config, items):
 
         new_id = "-".join(cluster_marks + [rest])
         item._nodeid = f"{base}[{new_id}]"
-
-
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "llminferenceservice: mark test as an LLM inference service test"
-    )
-    config.addinivalue_line("markers", "llmisvc_core: mark test as a core LLMISVC test")
-    config.addinivalue_line("markers", "autoscaling: mark test as an autoscaling test")
-    config.addinivalue_line(
-        "markers", "autoscaling_wva: mark test as a WVA autoscaling test"
-    )
-    config.addinivalue_line(
-        "markers",
-        "llmisvc_autoscaling: mark test as an LLMISVC autoscaling test",
-    )
-    config.addinivalue_line(
-        "markers", "autoscaling_hpa: mark test as an HPA autoscaling test"
-    )
-    config.addinivalue_line(
-        "markers", "autoscaling_keda: mark test as a KEDA autoscaling test"
-    )
-    config.addinivalue_line(
-        "markers", "model_routing: mark test as a model-based routing test"
-    )
-    config.addinivalue_line("markers", "lora: mark test as a LoRA adapter test")
-    config.addinivalue_line("markers", "pvc_storage: mark test as a PVC storage test")
-    config.addinivalue_line(
-        "markers", "tracing: mark test as a distributed tracing test"
-    )
-    config.addinivalue_line("markers", "flow_control: mark test as a flow control test")
 
 
 @pytest.fixture

--- a/test/e2e/llmisvc/test_flow_control.py
+++ b/test/e2e/llmisvc/test_flow_control.py
@@ -44,7 +44,6 @@ FC_OBJECTIVES = [
 FC_OBJECTIVE_NAMES = [o["name"] for o in FC_OBJECTIVES]
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.asyncio(loop_scope="session")
 @pytest.mark.parametrize(
     "test_case",

--- a/test/e2e/llmisvc/test_gateway_section_name.py
+++ b/test/e2e/llmisvc/test_gateway_section_name.py
@@ -129,7 +129,6 @@ def _cleanup_llmisvc(kserve_client, name, namespace, version="v1alpha1"):
             logger.warning(f"Failed to cleanup LLMInferenceService {name}: {e}")
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.cluster_cpu
 @pytest.mark.cluster_single_node
 @pytest.mark.llmd_simulator

--- a/test/e2e/llmisvc/test_llm_autoscaling_wva.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling_wva.py
@@ -498,7 +498,6 @@ def _new_kserve_client():
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_hpa
 @pytest.mark.parametrize(
     "test_case",
@@ -562,7 +561,6 @@ def test_llm_autoscaling_hpa_deployment(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_keda
 @pytest.mark.parametrize(
     "test_case",
@@ -626,7 +624,6 @@ def test_llm_autoscaling_keda_deployment(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_hpa
 @pytest.mark.parametrize(
     "test_case",
@@ -684,7 +681,6 @@ def test_llm_autoscaling_hpa_lws(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_keda
 @pytest.mark.parametrize(
     "test_case",
@@ -742,7 +738,6 @@ def test_llm_autoscaling_keda_lws(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_hpa
 @pytest.mark.parametrize(
     "test_case",
@@ -791,7 +786,6 @@ def test_llm_autoscaling_prefill_hpa(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_keda
 @pytest.mark.parametrize(
     "test_case",
@@ -840,7 +834,6 @@ def test_llm_autoscaling_prefill_keda(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_hpa
 @pytest.mark.parametrize(
     "test_case",
@@ -903,7 +896,6 @@ def test_llm_autoscaling_cleanup_hpa(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_keda
 @pytest.mark.parametrize(
     "test_case",
@@ -965,7 +957,6 @@ def test_llm_autoscaling_cleanup_keda(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_hpa
 @pytest.mark.parametrize(
     "test_case",
@@ -1026,7 +1017,6 @@ def test_llm_autoscaling_stop_hpa(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_keda
 @pytest.mark.parametrize(
     "test_case",
@@ -1087,7 +1077,6 @@ def test_llm_autoscaling_stop_keda(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_hpa
 @pytest.mark.parametrize(
     "test_case",
@@ -1163,7 +1152,6 @@ def test_llm_autoscaling_update_hpa(test_case: TestCase):
 # =============================================================================
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.autoscaling_keda
 @pytest.mark.parametrize(
     "test_case",

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -237,7 +237,6 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
     }
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.asyncio(loop_scope="session")
 @pytest.mark.parametrize(
     "test_case",

--- a/test/e2e/llmisvc/test_llm_inference_service_config_deletion.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_config_deletion.py
@@ -190,7 +190,6 @@ def _config_is_gone(kserve_client, config_name, namespace=KSERVE_TEST_NAMESPACE)
         ) from e
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.cluster_cpu
 @pytest.mark.cluster_single_node
 @log_execution
@@ -224,7 +223,6 @@ def test_config_finalizer_added():
         _cleanup_config_silent(kserve_client, config_name)
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.cluster_cpu
 @pytest.mark.cluster_single_node
 @log_execution
@@ -312,7 +310,6 @@ def test_config_deletion_blocked_when_referenced():
             _cleanup_config_silent(kserve_client, cfg_name)
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.cluster_cpu
 @pytest.mark.cluster_single_node
 @log_execution
@@ -348,7 +345,6 @@ def test_config_deletion_allowed_when_unreferenced():
         _cleanup_config_silent(kserve_client, config_name)
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.cluster_cpu
 @pytest.mark.cluster_single_node
 @log_execution
@@ -430,7 +426,6 @@ def _find_well_known_config(kserve_client, suffix, namespace=KSERVE_NAMESPACE):
     return None
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.cluster_cpu
 @pytest.mark.cluster_single_node
 @log_execution
@@ -465,7 +460,6 @@ def test_well_known_config_deletion_prevented_by_webhook():
     print(f"Well-known config {config_name} is intact (no deletionTimestamp)")
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.cluster_cpu
 @pytest.mark.cluster_single_node
 @log_execution

--- a/test/e2e/llmisvc/test_llm_inference_service_conversion.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_conversion.py
@@ -172,7 +172,6 @@ def delete_llmisvc_config_raw(
         ) from e
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.conversion
 class TestLLMInferenceServiceConversion:
     """Test suite for LLMInferenceService API version conversion."""

--- a/test/e2e/llmisvc/test_llm_inference_service_stop.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_stop.py
@@ -37,7 +37,6 @@ KSERVE_PLURAL_LLMINFERENCESERVICE = "llminferenceservices"
 STOP_ANNOTATION_KEY = "serving.kserve.io/stop"
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.asyncio(loop_scope="session")
 @pytest.mark.parametrize(
     "test_case",

--- a/test/e2e/llmisvc/test_llm_lora_adapters.py
+++ b/test/e2e/llmisvc/test_llm_lora_adapters.py
@@ -215,7 +215,6 @@ def run_lora_test(test_case: LoRATestCase):
                 service_name="lora-single-adapter-test",
             ),
             marks=[
-                pytest.mark.llminferenceservice,
                 pytest.mark.cluster_cpu,
                 pytest.mark.lora,
             ],
@@ -233,7 +232,6 @@ def run_lora_test(test_case: LoRATestCase):
                 service_name="lora-multiple-adapters-test",
             ),
             marks=[
-                pytest.mark.llminferenceservice,
                 pytest.mark.cluster_cpu,
                 pytest.mark.lora,
             ],

--- a/test/e2e/llmisvc/test_llm_tracing.py
+++ b/test/e2e/llmisvc/test_llm_tracing.py
@@ -171,7 +171,6 @@ def _assert_cross_service_correlation(
         )
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.tracing
 @pytest.mark.parametrize(
     "test_case",

--- a/test/e2e/llmisvc/test_pod_watch.py
+++ b/test/e2e/llmisvc/test_pod_watch.py
@@ -312,7 +312,6 @@ def delete_llmisvc_config(kserve_client: KServeClient, name: str, namespace: str
         pass
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.asyncio(scope="session")
 async def test_event_storm_prevention_init_container_isolation():
     """
@@ -511,7 +510,6 @@ async def test_event_storm_prevention_init_container_isolation():
         )
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.asyncio(scope="session")
 async def test_quick_reconciliation_on_init_container_failure():
     """

--- a/test/e2e/llmisvc/test_prestop_hook.py
+++ b/test/e2e/llmisvc/test_prestop_hook.py
@@ -38,7 +38,6 @@ _PRESTOP_SLEEP_SECONDS = 15
 _PRESTOP_TOLERANCE_SECONDS = 3
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.parametrize(
     "test_case",
     [

--- a/test/e2e/llmisvc/test_rolling_upgrade.py
+++ b/test/e2e/llmisvc/test_rolling_upgrade.py
@@ -38,7 +38,6 @@ from .test_llm_inference_service import (
 )
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.parametrize(
     "test_case",
     [

--- a/test/e2e/llmisvc/test_storage_version_migration.py
+++ b/test/e2e/llmisvc/test_storage_version_migration.py
@@ -62,7 +62,6 @@ def wait_for(assertion_fn, timeout: float = 60.0, interval: float = 1.0):
             time.sleep(interval)
 
 
-@pytest.mark.llminferenceservice
 @pytest.mark.conversion
 class TestStorageVersionMigration:
     """Test storage version migration runs correctly during controller startup."""

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -23,9 +23,13 @@ markers =
     modelcache: e2e tests for model caching
     llminferenceservice: e2e tests for llm inference service controller
     llmisvc_core: core LLMISVC e2e tests
-    autoscaling_hpa: e2e tests for HPA-based autoscaling
-    autoscaling_keda: e2e tests for KEDA-based autoscaling
+    llmisvc_autoscaling: LLMISVC autoscaling e2e tests
     conversion: e2e tests for llm inference service api version conversion
+    model_routing: model-based routing e2e tests
+    lora: e2e tests for LoRA adapters
+    pvc_storage: PVC storage e2e tests
+    tracing: distributed tracing e2e tests
+    flow_control: flow control e2e tests
     cluster_cpu: test targeting cluster with CPU
     cluster_amd: test targeting cluster with AMD
     cluster_intel: test targeting cluster with Intel
@@ -39,8 +43,5 @@ markers =
     auth: test requiring authentication setup
     llmd_simulator: test using llm-d simulator
     dual_protocol: test for dual protocol gRPC and REST predictor for Standard mode with Gateway API
-    lora: e2e tests for LoRA adapters
-    autoscaling_wva: e2e tests for WVA autoscaling
-    llmisvc_autoscaling: LLMISVC autoscaling e2e tests
     autogluon: e2e tests for autogluon runtime
     storage: e2e tests for storage URI schemes (oci+native://, pvc://, etc.)

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -24,6 +24,8 @@ markers =
     llminferenceservice: e2e tests for llm inference service controller
     llmisvc_core: core LLMISVC e2e tests
     llmisvc_autoscaling: LLMISVC autoscaling e2e tests
+    autoscaling_hpa: e2e tests for HPA-based autoscaling
+    autoscaling_keda: e2e tests for KEDA-based autoscaling
     conversion: e2e tests for llm inference service api version conversion
     model_routing: model-based routing e2e tests
     lora: e2e tests for LoRA adapters


### PR DESCRIPTION
## Summary

- Auto-assign `llminferenceservice` marker to all tests in `test/e2e/llmisvc/` via the existing `pytest_collection_modifyitems` hook, eliminating the need to manually decorate every test function/class.
- Consolidate marker declarations: `pytest.ini` is now the single source of truth for static markers; `conftest.py` only registers dynamic `autoscaling_<variant>` markers discovered from the filesystem (compatible with `--strict-markers`).
- Remove 31 hardcoded `@pytest.mark.llminferenceservice` occurrences across 13 test files.

## Motivation

The `llminferenceservice` marker was manually applied to every test, which was error-prone (easy to forget on new tests) and noisy. The `llmisvc_core` marker already used automatic assignment — this PR extends the same pattern to the
parent `llminferenceservice` marker.

Marker declarations were duplicated between `pytest.ini` and `conftest.py`'s `pytest_configure`. This consolidation removes the duplication while keeping dynamic variant markers (e.g. `autoscaling_wva`, `autoscaling_keda`) auto-registered
from filenames so adding a new variant requires zero config changes.