### PR TITLE
fix(helm): honour explicit enabled: false on shared resource toggles

### DIFF
--- a/charts/_common/_utils.tpl
+++ b/charts/_common/_utils.tpl
@@ -107,6 +107,30 @@ Items in base without matching patch are preserved
 {{- end }}
 
 {{/*
+Resolve a per-feature "enabled" toggle with a global fallback.
+
+When the user explicitly sets .enabled to a boolean (true / false),
+that value is honoured.  When it is left at the default empty string,
+the fallback value (typically .Values.kserve.createSharedResources)
+is used instead.
+
+The built-in Sprig `default` function treats Go zero-values (including
+the boolean false) as "empty" and substitutes the fallback, which makes
+it impossible to disable a feature via `enabled: false`.  This helper
+avoids that pitfall by checking `kindIs "bool"` first.
+
+Usage:
+  {{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.storagecontainer.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
+*/}}
+{{- define "kserve-common.featureEnabled" -}}
+{{- if kindIs "bool" .enabled -}}
+  {{- .enabled -}}
+{{- else -}}
+  {{- .fallback -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Safe namespace replacement - only replaces exact "namespace: kserve" pattern
 */}}
 {{- define "kserve-common.replaceNamespace" -}}

--- a/charts/kserve-llmisvc-resources/templates/_utils.tpl
+++ b/charts/kserve-llmisvc-resources/templates/_utils.tpl
@@ -107,6 +107,30 @@ Items in base without matching patch are preserved
 {{- end }}
 
 {{/*
+Resolve a per-feature "enabled" toggle with a global fallback.
+
+When the user explicitly sets .enabled to a boolean (true / false),
+that value is honoured.  When it is left at the default empty string,
+the fallback value (typically .Values.kserve.createSharedResources)
+is used instead.
+
+The built-in Sprig `default` function treats Go zero-values (including
+the boolean false) as "empty" and substitutes the fallback, which makes
+it impossible to disable a feature via `enabled: false`.  This helper
+avoids that pitfall by checking `kindIs "bool"` first.
+
+Usage:
+  {{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.storagecontainer.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
+*/}}
+{{- define "kserve-common.featureEnabled" -}}
+{{- if kindIs "bool" .enabled -}}
+  {{- .enabled -}}
+{{- else -}}
+  {{- .fallback -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Safe namespace replacement - only replaces exact "namespace: kserve" pattern
 */}}
 {{- define "kserve-common.replaceNamespace" -}}

