### PR TITLE
fix(e2e): make KEDA operator pod label configurable via env var

### DIFF
--- a/test/e2e/llmisvc/test_llm_autoscaling_wva.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling_wva.py
@@ -84,6 +84,9 @@ HPA_PLURAL = "horizontalpodautoscalers"
 
 PROMETHEUS_NAMESPACE = os.environ.get("PROMETHEUS_NAMESPACE", "monitoring")
 KEDA_NAMESPACE = os.environ.get("KEDA_NAMESPACE", "keda")
+KEDA_OPERATOR_POD_LABEL = os.environ.get(
+    "KEDA_OPERATOR_POD_LABEL", "app.kubernetes.io/name=keda-operator"
+)
 
 
 def _get_custom_resource(group, version, plural, name, namespace):
@@ -339,7 +342,7 @@ def assert_metrics_pipeline_ready(actuator="hpa"):
         v1 = client.CoreV1Api()
         pods = v1.list_namespaced_pod(
             namespace=KEDA_NAMESPACE,
-            label_selector="app.kubernetes.io/name=keda-operator",
+            label_selector=KEDA_OPERATOR_POD_LABEL,
         )
         running_names = [
             p.metadata.name for p in pods.items if p.status.phase == "Running"


### PR DESCRIPTION
## What

Makes the KEDA operator pod label selector in the autoscaling E2E health check configurable through the `KEDA_OPERATOR_POD_LABEL` environment variable, defaulting to the upstream community value `app.kubernetes.io/name=keda-operator`.

## Why

The KEDA operator pod label differs between distributions:

| Distribution | Label |
|---|---|
| Community KEDA | `app.kubernetes.io/name=keda-operator` |
| OpenShift Custom Metrics Autoscaler | `app=keda-operator` |

The current hardcoded label causes `assert_metrics_pipeline_ready("keda")` to fail on OpenShift clusters running the CMA operator, even though KEDA is fully functional. This blocks OpenShift CI from reusing the upstream test suite without patching the file.

## How

- Added `KEDA_OPERATOR_POD_LABEL` env var (follows the same pattern as the
  existing `KEDA_NAMESPACE` and `PROMETHEUS_NAMESPACE` env vars)
- Replaced the hardcoded `label_selector` string with the new variable