### PR TITLE
fix(e2e): use shared security context for canary lifecycle tests

### DIFF
--- a/test/e2e/llmisvc/test_llm_canary_lifecycle.py
+++ b/test/e2e/llmisvc/test_llm_canary_lifecycle.py
@@ -29,6 +29,8 @@ from urllib.parse import urlparse
 import pytest
 from kubernetes import client as k8s_client, config
 
+from .fixtures import LLMD_SIMULATOR_SECURITY_CONTEXT
+
 logger = logging.getLogger(__name__)
 
 KUBE_CONTEXT = os.environ.get("KUBE_CONTEXT", None)
@@ -79,12 +81,6 @@ class WorkloadConfig:
             spec["storageInitializer"] = {"enabled": False}
         return spec
 
-
-LLMD_SIMULATOR_SECURITY_CONTEXT = {
-    "runAsNonRoot": True,
-    "runAsUser": 65532,
-    "runAsGroup": 65532,
-}
 
 INFERENCE_SIM = WorkloadConfig(
     name="canary-workload",


### PR DESCRIPTION
**What this PR does / why we need it**:

The canary lifecycle test hardcodes its own `LLMD_SIMULATOR_SECURITY_CONTEXT` with explicit `runAsUser`/`runAsGroup` values, duplicating the same constant already defined in `fixtures.py`. On platforms where SCCs reject explicit UIDs (e.g. OpenShift `restricted-v2`), all canary pods fail to schedule.

Imports the shared constant from `fixtures.py` instead, which already supports gating explicit UIDs behind the `RUN_AS_NON_ROOT` env var. No behavioral change on vanilla K8s where the env var defaults to false.

**Feature/Issue validation/testing**:

- [ ] Canary lifecycle tests pass on vanilla K8s (no behavioral change)
- [ ] Canary lifecycle tests pass on OpenShift with `RUN_AS_NON_ROOT=true`

**Release note**:
```release-note
NONE
```