### PR TITLE
fix(webhook): block host namespaces and projected SA tokens

### DIFF
--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -52,6 +52,10 @@ const (
 	DisallowedMultipleContainersInWorkerSpecError    = "the InferenceService %q is invalid: setting multiple containers in workerSpec is not allowed"
 	DisallowedWorkerSpecPipelineParallelSizeEnvError = "the InferenceService %q is invalid: setting PIPELINE_PARALLEL_SIZE in environment variables is not allowed"
 	DisallowedWorkerSpecTensorParallelSizeEnvError   = "the InferenceService %q is invalid: setting TENSOR_PARALLEL_SIZE in environment variables is not allowed"
+	DisallowedHostNetworkError                       = "the InferenceService %q is invalid: setting hostNetwork is not allowed in %s"
+	DisallowedHostPIDError                           = "the InferenceService %q is invalid: setting hostPID is not allowed in %s"
+	DisallowedHostIPCError                           = "the InferenceService %q is invalid: setting hostIPC is not allowed in %s"
+	DisallowedProjectedSATokenVolumeError            = "the InferenceService %q is invalid: projected volume %q with serviceAccountToken source is not allowed in %s"
 )
 
 // SupportedStorageSpecURIPrefixList Constants

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -132,6 +132,10 @@ func validateInferenceService(isvc *InferenceService) (admission.Warnings, error
 		return allWarnings, err
 	}
 
+	if err := validatePodSpecSecurityFields(isvc); err != nil {
+		return allWarnings, err
+	}
+
 	if err := validateMultiNodeVariables(isvc); err != nil {
 		return allWarnings, err
 	}
