### PR TITLE
fix(e2e): migrate vLLM CPU image from ECR to Docker Hub and cache in CI

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -35,6 +35,7 @@ env:
   DOCKER_IMAGES_PATH: "/mnt/docker-images"
   KO_DOCKER_REPO: "kserve"
   ENABLE_LLMISVC: "true"
+  VLLM_CPU_IMAGE: "vllm/vllm-openai-cpu:v0.19.0"
 
 jobs:
 
@@ -173,9 +174,25 @@ jobs:
           compression-level: 0
           if-no-files-found: error
 
+  seed-image-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull and save vLLM CPU image
+        run: |
+          docker pull --platform linux/amd64 ${{ env.VLLM_CPU_IMAGE }}
+          docker save ${{ env.VLLM_CPU_IMAGE }} -o /tmp/vllm-cpu.tar
+
+      - name: Upload vLLM CPU image artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vllm-cpu-image-${{ env.TAG }}
+          path: /tmp/vllm-cpu.tar
+          compression-level: 0
+          if-no-files-found: error
+
   test-llmisvc:
     runs-on: cncf-ubuntu-16-64-x86
-    needs: [detect-changes, llmisvc-image-build, seed-model-cache]
+    needs: [detect-changes, llmisvc-image-build, seed-model-cache, seed-image-cache]
     strategy:
       fail-fast: false
       matrix:
@@ -240,6 +257,15 @@ jobs:
           minikube image load ./tmp/opt-125m-cache.tar
           echo "OPT_125M_CACHE_IMAGE=kserve/opt-125m-cache:${{ env.TAG }}" >> $GITHUB_ENV
 
+      - name: Download vLLM CPU image artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: vllm-cpu-image-${{ env.TAG }}
+          path: ./tmp
+
+      - name: Load vLLM CPU image into minikube
+        run: minikube image load ./tmp/vllm-cpu.tar
+
       - name: KServe dependency setup
         uses: ./.github/actions/kserve-dep-setup
         with:
@@ -298,7 +324,7 @@ jobs:
 
   test-llmisvc-wva-autoscaling-hpa:
     runs-on: cncf-ubuntu-16-64-x86
-    needs: [detect-changes, llmisvc-image-build, seed-model-cache]
+    needs: [detect-changes, llmisvc-image-build, seed-model-cache, seed-image-cache]
     strategy:
       fail-fast: false
       matrix:
@@ -403,7 +429,7 @@ jobs:
 
   test-llmisvc-wva-autoscaling-keda:
     runs-on: cncf-ubuntu-16-64-x86
-    needs: [detect-changes, llmisvc-image-build, seed-model-cache]
+    needs: [detect-changes, llmisvc-image-build, seed-model-cache, seed-image-cache]
     strategy:
       fail-fast: false
       matrix:

--- a/docs/samples/llmisvc/lora-adapters/test-examples/01-lora-hf-cpu.yaml
+++ b/docs/samples/llmisvc/lora-adapters/test-examples/01-lora-hf-cpu.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     containers:
       - name: main
-        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1
+        image: vllm/vllm-openai-cpu:v0.19.0
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG

--- a/docs/samples/llmisvc/lora-adapters/test-examples/02-lora-multi-hf-cpu.yaml
+++ b/docs/samples/llmisvc/lora-adapters/test-examples/02-lora-multi-hf-cpu.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     containers:
       - name: main
-        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1
+        image: vllm/vllm-openai-cpu:v0.19.0
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG

--- a/docs/samples/llmisvc/lora-adapters/test-examples/04-lora-pvc-cpu.yaml
+++ b/docs/samples/llmisvc/lora-adapters/test-examples/04-lora-pvc-cpu.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     containers:
       - name: main
-        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.17.1
+        image: vllm/vllm-openai-cpu:v0.19.0
         env:
           - name: VLLM_LOGGING_LEVEL
             value: DEBUG

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     containers:
       - name: main
-        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0
+        image: vllm/vllm-openai-cpu:v0.19.0
         securityContext:
           runAsNonRoot: false
         env:

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-facebook-opt-125m-cpu.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     containers:
       - name: main
-        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0
+        image: vllm/vllm-openai-cpu:v0.19.0
         securityContext:
           runAsNonRoot: false
         env:

--- a/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m-cpu/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     containers:
       - name: main
