### PR TITLE
fix(storage): set restricted initializer security context

### DIFF
--- a/charts/_common/common-sections.yaml
+++ b/charts/_common/common-sections.yaml
@@ -34,6 +34,8 @@ kserve:
       capabilities:
         drop:
         - ALL
+      seccompProfile:
+        type: RuntimeDefault
     enableModelcar: true
     uidModelcar: 1010
     cpuModelcar: 10m
@@ -105,4 +107,3 @@ kserve:
   autoscaler:
     scaleUpStabilizationWindowSeconds: '0'
     scaleDownStabilizationWindowSeconds: '300'
-

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -155,6 +155,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.storage.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | kserve.storage.containerSecurityContext.privileged | bool | `false` |  |
 | kserve.storage.containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| kserve.storage.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | kserve.storage.cpuModelcar | string | `"10m"` |  |
 | kserve.storage.enableModelcar | bool | `true` |  |
 | kserve.storage.image | string | `"kserve/storage-initializer"` |  |

--- a/charts/kserve-llmisvc-resources/files/common/storagecontainer.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/storagecontainer.yaml
@@ -14,6 +14,15 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -34,6 +34,8 @@ kserve:
       capabilities:
         drop:
           - ALL
+      seccompProfile:
+        type: RuntimeDefault
     enableModelcar: true
     uidModelcar: 1010
     cpuModelcar: 10m

--- a/charts/kserve-localmodel-resources/README.md
+++ b/charts/kserve-localmodel-resources/README.md
@@ -95,6 +95,7 @@ $ helm install kserve-localmodel-resources oci://ghcr.io/kserve/charts/kserve-lo
 | kserve.storage.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | kserve.storage.containerSecurityContext.privileged | bool | `false` |  |
 | kserve.storage.containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| kserve.storage.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | kserve.storage.cpuModelcar | string | `"10m"` |  |
 | kserve.storage.enableModelcar | bool | `true` |  |
 | kserve.storage.image | string | `"kserve/storage-initializer"` |  |

--- a/charts/kserve-localmodel-resources/values.yaml
+++ b/charts/kserve-localmodel-resources/values.yaml
@@ -34,6 +34,8 @@ kserve:
       capabilities:
         drop:
           - ALL
+      seccompProfile:
+        type: RuntimeDefault
     enableModelcar: true
     uidModelcar: 1010
     cpuModelcar: 10m

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -123,6 +123,7 @@ $ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --v
 | kserve.storage.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | kserve.storage.containerSecurityContext.privileged | bool | `false` |  |
 | kserve.storage.containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| kserve.storage.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | kserve.storage.cpuModelcar | string | `"10m"` |  |
 | kserve.storage.enableModelcar | bool | `true` |  |
 | kserve.storage.image | string | `"kserve/storage-initializer"` |  |

--- a/charts/kserve-resources/files/common/storagecontainer.yaml
+++ b/charts/kserve-resources/files/common/storagecontainer.yaml
@@ -14,6 +14,15 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -34,6 +34,8 @@ kserve:
       capabilities:
         drop:
           - ALL
+      seccompProfile:
+        type: RuntimeDefault
     enableModelcar: true
     uidModelcar: 1010
     cpuModelcar: 10m

