### PR TITLE
fix(helm): honor storage initializer resource values

### DIFF
--- a/charts/_common/common-patches/configmap-patch.yaml
+++ b/charts/_common/common-patches/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/charts/kserve-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-resources/files/common/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},


### PR DESCRIPTION
**What this PR does / why we need it**:

The Helm charts expose `kserve.storage.resources`, but the generated
`inferenceservice-config` ConfigMap continued to use hard-coded storage
initializer requests and limits. As a result, `LLMInferenceService` ignored
the configured resources even though `ClusterStorageContainer` honored them.

This change templates all four storage initializer resource fields from the
shared Helm values and regenerates the common patches for both resource charts.

**Which issue(s) this PR fixes**:

Fixes #5412

**Feature/Issue validation/testing**:

- [x] Ran `make precommit` successfully.
- [x] Rendered both `kserve-resources` and `kserve-llmisvc-resources` with
  non-default CPU and memory values and verified the `storageInitializer` JSON
  contains the configured values.

**Special notes for your reviewer**:

None.

**Checklist**:

- [x] Verified the fix by rendering both affected Helm charts.
- [x] No code comments are needed for these direct value mappings.
- [x] Existing chart value documentation already covers
  `kserve.storage.resources`; no website update is needed.

**Release note**:

```release-note
The storage initializer in `inferenceservice-config` now honors the
`kserve.storage.resources` Helm values.
```
