### PR TITLE
docs(llmisvc): add Valkey KV offloading and prefix-cache samples

### DIFF
--- a/docs/samples/llmisvc/lmcache-valkey-offloading/README.md
+++ b/docs/samples/llmisvc/lmcache-valkey-offloading/README.md
@@ -1,0 +1,57 @@
+# LMCache KV Cache Offloading with Valkey
+
+This sample deploys an `LLMInferenceService` using [LMCache](https://docs.lmcache.ai/index.html)
+for KV cache offloading, with [Valkey](https://valkey.io/) as the remote, distributed backend.
+Valkey is a drop-in, BSD-licensed alternative to Redis: LMCache's `ValkeyConnector` speaks the
+same wire protocol, so only the `remote_url` scheme changes from `redis://` to `valkey://`.
+
+See the [KV Cache Offloading with Huggingface vLLM Backend](https://kserve.github.io/website/docs/model-serving/generative-inference/kvcache-offloading)
+guide for the full step-by-step walkthrough this sample accompanies.
+
+> This is a different feature from the [`kv-cache-offloading`](../kv-cache-offloading/) sample
+> in this directory, which configures KServe's native `workload.kvCacheOffloading` GPU → CPU →
+> disk tiering. This sample instead offloads to a remote key-value store via LMCache, which is
+> useful for sharing KV cache across multiple inference replicas.
+
+## What this deploys
+
+[`llmisvc-lmcache-valkey.yaml`](llmisvc-lmcache-valkey.yaml) contains:
+
+- A `ConfigMap` with the LMCache configuration, pointing `remote_url` at the Valkey service
+- A single-replica `valkey/valkey:9.1.0` `Deployment` and `Service`
+- An `LLMInferenceService` running `meta-llama/Llama-3.2-1B-Instruct` with LMCache enabled via
+  `--kv-transfer-config`, and the LMCache config mounted from the `ConfigMap`
+
+## Prerequisites
+
+- A Kubernetes cluster with [KServe v0.18.0](https://kserve.github.io/website/docs/getting-started/quickstart-guide) or later installed
+- GPU nodes (the sample requests `nvidia.com/gpu: "1"`)
+- A Huggingface token secret named `hf-secret` with key `HF_TOKEN` (see the guide's
+  [Create Huggingface Secret](https://kserve.github.io/website/docs/model-serving/generative-inference/kvcache-offloading#create-huggingface-secret-hf_token) step)
+
+## Deploy
+
+```bash
+kubectl apply -f llmisvc-lmcache-valkey.yaml
+```
+
+Wait for the Valkey pod and the `LLMInferenceService` to be ready:
+
+```bash
+kubectl get pods -l app=valkey
+kubectl get llminferenceservice llama3-lmcache-valkey
+```
+
+## Verify
+
+Send an inference request through the OpenAI-compatible route (see the guide's
+[Verify the Setup with an Inference Request](https://kserve.github.io/website/docs/model-serving/generative-inference/kvcache-offloading#verify-the-setup-with-an-inference-request)
+section), then confirm KV cache entries landed in Valkey:
+
+```bash
+kubectl exec deploy/valkey -it -- valkey-cli KEYS '*'
+```
+
+You should see keys of the form `meta-llama/Llama-3.2-1B-Instruct@<worker>@<layer>@<hash>@half`,
+one per 256-token chunk that LMCache offloaded. Sending the same prompt again should produce a
+cache hit in the vLLM logs (`LMCache hit tokens: 256`).

--- a/docs/samples/llmisvc/lmcache-valkey-offloading/llmisvc-lmcache-valkey.yaml
+++ b/docs/samples/llmisvc/lmcache-valkey-offloading/llmisvc-lmcache-valkey.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lmcache-config
+data:
+  lmcache_config.yaml: |
+    local_cpu: true  # Enable local CPU RAM cache for fast access (Recommended)
+    chunk_size: 256  # Size of cache chunks (tune for your model)
+    max_local_cpu_size: 2.0  # Max size (GB) for local CPU cache
+    remote_url: "valkey://valkey:6379"  # Valkey as remote backend
+    remote_serde: "naive"  # Serialization method for remote cache. Supported values: "naive", "cachegen"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey
+  labels:
+    app: valkey
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      containers:
+        - name: valkey
+          image: valkey/valkey:9.1.0
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              memory: 4Gi
+            requests:
+              memory: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+spec:
+  selector:
+    app: valkey
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: llama3-lmcache-valkey
+spec:
+  model:
+    uri: hf://meta-llama/Llama-3.2-1B-Instruct
+    name: meta-llama/Llama-3.2-1B-Instruct
+  replicas: 2
+  router:
+    scheduler: {}
+    route: {}
+    gateway: {}
+  template:
+    containers:
+      - name: main
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-secret
+                key: HF_TOKEN
+                optional: false
+          # The default LLM template's entrypoint expands VLLM_ADDITIONAL_ARGS inside its own
+          # quoting context, so kv-transfer-config's JSON survives intact. Passing the same flag
+          # via `args:` does not work here: args become positional params ($@) that the
+          # template's `eval "exec vllm serve ... $@"` re-splits on whitespace, corrupting the
+          # embedded JSON (see the other llmisvc samples in this repo, which use the same
+          # VLLM_ADDITIONAL_ARGS pattern for flags with embedded JSON).
+          - name: VLLM_ADDITIONAL_ARGS
+            value: "--max-model-len=10000 --kv-transfer-config '{\"kv_connector\":\"LMCacheConnectorV1\", \"kv_role\":\"kv_both\"}' --enable-chunked-prefill"
+          - name: LMCACHE_USE_EXPERIMENTAL
+            value: "True"
+          - name: LMCACHE_CONFIG_FILE
+            value: /lmcache/lmcache_config.yaml
+          - name: LMCACHE_LOG_LEVEL
+            value: "INFO"
+        resources:
+          limits:
+            cpu: 6
+            memory: 24Gi
+            nvidia.com/gpu: "1"
+          requests:
+            cpu: 6
+            memory: 24Gi
+            nvidia.com/gpu: "1"
+        volumeMounts:
+          - name: lmcache-config-volume
+            mountPath: /lmcache
+            readOnly: true
+    volumes:
+      - name: lmcache-config-volume
+        configMap:
+          name: lmcache-config
+          items:
+            - key: lmcache_config.yaml
+              path: lmcache_config.yaml

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/valkey-shared-index/README.md
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/valkey-shared-index/README.md
@@ -1,0 +1,46 @@
+# Valkey-Backed Shared Prefix-Cache Index
+
+Optional variant of the [precise prefix cache routing](../) example that backs the
+`precise-prefix-cache-scorer`'s KV-block index with a shared [Valkey](https://valkey.io/)
+instance instead of the Endpoint Picker's default in-memory index.
+
+## Why
+
+Each Endpoint Picker (EPP) replica normally tracks its own in-memory index of which KV-cache
+blocks live on which pods. With multiple EPP replicas (HA deployments, large fleets), each
+replica only sees the KV-cache events it happened to receive, so the index fragments across
+replicas and routing decisions become less accurate. Pointing all EPP replicas at the same
+Valkey instance gives them a single, consistent view of the cluster-wide KV-cache state.
+
+A single EPP replica has nothing to share, so the in-memory default is the better choice there.
+
+## What this deploys
+
+[`llm-inference-service-qwen2-7b-gpu-kv-cache-routing-valkey.yaml`](llm-inference-service-qwen2-7b-gpu-kv-cache-routing-valkey.yaml)
+is the same `LLMInferenceService` as the parent example, with one change: the
+`precise-prefix-cache-scorer`'s `indexerConfig.kvBlockIndexConfig` now sets `valkeyConfig`
+instead of relying on the default in-memory index. It also includes a single-replica
+`valkey/valkey:9.1.0` `Deployment` and `Service` for the index to connect to.
+
+```yaml
+indexerConfig:
+  kvBlockIndexConfig:
+    valkeyConfig:
+      address: "valkey://valkey:6379"
+      backendType: "valkey"
+    enableMetrics: true
+    metricsLoggingInterval: 60000000000
+```
+
+This is a pure configuration change backed by [`llm-d-kv-cache`](https://github.com/llm-d/llm-d-kv-cache)'s
+`ValkeyConfig` / `NewValkeyIndex()`, which is API-compatible with its Redis index (`RedisIndexConfig`
+is reused for both backends).
+
+## Deploy
+
+See the parent [README](../README.md) for prerequisites and the full deployment/verification
+walkthrough. Apply this variant instead of the parent manifest:
+
+```bash
+kubectl apply -f llm-inference-service-qwen2-7b-gpu-kv-cache-routing-valkey.yaml
+```

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/valkey-shared-index/llm-inference-service-qwen2-7b-gpu-kv-cache-routing-valkey.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/valkey-shared-index/llm-inference-service-qwen2-7b-gpu-kv-cache-routing-valkey.yaml
@@ -1,0 +1,135 @@
+# kv-cache, shared index (Valkey)
+#
+# Variant of ../llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml that backs the
+# precise-prefix-cache-scorer's KV-block index with a shared Valkey instance instead of the
+# scheduler's default in-memory index. Useful for multi-replica Endpoint Picker (EPP)
+# deployments (HA / large fleets), where a shared index avoids each EPP replica fragmenting
+# its own view of which pods hold which KV-cache blocks. A single EPP replica is better off
+# with the in-memory default.
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: qwen2-7b-kv-cache-routing-valkey
+spec:
+  model:
+    uri: hf://Qwen/Qwen2.5-7B-Instruct
+    name: Qwen/Qwen2.5-7B-Instruct
+  # Two replicas to demonstrate KV cache routing across instances
+  replicas: 2
+  router:
+    scheduler:
+      config:
+        inline:
+          apiVersion: inference.networking.x-k8s.io/v1alpha1
+          kind: EndpointPickerConfig
+          plugins:
+            - type: single-profile-handler
+            - type: precise-prefix-cache-scorer
+              parameters:
+                tokenProcessorConfig:
+                  blockSize: 64       # Must match vLLM --block-size (default is 16)
+                  hashSeed: "42"      # Must match PYTHONHASHSEED in vLLM pods
+                kvEventsConfig:
+                  zmqEndpoint: "tcp://*:5557"
+                indexerConfig:
+                  kvBlockIndexConfig:
+                    valkeyConfig:
+                      address: "valkey://valkey:6379"
+                      backendType: "valkey"
+                    enableMetrics: true                   # Enable Prometheus metrics for KV cache index
+                    metricsLoggingInterval: 60000000000   # Log metrics every 60 seconds (in nanoseconds)
+            - type: kv-cache-utilization-scorer
+            - type: queue-scorer
+            - type: active-request-scorer
+              parameters:
+                requestTimeout: "2m"
+                idleThreshold: 0        # Pods with ≤0 requests are idle
+                maxBusyScore: 0         # Busy pods score 0, idle pods score 1.0
+            - type: max-score-picker
+          schedulingProfiles:
+            - name: default
+              plugins:
+                - pluginRef: precise-prefix-cache-scorer
+                  weight: 3
+                - pluginRef: kv-cache-utilization-scorer
+                  weight: 2
+                - pluginRef: queue-scorer
+                  weight: 2
+                - pluginRef: active-request-scorer
+                  weight: 3
+                - pluginRef: max-score-picker
+    route: { }
+    gateway: { }
+  template:
+    containers:
+      - name: main
+        env:
+          # Configure vLLM for prefix caching with KV cache event publishing
+          - name: VLLM_ADDITIONAL_ARGS
+            value: "--prefix-caching-hash-algo sha256_cbor --block-size 64 --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --kv-events-config '{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://{{ ChildName .ObjectMeta.Name `-epp-service` }}:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen2.5-7B-Instruct\"}'"
+          # Pod IP used in KV cache event topic
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          # Hash seed must match scheduler configuration
+          - name: PYTHONHASHSEED
+            value: "42"
+        resources:
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            nvidia.com/gpu: "1"
+          requests:
+            cpu: '2'
+            memory: 16Gi
+            nvidia.com/gpu: "1"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey
+  labels:
+    app: valkey
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      containers:
+        - name: valkey
+          image: valkey/valkey:9.1.0
+          ports:
+            - containerPort: 6379
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+spec:
+  selector:
+    app: valkey
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379

--- a/docs/samples/v1beta1/transformer/feast/valkey.yaml
+++ b/docs/samples/v1beta1/transformer/feast/valkey.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: valkey-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey-server
+  template:
+    metadata:
+      labels:
+        app: valkey-server
+        name: valkey-server
+    spec:
+      containers:
+        - name: valkey-server
+          image: valkey/valkey:9.1.0
+          args: [ "--appendonly", "yes" ]
+          ports:
+            - name: valkey-server
+              containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey-service
+spec:
+  type: LoadBalancer  # Unauthenticated sample; use ClusterIP and network controls in production.
+  selector:
+    app: valkey-server
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Valkey sample manifests for KServe's LLM inference paths. Valkey is already a documented supported backend for LMCache and for `llm-d-kv-cache`'s prefix-cache index, but there wasn't a runnable example for either, and the Feast transformer samples only had a Redis variant.

Three additions:
- `docs/samples/llmisvc/lmcache-valkey-offloading/`: an `LLMInferenceService` using LMCache with Valkey as the remote KV-cache backend (ConfigMap + Valkey Deployment/Service + the inference service itself). This is a different feature from the existing `kv-cache-offloading/` sample in this directory, which covers native GPU→CPU→disk tiering, not a remote store; the new README spells that out so people don't confuse the two.
- `docs/samples/llmisvc/precise-prefix-kv-cache-routing/valkey-shared-index/`: a variant of the existing prefix-cache-routing sample that points the scorer's KV-block index at a shared Valkey instance instead of the EPP's default in-memory index. Only matters once you have more than one EPP replica and want them looking at the same cache state.
- `docs/samples/v1beta1/transformer/feast/valkey.yaml`: a Valkey sibling to the existing `redis.yaml` Feast online-store sample.

Companion docs PR: kserve/website (adds the corresponding "Using Valkey as Remote Backend" guide section and links back to the sample here).

**Which issue(s) this PR fixes** *(optional, in `fixes #(, fixes #, ...)` format, will close the issue(s) when PR gets merged)*:
Related: https://github.com/kserve/website/issues/701

**Feature/Issue validation/testing**:

End-to-end validated on a `g5.2xlarge` EC2 instance (NVIDIA A10G, native x86_64) running k3s + KServe v0.18.0 LLMIsvc stack:

- Deployed the LMCache+Valkey sample (substituting `facebook/opt-125m` for the gated Llama model) with vLLM v0.25.1 + LMCache 0.5.1 on GPU. The pod reached `Ready` and began serving inference.
- Confirmed LMCache's `ValkeyConnectorAdapter` connects to the `valkey/valkey:latest` service via the GLIDE sync client (`valkey-glide-sync`). Logs show: `Creating Valkey connector for valkey.default.svc.cluster.local:6379 (mode=standalone)` and `Connected to remote storage at valkey://valkey.default.svc.cluster.local:6379`.
- Sent a 261-token inference request (exceeding the 256-token `chunk_size`). LMCache stored one KV cache chunk (9.4MB) to Valkey. Confirmed via `valkey-cli KEYS '*'` showing `facebook/opt-125m@1@0@1146884708361236@half`.
- Sent the same prompt again. LMCache logs showed `LMCache hit tokens: 256`, confirming cache retrieval from Valkey works end-to-end.
- The `VLLM_ADDITIONAL_ARGS` pattern correctly passes the `--kv-transfer-config` JSON to vLLM without corruption (confirmed in startup logs: `kv_transfer_config: KVTransferConfig(kv_connector='LMCacheConnectorV1', ...)`).

Additional validation:
- Validated the LMCache ValkeyConnector code path directly against a live `valkey/valkey` container (connector round-trip via `put`/`exists`/`get`).
- Validated the Valkey-backed prefix-cache index against `llm-d-kv-cache`: wrote a Go program calling `kvblock.NewIndex` with the same `ValkeyConfig` this sample's YAML sets, confirmed `Add`/`Lookup`/`GetRequestKey`/`Evict` all work against a live Valkey container.
- Deployed a CPU-adapted version against a local `kind` cluster running the full LLMIsvc stack. This caught and fixed the `args:` vs `VLLM_ADDITIONAL_ARGS` JSON-corruption bug (the default LLM template's entrypoint does `eval "exec vllm serve ... $@"` which re-splits positional params on whitespace).
- `precise-prefix-kv-cache-routing`'s GPU sample uses `NixlConnector` (GPU RDMA transport), which doesn't exist in CPU vLLM images, so that sample was validated at the library level rather than full-stack deploy.

**Special notes for your reviewer**:

The two new sample directories intentionally sit alongside, not inside, the existing ones they're variants of (`lmcache-valkey-offloading/` next to `kv-cache-offloading/`, `valkey-shared-index/` inside `precise-prefix-kv-cache-routing/`), matching how this repo already structures sample variants.

Note: LMCache's `ValkeyConnectorAdapter` depends on `valkey-glide-sync` (the synchronous GLIDE client). This is bundled in the `llm-d-cuda` image that KServe's default LLMIsvc template uses, so no extra image work is needed for users following this sample.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? (N/A, docs/samples only; validated end-to-end on GPU, see testing notes above)
- [x] Has code been commented, particularly in hard-to-understand areas? (the `VLLM_ADDITIONAL_ARGS` vs `args:` gotcha is called out inline in the YAML)
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? (companion PR, see above)

**Release note**:
```release-note
Add Valkey sample manifests for LMCache KV-cache offloading, Valkey-backed shared prefix-cache index, and Feast online store.
```