### PR TITLE
fix(inferencegraph): propagate annotations to knative service

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -993,6 +993,147 @@ var _ = Describe("Inference Graph controller test", func() {
 		})
 	})
 
+	Context("When creating an inferencegraph in Knative deployment mode with custom annotations", func() {
+		It("Should propagate custom annotations to the knative service metadata as well as the revision template", func() {
+			By("By creating a new InferenceGraph")
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			graphName := "igknativeannotations1"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: graphName, Namespace: "default"}}
+			serviceKey := expectedRequest.NamespacedName
+			ctx := context.Background()
+			customAnnotationKey := "custom.annotation/hostname"
+			ig := &v1alpha1.InferenceGraph{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": string(constants.Knative),
+						customAnnotationKey:                "test-hostname",
+						// Annotations on the ServiceAnnotationDisallowedList must not leak onto the
+						// knative service metadata, even though they are still honored on the revision
+						// template (pod) annotations.
+						autoscaling.MaxScaleAnnotationKey: "5",
+					},
+				},
+				Spec: v1alpha1.InferenceGraphSpec{
+					Nodes: map[string]v1alpha1.InferenceRouter{
+						v1alpha1.GraphRootNodeName: {
+							RouterType: v1alpha1.Sequence,
+							Steps: []v1alpha1.InferenceStep{
+								{
+									InferenceTarget: v1alpha1.InferenceTarget{
+										ServiceURL: "http://someservice.example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ig)).Should(Succeed())
+			defer k8sClient.Delete(ctx, ig)
+
+			actualService := &knservingv1.Service{}
+			Eventually(func() error {
+				return k8sClient.Get(context.TODO(), serviceKey, actualService)
+			}, timeout, interval).Should(Succeed())
+
+			// The custom annotation reaches the knative service's top-level metadata (so it can be
+			// picked up by tools such as external-dns off the resulting Route/VirtualService) ...
+			Expect(actualService.Annotations).To(HaveKeyWithValue(customAnnotationKey, "test-hostname"))
+			// ... and remains on the revision template (pod) annotations too, unchanged from today.
+			Expect(actualService.Spec.Template.Annotations).To(HaveKeyWithValue(customAnnotationKey, "test-hostname"))
+
+			// Disallowed-list annotations must not leak onto the service metadata.
+			Expect(actualService.Annotations).NotTo(HaveKey(autoscaling.MaxScaleAnnotationKey))
+			Expect(actualService.Spec.Template.Annotations).To(HaveKeyWithValue(autoscaling.MaxScaleAnnotationKey, "5"))
+
+			// The autoscaling class annotation knative injects a default for must not leak onto the
+			// service metadata either, which would happen if annotations were captured for passthrough
+			// after SetAutoScalingAnnotations mutated the map instead of before.
+			Expect(actualService.Annotations).NotTo(HaveKey(autoscaling.ClassAnnotationKey))
+		})
+
+		It("Should update the knative service metadata when a custom annotation is changed on an existing IG", func() {
+			By("By creating a new InferenceGraph")
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			graphName := "igknativeannotations2"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: graphName, Namespace: "default"}}
+			serviceKey := expectedRequest.NamespacedName
+			ctx := context.Background()
+			customAnnotationKey := "custom.annotation/hostname"
+			ig := &v1alpha1.InferenceGraph{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": string(constants.Knative),
+						customAnnotationKey:                "hostname-a",
+					},
+				},
+				Spec: v1alpha1.InferenceGraphSpec{
+					Nodes: map[string]v1alpha1.InferenceRouter{
+						v1alpha1.GraphRootNodeName: {
+							RouterType: v1alpha1.Sequence,
+							Steps: []v1alpha1.InferenceStep{
+								{
+									InferenceTarget: v1alpha1.InferenceTarget{
+										ServiceURL: "http://someservice.example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ig)).Should(Succeed())
+			defer k8sClient.Delete(ctx, ig)
+
+			actualService := &knservingv1.Service{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, serviceKey, actualService)
+			}, timeout, interval).Should(Succeed())
+			Eventually(func() map[string]string {
+				_ = k8sClient.Get(ctx, serviceKey, actualService)
+				return actualService.Annotations
+			}, timeout, interval).Should(HaveKeyWithValue(customAnnotationKey, "hostname-a"))
+
+			By("Updating the custom annotation on the InferenceGraph")
+			actualIG := &v1alpha1.InferenceGraph{}
+			Expect(k8sClient.Get(ctx, serviceKey, actualIG)).Should(Succeed())
+			updatedIG := actualIG.DeepCopy()
+			updatedIG.Annotations[customAnnotationKey] = "hostname-b"
+			Expect(k8sClient.Update(ctx, updatedIG)).NotTo(HaveOccurred())
+
+			// The updated value must reach the existing knative service's metadata -- this exercises
+			// semanticEquals/reconcileKsvc's annotation sync path on the update branch, not just the
+			// initial create.
+			Eventually(func() map[string]string {
+				_ = k8sClient.Get(ctx, serviceKey, actualService)
+				return actualService.Annotations
+			}, timeout, interval).Should(HaveKeyWithValue(customAnnotationKey, "hostname-b"))
+			Expect(actualService.Spec.Template.Annotations).To(HaveKeyWithValue(customAnnotationKey, "hostname-b"))
+		})
+	})
+
 	Context("When creating an InferenceGraph in Knative mode", func() {
 		It("Should fail if Knative Serving is not installed", func() {
 			// Simulate Knative Serving is absent by setting to false the relevant item in utils.gvResourcesCache variable

--- a/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
+++ b/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
@@ -85,6 +85,15 @@ func reconcileKsvc(desired *knservingv1.Service, existing *knservingv1.Service) 
 	existing.Spec.ConfigurationSpec = desired.Spec.ConfigurationSpec
 	existing.Labels = desired.Labels
 	existing.Spec.Traffic = desired.Spec.Traffic
+	// Sync the annotations KServe manages on the knative service metadata (e.g. the OpenShift passthrough
+	// key and user-provided passthrough annotations). Other keys already on existing (such as those
+	// stamped by knative's webhook or other controllers) are preserved.
+	if existing.Annotations == nil {
+		existing.Annotations = make(map[string]string, len(desired.Annotations))
+	}
+	for key, value := range desired.Annotations {
+		existing.Annotations[key] = value
+	}
 	return nil
 }
 
@@ -153,7 +162,21 @@ func (r *GraphKnativeServiceReconciler) Reconcile(ctx context.Context) (*knservi
 func semanticEquals(desiredService, service *knservingv1.Service) bool {
 	return equality.Semantic.DeepEqual(desiredService.Spec.ConfigurationSpec, service.Spec.ConfigurationSpec) &&
 		equality.Semantic.DeepEqual(desiredService.Labels, service.Labels) &&
-		equality.Semantic.DeepEqual(desiredService.Spec.RouteSpec, service.Spec.RouteSpec)
+		equality.Semantic.DeepEqual(desiredService.Spec.RouteSpec, service.Spec.RouteSpec) &&
+		annotationsSubsetEqual(desiredService.Annotations, service.Annotations)
+}
+
+// annotationsSubsetEqual returns true if every key/value pair in desired is present with the same value
+// in existing. Extra keys on existing (e.g. stamped by knative's webhook or other controllers) are
+// tolerated and not treated as a diff, mirroring how the InferenceService knative reconciler only
+// tracks the annotation keys it manages instead of doing a blanket comparison.
+func annotationsSubsetEqual(desired, existing map[string]string) bool {
+	for key, value := range desired {
+		if existingValue, ok := existing[key]; !ok || existingValue != value {
+			return false
+		}
+	}
+	return true
 }
 
 func createKnativeService(
@@ -170,6 +193,17 @@ func createKnativeService(
 		annotations = make(map[string]string)
 	}
 
+	// Determine which user-provided annotations should also be propagated to the knative service's
+	// top-level metadata.annotations (e.g. so tools like external-dns can read them off the resulting
+	// Route/VirtualService), mirroring the InferenceService knative reconciler's use of
+	// ServiceAnnotationDisallowedList. This must be computed from a fresh map (utils.Filter copies,
+	// it does not alias `annotations`) before SetAutoScalingAnnotations below mutates `annotations` in
+	// place -- otherwise the autoscaling.knative.dev/{class,target,metric} keys it injects would leak
+	// into the service metadata too, since they aren't part of the disallowed list.
+	passthroughAnnotations := utils.Filter(annotations, func(key string) bool {
+		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
+	})
+
 	knutils.SetAutoScalingAnnotations(
 		annotations,
 		graph.Spec.ScaleTarget,
@@ -185,6 +219,12 @@ func createKnativeService(
 	if value, ok := annotations[constants.KnativeOpenshiftEnablePassthroughKey]; ok {
 		ksvcAnnotations[constants.KnativeOpenshiftEnablePassthroughKey] = value
 		delete(annotations, constants.KnativeOpenshiftEnablePassthroughKey)
+	}
+
+	// Copy the remaining user annotations onto the knative service metadata. They are left in place on
+	// the revision template (pod) annotations as well, so this is additive and backwards compatible.
+	for key, value := range passthroughAnnotations {
+		ksvcAnnotations[key] = value
 	}
 
 	labels := utils.Filter(componentMeta.Labels, func(key string) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Custom annotations on an InferenceGraph were only copied to the Knative `Service`'s revision template (the pod), not to the `Service`'s own `metadata.annotations`. The one exception was the OpenShift `enablePassthrough` key.

Because of this, tools that read annotations off the resulting `Route`/`VirtualService` — such as `external-dns` reading a custom hostname — never saw the user's annotations.

This change filters the user annotations through the same `constants.ServiceAnnotationDisallowedList` the InferenceService reconciler uses, then copies the rest onto the `Service` metadata. The annotations stay on the revision template too, so nothing that worked before changes. The passthrough set is read before `SetAutoScalingAnnotations` runs, so the `autoscaling.knative.dev/*` keys it adds don't end up on the `Service` metadata. Both create and update are handled, so editing an annotation on an existing InferenceGraph updates the live `Service`. This matches how InferenceService already works.

**Which issue(s) this PR fixes**:
Fixes #3554


**Feature/Issue validation/testing**:

Added envtest specs to the InferenceGraph controller suite:

- [x] A custom annotation on the InferenceGraph reaches the `Service` `metadata.annotations` and stays on the revision template. A disallowed-list key (max-scale) stays on the revision template but does not reach the `Service` metadata, and neither does the autoscaling class key.
- [x] Editing a custom annotation on an existing InferenceGraph updates the live `Service` `metadata.annotations`.

- Logs

```
Will run 2 of 22 specs
Ran 2 of 22 Specs — 2 Passed | 0 Failed
```

`go build` and `go vet` on `./pkg/controller/v1alpha1/inferencegraph/...` pass.

**Special notes for your reviewer**:

The revision-template annotations are unchanged; this only adds a copy onto the `Service` metadata. The filter is the same one InferenceService uses.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? (No docs change needed.)

**Release note**:
```release-note
Fix InferenceGraph so user-provided annotations are propagated to the underlying Knative Service metadata, not only the revision template, so tools such as external-dns can read them.
```
