### PR TITLE
fix(aiffairness): handle missing outputs in AIFModel.explain()

### DIFF
--- a/python/aiffairness/aifserver/model.py
+++ b/python/aiffairness/aifserver/model.py
@@ -59,7 +59,14 @@ class AIFModel(kserve.Model):
 
     def explain(self, payload: Dict, headers: Dict[str, str] = None) -> Dict:
         inputs = payload["instances"]
-        predictions = np.array(payload["outputs"])
+        # An explain request may omit "outputs": in that case the model is
+        # responsible for producing the predictions itself, rather than
+        # crashing with a KeyError. Fall back to running prediction on the
+        # provided instances.
+        if "outputs" in payload:
+            predictions = np.array(payload["outputs"])
+        else:
+            predictions = self._predict(inputs)
 
         dataframe_predicted = pd.DataFrame(inputs, columns=self.feature_names)
         dataframe_predicted[self.label_names[0]] = predictions

--- a/python/aiffairness/aifserver/test_model.py
+++ b/python/aiffairness/aifserver/test_model.py
@@ -1,0 +1,70 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for AIFModel.explain().
+
+aif360/kserve/nest_asyncio are replaced with lightweight stand-ins in
+conftest.py, so these tests exercise AIFModel's own request handling
+(specifically the "outputs" fallback) rather than the aif360 metric math.
+"""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from aifserver.model import AIFModel
+
+INSTANCES = [[25, 50000], [40, 80000], [30, 60000], [35, 70000]]
+
+
+def _make_model():
+    return AIFModel(
+        name="test",
+        feature_names=["age", "income"],
+        label_names=["label"],
+        favorable_label=1.0,
+        unfavorable_label=0.0,
+        privileged_groups=[{"age": 1}],
+        unprivileged_groups=[{"age": 0}],
+    )
+
+
+def test_explain_missing_outputs_falls_back_to_predict():
+    """explain() must not raise KeyError when "outputs" is absent (issue #5850)."""
+    model = _make_model()
+    with mock.patch.object(
+        model, "_predict", return_value=np.array([1, 0, 1, 0])
+    ) as mocked_predict:
+        result = model.explain({"instances": INSTANCES})
+
+    mocked_predict.assert_called_once_with(INSTANCES)
+    assert result["predictions"] == [1, 0, 1, 0]
+
+
+def test_explain_uses_provided_outputs_without_predicting():
+    """When "outputs" is present it is used directly; no prediction is run."""
+    model = _make_model()
+    with mock.patch.object(model, "_predict") as mocked_predict:
+        result = model.explain({"instances": INSTANCES, "outputs": [1, 0, 1, 0]})
+
+    mocked_predict.assert_not_called()
+    assert result["predictions"] == [1, 0, 1, 0]
+
+
+def test_explain_requires_instances():
+    """A payload without "instances" is still a hard error."""
+    model = _make_model()
+    with pytest.raises(KeyError):
+        model.explain({"outputs": [1, 0, 1, 0]})

--- a/python/aiffairness/conftest.py
+++ b/python/aiffairness/conftest.py
@@ -1,0 +1,50 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test setup for the aifserver package.
+
+model.py imports aif360, kserve and nest_asyncio at module load. Those are heavy
+runtime dependencies; the unit tests only exercise AIFModel's own request
+handling, so we install lightweight stand-ins here (before the package is
+imported during collection) to keep the tests hermetic and fast.
+"""
+
+import sys
+import types
+from unittest import mock
+
+# kserve.Model must be a real class because AIFModel subclasses it.
+_kserve = types.ModuleType("kserve")
+
+
+class _Model:
+    def __init__(self, name):
+        self.name = name
+
+
+_kserve.Model = _Model
+sys.modules.setdefault("kserve", _kserve)
+
+_nest_asyncio = types.ModuleType("nest_asyncio")
+_nest_asyncio.apply = lambda: None
+sys.modules.setdefault("nest_asyncio", _nest_asyncio)
+
+# aif360 pieces are constructed but never asserted on in these tests.
+_metrics = types.ModuleType("aif360.metrics")
+_metrics.BinaryLabelDatasetMetric = mock.MagicMock(name="BinaryLabelDatasetMetric")
+_datasets = types.ModuleType("aif360.datasets")
+_datasets.BinaryLabelDataset = mock.MagicMock(name="BinaryLabelDataset")
+sys.modules.setdefault("aif360", types.ModuleType("aif360"))
+sys.modules.setdefault("aif360.metrics", _metrics)
+sys.modules.setdefault("aif360.datasets", _datasets)


### PR DESCRIPTION
**What this PR does / why we need it**:

`AIFModel.explain()` read `payload["outputs"]` directly, so an explain request that omitted `"outputs"` crashed with `KeyError: 'outputs'` instead of being handled. An explain request carries the input instances and the model is responsible for producing predictions, so this falls back to the existing (previously unused) `_predict()` helper when `"outputs"` is absent. A provided `"outputs"` is still used as-is, so existing behaviour is unchanged.

**Which issue(s) this PR fixes**:
Fixes #5850

**Feature/Issue validation/testing**:

Added `python/aiffairness/aifserver/test_model.py` with unit tests for both branches. The heavy `aif360` / `kserve` / `nest_asyncio` imports are stubbed in a new `conftest.py`, so the tests exercise `AIFModel`'s own request handling without pulling in those runtime dependencies.

- [x] `test_explain_missing_outputs_falls_back_to_predict` — reproduces the issue: fails with `KeyError` on the current code, passes with the fix.
- [x] `test_explain_uses_provided_outputs_without_predicting` — a supplied `"outputs"` is used and no prediction is run.
- [x] `test_explain_requires_instances` — a payload without `"instances"` is still a hard error.

- Logs

```
$ pytest aifserver/test_model.py -v
aifserver/test_model.py::test_explain_missing_outputs_falls_back_to_predict PASSED
aifserver/test_model.py::test_explain_uses_provided_outputs_without_predicting PASSED
aifserver/test_model.py::test_explain_requires_instances PASSED
3 passed
```

**Special notes for your reviewer**:

The `_predict()` helper already existed on `AIFModel` but was unused; this wires it into the missing-`outputs` path, which matches option 1 in the issue ("generate predictions internally"). Happy to switch to a hard validation error instead if maintainers prefer that direction.

**Checklist**:

- [x] Run `black` on the changed Python files.