--- a/charts/kserve-llmisvc-resources/templates/common/certmanager.yaml
+++ b/charts/kserve-llmisvc-resources/templates/common/certmanager.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kserve.certManager.enabled | default .Values.kserve.createSharedResources }}
+{{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.certManager.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
 {{- include "kserve-common.renderSimpleResource" (dict
   "baseFile" "files/common/certmanager.yaml"
   "replaceNamespace" true

--- a/charts/kserve-llmisvc-resources/templates/common/clusterstoragecontainer.yaml
+++ b/charts/kserve-llmisvc-resources/templates/common/clusterstoragecontainer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kserve.storagecontainer.enabled | default .Values.kserve.createSharedResources }}
+{{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.storagecontainer.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
 {{- include "kserve-common.renderPatchedResource" (dict
   "baseFile" "files/common/storagecontainer.yaml"
   "patchFile" "files/common/storagecontainer-patch.yaml"

--- a/charts/kserve-llmisvc-resources/templates/common/configmap.yaml
+++ b/charts/kserve-llmisvc-resources/templates/common/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kserve.inferenceServiceConfig.enabled | default .Values.kserve.createSharedResources }}
+{{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.inferenceServiceConfig.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
 {{- include "kserve-common.renderPatchedResource" (dict
   "baseFile" "files/common/configmap.yaml"
   "patchFile" "files/common/configmap-patch.yaml"

--- a/charts/kserve-localmodel-resources/templates/_utils.tpl
+++ b/charts/kserve-localmodel-resources/templates/_utils.tpl
@@ -107,6 +107,30 @@ Items in base without matching patch are preserved
 {{- end }}
 
 {{/*
+Resolve a per-feature "enabled" toggle with a global fallback.
+
+When the user explicitly sets .enabled to a boolean (true / false),
+that value is honoured.  When it is left at the default empty string,
+the fallback value (typically .Values.kserve.createSharedResources)
+is used instead.
+
+The built-in Sprig `default` function treats Go zero-values (including
+the boolean false) as "empty" and substitutes the fallback, which makes
+it impossible to disable a feature via `enabled: false`.  This helper
+avoids that pitfall by checking `kindIs "bool"` first.
+
+Usage:
+  {{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.storagecontainer.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
+*/}}
+{{- define "kserve-common.featureEnabled" -}}
+{{- if kindIs "bool" .enabled -}}
+  {{- .enabled -}}
+{{- else -}}
+  {{- .fallback -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Safe namespace replacement - only replaces exact "namespace: kserve" pattern
 */}}
 {{- define "kserve-common.replaceNamespace" -}}

--- a/charts/kserve-resources/templates/_utils.tpl
+++ b/charts/kserve-resources/templates/_utils.tpl
@@ -107,6 +107,30 @@ Items in base without matching patch are preserved
 {{- end }}
 
 {{/*
+Resolve a per-feature "enabled" toggle with a global fallback.
+
+When the user explicitly sets .enabled to a boolean (true / false),
+that value is honoured.  When it is left at the default empty string,
+the fallback value (typically .Values.kserve.createSharedResources)
+is used instead.
+
+The built-in Sprig `default` function treats Go zero-values (including
+the boolean false) as "empty" and substitutes the fallback, which makes
+it impossible to disable a feature via `enabled: false`.  This helper
+avoids that pitfall by checking `kindIs "bool"` first.
+
+Usage:
+  {{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.storagecontainer.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
+*/}}
+{{- define "kserve-common.featureEnabled" -}}
+{{- if kindIs "bool" .enabled -}}
+  {{- .enabled -}}
+{{- else -}}
+  {{- .fallback -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Safe namespace replacement - only replaces exact "namespace: kserve" pattern
 */}}
 {{- define "kserve-common.replaceNamespace" -}}

--- a/charts/kserve-resources/templates/common/certmanager.yaml
+++ b/charts/kserve-resources/templates/common/certmanager.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kserve.certManager.enabled | default .Values.kserve.createSharedResources }}
+{{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.certManager.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
 {{- include "kserve-common.renderSimpleResource" (dict
   "baseFile" "files/common/certmanager.yaml"
   "replaceNamespace" true

--- a/charts/kserve-resources/templates/common/clusterstoragecontainer.yaml
+++ b/charts/kserve-resources/templates/common/clusterstoragecontainer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kserve.storagecontainer.enabled | default .Values.kserve.createSharedResources }}
+{{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.storagecontainer.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
 {{- include "kserve-common.renderPatchedResource" (dict
   "baseFile" "files/common/storagecontainer.yaml"
   "patchFile" "files/common/storagecontainer-patch.yaml"

--- a/charts/kserve-resources/templates/common/configmap.yaml
+++ b/charts/kserve-resources/templates/common/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kserve.inferenceServiceConfig.enabled | default .Values.kserve.createSharedResources }}
+{{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.inferenceServiceConfig.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
 {{- include "kserve-common.renderPatchedResource" (dict
   "baseFile" "files/common/configmap.yaml"
   "patchFile" "files/common/configmap-patch.yaml"

--- a/charts/kserve-runtime-configs/templates/_utils.tpl
+++ b/charts/kserve-runtime-configs/templates/_utils.tpl
@@ -107,6 +107,30 @@ Items in base without matching patch are preserved
 {{- end }}
 
 {{/*
+Resolve a per-feature "enabled" toggle with a global fallback.
+
+When the user explicitly sets .enabled to a boolean (true / false),
+that value is honoured.  When it is left at the default empty string,
+the fallback value (typically .Values.kserve.createSharedResources)
+is used instead.
+
+The built-in Sprig `default` function treats Go zero-values (including
+the boolean false) as "empty" and substitutes the fallback, which makes
+it impossible to disable a feature via `enabled: false`.  This helper
+avoids that pitfall by checking `kindIs "bool"` first.
+
+Usage:
+  {{- if eq (include "kserve-common.featureEnabled" (dict "enabled" .Values.kserve.storagecontainer.enabled "fallback" .Values.kserve.createSharedResources)) "true" }}
+*/}}
+{{- define "kserve-common.featureEnabled" -}}
+{{- if kindIs "bool" .enabled -}}
+  {{- .enabled -}}
+{{- else -}}
+  {{- .fallback -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Safe namespace replacement - only replaces exact "namespace: kserve" pattern
 */}}
 {{- define "kserve-common.replaceNamespace" -}}


### PR DESCRIPTION
## What this PR does

The Sprig `default` function treats Go zero-values (including the boolean `false`) as "empty" and substitutes the fallback. This made it impossible to disable individual shared resources (`storagecontainer`, `certManager`, `inferenceServiceConfig`) via `enabled: false`, because the condition always fell through to `createSharedResources: true`.

For example, in `clusterstoragecontainer.yaml`:

```
{{- if .Values.kserve.storagecontainer.enabled | default .Values.kserve.createSharedResources }}
```

Setting `kserve.storagecontainer.enabled=false` should skip the `default` ClusterStorageContainer, but `false` is treated as empty by Sprig, so it falls through to `createSharedResources: true` — making it impossible to opt out.

## Fix

Add a `kserve-common.featureEnabled` helper template that uses `kindIs "bool"` to distinguish an explicit boolean value from the default empty string:

- **`enabled: false`** (bool) → skip the resource
- **`enabled: true`** (bool) → render the resource  
- **`enabled: ''`** (empty string, the default) → fall back to `createSharedResources`

Updated all six affected templates across `kserve-resources` and `kserve-llmisvc-resources` charts, plus the shared `_common/_utils.tpl` and per-chart `_utils.tpl` copies.

## Testing

Verified on a Kind cluster (K8s 1.34):

| Scenario | ClusterStorageContainer | Expected |
|----------|------------------------|----------|
| Default (`enabled: ''`) | Created | Created |
| `--set kserve.storagecontainer.enabled=false` | **Not created** | Not created |
| `--set kserve.storagecontainer.enabled=true` | Created | Created |

All three `helm lint` checks pass for `kserve-resources`, `kserve-llmisvc-resources`, and `kserve-localmodel-resources`.

Fixes #5868

/kind bug