@@ -346,6 +350,56 @@ func validateBlockedEnvVars(isvc *InferenceService) error {
 		if isvc.Spec.Explainer.ART != nil {
 			if err := validation.ValidateBlockedEnvVars([]corev1.Container{isvc.Spec.Explainer.ART.Container}, validation.DefaultBlockedEnvVars); err != nil {
 				return fmt.Errorf("the InferenceService %q is invalid: %w", isvc.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validatePodSpecSecurityFields(isvc *InferenceService) error {
+	if err := validatePodSpecSecurity(isvc.Name, &isvc.Spec.Predictor.PodSpec, "predictor"); err != nil {
+		return err
+	}
+
+	if isvc.Spec.Predictor.WorkerSpec != nil {
+		if err := validatePodSpecSecurity(isvc.Name, &isvc.Spec.Predictor.WorkerSpec.PodSpec, "predictor workerSpec"); err != nil {
+			return err
+		}
+	}
+
+	if isvc.Spec.Transformer != nil {
+		if err := validatePodSpecSecurity(isvc.Name, &isvc.Spec.Transformer.PodSpec, "transformer"); err != nil {
+			return err
+		}
+	}
+
+	if isvc.Spec.Explainer != nil {
+		if err := validatePodSpecSecurity(isvc.Name, &isvc.Spec.Explainer.PodSpec, "explainer"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validatePodSpecSecurity(isvcName string, podSpec *PodSpec, component string) error {
+	if podSpec.HostNetwork {
+		return fmt.Errorf(DisallowedHostNetworkError, isvcName, component)
+	}
+	if podSpec.HostPID {
+		return fmt.Errorf(DisallowedHostPIDError, isvcName, component)
+	}
+	if podSpec.HostIPC {
+		return fmt.Errorf(DisallowedHostIPCError, isvcName, component)
+	}
+
+	for _, vol := range podSpec.Volumes {
+		if vol.Projected != nil {
+			for _, src := range vol.Projected.Sources {
+				if src.ServiceAccountToken != nil {
+					return fmt.Errorf(DisallowedProjectedSATokenVolumeError, isvcName, vol.Name, component)
+				}
 			}
 		}
 	}

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -2653,6 +2653,309 @@ func TestValidateCanarySpecs(t *testing.T) {
 	}
 }
 
+func TestPodSpecSecurityValidation(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	scenarios := map[string]struct {
+		isvc     InferenceService
+		expected gomega.OmegaMatcher
+	}{
+		"predictor hostNetwork blocked": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						PodSpec: PodSpec{
+							HostNetwork: true,
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("setting hostNetwork is not allowed in predictor")),
+		},
+		"predictor hostPID blocked": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						PodSpec: PodSpec{
+							HostPID: true,
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("setting hostPID is not allowed in predictor")),
+		},
+		"predictor hostIPC blocked": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						PodSpec: PodSpec{
+							HostIPC: true,
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("setting hostIPC is not allowed in predictor")),
+		},
+		"predictor projected SA token volume blocked": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						PodSpec: PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "stolen-sa-token",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Path:              "token",
+														ExpirationSeconds: proto.Int64(3600),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("projected volume \"stolen-sa-token\" with serviceAccountToken source is not allowed in predictor")),
+		},
+		"projected volume without SA token allowed": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						PodSpec: PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "configmap-projection",
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ConfigMap: &corev1.ConfigMapProjection{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "my-config",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.BeNil(),
+		},
+		"transformer hostNetwork blocked": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+					Transformer: &TransformerSpec{
+						PodSpec: PodSpec{
+							HostNetwork: true,
+							Containers: []corev1.Container{
+								{
+									Image: "transformer:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("setting hostNetwork is not allowed in transformer")),
+		},
+		"explainer hostPID blocked": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+					Explainer: &ExplainerSpec{
+						PodSpec: PodSpec{
+							HostPID: true,
+							Containers: []corev1.Container{
+								{
+									Image: "explainer:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("setting hostPID is not allowed in explainer")),
+		},
+		"workerSpec hostNetwork blocked": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/autoscalerClass": "none",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String("pvc://my-pvc/model"),
+							},
+						},
+						WorkerSpec: &WorkerSpec{
+							PodSpec: PodSpec{
+								HostNetwork: true,
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("setting hostNetwork is not allowed in predictor workerSpec")),
+		},
+		"workerSpec projected SA token blocked": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/autoscalerClass": "none",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String("pvc://my-pvc/model"),
+							},
+						},
+						WorkerSpec: &WorkerSpec{
+							PodSpec: PodSpec{
+								Volumes: []corev1.Volume{
+									{
+										Name: "sa-token",
+										VolumeSource: corev1.VolumeSource{
+											Projected: &corev1.ProjectedVolumeSource{
+												Sources: []corev1.VolumeProjection{
+													{
+														ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+															Path: "token",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("projected volume \"sa-token\" with serviceAccountToken source is not allowed in predictor workerSpec")),
+		},
+		"valid isvc without security-sensitive fields": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			expected: gomega.BeNil(),
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			validator := InferenceServiceValidator{}
+			_, err := validator.ValidateCreate(t.Context(), &scenario.isvc)
+			g.Expect(err).To(scenario.expected)
+		})
+	}
+
+	t.Run("update adding hostNetwork blocked", func(t *testing.T) {
+		validator := InferenceServiceValidator{}
+		oldISVC := InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+			Spec: InferenceServiceSpec{
+				Predictor: PredictorSpec{
+					Tensorflow: &TFServingSpec{
+						PredictorExtensionSpec: PredictorExtensionSpec{
+							StorageURI:     proto.String("gs://testbucket/testmodel"),
+							RuntimeVersion: proto.String("0.14.0"),
+						},
+					},
+				},
+			},
+		}
+		newISVC := oldISVC.DeepCopy()
+		newISVC.Spec.Predictor.HostNetwork = true
+
+		_, err := validator.ValidateUpdate(t.Context(), &oldISVC, newISVC)
+		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("setting hostNetwork is not allowed in predictor")))
+	})
+}
+
 func TestValidatePredictorNameChange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	validator := InferenceServiceValidator{}


### PR DESCRIPTION
**What this PR does / why we need it**:

KServe accepts security-sensitive PodSpec fields on InferenceService CRs without validating them. Users can set `hostNetwork`, `hostPID`, or `hostIPC`, or mount projected volumes with `serviceAccountToken` sources, bypassing KServe's `automountServiceAccountToken: false` control when those fields are translated into Deployment/Pod specs.

This PR adds validating webhook checks to reject those fields across predictor, transformer, explainer, and predictor `workerSpec`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/apis/serving/v1beta1/... -run TestPodSpecSecurityValidation -v`
- [x] `go test ./pkg/apis/serving/v1beta1/... -count=1`

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Block hostNetwork, hostPID, hostIPC, and projected service account token volumes in InferenceService validating webhook.
```