### PR TITLE
fix(kfp): handle filename-only output path

### DIFF
--- a/docs/kfp/src/kservedeployer.py
+++ b/docs/kfp/src/kservedeployer.py
@@ -555,8 +555,9 @@ def main():
             except KeyError:
                 pass
 
-        if not os.path.exists(os.path.dirname(output_path)):
-            os.makedirs(os.path.dirname(output_path))
+        output_dir = os.path.dirname(output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir)
         with open(output_path, "w") as report:
             report.write(json.dumps(model_status, indent=4))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes output path handling in the KFP KServe deployer.

Previously, `docs/kfp/src/kservedeployer.py` always attempted to create the parent directory using:

`os.path.dirname(output_path)`

When `--output-path` is a filename-only path such as:

`status.json`

`os.path.dirname("status.json")` returns an empty string. This can cause the deployer to call:

`os.makedirs("")`

which fails because an empty directory path is invalid.

This PR updates the logic to only create the parent directory when the directory component is non-empty.

This keeps existing behavior for paths with directories, such as:

`/tmp/output/status.json`

while also allowing filename-only paths, such as:

`status.json`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #5853

**Feature/Issue validation/testing**:

- [x] Ran Python compile check for the modified file.

```bash
python -m py_compile docs/kfp/src/kservedeployer.py