### PR TITLE
fix(llmisvc): handling stopped members in group

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_router_group_test.go
@@ -628,21 +628,15 @@ var _ = Describe("LLMInferenceService Group Routing", func() {
 			})
 			Expect(errRetry).ToNot(HaveOccurred())
 
-			// then - on the remaining member B's HTTPRoute, member A should have weight 0
+			// then - on the remaining member B's HTTPRoute, stopped member A
+			// should be omitted entirely (no weight:0 backendRef that gateways may leak traffic to)
 			Eventually(func(g Gomega, ctx context.Context) {
 				routes, err := managedRoutes(ctx, llmSvcB)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(routes).To(HaveLen(1))
 
 				backendRefs := groupRoutingBackendRefs(&routes[0], llmSvcB)
-				g.Expect(backendRefs).To(HaveLen(2), "stopped member should still appear in backendRefs")
-
-				g.Expect(backendRefs).To(ContainElement(
-					SatisfyAll(
-						HaveBackendName(svcNameA),
-						HaveBackendWeight(int32(0)),
-					),
-				))
+				g.Expect(backendRefs).To(HaveLen(1), "stopped member should be omitted from backendRefs")
 				g.Expect(backendRefs).To(ContainElement(
 					SatisfyAll(
 						HaveBackendName(svcNameB),
@@ -669,6 +663,115 @@ var _ = Describe("LLMInferenceService Group Routing", func() {
 						g.Expect(member.Weight).To(Equal(int32(40)), "non-stopped member weight should be preserved")
 					}
 				}
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should preserve stopped member in group status when model names diverge from runtime", func(ctx SpecContext) {
+			// When status.Addresses has model-routing URLs, resolvedModelNames
+			// returns namespace-qualified names (publishers/ns/models/name).
+			// A force-stopped member's addresses are cleared, so
+			// resolvedModelNames falls back to the plain spec name. Without the
+			// fix, slices.Equal fails and the stopped member is classified as
+			// divergent, disappearing from group status.
+
+			groupName := "stop-diverge"
+			svcNameA := "test-stop-div-a"
+			svcNameB := "test-stop-div-b"
+			gwName := "stop-div-gw"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			// Pre-created gateway with addresses so the controller discovers
+			// model-routing URLs and populates Status.Addresses with
+			// namespace-qualified model names (publishers/ns/models/name).
+			gw := Gateway(gwName,
+				InNamespace[*gwapiv1.Gateway](testNs.Name),
+				WithListener(gwapiv1.HTTPProtocolType),
+			)
+			Expect(envTest.Client.Create(ctx, gw)).To(Succeed())
+			ensureGatewayReady(ctx, envTest.Client, gw)
+			setGatewayStatusAddresses(ctx, envTest.Client, gw, "203.0.113.99")
+
+			gwRef := LLMGatewayRef(gwName, testNs.Name)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithGatewayRefs(gwRef),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(60),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithGatewayRefs(gwRef),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(40),
+			)
+
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+
+			// Wait for model-routing model names to appear in status.Addresses
+			expectedModelName := "publishers/" + testNs.Name + "/models/facebook/opt-125m"
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcB), current)).To(Succeed())
+				g.Expect(current.Status.Addresses).ToNot(BeEmpty())
+
+				var modelNames []string
+				for _, addr := range current.Status.Addresses {
+					for _, m := range addr.Models {
+						modelNames = append(modelNames, m.Name)
+					}
+				}
+				g.Expect(modelNames).To(ContainElement(expectedModelName),
+					"status.Addresses should contain namespace-qualified model name")
+			}).WithContext(ctx).Should(Succeed())
+
+			// Force-stop member A - clears its status.Addresses, making
+			// resolvedModelNames fall back to plain spec name "facebook/opt-125m"
+			// while peer B has "publishers/ns/models/facebook/opt-125m".
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvcA, func() error {
+					if llmSvcA.Annotations == nil {
+						llmSvcA.Annotations = make(map[string]string)
+					}
+					llmSvcA.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// Verify stopped member A still appears in B's group status
+			Eventually(func(g Gomega, ctx context.Context) {
+				currentB := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcB), currentB)).To(Succeed())
+				g.Expect(currentB.Status.Router).ToNot(BeNil())
+				g.Expect(currentB.Status.Router.Group).ToNot(BeNil(), "group status should be preserved")
+				g.Expect(currentB.Status.Router.Group.Members).To(HaveLen(2),
+					"stopped member must not disappear from group status due to model name divergence")
+				g.Expect(currentB.Status.Router.Group.Members).To(ContainElement(
+					SatisfyAll(
+						HaveField("Name", svcNameA),
+						HaveField("Stopped", BeTrue()),
+						HaveField("Weight", Equal(int32(60))),
+					),
+				))
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})

