### PR TITLE
fix(e2e): preserve test namespaces on failure

### DIFF
--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import pytest
 from pathlib import Path
 
@@ -23,10 +25,12 @@ from .namespace import (
     generate_namespace_name,
     provision_namespace_secrets,
     skip_deletion,
+    skip_deletion_on_failure,
 )
 from .fixtures import inject_k8s_proxy
-
 from .traffic import TrafficDriver
+
+logger = logging.getLogger(__name__)
 
 _LLMISVC_DIR = Path(__file__).parent
 _AUTOSCALING_STEM_PREFIX = "test_llm_autoscaling_"
@@ -83,6 +87,14 @@ def _auto_assign_group_markers(items):
             item.add_marker(pytest.mark.llmisvc_core)
 
 
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Stash test outcome on the node so fixtures can check it at teardown."""
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"rep_{rep.when}", rep)
+
+
 def pytest_configure(config):
     """Register dynamic autoscaling variant markers derived from filenames.
 
@@ -134,8 +146,15 @@ def test_namespace(request):
     create_test_namespace(ns)
     provision_namespace_secrets(ns)
     yield ns
-    if not skip_deletion():
-        delete_test_namespace(ns)
+    if skip_deletion():
+        return
+    rep_call = getattr(request.node, "rep_call", None)
+    rep_setup = getattr(request.node, "rep_setup", None)
+    failed = (rep_call and rep_call.failed) or (rep_setup and rep_setup.failed)
+    if failed and skip_deletion_on_failure():
+        logger.info("Skipping deletion of namespace %s (SKIP_DELETION_ON_FAILURE)", ns)
+        return
+    delete_test_namespace(ns)
 
 
 @pytest.fixture

--- a/test/e2e/llmisvc/namespace.py
+++ b/test/e2e/llmisvc/namespace.py
@@ -54,8 +54,16 @@ def generate_namespace_name(node_name: str) -> str:
     return f"{prefix}{safe_base}{sep}{name_hash}"
 
 
+def _env_bool(name: str) -> bool:
+    return os.getenv(name, "False").lower() in ("true", "1", "t")
+
+
 def skip_deletion() -> bool:
-    return os.getenv("SKIP_RESOURCE_DELETION", "False").lower() in ("true", "1", "t")
+    return _env_bool("SKIP_RESOURCE_DELETION")
+
+
+def skip_deletion_on_failure() -> bool:
+    return _env_bool("SKIP_DELETION_ON_FAILURE")
 
 
 def create_test_namespace(namespace: str) -> None:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `test_namespace` fixture deletes per-test namespaces unconditionally, losing all pod events and resource state needed for post-mortem. The `SKIP_DELETION_ON_FAILURE` env var was already supported by the `test_case` path but not by the shared `test_namespace` fixture.

Adds `pytest_runtest_makereport` hook to capture test outcome, then skips namespace deletion when the test or its setup failed and `SKIP_DELETION_ON_FAILURE` is set.

**Release note**:
```release-note
NONE
```