--- a/config/storagecontainers/default.yaml
+++ b/config/storagecontainers/default.yaml
@@ -7,6 +7,15 @@ spec:
     name: storage-initializer
     image: default-storage-initilizer:replace
     imagePullPolicy: IfNotPresent
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     resources:
       requests:
         memory: 100Mi

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -56313,6 +56313,15 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -56330,6 +56330,15 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -55899,6 +55899,15 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -55912,6 +55912,15 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -109309,6 +109309,15 @@ spec:
       requests:
         cpu: 100m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
   supportedUriFormats:
   - prefix: gs://
   - prefix: s3://

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -326,6 +326,21 @@ func CreateInitContainerWithConfig(storageConfig *types.StorageInitializerConfig
 		Image:                    storageInitializerImage,
 		Args:                     containerArgs,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		// Mirror config/storagecontainers/default.yaml so the fallback init container
+		// injected without a ClusterStorageContainer also passes the restricted Pod
+		// Security Standard. The image declares OCI user 1000, so runAsNonRoot is
+		// verifiable without a fixed runAsUser.
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			Privileged:   ptr.To(false),
+			RunAsNonRoot: ptr.To(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 		Resources: corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU:    resource.MustParse(storageConfig.CpuLimit),

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -3178,6 +3178,99 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 	}
 }
 
+// TestStorageInitializerRestrictedSecurityContext asserts that the injected
+// storage-initializer init container carries every field the restricted Pod
+// Security Standard requires, both when the webhook builds the container itself
+// and when a ClusterStorageContainer mirroring config/storagecontainers/default.yaml
+// supplies it.
+func TestStorageInitializerRestrictedSecurityContext(t *testing.T) {
+	restrictedSpec := v1alpha1.ClusterStorageContainer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "restricted-default",
+		},
+		Spec: v1alpha1.StorageContainerSpec{
+			Container: corev1.Container{
+				Name:            "storage-initializer",
+				Image:           "kserve/storage-initializer:latest",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: storageInitializerSecurityContext(),
+			},
+			SupportedUriFormats: []v1alpha1.SupportedUriFormat{{Prefix: "restricted://"}},
+		},
+	}
+	if err := c.Create(t.Context(), &restrictedSpec); err != nil {
+		t.Fatalf("unable to create cluster storage container: %v", err)
+	}
+	defer func() {
+		if err := c.Delete(t.Context(), &restrictedSpec); err != nil {
+			t.Errorf("unable to delete cluster storage container: %v", err)
+		}
+	}()
+
+	scenarios := map[string]struct {
+		storageURI    string
+		expectedImage string
+	}{
+		"without ClusterStorageContainer": {
+			storageURI:    "https://unmatched.example.com/model.bin",
+			expectedImage: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+		},
+		"with ClusterStorageContainer from default.yaml": {
+			storageURI:    "restricted://foo",
+			expectedImage: "kserve/storage-initializer:latest",
+		},
+	}
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.StorageInitializerSourceUriInternalAnnotationKey: scenario.storageURI,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.InferenceServiceContainerName,
+						},
+					},
+				},
+			}
+			injector := &StorageInitializerInjector{
+				credentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{
+					Data: map[string]string{},
+				}),
+				config: storageInitializerConfig,
+				client: c,
+			}
+			require.NoError(t, injector.InjectStorageInitializer(t.Context(), pod))
+
+			var initContainer *corev1.Container
+			for i := range pod.Spec.InitContainers {
+				if pod.Spec.InitContainers[i].Name == constants.StorageInitializerContainerName {
+					initContainer = &pod.Spec.InitContainers[i]
+				}
+			}
+			require.NotNil(t, initContainer, "storage-initializer init container was not injected")
+			// The image tells which path built the container.
+			assert.Equal(t, scenario.expectedImage, initContainer.Image)
+
+			securityContext := initContainer.SecurityContext
+			require.NotNil(t, securityContext)
+			assert.Equal(t, ptr.Bool(false), securityContext.AllowPrivilegeEscalation)
+			assert.Equal(t, ptr.Bool(false), securityContext.Privileged)
+			assert.Equal(t, ptr.Bool(true), securityContext.RunAsNonRoot)
+			require.NotNil(t, securityContext.Capabilities)
+			assert.Equal(t, []corev1.Capability{"ALL"}, securityContext.Capabilities.Drop)
+			require.NotNil(t, securityContext.SeccompProfile)
+			assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, securityContext.SeccompProfile.Type)
+			// The image declares its non-root user, so the kubelet verifies
+			// runAsNonRoot without a fixed runAsUser pinned in the manifest.
+			assert.Nil(t, securityContext.RunAsUser)
+		})
+	}
+}
+
 func TestAddOrReplaceEnv(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -72,6 +72,31 @@ var (
 	}
 )
 