--- a/pkg/controller/v1alpha2/llmisvc/router_group.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group.go
@@ -86,11 +86,22 @@ func (r *LLMISVCReconciler) injectGroupBackendRefs(
 	}
 
 	selfModels := resolvedModelNames(llmSvc)
+	selfSpecName := ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.Name)
 
 	for _, m := range resolved {
-		if slices.Equal(m.modelNames, selfModels) {
+		switch {
+		case m.stopped:
+			// Stopped members have no status.Addresses so their modelNames are
+			// spec-derived. Compare against self's spec model name rather than
+			// runtime-resolved names which may include runtime-only aliases.
+			if slices.Contains(m.modelNames, selfSpecName) {
+				matching = append(matching, m)
+			} else {
+				divergent = append(divergent, m)
+			}
+		case slices.Equal(m.modelNames, selfModels):
 			matching = append(matching, m)
-		} else {
+		default:
 			divergent = append(divergent, m)
 		}
 	}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_routing.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_routing.go
@@ -32,14 +32,15 @@ import (
 func rewriteRulesForGroup(route *gwapiv1.HTTPRoute, llmSvc *v1alpha2.LLMInferenceService, members []resolvedMember) {
 	allBackendRefs := make([]gwapiv1.HTTPBackendRef, 0, len(members))
 	for _, m := range members {
-		w := m.weight
+		// Omit stopped members entirely - a weight:0 backendRef still causes
+		// some gateways (e.g. Envoy Gateway) to leak traffic to the backend.
 		if m.stopped {
-			w = 0
+			continue
 		}
 		allBackendRefs = append(allBackendRefs, gwapiv1.HTTPBackendRef{
 			BackendRef: gwapiv1.BackendRef{
 				BackendObjectReference: m.backendRef,
-				Weight:                 ptr.To(w),
+				Weight:                 ptr.To(m.weight),
 			},
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Two related fixes for force-stopped group members:

1. **Group status visibility** - when a member is force-stopped, the controller clears its `status.Addresses`. Peers then resolve model names from the spec fallback instead of status, producing plain names (`facebook/opt-125m`) that don't match the running peer's namespace-qualified names (`publishers/ns/models/facebook/opt-125m`). The model-name comparison classified the stopped member as divergent, causing it to disappear from group status entirely. Stopped members now compare spec-level model names instead of runtime-resolved ones.

2. **Dropped weight:0 backendRefs** - previously, stopped members were kept in the HTTPRoute with `weight: 0`. Some gateways (e.g. Envoy Gateway) seem leak traffic to weight:0 backends. Stopped members are now omitted from backendRefs entirely - the member still appears in group status with `stopped: true` and its declared weight, but receives zero traffic by absence rather than by a weight the gateway may not honor.

**Feature/Issue validation/testing**:

- [x] Existing force-stop envtest updated to verify stopped member is omitted from backendRefs (1 ref, not 2)
- [x] New envtest with gateway addresses triggers namespace-qualified model names, stops a member, and verifies it still appears in group status
- [x] All existing unit tests pass

**Special notes for your reviewer**:

The existing force-stop envtest passed before this fix because both members shared the same model name and the envtest gateway had no addresses - so `resolvedModelNames` always fell back to spec on both sides. The new test creates a gateway with addresses to exercise the real divergence path.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```