### PR TITLE
test(llmisvc): e2e tests for canary deployment

### DIFF
--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -26,6 +26,8 @@ from .namespace import (
 )
 from .fixtures import inject_k8s_proxy
 
+from .traffic import TrafficDriver
+
 _LLMISVC_DIR = Path(__file__).parent
 _AUTOSCALING_STEM_PREFIX = "test_llm_autoscaling_"
 
@@ -33,6 +35,24 @@ _AUTOSCALING_STEM_PREFIX = "test_llm_autoscaling_"
 # Autoscaling files (``test_llm_autoscaling_<variant>.py``) are handled
 # separately below; add other special-case filenames here.
 _LLMISVC_CORE_EXCLUDED = {"test_llm_tracing.py"}
+
+
+@pytest.fixture
+def traffic_driver():
+    """Factory fixture - creates TrafficDrivers, auto-starts, auto-stops on teardown."""
+    drivers: list[TrafficDriver] = []
+
+    def factory(url: str, *, warmup: bool = False, **kwargs) -> TrafficDriver:
+        driver = TrafficDriver(url, **kwargs)
+        drivers.append(driver)
+        driver.start(warmup=warmup)
+        return driver
+
+    yield factory
+
+    for d in reversed(drivers):
+        if d.is_running:
+            d.stop()
 
 
 def _auto_assign_group_markers(items):
@@ -76,6 +96,10 @@ def pytest_configure(config):
             "markers",
             f"autoscaling_{variant}: auto-discovered autoscaling variant marker",
         )
