### PR TITLE
fix(ci): apply HF env fixes to s3-init job and improve failure diagnostics

### DIFF
--- a/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
@@ -16,6 +16,10 @@ spec:
         env:
         - name: HF_HUB_DISABLE_PROGRESS_BARS
           value: "1"
+        - name: HF_HUB_DISABLE_XET
+          value: "1"
+        - name: HF_HUB_ENABLE_HF_TRANSFER
+          value: "0"
         - name: TOKIO_WORKER_THREADS
           value: "1"
         - name: STORAGE_IGNORE_PATTERNS

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -101,6 +101,7 @@ if [[ $ENABLE_LLMISVC == "false" || $ENABLE_KSERVE_WITH_LLMISVC == "true" ]]; th
   if ! kubectl wait --for=condition=complete --timeout=900s job/s3-init -n kserve; then
     echo "S3 init job failed. Pod status and logs:"
     kubectl get pods -l job-name=s3-init -n kserve
+    kubectl describe pods -l job-name=s3-init -n kserve || true
     kubectl logs -l job-name=s3-init -n kserve --all-containers --tail=50 || true
     exit 1
   fi
@@ -149,6 +150,7 @@ else
   if ! kubectl wait --for=condition=complete --timeout=900s job/s3-init -n kserve; then
     echo "S3 init job failed. Pod status and logs:"
     kubectl get pods -l job-name=s3-init -n kserve
+    kubectl describe pods -l job-name=s3-init -n kserve || true
     kubectl logs -l job-name=s3-init -n kserve --all-containers --tail=50 || true
     exit 1
   fi


### PR DESCRIPTION
## What this PR does

Two fixes for the `s3-init` job that pre-loads `facebook/opt-125m` into SeaweedFS during e2e test setup.

### 1. Missing HF env vars in `seaweedfs-init-job.yaml`

PR #5742 added `HF_HUB_DISABLE_XET=1` and `HF_HUB_ENABLE_HF_TRANSFER=0` to the `kserve-huggingfaceserver` ClusterServingRuntime via `kubectl patch`, but these were never applied to the `download-hf-model` init container in `seaweedfs-init-job.yaml`.

This left the s3-init job vulnerable to the same xet-bridge/HF transfer issues, causing `Init:Error` failures as seen in the `test-llm` and `test-huggingface-server-vllm` jobs (e.g. run [29477045203](https://github.com/kserve/kserve/actions/runs/29477045203)).

### 2. Missing `kubectl describe` in failure diagnostics

When `s3-init` fails, `setup-kserve.sh` only runs `kubectl get pods` and `kubectl logs`. The `kubectl logs` call is unreliable because pods stuck in `Init:Error` may still be in `PodInitializing` at collection time (returning `BadRequest`). Adding `kubectl describe` captures Kubernetes events and the init container exit code, making future failures debuggable.

## Root cause trace

- `test-llm (kustomize)` run 29477045203: all 4 s3-init retry pods hit `Init:Error` within 13–15 min
- `kubectl logs` returned `BadRequest` (pod still initializing at collection time)
- No `describe` output → init container exit reason unknown
- With this fix, `HF_HUB_DISABLE_XET` prevents the xet-bridge from being invoked, and `HF_HUB_ENABLE_HF_TRANSFER` disables the fast-transfer path that can fail in restricted network environments