### PR TITLE
feat: restructure CRD management for independent installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,11 +221,14 @@ manifests: controller-gen kustomize yq
 	@$(YQ) '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties | .. | select(has("protocol")) | path' config/crd/full/serving.kserve.io_clusterservingruntimes.yaml -o j | jq -r '. | map(select(numbers)="["+tostring+"]") | join(".")' | awk '{print "."$$0".protocol.default"}' | xargs -n1 -I{} $(YQ) '{} = "TCP"' -i config/crd/full/serving.kserve.io_clusterservingruntimes.yaml
 	@$(YQ) '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties | .. | select(has("protocol")) | path' config/crd/full/serving.kserve.io_servingruntimes.yaml -o j | jq -r '. | map(select(numbers)="["+tostring+"]") | join(".")' | awk '{print "."$$0".protocol.default"}' | xargs -n1 -I{} $(YQ) '{} = "TCP"' -i config/crd/full/serving.kserve.io_servingruntimes.yaml
 	
-	# Copy the full crd to the helm chart
-	cp config/crd/full/*.yaml charts/kserve-crd/templates/	
+	# Copy kserve crd (with conversion webhook patches applied via kustomize)
+	$(KUSTOMIZE) build config/crd/full | $(YQ) 'select(.metadata.name == "inferenceservices.serving.kserve.io")' > charts/kserve-crd/templates/serving.kserve.io_inferenceservices.yaml
+	$(KUSTOMIZE) build config/crd/full | $(YQ) 'select(.metadata.name == "trainedmodels.serving.kserve.io")' > charts/kserve-crd/templates/serving.kserve.io_trainedmodels.yaml
+	$(KUSTOMIZE) build config/crd/full | $(YQ) 'select(.metadata.name == "clusterservingruntimes.serving.kserve.io")' > charts/kserve-crd/templates/serving.kserve.io_clusterservingruntimes.yaml
+	$(KUSTOMIZE) build config/crd/full | $(YQ) 'select(.metadata.name == "servingruntimes.serving.kserve.io")' > charts/kserve-crd/templates/serving.kserve.io_servingruntimes.yaml
+	$(KUSTOMIZE) build config/crd/full | $(YQ) 'select(.metadata.name == "inferencegraphs.serving.kserve.io")' > charts/kserve-crd/templates/serving.kserve.io_inferencegraphs.yaml
 	cp config/crd/full/clusterstoragecontainer/serving.kserve.io_clusterstoragecontainers.yaml charts/kserve-crd/files/
-	cp config/crd/full/clusterstoragecontainer/serving.kserve.io_clusterstoragecontainers.yaml charts/kserve-llmisvc-crd/files/	
-	rm charts/kserve-crd/templates/kustomization.yaml
+	cp config/crd/full/clusterstoragecontainer/serving.kserve.io_clusterstoragecontainers.yaml charts/kserve-llmisvc-crd/files/
 	cp -f config/crd/full/localmodel/*.yaml charts/kserve-localmodel-crd/templates/
 	rm charts/kserve-localmodel-crd/templates/kustomization.yaml
 	
@@ -248,12 +251,15 @@ manifests: controller-gen kustomize yq
 	# Generate minimal crd
 	./hack/minimal-crdgen.sh
 	
-	# Copy the minimal crd to the helm chart
-	cp -f config/crd/minimal/*.yaml charts/kserve-crd-minimal/templates/
+	# Copy kserve minimal crd (with conversion webhook patches applied via kustomize)
+	$(KUSTOMIZE) build config/crd/minimal | $(YQ) 'select(.metadata.name == "inferenceservices.serving.kserve.io")' > charts/kserve-crd-minimal/templates/serving.kserve.io_inferenceservices.yaml
+	$(KUSTOMIZE) build config/crd/minimal | $(YQ) 'select(.metadata.name == "trainedmodels.serving.kserve.io")' > charts/kserve-crd-minimal/templates/serving.kserve.io_trainedmodels.yaml
+	$(KUSTOMIZE) build config/crd/minimal | $(YQ) 'select(.metadata.name == "clusterservingruntimes.serving.kserve.io")' > charts/kserve-crd-minimal/templates/serving.kserve.io_clusterservingruntimes.yaml
+	$(KUSTOMIZE) build config/crd/minimal | $(YQ) 'select(.metadata.name == "servingruntimes.serving.kserve.io")' > charts/kserve-crd-minimal/templates/serving.kserve.io_servingruntimes.yaml
+	$(KUSTOMIZE) build config/crd/minimal | $(YQ) 'select(.metadata.name == "inferencegraphs.serving.kserve.io")' > charts/kserve-crd-minimal/templates/serving.kserve.io_inferencegraphs.yaml
 	cp -f config/crd/minimal/localmodel/*.yaml charts/kserve-localmodel-crd-minimal/templates/
 	cp -f config/crd/minimal/clusterstoragecontainer/serving.kserve.io_clusterstoragecontainers.yaml charts/kserve-crd-minimal/files/
 	cp -f config/crd/minimal/clusterstoragecontainer/serving.kserve.io_clusterstoragecontainers.yaml charts/kserve-llmisvc-crd-minimal/files/
-	rm charts/kserve-crd-minimal/templates/kustomization.yaml
 	rm charts/kserve-localmodel-crd-minimal/templates/kustomization.yaml
 
 	# Copy minimal llmisvc crd (with conversion webhook patches applied via kustomize)

--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_clusterservingruntimes.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_clusterservingruntimes.yaml
@@ -13,38 +13,38 @@ spec:
     singular: clusterservingruntime
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.disabled
-      name: Disabled
-      type: boolean
-    - jsonPath: .spec.supportedModelFormats[*].name
-      name: ModelType
-      type: string
-    - jsonPath: .spec.containers[*].name
-      name: Containers
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.disabled
+          name: Disabled
+          type: boolean
+        - jsonPath: .spec.supportedModelFormats[*].name
+          name: ModelType
+          type: string
+        - jsonPath: .spec.containers[*].name
+          name: Containers
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_inferencegraphs.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_inferencegraphs.yaml
@@ -11,40 +11,40 @@ spec:
     listKind: InferenceGraphList
     plural: inferencegraphs
     shortNames:
-    - ig
+      - ig
     singular: inferencegraph
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_inferenceservices.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_inferenceservices.yaml
@@ -11,52 +11,52 @@ spec:
     listKind: InferenceServiceList
     plural: inferenceservices
     shortNames:
-    - isvc
+      - isvc
     singular: inferenceservice
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - jsonPath: .status.components.predictor.traffic[?(@.tag=='prev')].percent
-      name: Prev
-      type: integer
-    - jsonPath: .status.components.predictor.traffic[?(@.latestRevision==true)].percent
-      name: Latest
-      type: integer
-    - jsonPath: .status.components.predictor.traffic[?(@.tag=='prev')].revisionName
-      name: PrevRolledoutRevision
-      type: string
-    - jsonPath: .status.components.predictor.traffic[?(@.latestRevision==true)].revisionName
-      name: LatestReadyRevision
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .status.components.predictor.traffic[?(@.tag=='prev')].percent
+          name: Prev
+          type: integer
+        - jsonPath: .status.components.predictor.traffic[?(@.latestRevision==true)].percent
+          name: Latest
+          type: integer
+        - jsonPath: .status.components.predictor.traffic[?(@.tag=='prev')].revisionName
+          name: PrevRolledoutRevision
+          type: string
+        - jsonPath: .status.components.predictor.traffic[?(@.latestRevision==true)].revisionName
+          name: LatestReadyRevision
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_servingruntimes.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_servingruntimes.yaml
@@ -13,38 +13,38 @@ spec:
     singular: servingruntime
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.disabled
-      name: Disabled
-      type: boolean
-    - jsonPath: .spec.supportedModelFormats[*].name
-      name: ModelType
-      type: string
-    - jsonPath: .spec.containers[*].name
-      name: Containers
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.disabled
+          name: Disabled
+          type: boolean
+        - jsonPath: .spec.supportedModelFormats[*].name
+          name: ModelType
+          type: string
+        - jsonPath: .spec.containers[*].name
+          name: Containers
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/charts/kserve-crd-minimal/templates/serving.kserve.io_trainedmodels.yaml
+++ b/charts/kserve-crd-minimal/templates/serving.kserve.io_trainedmodels.yaml
@@ -11,40 +11,40 @@ spec:
     listKind: TrainedModelList
     plural: trainedmodels
     shortNames:
-    - tm
+      - tm
     singular: trainedmodel
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-map-type: atomic
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-map-type: atomic
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/kserve-crd/templates/serving.kserve.io_clusterservingruntimes.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_clusterservingruntimes.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/kserve-crd/templates/serving.kserve.io_inferencegraphs.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_inferencegraphs.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -12,642 +11,642 @@ spec:
     listKind: InferenceGraphList
     plural: inferencegraphs
     shortNames:
-    - ig
+      - ig
     singular: inferencegraph
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              affinity:
-                properties:
-                  nodeAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            preference:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchFields:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        properties:
-                          nodeSelectorTerms:
-                            items:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchFields:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            type: array
-                            x-kubernetes-list-type: atomic
-                        required:
-                        - nodeSelectorTerms
-                        type: object
-                        x-kubernetes-map-type: atomic
-                    type: object
-                  podAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            podAffinityTerm:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                matchLabelKeys:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                mismatchLabelKeys:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                namespaceSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            labelSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            matchLabelKeys:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            mismatchLabelKeys:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            namespaceSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            namespaces:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            topologyKey:
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  podAntiAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            podAffinityTerm:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                matchLabelKeys:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                mismatchLabelKeys:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                namespaceSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            labelSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            matchLabelKeys:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            mismatchLabelKeys:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            namespaceSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            namespaces:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            topologyKey:
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                type: object
-              maxReplicas:
-                format: int32
-                type: integer
-              minReplicas:
-                format: int32
-                type: integer
-              nodeName:
-                type: string
-              nodeSelector:
-                additionalProperties:
-                  type: string
-                type: object
-              nodes:
-                additionalProperties:
+    - additionalPrinterColumns:
+        - jsonPath: .status.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                affinity:
                   properties:
-                    routerType:
-                      enum:
-                      - Sequence
-                      - Splitter
-                      - Ensemble
-                      - Switch
-                      type: string
-                    steps:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologyKey:
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+                maxReplicas:
+                  format: int32
+                  type: integer
+                minReplicas:
+                  format: int32
+                  type: integer
+                nodeName:
+                  type: string
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  type: object
+                nodes:
+                  additionalProperties:
+                    properties:
+                      routerType:
+                        enum:
+                          - Sequence
+                          - Splitter
+                          - Ensemble
+                          - Switch
+                        type: string
+                      steps:
+                        items:
+                          properties:
+                            condition:
+                              type: string
+                            data:
+                              type: string
+                            dependency:
+                              enum:
+                                - Soft
+                                - Hard
+                              type: string
+                            mapPredictionsToInstances:
+                              type: boolean
+                            name:
+                              type: string
+                            nodeName:
+                              type: string
+                            serviceName:
+                              type: string
+                            serviceUrl:
+                              type: string
+                            weight:
+                              format: int64
+                              type: integer
+                          type: object
+                        type: array
+                    required:
+                      - routerType
+                    type: object
+                  type: object
+                resources:
+                  properties:
+                    claims:
                       items:
                         properties:
-                          condition:
-                            type: string
-                          data:
-                            type: string
-                          dependency:
-                            enum:
-                            - Soft
-                            - Hard
-                            type: string
-                          mapPredictionsToInstances:
-                            type: boolean
                           name:
                             type: string
-                          nodeName:
+                          request:
                             type: string
-                          serviceName:
-                            type: string
-                          serviceUrl:
-                            type: string
-                          weight:
-                            format: int64
-                            type: integer
+                        required:
+                          - name
                         type: object
                       type: array
-                  required:
-                  - routerType
-                  type: object
-                type: object
-              resources:
-                properties:
-                  claims:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                        request:
-                          type: string
-                      required:
-                      - name
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                       type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - name
-                    x-kubernetes-list-type: map
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    type: object
-                type: object
-              routerTimeouts:
-                properties:
-                  serverIdle:
-                    format: int64
-                    type: integer
-                  serverRead:
-                    format: int64
-                    type: integer
-                  serverWrite:
-                    format: int64
-                    type: integer
-                  serviceClient:
-                    format: int64
-                    type: integer
-                type: object
-              scaleMetric:
-                enum:
-                - cpu
-                - memory
-                - concurrency
-                - rps
-                type: string
-              scaleTarget:
-                format: int32
-                type: integer
-              serviceAccountName:
-                type: string
-              timeout:
-                format: int64
-                type: integer
-              tolerations:
-                items:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                routerTimeouts:
                   properties:
-                    effect:
-                      type: string
-                    key:
-                      type: string
-                    operator:
-                      type: string
-                    tolerationSeconds:
+                    serverIdle:
                       format: int64
                       type: integer
-                    value:
-                      type: string
+                    serverRead:
+                      format: int64
+                      type: integer
+                    serverWrite:
+                      format: int64
+                      type: integer
+                    serviceClient:
+                      format: int64
+                      type: integer
                   type: object
-                type: array
-            required:
-            - nodes
-            type: object
-          status:
-            properties:
-              annotations:
-                additionalProperties:
+                scaleMetric:
+                  enum:
+                    - cpu
+                    - memory
+                    - concurrency
+                    - rps
                   type: string
-                type: object
-              conditions:
-                items:
-                  properties:
-                    lastTransitionTime:
-                      type: string
-                    message:
-                      type: string
-                    reason:
-                      type: string
-                    severity:
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - status
-                  - type
+                scaleTarget:
+                  format: int32
+                  type: integer
+                serviceAccountName:
+                  type: string
+                timeout:
+                  format: int64
+                  type: integer
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+              required:
+                - nodes
+              type: object
+            status:
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
                   type: object
-                type: array
-              deploymentMode:
-                type: string
-              observedGeneration:
-                format: int64
-                type: integer
-              url:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      severity:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                deploymentMode:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                url:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/kserve-crd/templates/serving.kserve.io_inferenceservices.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_inferenceservices.yaml
@@ -1,8 +1,8 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: kserve/serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: inferenceservices.serving.kserve.io
 spec:

--- a/charts/kserve-crd/templates/serving.kserve.io_servingruntimes.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_servingruntimes.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/kserve-crd/templates/serving.kserve.io_trainedmodels.yaml
+++ b/charts/kserve-crd/templates/serving.kserve.io_trainedmodels.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -12,100 +11,100 @@ spec:
     listKind: TrainedModelList
     plural: trainedmodels
     shortNames:
-    - tm
+      - tm
     singular: trainedmodel
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              inferenceService:
-                type: string
-              model:
-                properties:
-                  framework:
-                    type: string
-                  memory:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  storageUri:
-                    type: string
-                required:
-                - framework
-                - memory
-                - storageUri
-                type: object
-            required:
-            - inferenceService
-            - model
-            type: object
-          status:
-            properties:
-              address:
-                properties:
-                  CACerts:
-                    type: string
-                  audience:
-                    type: string
-                  name:
-                    type: string
-                  url:
-                    type: string
-                type: object
-              annotations:
-                additionalProperties:
+    - additionalPrinterColumns:
+        - jsonPath: .status.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                inferenceService:
                   type: string
-                type: object
-              conditions:
-                items:
+                model:
                   properties:
-                    lastTransitionTime:
+                    framework:
                       type: string
-                    message:
-                      type: string
-                    reason:
-                      type: string
-                    severity:
-                      type: string
-                    status:
-                      type: string
-                    type:
+                    memory:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    storageUri:
                       type: string
                   required:
-                  - status
-                  - type
+                    - framework
+                    - memory
+                    - storageUri
                   type: object
-                type: array
-              observedGeneration:
-                format: int64
-                type: integer
-              url:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              required:
+                - inferenceService
+                - model
+              type: object
+            status:
+              properties:
+                address:
+                  properties:
+                    CACerts:
+                      type: string
+                    audience:
+                      type: string
+                    name:
+                      type: string
+                    url:
+                      type: string
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      severity:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  format: int64
+                  type: integer
+                url:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/components/kserve/kustomization.yaml
+++ b/config/components/kserve/kustomization.yaml
@@ -2,4 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
+- ../../crd
 - ../../default
+

--- a/config/components/llmisvc/kustomization.yaml
+++ b/config/components/llmisvc/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
+- ../../crd/full/llmisvc
 - ../../llmisvc

--- a/config/components/localmodel/kustomization.yaml
+++ b/config/components/localmodel/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
+- ../../crd/full/localmodel
 - ../../localmodels
 

--- a/config/crd/full/isvc_conversion_webhook_patch.yaml
+++ b/config/crd/full/isvc_conversion_webhook_patch.yaml
@@ -1,0 +1,7 @@
+# Patch to add cert-manager CA injection annotation to InferenceService CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kserve/serving-cert
+  name: inferenceservices.serving.kserve.io

--- a/config/crd/full/kustomization.yaml
+++ b/config/crd/full/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
   - serving.kserve.io_servingruntimes.yaml
   - serving.kserve.io_inferencegraphs.yaml
   - ./clusterstoragecontainer
+
+patches:
+  - path: isvc_conversion_webhook_patch.yaml

--- a/config/default/cainjection_conversion_webhook.yaml
+++ b/config/default/cainjection_conversion_webhook.yaml
@@ -1,8 +1,0 @@
-# The following patch adds a directive for certmanager to inject CA into the CRD
-# CRD conversion requires k8s 1.16 or later.
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: $(kserveNamespace)/serving-cert
-  name: inferenceservices.serving.kserve.io

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -11,7 +11,6 @@ labels:
     app.kubernetes.io/component: kserve
 resources:
 - ../certmanager/kserve
-- ../crd
 - ../rbac
 - ../manager
 - ../webhook
@@ -120,14 +119,6 @@ replacements:
       delimiter: '/'
       index: 0
     select:
-      kind: CustomResourceDefinition
-      name: inferenceservices.serving.kserve.io
-  - fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: '/'
-      index: 0
-    select:
       kind: MutatingWebhookConfiguration
       name: inferenceservice.serving.kserve.io
   - fieldPaths:
@@ -189,4 +180,3 @@ patches:
 - path: clusterservingruntime_validatingwebhook_cainjection_patch.yaml
 - path: servingruntime_validationwebhook_cainjection_patch.yaml
 - path: manager_resources_patch.yaml
-- path: cainjection_conversion_webhook.yaml

--- a/config/llmisvc/kustomization.yaml
+++ b/config/llmisvc/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: kserve
 resources:
   - service.yaml
   - manager.yaml
-  - ../crd/full/llmisvc
   - ../certmanager/llmisvc
   - ../rbac/llmisvc
   - ../webhook/llmisvc
@@ -122,7 +121,7 @@ replacements:
     - spec.template.spec.serviceAccountName
     select:
       kind: Deployment
-      name: llmisvc-controller-manager    
+      name: llmisvc-controller-manager
 patches:
 - path: llmisvc_mutatingwebhook_cainjection_patch.yaml
 - path: llmisvc_validatingwebhook_cainjection_patch.yaml

--- a/config/localmodels/kustomization.yaml
+++ b/config/localmodels/kustomization.yaml
@@ -9,7 +9,6 @@ labels:
     app.kubernetes.io/component: localmodel
 
 resources:
-- ../crd/full/localmodel
 - ../certmanager/localmodel
 - ../rbac/localmodel
 - manager.yaml

--- a/config/overlays/standalone/kserve/kustomization.yaml
+++ b/config/overlays/standalone/kserve/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
 
 components:
 - ../../../components/kserve
-

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -11479,6 +11479,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: kserve/serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: inferenceservices.serving.kserve.io
 spec:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -11065,6 +11065,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: kserve/serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   name: inferenceservices.serving.kserve.io
 spec:

--- a/hack/setup/scripts/generate_chart_manifests.sh
+++ b/hack/setup/scripts/generate_chart_manifests.sh
@@ -2,41 +2,8 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 
 source "${SCRIPT_DIR}/../common.sh"
 
-# Track all modified folders
-declare -a MODIFIED_FOLDERS=()
-
-# Cleanup function - restore all modified kustomization files
-cleanup() {
-    for folder in "${MODIFIED_FOLDERS[@]}"; do
-        if [ -f "${folder}/kustomization.yaml.bak" ]; then
-            mv "${folder}/kustomization.yaml.bak" "${folder}/kustomization.yaml"
-        fi
-    done
-}
-
-# Comment out CRD references in kustomization.yaml
-comment_crd(){
-    local kustomization_folder="${1}"
-    # Only create backup if it doesn't exist (idempotent for failed runs)
-    if [ ! -f "${kustomization_folder}/kustomization.yaml.bak" ]; then
-        cp "${kustomization_folder}/kustomization.yaml" "${kustomization_folder}/kustomization.yaml.bak"
-    fi
-    # Use temp file for portability across GNU sed (Linux) and BSD sed (macOS)
-    local file="${kustomization_folder}/kustomization.yaml"
-    sed 's| *- \.\./crd$|# - ../crd|' "$file" \
-      | sed 's| *- \.\./crd/full/localmodel$|# - ../crd/full/localmodel|' \
-      | sed 's| *- \.\./crd/full/llmisvc$|# - ../crd/full/llmisvc|' \
-      | sed 's| *- path: cainjection_conversion_webhook\.yaml$|# - path: cainjection_conversion_webhook.yaml|' \
-      > "${file}.tmp" && mv "${file}.tmp" "$file"
-    MODIFIED_FOLDERS+=("${kustomization_folder}")
-}
-
-# Set trap once at the beginning
-trap cleanup EXIT ERR INT TERM
-
 # KServe and Common
-comment_crd "${REPO_ROOT}/config/default"
-kustomize build ${REPO_ROOT}/config/components/kserve > ${REPO_ROOT}/charts/kserve-resources/files/kserve/resources.yaml
+kustomize build ${REPO_ROOT}/config/default > ${REPO_ROOT}/charts/kserve-resources/files/kserve/resources.yaml
 kustomize build ${REPO_ROOT}/config/certmanager > ${REPO_ROOT}/charts/kserve-resources/files/common/certmanager.yaml
 kustomize build ${REPO_ROOT}/config/configmap > ${REPO_ROOT}/charts/kserve-resources/files/common/configmap.yaml
 
@@ -45,7 +12,6 @@ kustomize build ${REPO_ROOT}/config/llmisvcconfig > ${REPO_ROOT}/charts/kserve-r
 kustomize build ${REPO_ROOT}/config/runtimes > ${REPO_ROOT}/charts/kserve-runtime-configs/files/runtimes/resources.yaml
 
 # LLMISVC and Common
-comment_crd "${REPO_ROOT}/config/llmisvc"
 kustomize build ${REPO_ROOT}/config/llmisvc > ${REPO_ROOT}/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
 kustomize build ${REPO_ROOT}/config/certmanager > ${REPO_ROOT}/charts/kserve-llmisvc-resources/files/common/certmanager.yaml
 kustomize build ${REPO_ROOT}/config/configmap > ${REPO_ROOT}/charts/kserve-llmisvc-resources/files/common/configmap.yaml
@@ -57,7 +23,6 @@ kustomize build ${REPO_ROOT}/config/storagecontainers > ${REPO_ROOT}/charts/kser
 echo "✅ Built storagecontainer resources"
 
 # LocalModel and Common
-comment_crd "${REPO_ROOT}/config/localmodels"
 kustomize build ${REPO_ROOT}/config/localmodels > ${REPO_ROOT}/charts/kserve-localmodel-resources/files/resources.yaml
 
 # Generate values.yaml from common sections


### PR DESCRIPTION
  ## What this PR does / why we need it

  This PR restructures CRD management to enable standalone CRD installation with proper cert-manager webhook support. Currently, `kustomize build config/crd/` produces incomplete CRDs without cert-manager annotations, making standalone CRD installation non-functional.

  ## Key changes

  - **Move cert-manager patch**: `config/default/cainjection_conversion_webhook.yaml` → `config/crd/full/isvc_conversion_webhook_patch.yaml`
  - **Update CRD kustomization**: Apply cert-manager patch in `config/crd/full/kustomization.yaml`
  - **Clean up references**: Remove CRD dependencies from `config/default`, `config/llmisvc`, `config/localmodels`
  - **Fix Makefile**: Use `kustomize build` for helm chart generation instead of raw file copying
  - **Update components**: Ensure proper CRD inclusion in component layers

  ## Benefits

  ✅ **Installation flexibility**: CRDs can be installed independently from controllers
  ✅ **Backward compatibility**: All existing installation methods continue to work
  
  ## Testing
  
  - [x] `kustomize build config/crd/full` includes cert-manager annotation
  - [x] `kustomize build config/overlays/standalone/kserve` works correctly
  - [x] Helm charts render with proper CRD patches applied
  - [x] Installation scripts remain functional
  
  ## Before/After
  
  **Before:**
  ```yaml
  # kustomize build config/crd/full
  metadata:
    annotations:
      controller-gen.kubebuilder.io/version: v0.19.0
    name: inferenceservices.serving.kserve.io

  After:
  # kustomize build config/crd/full  
  metadata:
    annotations:
      cert-manager.io/inject-ca-from: kserve/serving-cert
      controller-gen.kubebuilder.io/version: v0.19.0
    name: inferenceservices.serving.kserve.io
```
  Fixes standalone CRD installation workflow while maintaining backward compatibility with existing installation methods.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note

```