+    config.addinivalue_line(
+        "markers",
+        "traffic: continuous traffic test (uses TrafficDriver)",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/test/e2e/llmisvc/test_llm_canary_lifecycle.py
+++ b/test/e2e/llmisvc/test_llm_canary_lifecycle.py
@@ -1,0 +1,1213 @@
+"""Zero-downtime canary rollout lifecycle under continuous traffic.
+
+Self-contained: deploys members, runs canary lifecycle under load,
+validates zero errors and correct distribution, then cleans up.
+
+Uses Service backends (works with any gateway). InferencePool scenarios
+require Istio and are in a separate test job.
+
+Marked @pytest.mark.traffic for selective runs.
+
+Note: this file uses its own resource management (apply_member, apply_config,
+wait_ready, etc.) rather than the test_case fixture from fixtures.py. The
+test_case/TestCase pattern is designed for single-service "create, wait, query,
+delete" workflows and does not support group membership, mid-test weight
+patching, or multi-member lifecycle mutations. This is consistent with other
+specialized test files (test_flow_control.py, test_rolling_upgrade.py).
+A future unification could extend TestCase with group/weight fields and
+patching support.
+"""
+
+import json
+import logging
+import os
+import requests
+import time
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import pytest
+from kubernetes import client as k8s_client, config
+
+logger = logging.getLogger(__name__)
+
+KUBE_CONTEXT = os.environ.get("KUBE_CONTEXT", None)
+KSERVE_GROUP = "serving.kserve.io"
+KSERVE_VERSION = "v1alpha2"
+KSERVE_PLURAL = "llminferenceservices"
+KSERVE_CONFIG_PLURAL = "llminferenceserviceconfigs"
+
+MODEL = "tiny-llama"
+GROUP = "tiny-llama"
+MODEL_URI = "hf://hmellor/tiny-random-LlamaForCausalLM"
+
+INFERENCE_SIM_IMAGE = os.environ.get(
+    "INFERENCE_SIM_IMAGE",
+    "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2",
+)
+
+
+@dataclass
+class WorkloadConfig:
+    """Workload container configuration. Pluggable - swap for inference-sim,
+    GPU vLLM, or any OpenAI-compatible server."""
+
+    name: str  # config name in the namespace
+    image: str
+    args: list = None
+    env: list = None
+    resources: dict = None
+
+    command: list = None  # overrides the controller's entrypoint wrapper
+    security_context: dict = None
+    storage_initializer: bool = True  # False for non-vLLM workloads
+
+    def to_spec(self) -> dict:
+        container = {"name": "main", "image": self.image}
+        if self.command:
+            container["command"] = self.command
+        if self.args:
+            container["args"] = self.args
+        if self.env:
+            container["env"] = self.env
+        if self.resources:
+            container["resources"] = self.resources
+        if self.security_context:
+            container["securityContext"] = self.security_context
+        spec = {"template": {"containers": [container]}}
+        if not self.storage_initializer:
+            spec["storageInitializer"] = {"enabled": False}
+        return spec
+
+
+LLMD_SIMULATOR_SECURITY_CONTEXT = {
+    "runAsNonRoot": True,
+    "runAsUser": 65532,
+    "runAsGroup": 65532,
+}
+
+INFERENCE_SIM = WorkloadConfig(
+    name="canary-workload",
+    image=INFERENCE_SIM_IMAGE,
+    command=["/app/llm-d-inference-sim"],
+    args=["--port", "8000", "--model", MODEL, "--mode", "echo"],
+    env=[
+        {"name": "POD_NAME", "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}},
+    ],
+    resources={
+        "requests": {"cpu": "50m", "memory": "64Mi"},
+        "limits": {"cpu": "200m", "memory": "128Mi"},
+    },
+    security_context=LLMD_SIMULATOR_SECURITY_CONTEXT,
+    storage_initializer=False,
+)
+
+
+DIV_GROUP = "divergence-test"
+DIV_V1 = "test-div-v1"
+DIV_V2 = "test-div-v2"
+DIV_MODEL_V1 = "model-alpha"
+DIV_MODEL_V2 = "model-beta"
+
+
+def apply_divergence_member(api, name, model_name, weight, ns):
+    """Deploy a member for divergence tests (service backend, no scheduler)."""
+    model_spec = {"name": model_name, "uri": MODEL_URI}
+    body = {
+        "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
+        "kind": "LLMInferenceService",
+        "metadata": {"name": name, "namespace": ns},
+        "spec": {
+            "model": model_spec,
+            "baseRefs": [{"name": INFERENCE_SIM.name}],
+            "router": {
+                "route": {
+                    "group": DIV_GROUP,
+                    "weight": weight,
+                    "http": {},
+                },
+            },
+        },
+    }
+    try:
+        api.create_namespaced_custom_object(
+            KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, body
+        )
+    except k8s_client.ApiException as e:
+        if e.status == 409:
+            api.patch_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, name, body
+            )
+        else:
+            raise
+    logger.info(f"Applied divergence member {name} (model={model_name})")
+
+
+@dataclass
+class MemberSpec:
+    """Describes a group member's routing and backend configuration."""
+
+    name: str
+    weight: int
+    scheduler: bool  # True = InferencePool (EPP), False = plain Service
+    workload: WorkloadConfig = None  # defaults to VLLM_CPU
+
+    def __post_init__(self):
+        if self.workload is None:
+            self.workload = INFERENCE_SIM
+
+
+@dataclass
+class Scenario:
+    """A canary test scenario - two members with specified backends."""
+
+    name: str
+    v1: MemberSpec
+    v2: MemberSpec
+    description: str = ""
+
+
+SCENARIOS = {
+    "service": Scenario(
+        name="service",
+        description="Both members use plain Service backend (no scheduler)",
+        v1=MemberSpec(name="canary-v1", weight=9, scheduler=False),
+        v2=MemberSpec(name="canary-v2", weight=1, scheduler=False),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# K8s helpers
+# ---------------------------------------------------------------------------
+
+
+def get_api():
+    config.load_kube_config(context=KUBE_CONTEXT)
+    return k8s_client.CustomObjectsApi()
+
+
+def apply_config(api, name, ns, spec):
+    body = {
+        "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
+        "kind": "LLMInferenceServiceConfig",
+        "metadata": {"name": name, "namespace": ns},
+        "spec": spec,
+    }
+    try:
+        api.create_namespaced_custom_object(
+            KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_CONFIG_PLURAL, body
+        )
+    except k8s_client.ApiException as e:
+        if e.status == 409:
+            api.patch_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_CONFIG_PLURAL, name, body
+            )
+        else:
+            raise
+
+
+def apply_member(api, member: MemberSpec, ns):
+    spec = {
+        "model": {"name": MODEL, "uri": MODEL_URI},
+        "baseRefs": [
+            {"name": member.workload.name},
+        ],
+        "router": {
+            "route": {
+                "group": GROUP,
+                "weight": member.weight,
+                "http": {},
+            },
+        },
+    }
+    if member.scheduler:
+        spec["router"]["scheduler"] = {}
+
+    body = {
+        "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
+        "kind": "LLMInferenceService",
+        "metadata": {
+            "name": member.name,
+            "namespace": ns,
+        },
+        "spec": spec,
+    }
+    try:
+        api.create_namespaced_custom_object(
+            KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, body
+        )
+    except k8s_client.ApiException as e:
+        if e.status == 409:
+            api.patch_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, member.name, body
+            )
+        else:
+            raise
+    logger.info(
+        f"Applied {member.name} (weight={member.weight}, scheduler={member.scheduler})"
+    )
+
+
+def delete_member(api, name, ns, wait=False):
+    try:
+        api.delete_namespaced_custom_object(
+            KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, name
+        )
+    except k8s_client.ApiException as e:
+        if e.status != 404:
+            raise
+        return
+    if wait:
+        deadline = time.monotonic() + 120
+        while time.monotonic() < deadline:
+            try:
+                api.get_namespaced_custom_object(
+                    KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, name
+                )
+            except k8s_client.ApiException as e:
+                if e.status == 404:
+                    return
+            time.sleep(2)
+        logger.warning(f"{name} still exists after 120s")
+
+
+def wait_ready(api, name, ns, timeout=600):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            obj = api.get_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, name
+            )
+            conditions = obj.get("status", {}).get("conditions", [])
+            for c in conditions:
+                if c.get("type") == "Ready" and c.get("status") == "True":
+                    return
+        except k8s_client.ApiException:
+            pass
+        time.sleep(5)
+    raise TimeoutError(f"{name} not Ready within {timeout}s")
+
+
+def get_gateway_base_url(api, name, ns, timeout=30):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            obj = api.get_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, name
+            )
+            url = obj.get("status", {}).get("url", "")
+            if not url:
+                addresses = obj.get("status", {}).get("addresses", [])
+                if addresses:
+                    url = addresses[0].get("url", "")
+            if url:
+                parsed = urlparse(url)
+                return f"{parsed.scheme}://{parsed.netloc}"
+        except k8s_client.ApiException:
+            pass
+        time.sleep(2)
+    raise TimeoutError(f"No URL in {name} status after {timeout}s")
+
+
+def wait_for_condition(
+    api, name, ns, condition_type, status=None, reason=None, timeout=120
+):
+    """Wait for a condition to reach the expected state."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            obj = api.get_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, name
+            )
+            conditions = obj.get("status", {}).get("conditions", [])
+            for c in conditions:
+                if c["type"] == condition_type:
+                    match = True
+                    if status and c.get("status") != status:
+                        match = False
+                    if reason and c.get("reason") != reason:
+                        match = False
+                    if match:
+                        return c
+        except k8s_client.ApiException:
+            pass
+        time.sleep(1)
+    raise TimeoutError(
+        f"{name}: condition {condition_type} not reached (status={status}, reason={reason})"
+    )
+
+
+def wait_for_condition_absent(api, name, ns, condition_type, timeout=120):
+    """Wait for a condition to be removed from the status."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            obj = api.get_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, name
+            )
+            conditions = obj.get("status", {}).get("conditions", [])
+            if not any(c["type"] == condition_type for c in conditions):
+                return
+        except k8s_client.ApiException:
+            pass
+        time.sleep(1)
+    raise TimeoutError(
+        f"{name}: condition {condition_type} still present after {timeout}s"
+    )
+
+
+def get_group_members(api, name, ns):
+    """Return the list of member names from group status."""
+    obj = api.get_namespaced_custom_object(
+        KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, name
+    )
+    group = obj.get("status", {}).get("router", {}).get("group", {})
+    return [m["name"] for m in group.get("members", [])]
+
+
+def patch_model_name(api, name, model_name, ns):
+    """Patch the model.name field on an LLMInferenceService."""
+    api.patch_namespaced_custom_object(
+        KSERVE_GROUP,
+        KSERVE_VERSION,
+        ns,
+        KSERVE_PLURAL,
+        name,
+        {"spec": {"model": {"name": model_name}}},
+    )
+
+
+def patch_annotations(api, name, ns, annotations):
+    api.patch_namespaced_custom_object(
+        KSERVE_GROUP,
+        KSERVE_VERSION,
+        ns,
+        KSERVE_PLURAL,
+        name,
+        {"metadata": {"annotations": annotations}},
+    )
+
+
+def patch_stop(api, name, ns, stopped=True):
+    patch_annotations(api, name, ns, {"serving.kserve.io/stop": str(stopped).lower()})
+    logger.info(f"{'Stopped' if stopped else 'Resumed'} {name}")
+
+
+def get_member_status(api, observer, member, ns):
+    obj = api.get_namespaced_custom_object(
+        KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, observer
+    )
+    for m in (
+        obj.get("status", {}).get("router", {}).get("group", {}).get("members", [])
+    ):
+        if m.get("name") == member:
+            return m
+    return None
+
+
+def wait_for_healthy_route(gateway_url, headers, payload, consecutive=3, timeout=30):
+    """Poll the gateway until we get consecutive 2xx responses.
+
+    Requires multiple consecutive successes to avoid false positives from
+    stale pre-mutation routes that haven't been reprogrammed yet.
+    """
+    streak = 0
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.post(gateway_url, headers=headers, json=payload, timeout=5)
+            if 200 <= resp.status_code < 300:
+                streak += 1
+                if streak >= consecutive:
+                    return
+            else:
+                streak = 0
+        except requests.RequestException:
+            streak = 0
+        time.sleep(0.5)
+    raise TimeoutError(
+        f"Route not healthy after {timeout}s ({streak}/{consecutive} consecutive 2xx) from {gateway_url}"
+    )
+
+
+def wait_for_member_count(api, name, ns, count, timeout=120):
+    deadline = time.monotonic() + timeout
+    members = []
+    while time.monotonic() < deadline:
+        members = get_group_members(api, name, ns)
+        if len(members) == count:
+            return members
+        time.sleep(2)
+    raise TimeoutError(
+        f"{name}: expected {count} group members, got {len(members)}: {members}"
+    )
+
+
+def wait_for_member_stopped(api, observer, member, ns, stopped=True, timeout=120):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        m = get_member_status(api, observer, member, ns)
+        if m and m.get("stopped", False) == stopped:
+            return m
+        time.sleep(2)
+    raise TimeoutError(f"{member} stopped={stopped} not seen from {observer}")
+
+
+def patch_weight(api, name, weight, ns):
+    api.patch_namespaced_custom_object(
+        KSERVE_GROUP,
+        KSERVE_VERSION,
+        ns,
+        KSERVE_PLURAL,
+        name,
+        body={"spec": {"router": {"route": {"weight": weight}}}},
+    )
+    logger.info(f"Patched {name} weight={weight}")
+
+
+def get_group_weight(api, observer, member, ns):
+    obj = api.get_namespaced_custom_object(
+        KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, observer
+    )
+    for m in (
+        obj.get("status", {}).get("router", {}).get("group", {}).get("members", [])
+    ):
+        if m.get("name") == member:
+            return m.get("weight")
+    return None
+
+
+def wait_for_group_weight(api, observer, member, expected, ns, timeout=30):
+    deadline = time.monotonic() + timeout
+    w = None
+    while time.monotonic() < deadline:
+        w = get_group_weight(api, observer, member, ns)
+        if w == expected:
+            return
+        time.sleep(1)
+    raise TimeoutError(f"{member} weight={w}, expected {expected} (from {observer})")
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def canary_env(request, test_namespace):
+    """Deploy a canary scenario - namespace teardown handles cleanup."""
+    scenario_name = request.param
+    scenario = SCENARIOS[scenario_name]
+    api = get_api()
+    ns = test_namespace
+
+    # Apply workload configs (deduplicate if both members use the same one)
+    seen_configs = set()
+    for member in [scenario.v1, scenario.v2]:
+        if member.workload.name not in seen_configs:
+            apply_config(api, member.workload.name, ns, member.workload.to_spec())
+            seen_configs.add(member.workload.name)
+
+    apply_member(api, scenario.v1, ns)
+    apply_member(api, scenario.v2, ns)
+
+    logger.info(f"Waiting for {scenario.v1.name} Ready...")
+    wait_ready(api, scenario.v1.name, ns)
+    logger.info(f"Waiting for {scenario.v2.name} Ready...")
+    wait_ready(api, scenario.v2.name, ns)
+
+    yield scenario, api, ns
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.traffic
+@pytest.mark.llminferenceservice
+@pytest.mark.cluster_cpu
+class TestCanaryLifecycle:
+    """Zero-downtime canary rollout under continuous traffic."""
+
+    @pytest.mark.parametrize(
+        "canary_env",
+        ["service"],
+        indirect=True,
+        ids=["service"],
+    )
+    def test_canary_service_backend(self, canary_env, traffic_driver):
+        """Service backend - works with any gateway."""
+        self._run_canary_lifecycle(canary_env, traffic_driver)
+
+    def test_model_name_divergence(self, test_namespace):
+        """Members with different model.name form independent sub-groups.
+
+        Each sub-group is individually ready (GroupReady=True), but the group
+        is degraded (GroupDegraded=True/MemberDivergence) because members
+        diverge on model identity.
+        """
+        api = get_api()
+        ns = test_namespace
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_divergence_member(api, DIV_V1, DIV_MODEL_V1, 5, ns)
+        apply_divergence_member(api, DIV_V2, DIV_MODEL_V2, 5, ns)
+
+        wait_ready(api, DIV_V1, ns)
+        wait_ready(api, DIV_V2, ns)
+
+        # Both members should be GroupReady (each sub-group works)
+        for name in [DIV_V1, DIV_V2]:
+            c = wait_for_condition(api, name, ns, "GroupReady", status="True")
+            assert c["status"] == "True", f"{name}: GroupReady={c['status']}"
+
+        # Both should be GroupDegraded with MemberDivergence
+        for name in [DIV_V1, DIV_V2]:
+            c = wait_for_condition(
+                api,
+                name,
+                ns,
+                "GroupDegraded",
+                status="True",
+                reason="MemberDivergence",
+            )
+            assert c["status"] == "True", f"{name}: GroupDegraded={c['status']}"
+            assert c["reason"] == "MemberDivergence", f"{name}: reason={c['reason']}"
+
+        # Each member's sub-group should contain only itself
+        v1_members = get_group_members(api, DIV_V1, ns)
+        v2_members = get_group_members(api, DIV_V2, ns)
+        assert v1_members == [DIV_V1], f"v1 group members: {v1_members}"
+        assert v2_members == [DIV_V2], f"v2 group members: {v2_members}"
+
+        logger.info("Model name divergence verified")
+
+    def test_model_name_divergence_resolves(self, test_namespace):
+        """Fixing a divergent model.name clears the degraded condition.
+
+        Start with divergent model names, then patch v2 to match v1. Both
+        members should appear in each other's group and GroupDegraded should
+        clear.
+        """
+        api = get_api()
+        ns = test_namespace
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_divergence_member(api, DIV_V1, DIV_MODEL_V1, 5, ns)
+        apply_divergence_member(api, DIV_V2, DIV_MODEL_V2, 5, ns)
+
+        wait_ready(api, DIV_V1, ns)
+        wait_ready(api, DIV_V2, ns)
+
+        # Confirm divergence is detected first
+        wait_for_condition(
+            api,
+            DIV_V1,
+            ns,
+            "GroupDegraded",
+            status="True",
+            reason="MemberDivergence",
+        )
+
+        # Fix: patch v2's model name to match v1
+        patch_model_name(api, DIV_V2, DIV_MODEL_V1, ns)
+        logger.info(f"Patched {DIV_V2} model name to {DIV_MODEL_V1}")
+
+        # Wait for ready again (model name change triggers reconcile)
+        wait_ready(api, DIV_V2, ns)
+
+        # GroupReady should still be True
+        for name in [DIV_V1, DIV_V2]:
+            c = wait_for_condition(api, name, ns, "GroupReady", status="True")
+            assert c["status"] == "True", f"{name}: GroupReady={c['status']}"
+
+        # GroupDegraded should be cleared (controller removes the condition
+        # via ClearCondition, so it becomes absent rather than status=False)
+        for name in [DIV_V1, DIV_V2]:
+            wait_for_condition_absent(api, name, ns, "GroupDegraded")
+
+        # Both members should now appear in each other's group.
+        # Wait for group membership to converge (may lag behind condition update).
+        for name in [DIV_V1, DIV_V2]:
+            wait_for_member_count(api, name, ns, 2)
+            members = get_group_members(api, name, ns)
+            assert DIV_V1 in members, f"{name} missing {DIV_V1}: {members}"
+            assert DIV_V2 in members, f"{name} missing {DIV_V2}: {members}"
+
+        logger.info("Model name divergence resolution verified")
+
+    def test_weight_without_group_rejected(self, test_namespace):
+        """Webhook rejects LLMISVC with weight but no group. (spike step 11)"""
+        api = get_api()
+        ns = test_namespace
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+
+        body = {
+            "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
+            "kind": "LLMInferenceService",
+            "metadata": {"name": "webhook-reject", "namespace": ns},
+            "spec": {
+                "model": {"name": MODEL, "uri": MODEL_URI},
+                "baseRefs": [{"name": INFERENCE_SIM.name}],
+                "router": {
+                    "route": {
+                        "weight": 5,
+                        "http": {},
+                    },
+                },
+            },
+        }
+
+        with pytest.raises(k8s_client.ApiException) as exc_info:
+            api.create_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, body
+            )
+        assert exc_info.value.status == 422, (
+            f"Expected 422 webhook rejection, got {exc_info.value.status}"
+        )
+        err_msg = json.loads(exc_info.value.body).get("message", "")
+        assert "weight requires group" in err_msg.lower(), (
+            f"Expected 'weight requires group' in error message: {err_msg}"
+        )
+        logger.info("Webhook rejection verified: weight without group")
+
+    def _run_canary_lifecycle(self, canary_env, traffic_driver):
+        scenario, api, ns = canary_env
+        v1 = scenario.v1.name
+        v2 = scenario.v2.name
+
+        gateway = get_gateway_base_url(api, v1, ns)
+        driver = traffic_driver(
+            url=f"{gateway}/v1/completions",
+            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            rate=2,
+            timeout=15.0,
+            warmup=True,
+        )
+
+        # Phase 1: baseline (v1=9, v2=1)
+        driver.mark("baseline")
+        time.sleep(20)
+
+        # Phase 2: canary ramp (v1=7, v2=3)
+        driver.mark("canary_mutation")
+        patch_weight(api, v2, 3, ns)
+        patch_weight(api, v1, 7, ns)
+        wait_for_group_weight(api, v1, v2, 3, ns)
+        wait_for_healthy_route(
+            f"{gateway}/v1/completions",
+            {
+                "X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}",
+                "Content-Type": "application/json",
+            },
+            {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+        )
+        driver.mark("canary")
+        time.sleep(20)
+
+        # Phase 3: promote (v1=0, v2=9)
+        driver.mark("promote_mutation")
+        patch_weight(api, v1, 0, ns)
+        patch_weight(api, v2, 9, ns)
+        wait_for_group_weight(api, v2, v1, 0, ns)
+        wait_for_healthy_route(
+            f"{gateway}/v1/completions",
+            {
+                "X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}",
+                "Content-Type": "application/json",
+            },
+            {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+        )
+        driver.mark("promote")
+        time.sleep(20)
+
+        report = driver.stop()
+
+        # --- Sample validity ---
+        for name in ["baseline", "canary", "promote"]:
+            phase = report.phase(name)
+            phase.assert_min_samples(10, name)
+            assert phase.achieved_rate >= 0.5, (
+                f"{name}: rate collapsed to {phase.achieved_rate:.1f} rps\n"
+                f"{phase.summary()}"
+            )
+
+        # --- Zero errors in stable phases. A 5s gateway convergence delay
+        # after each mutation excludes transient 500s during route programming. ---
+        for name in ["baseline", "canary", "promote"]:
+            report.phase(name).assert_no_errors(f"stable phase: {name}")
+
+        # --- Distribution (via inference-sim's x-inference-pod header) ---
+        def is_v1(r):
+            pod = r.headers.get("x-inference-pod", "")
+            return pod.startswith(v1)
+
+        def is_v2(r):
+            pod = r.headers.get("x-inference-pod", "")
+            return pod.startswith(v2)
+
+        baseline = report.phase("baseline")
+        v1_pct = baseline.where(is_v1).count * 100 / baseline.count
+        assert 65 <= v1_pct <= 100, (
+            f"Baseline v1={v1_pct:.0f}% outside [65-100%]\n{baseline.summary()}"
+        )
+
+        canary = report.phase("canary")
+        v2_pct = canary.where(is_v2).count * 100 / canary.count
+        assert 10 <= v2_pct <= 55, (
+            f"Canary v2={v2_pct:.0f}% outside [10-55%]\n{canary.summary()}"
+        )
+
+        promote = report.phase("promote")
+        v1_after = promote.where(is_v1).count
+        assert v1_after <= 3, (
+            f"v1 traffic after promote: {v1_after}/{promote.count}\n{promote.summary()}"
+        )
+
+        # --- Propagation delay ---
+        for mutation, settled in [
+            ("canary_mutation", "canary"),
+            ("promote_mutation", "promote"),
+        ]:
+            delay = report.marks[settled] - report.marks[mutation]
+            logger.info(f"Propagation {mutation} -> {settled}: {delay:.1f}s")
+            assert delay < 60, f"{mutation} -> {settled} took {delay:.1f}s"
+
+        logger.info(
+            f"Canary lifecycle ({scenario.name}) complete: {report.all.summary()}"
+        )
+
+    # ------------------------------------------------------------------
+    # Group lifecycle edge cases (ported from controlled-deployment spike)
+    # ------------------------------------------------------------------
+
+    def test_force_stop(self, test_namespace, traffic_driver):
+        """Force-stop a member - scales to zero, stopped=true in group status,
+        traffic shifts to remaining member. (spike step 8)"""
+        api = get_api()
+        ns = test_namespace
+
+        v1 = MemberSpec(name="stop-v1", weight=9, scheduler=False)
+        v2 = MemberSpec(name="stop-v2", weight=1, scheduler=False)
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_member(api, v1, ns)
+        apply_member(api, v2, ns)
+
+        wait_ready(api, v1.name, ns)
+        wait_ready(api, v2.name, ns)
+
+        gateway = get_gateway_base_url(api, v1.name, ns)
+        driver = traffic_driver(
+            url=f"{gateway}/v1/completions",
+            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            rate=2,
+            timeout=15.0,
+            warmup=True,
+        )
+
+        driver.mark("before_stop")
+        time.sleep(10)
+
+        patch_stop(api, v2.name, ns)
+        wait_for_member_stopped(api, v1.name, v2.name, ns, stopped=True)
+
+        wait_for_healthy_route(
+            f"{gateway}/v1/completions",
+            {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+        )
+        driver.mark("settled")
+        time.sleep(15)
+
+        report = driver.stop()
+
+        settled = report.phase("settled")
+        settled.assert_no_errors(
+            "force-stop: traffic should flow to v1 after convergence"
+        )
+
+        def is_v2(r):
+            return r.headers.get("x-inference-pod", "").startswith(v2.name)
+
+        v2_after = settled.where(is_v2).count
+        assert v2_after == 0, f"v2 got {v2_after} requests after stop"
+
+        m = get_member_status(api, v1.name, v2.name, ns)
+        assert m is not None, "v2 should still be in group status"
+        assert m.get("stopped") is True, f"v2 stopped={m.get('stopped')}"
+        assert m.get("weight") == 1, f"v2 declared weight={m.get('weight')}, expected 1"
+
+        # Verify workload scaled down (deleted or scaled to zero)
+        apps = k8s_client.AppsV1Api()
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            deps = apps.list_namespaced_deployment(
+                ns,
+                label_selector=f"app.kubernetes.io/part-of=llminferenceservice,app.kubernetes.io/instance={v2.name}",
+            )
+            if not deps.items or all(d.spec.replicas == 0 for d in deps.items):
+                break
+            time.sleep(2)
+        else:
+            replicas = [d.spec.replicas for d in deps.items]
+            raise AssertionError(f"v2 deployment not scaled down: replicas={replicas}")
+
+        logger.info("Force-stop verified")
+
+    def test_decommission(self, test_namespace, traffic_driver):
+        """Delete a member from the group - remaining member stays Ready,
+        traffic continues. (spike step 9)"""
+        api = get_api()
+        ns = test_namespace
+
+        v1 = MemberSpec(name="decom-v1", weight=9, scheduler=False)
+        v2 = MemberSpec(name="decom-v2", weight=1, scheduler=False)
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_member(api, v1, ns)
+        apply_member(api, v2, ns)
+
+        wait_ready(api, v1.name, ns)
+        wait_ready(api, v2.name, ns)
+
+        gateway = get_gateway_base_url(api, v1.name, ns)
+        driver = traffic_driver(
+            url=f"{gateway}/v1/completions",
+            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            rate=2,
+            timeout=15.0,
+            warmup=True,
+        )
+
+        driver.mark("before_delete")
+        time.sleep(10)
+
+        driver.mark("delete")
+        delete_member(api, v2.name, ns, wait=True)
+        wait_for_member_count(api, v1.name, ns, 1)
+
+        driver.mark("settled")
+        time.sleep(15)
+
+        report = driver.stop()
+
+        # Intentionally strict: zero errors across the entire run including
+        # the delete-to-route-reprogramming window. This is the zero-downtime
+        # deletion claim. If it flakes, that's a real gateway routing gap
+        # worth investigating rather than masking with tolerance.
+        report.all.assert_no_errors("decommission: zero errors including transition")
+
+        members = get_group_members(api, v1.name, ns)
+        assert v2.name not in members, f"v2 still in group: {members}"
+
+        wait_for_condition(api, v1.name, ns, "Ready", status="True")
+
+        logger.info("Decommission verified")
+
+    def test_leave_group(self, test_namespace):
+        """Remove group+weight from a member - leaves the group. (spike step 14)"""
+        api = get_api()
+        ns = test_namespace
+
+        v1 = MemberSpec(name="leave-v1", weight=5, scheduler=False)
+        v2 = MemberSpec(name="leave-v2", weight=5, scheduler=False)
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_member(api, v1, ns)
+        apply_member(api, v2, ns)
+
+        wait_ready(api, v1.name, ns)
+        wait_ready(api, v2.name, ns)
+        wait_for_member_count(api, v1.name, ns, 2)
+
+        # Remove group and weight from v2
+        api.patch_namespaced_custom_object(
+            KSERVE_GROUP,
+            KSERVE_VERSION,
+            ns,
+            KSERVE_PLURAL,
+            v2.name,
+            {"spec": {"router": {"route": {"group": None, "weight": None}}}},
+        )
+        logger.info(f"Removed group+weight from {v2.name}")
+
+        wait_for_member_count(api, v1.name, ns, 1)
+
+        members = get_group_members(api, v1.name, ns)
+        assert v2.name not in members, f"v2 still in group: {members}"
+
+        # v1 should still be Ready
+        wait_for_condition(api, v1.name, ns, "Ready", status="True")
+
+        # v2's routing-group label should be removed
+        obj = api.get_namespaced_custom_object(
+            KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, v2.name
+        )
+        labels = obj.get("metadata", {}).get("labels", {})
+        assert "serving.kserve.io/routing-group" not in labels, (
+            f"routing-group label still present: {labels}"
+        )
+
+        logger.info("Leave group verified")
+
+    def test_three_member_group(self, test_namespace, traffic_driver):
+        """Three members in a group all receive traffic. (spike step 15)"""
+        api = get_api()
+        ns = test_namespace
+
+        v1 = MemberSpec(name="tri-v1", weight=5, scheduler=False)
+        v2 = MemberSpec(name="tri-v2", weight=3, scheduler=False)
+        v3 = MemberSpec(name="tri-v3", weight=2, scheduler=False)
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        for m in [v1, v2, v3]:
+            apply_member(api, m, ns)
+
+        for m in [v1, v2, v3]:
+            wait_ready(api, m.name, ns)
+        wait_for_member_count(api, v1.name, ns, 3)
+
+        gateway = get_gateway_base_url(api, v1.name, ns)
+        driver = traffic_driver(
+            url=f"{gateway}/v1/completions",
+            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            rate=2,
+            timeout=15.0,
+            warmup=True,
+        )
+
+        time.sleep(30)
+        report = driver.stop()
+
+        report.all.assert_no_errors("three-member group")
+
+        for m in [v1, v2, v3]:
+
+            def match(r, prefix=m.name):
+                return r.headers.get("x-inference-pod", "").startswith(prefix)
+
+            count = report.all.where(match).count
+            assert count > 0, f"{m.name} received no traffic ({report.all.count} total)"
+
+        logger.info("Three-member group verified")
+
+    def test_late_join(self, test_namespace, traffic_driver):
+        """A member joins an already-running group. (spike step 16)"""
+        api = get_api()
+        ns = test_namespace
+
+        v1 = MemberSpec(name="late-v1", weight=9, scheduler=False)
+        v2 = MemberSpec(name="late-v2", weight=1, scheduler=False)
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_member(api, v1, ns)
+
+        wait_ready(api, v1.name, ns)
+
+        gateway = get_gateway_base_url(api, v1.name, ns)
+        driver = traffic_driver(
+            url=f"{gateway}/v1/completions",
+            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            rate=2,
+            timeout=15.0,
+            warmup=True,
+        )
+
+        driver.mark("v1_only")
+        time.sleep(10)
+
+        # Late-join v2
+        apply_member(api, v2, ns)
+        wait_ready(api, v2.name, ns)
+        wait_for_member_count(api, v1.name, ns, 2)
+        wait_for_healthy_route(
+            f"{gateway}/v1/completions",
+            {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+        )
+
+        driver.mark("both")
+        time.sleep(20)
+
+        report = driver.stop()
+        report.all.assert_no_errors("late-join")
+
+        both = report.phase("both")
+
+        def is_v2(r):
+            return r.headers.get("x-inference-pod", "").startswith(v2.name)
+
+        v2_count = both.where(is_v2).count
+        assert v2_count > 0, f"v2 received no traffic after join ({both.count} total)"
+
+        logger.info("Late-join verified")
+
+    def test_delete_at_nonzero_weight(self, test_namespace, traffic_driver):
+        """Delete a member with weight>0 - no route breakage. (spike step 17)"""
+        api = get_api()
+        ns = test_namespace
+
+        v1 = MemberSpec(name="delw-v1", weight=5, scheduler=False)
+        v2 = MemberSpec(name="delw-v2", weight=5, scheduler=False)
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_member(api, v1, ns)
+        apply_member(api, v2, ns)
+
+        wait_ready(api, v1.name, ns)
+        wait_ready(api, v2.name, ns)
+
+        gateway = get_gateway_base_url(api, v1.name, ns)
+        driver = traffic_driver(
+            url=f"{gateway}/v1/completions",
+            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            rate=2,
+            timeout=15.0,
+            warmup=True,
+        )
+
+        time.sleep(10)
+        driver.mark("delete")
+
+        delete_member(api, v2.name, ns, wait=True)
+        wait_for_member_count(api, v1.name, ns, 1)
+
+        driver.mark("settled")
+        time.sleep(15)
+
+        report = driver.stop()
+
+        report.all.assert_no_errors(
+            "delete at weight>0: zero errors including transition"
+        )
+
+        logger.info("Delete at nonzero weight verified")
+
+    def test_rollback(self, test_namespace, traffic_driver):
+        """Promote v2 then rollback to v1 - traffic returns. (spike step 7)"""
+        api = get_api()
+        ns = test_namespace
+
+        v1 = MemberSpec(name="roll-v1", weight=9, scheduler=False)
+        v2 = MemberSpec(name="roll-v2", weight=1, scheduler=False)
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_member(api, v1, ns)
+        apply_member(api, v2, ns)
+
+        wait_ready(api, v1.name, ns)
+        wait_ready(api, v2.name, ns)
+
+        gateway = get_gateway_base_url(api, v1.name, ns)
+        driver = traffic_driver(
+            url=f"{gateway}/v1/completions",
+            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            rate=2,
+            timeout=15.0,
+            warmup=True,
+        )
+
+        route_headers = {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"}
+        route_payload = {"model": MODEL, "prompt": "Hello", "max_tokens": 5}
+
+        # Promote v2
+        driver.mark("promote_mutation")
+        patch_weight(api, v1.name, 0, ns)
+        patch_weight(api, v2.name, 9, ns)
+        wait_for_group_weight(api, v2.name, v1.name, 0, ns)
+        wait_for_healthy_route(
+            f"{gateway}/v1/completions", route_headers, route_payload
+        )
+        driver.mark("promoted")
+        time.sleep(15)
+
+        # Rollback to v1
+        driver.mark("rollback_mutation")
+        patch_weight(api, v1.name, 9, ns)
+        patch_weight(api, v2.name, 0, ns)
+        wait_for_group_weight(api, v1.name, v2.name, 0, ns)
+        wait_for_healthy_route(
+            f"{gateway}/v1/completions", route_headers, route_payload
+        )
+        driver.mark("settled")
+        time.sleep(15)
+
+        report = driver.stop()
+
+        for phase in ["promoted", "settled"]:
+            report.phase(phase).assert_no_errors(f"rollback: stable phase {phase}")
+
+        settled = report.phase("settled")
+
+        def is_v2(r):
+            return r.headers.get("x-inference-pod", "").startswith(v2.name)
+
+        v2_count = settled.where(is_v2).count
+        assert v2_count <= 3, f"v2 got {v2_count} requests after rollback"
+
+        logger.info("Rollback verified")
+
+    def test_force_stop_route_owner(self, test_namespace, traffic_driver):
+        """Force-stop the route owner - traffic shifts to other member. (spike step 18)"""
+        api = get_api()
+        ns = test_namespace
+
+        v1 = MemberSpec(name="owner-v1", weight=5, scheduler=False)
+        v2 = MemberSpec(name="owner-v2", weight=5, scheduler=False)
+
+        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        apply_member(api, v1, ns)
+        apply_member(api, v2, ns)
+
+        wait_ready(api, v1.name, ns)
+        wait_ready(api, v2.name, ns)
+
+        gateway = get_gateway_base_url(api, v1.name, ns)
+        driver = traffic_driver(
+            url=f"{gateway}/v1/completions",
+            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            rate=2,
+            timeout=15.0,
+            warmup=True,
+        )
+
+        time.sleep(10)
+        driver.mark("before_stop")
+
+        # v1 is the route owner (created first). Force-stop it.
+        patch_stop(api, v1.name, ns)
+        wait_for_member_stopped(api, v2.name, v1.name, ns, stopped=True)
+
+        # Route ownership handoff: v1's route is deleted, v2 creates a new one.
+        wait_for_healthy_route(
+            f"{gateway}/v1/completions",
+            {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+        )
+        driver.mark("settled")
+        time.sleep(15)
+
+        report = driver.stop()
+
+        settled = report.phase("settled")
+        settled.assert_no_errors("force-stop route owner: traffic should shift to v2")
+
+        def is_v1(r):
+            return r.headers.get("x-inference-pod", "").startswith(v1.name)
+
+        v1_after = settled.where(is_v1).count
+        assert v1_after == 0, f"v1 got {v1_after} requests after stop"
+
+        logger.info("Force-stop route owner verified")

--- a/test/e2e/llmisvc/traffic/README.md
+++ b/test/e2e/llmisvc/traffic/README.md
@@ -1,0 +1,145 @@
+# traffic - continuous traffic testing for LLMInferenceService
+
+A lightweight traffic driver for validating system behavior *during* state changes, not just at rest. Existing kserve e2e tests probe endpoints after mutations settle - this package sends traffic continuously while the test mutates cluster state, then lets you query the results by time window.
+
+## Why
+
+Step-by-step "mutate, wait, probe" tests miss transient failures. A canary weight change that drops 5% of requests for 2 seconds looks fine if you only check after it settles. Continuous traffic catches it.
+
+The package is ~250 lines, pure Python, no external deps beyond `requests` (already in the test deps). No k6, no locust, no subprocess.
+
+## What's in the box
+
+**`TrafficDriver`** - background thread that sends HTTP requests at a controlled rate and records every response.
+
+**`TrafficReport`** - mark-based windowing over the recorded responses. Drop marks at key moments (before mutation, after settle), then query phases.
+
+**`Slice`** - chainable queryable view with filtering, grouping, distribution, latency percentiles, and assertion helpers.
+
+## Quick example
+
+```python
+def test_rolling_upgrade_under_load(traffic_driver):
+    driver = traffic_driver(url=gateway_url, rate=2, warmup=True)
+
+    driver.mark("baseline")
+    time.sleep(10)
+
+    driver.mark("mutation")
+    patch_weight(api, v2, weight=5, ns=ns)
+    wait_for_group_weight(api, v1, v2, 5, ns)
+    driver.mark("settled")
+    time.sleep(10)
+
+    report = driver.stop()
+
+    # Zero errors during transition
+    report.around("mutation", before=0, after=10).assert_no_errors("weight change")
+
+    # Distribution shifted
+    baseline_v1 = report.phase("baseline").where(is_v1).count
+    settled_v1 = report.phase("settled").where(is_v1).count
+    assert settled_v1 < baseline_v1
+```
+
+## API
+
+### TrafficDriver
+
+```python
+driver = TrafficDriver(
+    url="http://gateway/v1/completions",
+    method="POST",                          # default
+    headers={"X-Gateway-Model-Name": "..."},
+    payload={"model": "m", "prompt": "hi", "max_tokens": 5},
+    rate=2.0,                               # requests per second
+    timeout=15.0,                           # per-request timeout
+    session=None,                           # optional shared session
+)
+
+driver.start(warmup=True)   # blocks until first 2xx, warmup excluded from report
+driver.mark("phase_name")   # record a named timestamp
+report = driver.stop()       # stop sending, return TrafficReport
+```
+
+### TrafficReport
+
+```python
+report.all                              # Slice over everything
+report.phase("baseline")               # between "baseline" mark and next mark
+report.between("a", "b")               # between two marks
+report.around("mutation", before=2, after=10)  # window around a mark
+report.since("settled")                 # from mark to end
+report.until("mutation")               # from start to mark
+report.marks                            # dict of mark_name -> monotonic timestamp
+```
+
+### Slice
+
+```python
+s = report.phase("baseline")
+
+s.count                                 # total requests
+s.successes()                           # Slice of 2xx responses
+s.errors()                              # Slice of non-2xx / connection errors
+s.where(lambda r: "v1" in r.headers.get("x-inference-pod", ""))
+
+s.by_header("x-inference-pod")          # Dict[str, Slice] grouped by header value
+s.by_status()                           # Dict[int, Slice] grouped by status code
+s.header_values("x-inference-pod")      # Counter[str]
+
+s.latency_percentile(0.95)             # p95 latency in seconds
+s.achieved_rate                         # actual requests/sec
+s.first_seen(predicate)                 # first ResponseRecord matching predicate
+
+s.assert_no_errors("context msg")       # raises with rich summary on failure
+s.assert_error_rate(0.01, "msg")        # max 1% error rate
+s.assert_min_samples(10, "msg")         # minimum sample count
+s.summary()                             # human-readable summary string
+```
+
+## Fixture
+
+The `traffic_driver` fixture in `conftest.py` is a factory - call it to create a driver, it auto-starts and auto-stops on teardown:
+
+```python
+@pytest.fixture
+def traffic_driver():
+    drivers = []
+    def factory(url, *, warmup=False, **kwargs):
+        driver = TrafficDriver(url, **kwargs)
+        drivers.append(driver)
+        driver.start(warmup=warmup)
+        return driver
+    yield factory
+    for d in reversed(drivers):
+        if d.is_running:
+            d.stop()
+```
+
+## Running
+
+Tests are marked `llminferenceservice`, `traffic`, and `cluster_cpu`. They use Service backends and work with any gateway (Envoy Gateway, Istio).
+
+```bash
+# From kserve repo root
+source python/kserve/.venv/bin/activate
+cd test/e2e
+
+pytest llmisvc/test_llm_canary_lifecycle.py \
+  -v -s --network-layer=envoy-gateway --log-cli-level=INFO
+
+# Via CI runner
+./test/scripts/gh-actions/run-e2e-tests.sh "traffic and cluster_cpu" 0 "envoy-gateway"
+```
+
+## Why not the test_case fixture?
+
+The canary lifecycle tests use their own resource management (`apply_member`, `apply_config`, `wait_ready`, etc.) rather than the `test_case` fixture from `fixtures.py`. The `test_case`/`TestCase` pattern is designed for single-service "create, wait, query, delete" workflows - it does not support group membership, mid-test weight patching, or multi-member lifecycle mutations. This is consistent with other specialized test files (`test_flow_control.py`, `test_rolling_upgrade.py`). A future unification could extend `TestCase` with group/weight fields.
+
+## Design choices
+
+- **Threading over asyncio** - the existing kserve e2e framework uses sync k8s clients. A daemon thread is the simplest model that works with sync mutations in the main thread.
+- **Rate-limited, not burst** - drift-compensating `next_tick` scheduling at a fixed rate. This is behavioral validation, not load testing. Consistent rate makes distribution assertions meaningful.
+- **Headers captured** - every response's headers are recorded. Tests pick which header to use for attribution (`x-inference-pod`, `x-served-by`, or anything the workload exposes).
+- **Mark-based phases** - no upfront phase declaration. Drop marks wherever you want, query any window after the fact.

--- a/test/e2e/llmisvc/traffic/__init__.py
+++ b/test/e2e/llmisvc/traffic/__init__.py
@@ -1,0 +1,4 @@
+from ._report import ResponseRecord, Slice, TrafficReport
+from ._driver import TrafficDriver
+
+__all__ = ["ResponseRecord", "Slice", "TrafficReport", "TrafficDriver"]

--- a/test/e2e/llmisvc/traffic/_driver.py
+++ b/test/e2e/llmisvc/traffic/_driver.py
@@ -1,0 +1,200 @@
+"""Background HTTP traffic generator with per-request recording."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any, Dict, Optional, Union
+
+import requests
+
+from ._report import ResponseRecord, TrafficReport
+
+
+class TrafficDriver:
+    """Sends HTTP requests at a controlled rate in a background thread.
+
+    Sends one request at a time at a target rate. If a request takes
+    longer than the inter-request interval, the next send is immediate
+    (no queuing, achieved rate drops).
+
+    Payload: if `payload` is a dict, it is serialized with json.dumps()
+    and Content-Type is set to application/json (unless overridden in headers).
+
+    Headers: response headers are stored with lowercased keys.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        method: str = "POST",
+        headers: Optional[Dict[str, str]] = None,
+        payload: Optional[Union[str, bytes, Dict[str, Any]]] = None,
+        rate: float = 2.0,
+        timeout: float = 5.0,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self._url = url
+        self._method = method.upper()
+        self._timeout = timeout
+        self._rate = rate
+        self._owns_session = session is None
+        self._session = session or requests.Session()
+
+        self._headers: Dict[str, str] = dict(headers or {})
+        if isinstance(payload, dict):
+            self._payload: Optional[Union[str, bytes]] = json.dumps(payload)
+            self._headers.setdefault("Content-Type", "application/json")
+        else:
+            self._payload = payload
+
+        self._records: list[ResponseRecord] = []
+        self._marks: Dict[str, float] = {}
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._started = False
+        self._stopped = False
+        self._report: Optional[TrafficReport] = None
+        self._request_count = 0
+
+    def start(
+        self, *, warmup: bool = False, warmup_timeout: float = 60.0
+    ) -> TrafficDriver:
+        """Start sending traffic. Returns self for chaining."""
+        if self._started:
+            raise RuntimeError("Driver already started")
+
+        if warmup:
+            self._warmup(warmup_timeout)
+
+        self._started = True
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> TrafficReport:
+        """Stop traffic and return the report. Idempotent."""
+        if self._stopped and self._report is not None:
+            return self._report
+
+        if not self._started:
+            self._report = TrafficReport([], {}, time.monotonic())
+            self._stopped = True
+            return self._report
+
+        self._stop_event.set()
+        self._thread.join(timeout=self._timeout + 1)
+
+        stop_ts = time.monotonic()
+        with self._lock:
+            self._report = TrafficReport(
+                list(self._records), dict(self._marks), stop_ts
+            )
+
+        if self._owns_session:
+            self._session.close()
+
+        self._stopped = True
+        return self._report
+
+    def mark(self, name: str) -> None:
+        """Record a named timestamp for phase-based analysis."""
+        ts = time.monotonic()
+        with self._lock:
+            self._marks[name] = ts
+
+    @property
+    def is_running(self) -> bool:
+        return self._started and not self._stopped
+
+    @property
+    def request_count(self) -> int:
+        return self._request_count
+
+    @property
+    def report(self) -> TrafficReport:
+        """Access after stop(). Raises RuntimeError if still running."""
+        if self.is_running:
+            raise RuntimeError(
+                "Cannot access report while driver is running. Call stop() first."
+            )
+        if self._report is None:
+            raise RuntimeError("Driver was never started.")
+        return self._report
+
+    def _warmup(self, timeout: float) -> None:
+        """Send probe requests until first 2xx. Not included in report."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                resp = self._session.request(
+                    self._method,
+                    self._url,
+                    headers=self._headers,
+                    data=self._payload,
+                    timeout=self._timeout,
+                )
+                if 200 <= resp.status_code < 300:
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(1)
+        raise TimeoutError(
+            f"Warmup failed: no successful response within {timeout}s from {self._url}"
+        )
+
+    def _run(self) -> None:
+        """Send loop - runs in background thread."""
+        interval = 1.0 / self._rate
+        next_tick = time.monotonic()
+
+        while not self._stop_event.is_set():
+            now = time.monotonic()
+            if now < next_tick:
+                wait_time = next_tick - now
+                if self._stop_event.wait(wait_time):
+                    break
+
+            next_tick += interval
+            record = self._send_one()
+            self._request_count += 1
+            with self._lock:
+                self._records.append(record)
+
+    def _send_one(self) -> ResponseRecord:
+        """Send a single request and record the result."""
+        ts = time.monotonic()
+        wall = time.time()
+        try:
+            resp = self._session.request(
+                self._method,
+                self._url,
+                headers=self._headers,
+                data=self._payload,
+                timeout=self._timeout,
+            )
+            latency = time.monotonic() - ts
+            resp_headers = {k.lower(): v for k, v in resp.headers.items()}
+            body = None
+            if not (200 <= resp.status_code < 300):
+                body = resp.text[:512] if resp.text else None
+            return ResponseRecord(
+                timestamp=ts,
+                wall_clock=wall,
+                status=resp.status_code,
+                latency=latency,
+                headers=resp_headers,
+                body=body,
+            )
+        except requests.RequestException as e:
+            latency = time.monotonic() - ts
+            return ResponseRecord(
+                timestamp=ts,
+                wall_clock=wall,
+                status=0,
+                latency=latency,
+                error=str(e),
+            )

--- a/test/e2e/llmisvc/traffic/_report.py
+++ b/test/e2e/llmisvc/traffic/_report.py
@@ -1,0 +1,264 @@
+"""Data model and queryable views for traffic driver results."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class ResponseRecord:
+    """Single HTTP response captured by the driver."""
+
+    timestamp: float  # time.monotonic()
+    wall_clock: float  # time.time()
+    status: int  # HTTP status code (0 for connection errors)
+    latency: float  # seconds
+    headers: Dict[str, str] = field(default_factory=dict)  # lowercased keys
+    error: Optional[str] = None
+    body: Optional[str] = None  # response body for non-2xx (truncated to 512 chars)
+    body: Optional[str] = None  # response body for non-2xx (truncated to 512 chars)
+
+    @property
+    def is_success(self) -> bool:
+        return 200 <= self.status < 300
+
+    @property
+    def is_error(self) -> bool:
+        return not self.is_success
+
+
+class Slice:
+    """Filtered, queryable view over response records.
+
+    All computed values are properties (lazy). Returns 0/0.0 for empty
+    slices on numeric properties. Assertion methods fail on empty slices.
+    """
+
+    def __init__(self, records: Sequence[ResponseRecord]) -> None:
+        self._records = list(records)
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    def __iter__(self):
+        return iter(self._records)
+
+    @property
+    def count(self) -> int:
+        return len(self._records)
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for r in self._records if r.is_error)
+
+    @property
+    def success_count(self) -> int:
+        return sum(1 for r in self._records if r.is_success)
+
+    @property
+    def error_rate(self) -> float:
+        if not self._records:
+            return 0.0
+        return self.error_count / len(self._records)
+
+    @property
+    def achieved_rate(self) -> float:
+        """Requests per second actually delivered."""
+        if len(self._records) < 2:
+            return 0.0
+        duration = self._records[-1].timestamp - self._records[0].timestamp
+        if duration <= 0:
+            return 0.0
+        return len(self._records) / duration
+
+    @property
+    def status_codes(self) -> Counter:
+        return Counter(r.status for r in self._records)
+
+    @property
+    def latency_p50(self) -> float:
+        return self.latency_percentile(0.50)
+
+    @property
+    def latency_p95(self) -> float:
+        return self.latency_percentile(0.95)
+
+    @property
+    def latency_p99(self) -> float:
+        return self.latency_percentile(0.99)
+
+    def latency_percentile(self, p: float) -> float:
+        if not self._records:
+            return 0.0
+        latencies = sorted(r.latency for r in self._records)
+        idx = int(len(latencies) * p)
+        idx = min(idx, len(latencies) - 1)
+        return latencies[idx]
+
+    def where(self, predicate: Callable[[ResponseRecord], bool]) -> Slice:
+        return Slice([r for r in self._records if predicate(r)])
+
+    def errors(self) -> Slice:
+        return self.where(lambda r: r.is_error)
+
+    def successes(self) -> Slice:
+        return self.where(lambda r: r.is_success)
+
+    def by(self, classifier: Callable[[ResponseRecord], str]) -> Dict[str, Slice]:
+        groups: Dict[str, List[ResponseRecord]] = {}
+        for r in self._records:
+            key = classifier(r)
+            groups.setdefault(key, []).append(r)
+        return {k: Slice(v) for k, v in groups.items()}
+
+    def by_header(self, name: str, *, missing: str = "<missing>") -> Dict[str, Slice]:
+        return self.by(lambda r: r.headers.get(name.lower(), missing))
+
+    def by_status(self) -> Dict[int, Slice]:
+        groups: Dict[int, List[ResponseRecord]] = {}
+        for r in self._records:
+            groups.setdefault(r.status, []).append(r)
+        return {k: Slice(v) for k, v in groups.items()}
+
+    def header_values(self, name: str) -> Counter:
+        return Counter(r.headers.get(name.lower(), "") for r in self._records)
+
+    def first_seen(
+        self, predicate: Callable[[ResponseRecord], bool]
+    ) -> Optional[ResponseRecord]:
+        for r in self._records:
+            if predicate(r):
+                return r
+        return None
+
+    def assert_error_rate(self, max_rate: float, msg: str = "") -> None:
+        if not self._records:
+            raise AssertionError(
+                f"{msg + ': ' if msg else ''}cannot assert error rate on empty slice"
+            )
+        if self.error_rate > max_rate:
+            raise AssertionError(
+                f"{msg + ': ' if msg else ''}"
+                f"error rate {self.error_rate:.1%} exceeds {max_rate:.1%}\n"
+                f"{self.summary()}"
+            )
+
+    def assert_no_errors(self, msg: str = "") -> None:
+        self.assert_error_rate(0.0, msg)
+
+    def assert_min_samples(self, n: int, msg: str = "") -> None:
+        if self.count < n:
+            raise AssertionError(
+                f"{msg + ': ' if msg else ''}"
+                f"expected at least {n} samples, got {self.count}\n"
+                f"{self.summary()}"
+            )
+
+    def summary(self) -> str:
+        if not self._records:
+            return "Slice: 0 requests"
+        duration = self._records[-1].timestamp - self._records[0].timestamp
+        lines = [
+            f"Slice: {self.count} requests over {duration:.1f}s "
+            f"({self.achieved_rate:.1f} req/s)",
+            f"  Successes: {self.success_count} ({self.success_count * 100 / self.count:.1f}%)",
+            f"  Errors:    {self.error_count} ({self.error_rate:.1%})",
+            f"  Status codes: {dict(self.status_codes)}",
+        ]
+        if self.success_count > 0:
+            lines.append(
+                f"  Latency p50: {self.latency_p50:.3f}s, "
+                f"p95: {self.latency_p95:.3f}s, "
+                f"p99: {self.latency_p99:.3f}s"
+            )
+        if self.error_count > 0:
+            samples = []
+            for r in self._records:
+                if r.is_error and (r.body or r.error):
+                    samples.append(f"    [{r.status}] {r.body or r.error}")
+                    if len(samples) >= 3:
+                        break
+            if samples:
+                lines.append("  Error samples:")
+                lines.extend(samples)
+        return "\n".join(lines)
+
+
+class TrafficReport:
+    """Complete record of a traffic driving session."""
+
+    def __init__(
+        self,
+        records: List[ResponseRecord],
+        marks: Dict[str, float],
+        stop_timestamp: float,
+    ) -> None:
+        self._records = sorted(records, key=lambda r: r.timestamp)
+        self._marks = dict(marks)
+        self._stop_ts = stop_timestamp
+        self._mark_order = sorted(marks.items(), key=lambda x: x[1])
+
+    @property
+    def all(self) -> Slice:
+        return Slice(self._records)
+
+    @property
+    def marks(self) -> Dict[str, float]:
+        return dict(self._marks)
+
+    @property
+    def duration(self) -> float:
+        if not self._records:
+            return 0.0
+        return self._records[-1].timestamp - self._records[0].timestamp
+
+    def phase(self, name: str) -> Slice:
+        """Records between mark `name` and the next mark (half-open)."""
+        if name not in self._marks:
+            available = [m[0] for m in self._mark_order]
+            raise KeyError(f"Unknown mark {name!r}. Available: {available}")
+        start = self._marks[name]
+        end = self._stop_ts
+        for i, (mark_name, _mark_ts) in enumerate(self._mark_order):
+            if mark_name == name and i + 1 < len(self._mark_order):
+                end = self._mark_order[i + 1][1]
+                break
+        return Slice([r for r in self._records if start <= r.timestamp < end])
+
+    def between(self, a: str, b: str) -> Slice:
+        """Half-open interval [mark_a, mark_b)."""
+        for name in (a, b):
+            if name not in self._marks:
+                available = [m[0] for m in self._mark_order]
+                raise KeyError(f"Unknown mark {name!r}. Available: {available}")
+        start = self._marks[a]
+        end = self._marks[b]
+        return Slice([r for r in self._records if start <= r.timestamp < end])
+
+    def around(self, name: str, *, before: float = 5.0, after: float = 5.0) -> Slice:
+        """Closed interval [mark - before, mark + after]."""
+        if name not in self._marks:
+            available = [m[0] for m in self._mark_order]
+            raise KeyError(f"Unknown mark {name!r}. Available: {available}")
+        ts = self._marks[name]
+        return Slice(
+            [r for r in self._records if ts - before <= r.timestamp <= ts + after]
+        )
+
+    def since(self, name: str) -> Slice:
+        """[mark, end_of_recording)."""
+        if name not in self._marks:
+            available = [m[0] for m in self._mark_order]
+            raise KeyError(f"Unknown mark {name!r}. Available: {available}")
+        start = self._marks[name]
+        return Slice([r for r in self._records if r.timestamp >= start])
+
+    def until(self, name: str) -> Slice:
+        """[start_of_recording, mark)."""
+        if name not in self._marks:
+            available = [m[0] for m in self._mark_order]
+            raise KeyError(f"Unknown mark {name!r}. Available: {available}")
+        end = self._marks[name]
+        return Slice([r for r in self._records if r.timestamp < end])


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds e2e tests covering the full canary deployment lifecycle for LLMInferenceService groups. These validate traffic splitting, group membership transitions, and edge cases that were previously only covered by the controlled-deployment spike.

**Test cases:**

| Test | What it validates |
|---|---|
| Canary service backend | Baseline 9/1 -> ramp 7/3 -> promote 0/9 under continuous traffic |
| Model name divergence | Different model.name triggers GroupDegraded=MemberDivergence |
| Divergence resolves | Patching model.name clears GroupDegraded |
| Webhook rejection | weight without group rejected at admission (422) |
| Force-stop | `serving.kserve.io/stop` scales to zero, traffic shifts |
| Decommission | Delete member, remaining stays Ready, zero-downtime |
| Leave group | Remove group+weight from spec, member exits group status |
| Three-member group | N>2 members all receive traffic proportionally |
| Late-join | Member joins running group, appears at declared weight |
| Delete at nonzero weight | No route breakage when deleting weight>0 member |
| Rollback | Promote then reverse - traffic returns to original |
| Force-stop route owner | Ownership handoff when route owner is stopped |

**Design:**

- Uses `llm-d-inference-sim` (not real vLLM) for fast, CPU-only execution
- Traffic split verified via `x-inference-pod` response header (pod name prefix matching)
- Gateway convergence polling (`wait_for_healthy_route` with consecutive 2xx) 
- All wait helpers handle transient API errors for CI resilience
- Service backend only (Envoy Gateway compatible) - pool/mixed scenarios as follow-up PR

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] All tests pass on kind + Envoy Gateway (884s total)
- [x] Tests pass with controller fix for stopped-member group status (depends on #5847)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```