### PR TITLE
fix(e2e): remove duplicate body field in ResponseRecord

### DIFF
--- a/test/e2e/llmisvc/traffic/_report.py
+++ b/test/e2e/llmisvc/traffic/_report.py
@@ -18,7 +18,6 @@ class ResponseRecord:
     headers: Dict[str, str] = field(default_factory=dict)  # lowercased keys
     error: Optional[str] = None
     body: Optional[str] = None  # response body for non-2xx (truncated to 512 chars)
-    body: Optional[str] = None  # response body for non-2xx (truncated to 512 chars)
 
     @property
     def is_success(self) -> bool:


### PR DESCRIPTION
**What this PR does / why we need it**:

`ResponseRecord` in `test/e2e/llmisvc/traffic/_report.py` has `body` declared twice. Python dataclasses silently accept this (last definition wins), but it's clearly a copy-paste artifact.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Feature/Issue validation/testing**:

- [x] One-line deletion, no behavior change

**Special notes for your reviewer**:

Spotted during review of #5849.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```