### PR TITLE
fix(e2e): inject default LLMISVC annotations via env var

### DIFF
--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -14,6 +14,7 @@
 
 import copy
 import hashlib
+import json
 import os
 import re
 import time
@@ -63,6 +64,16 @@ LLMD_SIMULATOR_SECURITY_CONTEXT = {
     "runAsUser": 65532,
     "runAsGroup": 65532,
 }
+
+# Default annotations applied to every LLMInferenceService created by the
+# test harness. Set LLMISVC_DEFAULT_ANNOTATIONS as a JSON object in CI to
+# inject platform-specific annotations without modifying test code.
+try:
+    DEFAULT_LLMISVC_ANNOTATIONS = json.loads(
+        os.environ.get("LLMISVC_DEFAULT_ANNOTATIONS", "{}")
+    )
+except (json.JSONDecodeError, TypeError):
+    DEFAULT_LLMISVC_ANNOTATIONS = {}
 
 STORAGE_INITIALIZER_INIT_CONTAINER = {
     "name": "storage-initializer",
@@ -1538,7 +1549,11 @@ def _setup_test_case_service(
     tc.llm_service = V1alpha1LLMInferenceService(
         api_version="serving.kserve.io/v1alpha1",
         kind="LLMInferenceService",
-        metadata=client.V1ObjectMeta(name=tc.service_name, namespace=namespace),
+        metadata=client.V1ObjectMeta(
+            name=tc.service_name,
+            namespace=namespace,
+            annotations=dict(DEFAULT_LLMISVC_ANNOTATIONS) or None,
+        ),
         spec={
             "baseRefs": [{"name": base_ref} for base_ref in unique_base_refs],
         },

--- a/test/e2e/llmisvc/test_llm_canary_lifecycle.py
+++ b/test/e2e/llmisvc/test_llm_canary_lifecycle.py
@@ -29,7 +29,7 @@ from urllib.parse import urlparse
 import pytest
 from kubernetes import client as k8s_client, config
 
-from .fixtures import LLMD_SIMULATOR_SECURITY_CONTEXT
+from .fixtures import DEFAULT_LLMISVC_ANNOTATIONS, LLMD_SIMULATOR_SECURITY_CONTEXT
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +123,15 @@ def apply_divergence_member(api, name, model_name, weight, ns):
     body = {
         "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
         "kind": "LLMInferenceService",
-        "metadata": {"name": name, "namespace": ns},
+        "metadata": {
+            "name": name,
+            "namespace": ns,
+            **(
+                {"annotations": dict(DEFAULT_LLMISVC_ANNOTATIONS)}
+                if DEFAULT_LLMISVC_ANNOTATIONS
+                else {}
+            ),
+        },
         "spec": {
             "model": model_spec,
             "baseRefs": [{"name": INFERENCE_SIM.name}],
@@ -237,6 +245,11 @@ def apply_member(api, member: MemberSpec, ns):
         "metadata": {
             "name": member.name,
             "namespace": ns,
+            **(
+                {"annotations": dict(DEFAULT_LLMISVC_ANNOTATIONS)}
+                if DEFAULT_LLMISVC_ANNOTATIONS
+                else {}
+            ),
         },
         "spec": spec,
     }

--- a/test/e2e/llmisvc/test_llm_inference_service_stop.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_stop.py
@@ -70,13 +70,6 @@ def test_llm_stop_feature(test_case: TestCase):
     service_name = test_case.llm_service.metadata.name
     test_failed = False
 
-    # Disable auth for this test
-    if not test_case.llm_service.metadata.annotations:
-        test_case.llm_service.metadata.annotations = {}
-    test_case.llm_service.metadata.annotations[
-        "security.opendatahub.io/enable-auth"
-    ] = "false"
-
     try:
         # Create the service
         print(f"Creating LLMInferenceService {service_name}")

--- a/test/e2e/llmisvc/test_llm_lora_adapters.py
+++ b/test/e2e/llmisvc/test_llm_lora_adapters.py
@@ -24,6 +24,7 @@ from typing import List, Optional
 
 from .diagnostic import collect_diagnostics
 from .fixtures import (
+    DEFAULT_LLMISVC_ANNOTATIONS,
     LLMINFERENCESERVICE_CONFIGS,
     _create_or_update_llmisvc_config,
     _get_model_name_from_configs,
@@ -69,7 +70,11 @@ def build_llm_service_from_refs(
     return V1alpha1LLMInferenceService(
         api_version="serving.kserve.io/v1alpha1",
         kind="LLMInferenceService",
-        metadata=client.V1ObjectMeta(name=service_name, namespace=namespace),
+        metadata=client.V1ObjectMeta(
+            name=service_name,
+            namespace=namespace,
+            annotations=dict(DEFAULT_LLMISVC_ANNOTATIONS) or None,
+        ),
         spec={"baseRefs": [{"name": ref} for ref in base_refs]},
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `DEFAULT_LLMISVC_ANNOTATIONS` to the test harness, parsed from the `LLMISVC_DEFAULT_ANNOTATIONS` env var (defaults to `{}`). The `test_case` fixture and canary test helpers inject these annotations into every LLMISVC at creation.

Platforms with gateway auth policies (e.g. OpenShift with Kuadrant/Authorino) can set the env var in CI to disable auth for non-auth tests without modifying test code. Removes the hardcoded `enable-auth=false` from the existing tests since it's now handled centrally.

**Release note**:
```release-note
NONE
```