-        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0
+        image: vllm/vllm-openai-cpu:v0.19.0
         securityContext:
           runAsNonRoot: false
         env:
@@ -32,7 +32,7 @@ spec:
     template:
       containers:
         - name: main
-          image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0
+          image: vllm/vllm-openai-cpu:v0.19.0
           env:
             - name: VLLM_LOGGING_LEVEL
               value: DEBUG

--- a/hack/release/smoke-test-data/llmisvc-opt-125m-cpu.yaml
+++ b/hack/release/smoke-test-data/llmisvc-opt-125m-cpu.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     containers:
       - name: main
-        image: public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0
+        image: vllm/vllm-openai-cpu:v0.19.0
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -35,6 +35,7 @@ SCHEDULER_CONFIGMAP_NAME = "scheduler-config-e2e"
 SCHEDULER_CONFIGMAP_KEY = "epp"
 
 OPT_125M_MODEL_URI = os.environ.get("OPT_125M_MODEL_URI", "hf://facebook/opt-125m")
+VLLM_CPU_IMAGE = os.environ.get("VLLM_CPU_IMAGE", "vllm/vllm-openai-cpu:v0.19.0")
 
 # PVC storage test constants
 PVC_STORAGE_NAME = "e2e-pvc-model-storage"
@@ -244,7 +245,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "containers": [
                 {
                     "name": "main",
-                    "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                    "image": VLLM_CPU_IMAGE,
                     "env": [
                         {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
@@ -266,7 +267,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "containers": [
                 {
                     "name": "main",
-                    "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                    "image": VLLM_CPU_IMAGE,
                     "env": [
                         {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                         {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
@@ -301,7 +302,7 @@ LLMINFERENCESERVICE_CONFIGS = {
                 "containers": [
                     {
                         "name": "main",
-                        "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                        "image": VLLM_CPU_IMAGE,
                         "env": [
                             {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
                             {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "1"},
@@ -597,7 +598,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "containers": [
                 {
                     "name": "main",
-                    "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                    "image": VLLM_CPU_IMAGE,
                     "command": ["vllm", "serve", "/mnt/models"],
                     "args": [
                         "--served-model-name",
@@ -623,7 +624,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "containers": [
                 {
                     "name": "main",
-                    "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                    "image": VLLM_CPU_IMAGE,
                     "command": ["vllm", "serve", "/mnt/models"],
                     "args": [
                         "--served-model-name",

--- a/test/e2e/llmisvc/test_llm_inference_service_conversion.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_conversion.py
@@ -34,6 +34,7 @@ from .fixtures import (
     OPT_125M_MODEL_URI,
     UPSTREAM_K8S_NON_ROOT_SECURITY_CONTEXT,
     UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
+    VLLM_CPU_IMAGE,
 )
 from .logging import log_execution, logger
 
@@ -230,7 +231,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                            "image": VLLM_CPU_IMAGE,
                             "env": [*UPSTREAM_K8S_VLLM_ENV_OVERRIDES],
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
@@ -321,7 +322,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                            "image": VLLM_CPU_IMAGE,
                             "env": [*UPSTREAM_K8S_VLLM_ENV_OVERRIDES],
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
@@ -421,7 +422,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                            "image": VLLM_CPU_IMAGE,
                             "env": [*UPSTREAM_K8S_VLLM_ENV_OVERRIDES],
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
@@ -552,7 +553,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                            "image": VLLM_CPU_IMAGE,
                             "env": [*UPSTREAM_K8S_VLLM_ENV_OVERRIDES],
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
@@ -697,7 +698,7 @@ class TestLLMInferenceServiceConversion:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                            "image": VLLM_CPU_IMAGE,
                             "env": [*UPSTREAM_K8S_VLLM_ENV_OVERRIDES],
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},

--- a/test/e2e/llmisvc/test_pod_watch.py
+++ b/test/e2e/llmisvc/test_pod_watch.py
@@ -38,6 +38,7 @@ from .fixtures import (
     OPT_125M_MODEL_URI,
     UPSTREAM_K8S_NON_ROOT_SECURITY_CONTEXT,
     UPSTREAM_K8S_VLLM_ENV_OVERRIDES,
+    VLLM_CPU_IMAGE,
     inject_k8s_proxy,
 )
 from .logging import logger
@@ -367,7 +368,7 @@ async def test_event_storm_prevention_init_container_isolation(test_namespace):
                     "containers": [
                         {
                             "name": "main",
-                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                            "image": VLLM_CPU_IMAGE,
                             "env": [*UPSTREAM_K8S_VLLM_ENV_OVERRIDES],
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},
@@ -563,7 +564,7 @@ async def test_quick_reconciliation_on_init_container_failure(test_namespace):
                     "containers": [
                         {
                             "name": "main",
-                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                            "image": VLLM_CPU_IMAGE,
                             "env": [*UPSTREAM_K8S_VLLM_ENV_OVERRIDES],
                             "resources": {
                                 "limits": {"cpu": "2", "memory": "7Gi"},

--- a/test/e2e/llmisvc/test_storage_version_migration.py
+++ b/test/e2e/llmisvc/test_storage_version_migration.py
@@ -36,6 +36,7 @@ from .fixtures import (
     inject_k8s_proxy,
     KSERVE_PLURAL_LLMINFERENCESERVICECONFIG,
     OPT_125M_MODEL_URI,
+    VLLM_CPU_IMAGE,
 )
 from .logging import logger
 
@@ -136,7 +137,7 @@ class TestStorageVersionMigration:
                     "containers": [
                         {
                             "name": "main",
-                            "image": "public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0",
+                            "image": VLLM_CPU_IMAGE,
                             "resources": {
                                 "limits": {"cpu": "1", "memory": "2Gi"},
                                 "requests": {"cpu": "100m", "memory": "512Mi"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces `public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo` with `vllm/vllm-openai-cpu` (Docker Hub) across all e2e tests, sample manifests, and CI workflows, keeping the version at **v0.19.0**.

ECR Public Gallery rate-limits unauthenticated pulls to 1 req/s per IP, causing intermittent `toomanyrequests` failures in CI (seen in [run 29383306027](https://github.com/kserve/kserve/actions/runs/29383306027)). `vllm/vllm-openai-cpu` is the official upstream Docker Hub location as of [vllm-project/vllm#32032](https://github.com/vllm-project/vllm/pull/32032) (merged Feb 2026) and vLLM's acceptance into Docker's Open Source Program ([vllm-project/vllm#31450](https://github.com/vllm-project/vllm/issues/31450)) means pulls are rate-limit free.

v0.25.1 was tested and has a breaking change on the CPU non-root path — the new Triton warmup step tries to write to `/.triton` at startup, which fails with `PermissionError` when running as `runAsUser: 1000`. Reproduced locally with the exact e2e setup (storage-initializer + LoRA adapter); v0.19.0 confirmed working. Version upgrade is tracked for a follow-up.

```
PermissionError: [Errno 13] Permission denied: '/.triton'
RuntimeError: Engine core initialization failed.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Feature/Issue validation/testing**:

- [x] Locally reproduced the `MinimumReplicasUnavailable` failure with `vllm/vllm-openai-cpu:v0.25.1` + LoRA + `runAsUser: 1000`
- [x] Locally confirmed `vllm/vllm-openai-cpu:v0.19.0` reaches `1/1 Ready` with `facebook/opt-125m` + `edbeeching/opt-125m-lora` adapter loaded

**Special notes for your reviewer**:

- Replace all `public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:v0.19.0` and `v0.17.1` refs with `vllm/vllm-openai-cpu:v0.19.0`
- Add `VLLM_CPU_IMAGE` env var in `fixtures.py` (default: `vllm/vllm-openai-cpu:v0.19.0`) — overridable at test time without code changes
- Update `test_llm_inference_service_conversion.py`, `test_pod_watch.py`, `test_storage_version_migration.py` to import and use `VLLM_CPU_IMAGE`
- Update `docs/samples/llmisvc/` and `hack/release/smoke-test-data/`
- Add `seed-image-cache` CI job: pulls `vllm/vllm-openai-cpu:v0.19.0` once and uploads as a GitHub Actions artifact (mirrors the existing `seed-model-cache` pattern); each of the 3 test jobs downloads and loads the image into minikube before tests run so Kubernetes never cold-pulls from any registry
- `seed-image-cache` runs in parallel with `llmisvc-image-build` and `seed-model-cache`; `VLLM_CPU_IMAGE` is defined once in the top-level workflow `env:` block

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```