+// storageInitializerSecurityContext mirrors the restricted Pod Security Standard
+// context that utils.CreateInitContainerWithConfig sets on the fallback
+// storage-initializer init container.
+func storageInitializerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		Privileged:   ptr.Bool(false),
+		RunAsNonRoot: ptr.Bool(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// storageInitializerSecurityContextWithUID is the restricted context after
+// SetIstioCniSecurityContext has added the Istio sidecar user identifier.
+func storageInitializerSecurityContextWithUID(uid int64) *corev1.SecurityContext {
+	securityContext := storageInitializerSecurityContext()
+	securityContext.RunAsUser = ptr.Int64(uid)
+	return securityContext
+}
+
 func TestStorageInitializerInjector(t *testing.T) {
 	scenarios := map[string]struct {
 		original *corev1.Pod
@@ -189,6 +214,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -255,6 +281,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      constants.StorageInitializerVolumeName,
@@ -322,6 +349,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      constants.StorageInitializerVolumeName,
@@ -389,6 +417,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      constants.StorageInitializerVolumeName,
@@ -513,6 +542,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -781,6 +811,7 @@ func TestCredentialInjection(t *testing.T) {
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -884,6 +915,7 @@ func TestCredentialInjection(t *testing.T) {
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -1006,6 +1038,7 @@ func TestCredentialInjection(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -1104,6 +1137,7 @@ func TestCredentialInjection(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -1210,6 +1244,7 @@ func TestStorageInitializerConfigmap(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -1580,6 +1615,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -1686,6 +1722,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -1810,6 +1847,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -1935,6 +1973,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -2051,6 +2090,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -2162,6 +2202,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -3026,6 +3067,7 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 								},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -3097,6 +3139,7 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -3543,9 +3586,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 									MountPath: constants.DefaultModelLocalMountPath,
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: ptr.Int64(501),
-							},
+							SecurityContext: storageInitializerSecurityContextWithUID(501),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -3619,9 +3660,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 									MountPath: constants.DefaultModelLocalMountPath,
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: ptr.Int64(1337),
-							},
+							SecurityContext: storageInitializerSecurityContextWithUID(1337),
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -3703,6 +3742,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -3770,6 +3810,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -3849,6 +3890,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -3928,6 +3970,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -4007,6 +4050,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -4085,6 +4129,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -4163,6 +4208,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",
@@ -4242,6 +4288,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
+							SecurityContext:          storageInitializerSecurityContext(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "kserve-provision-location",


### PR DESCRIPTION
**What this PR does / why we need it**:

Configures the default storage initializer container with a restricted Pod Security Standards-compatible security context in both Kustomize and Helm installation paths.

The storage initializer is injected into user workload pods. Without these defaults, namespaces enforcing the restricted policy can reject generated pods.

This also regenerates the chart values documentation, rendered storage-container resources, and quick-install scripts that embed the canonical resource.

**Which issue(s) this PR fixes**:

Follow-up to kubeflow/community-distribution#3527.

**Feature/Issue validation/testing**:

- [x] `make generate-chart-manifests`
- [x] `make generate-quick-install-scripts` (rerun verified idempotence)
- [x] Pinned `helm-docs` generation
- [x] Rendered `config/storagecontainers` with Kustomize
- [x] Rendered `kserve-resources` and `kserve-llmisvc-resources` with Helm
- [x] `git diff --check`

**Special notes for your reviewer**:

The image already declares user identifier 1000, so this change uses `runAsNonRoot: true` without hard-coding `runAsUser`.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
Configure the default storage initializer container for Kubernetes restricted Pod Security Standards.
```