### PR TITLE
test(llmisvc): remove IstioShadowService fixture from envtests

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_config_not_found_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_config_not_found_test.go
@@ -38,7 +38,7 @@ var _ = Describe("LLMInferenceService Config resolution", func() {
 		It("should set PresetsCombined=False with reason ConfigNotFound for a missing BaseRef", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-cfg-not-found"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -82,7 +82,7 @@ var _ = Describe("LLMInferenceService Config resolution", func() {
 		It("should recover PresetsCombined to True when the missing BaseRef config is created", func(ctx SpecContext) {
 			// given - a service pointing to a config that does not exist yet
 			svcName := "test-llm-cfg-not-found-recover"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 			configName := "recoverable-config"
 
 			llmSvc := LLMInferenceService(svcName,

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_kvcache_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_kvcache_test.go
@@ -38,7 +38,7 @@ var _ = Describe("LLMInferenceService Controller - KV Cache secondary tiers", fu
 		It("should inject an emptyDir volume for a secondary emptyDir tier", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-kvcache-emptydir"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("pvc://facebook-models/opt-125m")
 			Expect(err).ToNot(HaveOccurred())
@@ -106,7 +106,7 @@ var _ = Describe("LLMInferenceService Controller - KV Cache secondary tiers", fu
 		It("should inject an ephemeral PVC volume for a secondary pvc.spec tier", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-kvcache-pvc-spec"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("pvc://facebook-models/opt-125m")
 			Expect(err).ToNot(HaveOccurred())
@@ -183,7 +183,7 @@ var _ = Describe("LLMInferenceService Controller - KV Cache secondary tiers", fu
 		It("should inject a pre-existing PVC volume for a secondary pvc.ref tier", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-kvcache-pvc-ref"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("pvc://facebook-models/opt-125m")
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_migration_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_migration_test.go
@@ -40,7 +40,7 @@ var _ = Describe("InferencePool Migration", func() {
 		It("should create both v1 and v1alpha2 InferencePools when both CRDs are available", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-dual-pool"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -86,7 +86,7 @@ var _ = Describe("InferencePool Migration", func() {
 		It("should point HTTPRoute backendRef to v1alpha2 pool initially (before migration)", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-initial-backend"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -127,7 +127,7 @@ var _ = Describe("InferencePool Migration", func() {
 		It("should keep HTTPRoute pointing to v1 pool when migration annotation is already on HTTPRoute", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-pre-migrated"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Create LLMInferenceService (no annotation - migration state is on HTTPRoute)
 			llmSvc := LLMInferenceService(svcName,
@@ -201,7 +201,7 @@ var _ = Describe("InferencePool Migration", func() {
 		It("should swap HTTPRoute backendRef from v1alpha2 to v1 when Gateway rejects v1alpha2", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-gateway-rejection"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -263,7 +263,7 @@ var _ = Describe("InferencePool Migration", func() {
 		It("should not change migration annotation on HTTPRoute once set to v1", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-migration-lock"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Create LLMInferenceService
 			llmSvc := LLMInferenceService(svcName,

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_multi_node_test.go
@@ -47,7 +47,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create a basic multi-node deployment with worker spec", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -126,7 +126,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			func(ctx SpecContext, testName string, podSpec *corev1.PodSpec, extraAnnotations map[string]string, targetContainer string) {
 				// given
 				svcName := "test-llm-multinode-dra-" + testName
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				annotations := map[string]string{
 					constants.ManagedDRADeviceClassAnnotationKey: "gpu.nvidia.com",
@@ -236,7 +236,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create multi-node deployment with prefill workload", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-prefill"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -297,7 +297,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create multi-node deployment with prefill workload and managed DRA", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-mn-pd-dra"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -387,7 +387,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create RBAC resources when prefill and decode is used", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-rbac"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -467,7 +467,6 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// given
 			svcName := "test-llm-mn-ips"
 			testNs := NewTestNamespace(ctx, envTest,
-				WithIstioShadowService(svcName),
 				WithDefaultServiceAccountImagePullSecrets(
 					corev1.LocalObjectReference{Name: "my-registry-secret"},
 					corev1.LocalObjectReference{Name: "other-pull-secret"},
@@ -516,7 +515,6 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// given
 			svcName := "test-llm-mn-ips-prefill"
 			testNs := NewTestNamespace(ctx, envTest,
-				WithIstioShadowService(svcName),
 				WithDefaultServiceAccountImagePullSecrets(
 					corev1.LocalObjectReference{Name: "my-registry-secret"},
 				),
@@ -565,7 +563,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create multi-node SA with empty imagePullSecrets when default SA has none", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-mn-ips-empty"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -604,7 +602,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should delete multi-node resources when worker spec is removed", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-cleanup"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			parallelismSpec := ParallelismSpec(
 				WithDataParallelism(2),
@@ -669,7 +667,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should delete prefill resources when prefill spec is removed", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-prefill-cleanup"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -726,7 +724,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should set correct labels and annotation", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-lws-labels"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			localQueueName := "test-local-q"
 			preemptPriority := "0"
@@ -800,7 +798,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 
 		It("should not propagate model-based-routing annotation to LWS pod templates", func(ctx SpecContext) {
 			svcName := "test-llm-lws-no-mbr"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -840,7 +838,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should preserve externally set replicas when owner does not specify replicas", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-mn-preserve-replicas"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 			lwsName := types.NamespacedName{Name: svcName + "-kserve-mn", Namespace: testNs.Name}
 
 			// Create LLMInferenceService WITHOUT specifying replicas
@@ -911,7 +909,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should override externally set replicas when owner specifies replicas", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-mn-override-replicas"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 			lwsName := types.NamespacedName{Name: svcName + "-kserve-mn", Namespace: testNs.Name}
 
 			// Create LLMInferenceService WITH explicit replicas
@@ -983,7 +981,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 	Context("Readiness Event Emission", func() {
 		It("should emit a Warning LLMInferenceServiceNotReady Event with WorkerWorkloadReady when transitioning Ready to NotReady", func(ctx SpecContext) {
 			svcName := "test-llm-mn-event-notready"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_routing_status_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_routing_status_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Routing Status", func() {
 		It("populates status.router.gateways after reconcile", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-routing-status"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -80,7 +80,7 @@ var _ = Describe("Routing Status", func() {
 		It("sets status.router to nil when force-stop annotation is applied", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-routing-stop"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -129,7 +129,7 @@ var _ = Describe("Routing Status", func() {
 		It("leaves status.router nil when spec.router is nil", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-routing-nil"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -156,7 +156,7 @@ var _ = Describe("Routing Status", func() {
 		It("does not change status.router on consecutive reconciles with no spec change", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-routing-stable"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -208,7 +208,7 @@ var _ = Describe("Routing Status", func() {
 	Context("Status addresses contain model names", func() {
 		It("populates status.addresses[].models with the base model name", func(ctx SpecContext) {
 			svcName := "test-llm-addr-models"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			gwName := "addr-models-gw"
 			gw := Gateway(gwName,
@@ -260,7 +260,7 @@ var _ = Describe("Routing Status", func() {
 
 		It("includes LoRA adapter model names in status.addresses", func(ctx SpecContext) {
 			svcName := "test-llm-addr-lora"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			gwName := "addr-lora-gw"
 			gw := Gateway(gwName,

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -47,7 +47,7 @@ var _ = Describe("LLMInferenceService Scheduler Config", func() {
 		It("should use inline scheduler config in the scheduler deployment", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-inline-scheduler-config"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			customSchedulerConfig := `
 apiVersion: llm-d.ai/v1alpha1
@@ -138,7 +138,7 @@ schedulingProfiles:
 		It("should not override config when args already contain --config-text or --configFile", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-config-already-set"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Create scheduler template with existing --config-text
 			modelConfig := LLMInferenceServiceConfig("model-config",
@@ -215,7 +215,7 @@ schedulingProfiles:
 		It("should resolve scheduler config from ConfigMap ref and use it in deployment", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-configmap-ref-scheduler"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			configMapData := `
 apiVersion: llm-d.ai/v1alpha1
@@ -265,7 +265,7 @@ schedulingProfiles:
 		It("should use custom key from ConfigMap ref", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-configmap-custom-key"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			configMapData := `
 apiVersion: llm-d.ai/v1alpha1
@@ -315,7 +315,7 @@ schedulingProfiles:
 		It("should update scheduler deployment when referenced ConfigMap is updated", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-configmap-update"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			initialConfigData := `
 apiVersion: llm-d.ai/v1alpha1
@@ -403,7 +403,7 @@ schedulingProfiles:
 		It("should use default scheduler config when no config is specified (non-prefill)", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-default-scheduler-config"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -446,7 +446,7 @@ schedulingProfiles:
 		It("should use prefill/decode scheduler config when prefill is configured", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-prefill-scheduler-config"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -500,7 +500,7 @@ schedulingProfiles:
 		It("should resolve ConfigMap from system namespace when not found in service namespace", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-system-ns-configmap"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			systemConfigData := `
 apiVersion: llm-d.ai/v1alpha1
@@ -553,7 +553,7 @@ schedulingProfiles:
 		It("should report error when referenced ConfigMap does not exist", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-missing-configmap"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -586,7 +586,7 @@ schedulingProfiles:
 		It("should report error when ConfigMap is missing the referenced key", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-missing-key"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Create ConfigMap without the expected key
 			configMap := SchedulerConfigMapWithKey("scheduler-config-wrong-key", testNs.Name, "wrong-key", "some-config")
@@ -625,7 +625,7 @@ schedulingProfiles:
 		It("should inherit scheduler config from baseRef LLMInferenceServiceConfig", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-baseref-scheduler-config"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			schedulerConfigData := `
 apiVersion: llm-d.ai/v1alpha1
@@ -687,7 +687,7 @@ schedulingProfiles:
 		It("should inherit inline scheduler config from baseRef LLMInferenceServiceConfig", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-baseref-inline-config"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			inlineSchedulerConfig := `
 apiVersion: llm-d.ai/v1alpha1
@@ -758,7 +758,6 @@ schedulingProfiles:
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -802,7 +801,6 @@ schedulingProfiles:
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -846,7 +844,6 @@ schedulingProfiles:
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -890,7 +887,6 @@ schedulingProfiles:
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -975,7 +971,6 @@ schedulingProfiles:
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -1052,7 +1047,7 @@ schedulingProfiles:
 		It("should decompose precise-prefix-cache-scorer into 3-plugin pipeline with tokenizer URL", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-uds-tokenizer-inject"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			precisePrefixConfig := `
 apiVersion: llm-d.ai/v1alpha1
@@ -1119,7 +1114,7 @@ schedulingProfiles:
 		It("should strip legacy UDS tokenizer fields after decomposition", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-uds-tokenizer-override"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			//nolint:gosec // G101: not a credential, scheduler config YAML
 			configWithExistingTokenizer := `
@@ -1187,7 +1182,7 @@ schedulingProfiles:
 		It("should not inject tokenizersPoolConfig when no precise-prefix-cache-scorer plugin", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-uds-no-precise-prefix"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			configWithoutPrecisePrefix := `
 apiVersion: llm-d.ai/v1alpha1
@@ -1245,7 +1240,7 @@ schedulingProfiles:
 		It("should decompose precise-prefix-cache-scorer and preserve tokenProcessorConfig", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-tpc-migrate"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			oldFormatConfig := `
 apiVersion: llm-d.ai/v1alpha1
@@ -1314,7 +1309,7 @@ schedulingProfiles:
 		It("should decompose precise-prefix-cache-scorer even with top-level tokenProcessorConfig", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-tpc-no-overwrite"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			newFormatConfig := `
 apiVersion: llm-d.ai/v1alpha1
@@ -1385,7 +1380,7 @@ schedulingProfiles:
 		It("should propagate annotations and imagePullSecrets from main workload SA to generated scheduler SA", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-sa-propagation"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Create a main workload SA with annotations and imagePullSecrets
 			mainSA := &corev1.ServiceAccount{
@@ -1449,7 +1444,7 @@ schedulingProfiles:
 		It("should not add extra credentials when no main workload SA is specified", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-sa-no-propagation"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1483,7 +1478,7 @@ schedulingProfiles:
 		It("should update scheduler SA when main workload SA credentials change", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-sa-update"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Create a main workload SA with initial annotations
 			mainSA := &corev1.ServiceAccount{
@@ -1582,7 +1577,7 @@ schedulingProfiles:
 	Context("v0.9.0 prefix-cache-scorer parameter removal", func() {
 		It("should remove all parameters except prefixMatchInfoProducerName from prefix-cache-scorer", func(ctx SpecContext) {
 			svcName := "test-llm-pcs-param-removal"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			configWithPrefixCacheParams := `
 apiVersion: llm-d.ai/v1alpha1
@@ -1638,7 +1633,7 @@ schedulingProfiles:
 
 		It("should remove parameters entirely when no prefixMatchInfoProducerName is present", func(ctx SpecContext) {
 			svcName := "test-llm-pcs-param-all-removed"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			configWithOnlyDeprecatedParams := `
 apiVersion: llm-d.ai/v1alpha1
@@ -1694,7 +1689,7 @@ schedulingProfiles:
 
 		It("should not touch prefix-cache-scorer without parameters", func(ctx SpecContext) {
 			svcName := "test-llm-pcs-no-params"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			configWithNoParams := `
 apiVersion: llm-d.ai/v1alpha1
@@ -1752,7 +1747,7 @@ schedulingProfiles:
 			// 2. AMD instance with no router uses spec.labels to match the NVIDIA InferencePool selector
 			nvidiaSvcName := "test-llm-nvidia"
 			amdSvcName := "test-llm-amd"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(nvidiaSvcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Create NVIDIA instance with default scheduler
 			nvidiaLLMSvc := LLMInferenceService(nvidiaSvcName,
@@ -1845,7 +1840,7 @@ schedulingProfiles:
 
 		It("should not override explicitly set EPP port", func(ctx SpecContext) {
 			svcName := "test-llm-port-explicit"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			schedulerCfg := LLMInferenceServiceConfig("kserve-config-llm-scheduler",
 				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stale_pool_parent_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stale_pool_parent_test.go
@@ -36,7 +36,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 	Context("Stale InferencePool parent handling", func() {
 		It("should recover readiness after switching from a custom gateway to the default", func(ctx SpecContext) {
 			svcName := "test-stale-pool-parent"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_status_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_status_test.go
@@ -41,7 +41,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should populate status.appliedConfigs with well-known and explicit configs", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-applied-configs"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -107,7 +107,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should preserve pinned config annotations across reconciliations", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-pinning-stable"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -170,7 +170,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			// stable when a config deletion is requested but blocked.
 			// given
 			svcName := "test-llm-applied-cleared"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_stop_test.go
@@ -52,7 +52,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -163,7 +162,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -222,7 +220,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -359,7 +356,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -445,7 +441,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 				InNamespace[*v1alpha2.LLMInferenceService](nsName),
 				WithModelURI("hf://facebook/opt-125m"),
 			)
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName+"-1", nsName))).To(Succeed())
 			Expect(envTest.Create(ctx, llmSvc1)).To(Succeed())
 			defer func() {
 				Expect(envTest.Delete(ctx, llmSvc1)).To(Succeed())
@@ -456,7 +451,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 				InNamespace[*v1alpha2.LLMInferenceService](nsName),
 				WithModelURI("hf://facebook/opt-125m"),
 			)
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName+"-2", nsName))).To(Succeed())
 			Expect(envTest.Create(ctx, llmSvc2)).To(Succeed())
 			defer func() {
 				Expect(envTest.Delete(ctx, llmSvc2)).To(Succeed())
@@ -522,7 +516,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -606,7 +599,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -699,7 +691,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -794,7 +785,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -896,7 +886,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -989,7 +978,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -1108,7 +1096,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -1187,7 +1174,6 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			}
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -61,7 +61,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should create a basic single node deployment with just base refs", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelConfig := LLMInferenceServiceConfig("model-fb-opt-125m",
 				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
@@ -222,7 +222,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			func(ctx SpecContext, testName string, containers []corev1.Container, extraAnnotations map[string]string, targetContainer string) {
 				// given
 				svcName := "test-llm-dra-" + testName
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				modelConfig := LLMInferenceServiceConfig("model-fb-opt-125m",
 					InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
@@ -350,7 +350,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should clean up the ResourceClaimTemplate when managed DRA is disabled", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-dra-cleanup"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelConfig := LLMInferenceServiceConfig("model-fb-opt-125m",
 				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
@@ -418,7 +418,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should preserve pinned config annotations across reconciliations", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-pinning-stable"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -478,7 +478,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should propagate kueue labels and annotations to the deployment", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-kueue"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			localQueueName := "test-local-q"
 			preemptPriority := "0"
@@ -539,7 +539,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 		It("should not propagate model-based-routing annotation to pod template", func(ctx SpecContext) {
 			svcName := "test-llm-no-mbr-anno"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -568,7 +568,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should preserve externally set replicas when owner does not specify replicas", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-preserve-replicas"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 			deploymentName := types.NamespacedName{Name: svcName + "-kserve", Namespace: testNs.Name}
 
 			// Create LLMInferenceService WITHOUT specifying replicas
@@ -634,7 +634,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should override externally set replicas when owner specifies replicas", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-override-replicas"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 			deploymentName := types.NamespacedName{Name: svcName + "-kserve", Namespace: testNs.Name}
 
 			// Create LLMInferenceService WITH explicit replicas
@@ -703,7 +703,6 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			// given
 			svcName := "test-llm-ips-singlenode"
 			testNs := NewTestNamespace(ctx, envTest,
-				WithIstioShadowService(svcName),
 				WithDefaultServiceAccountImagePullSecrets(
 					corev1.LocalObjectReference{Name: "my-registry-secret"},
 					corev1.LocalObjectReference{Name: "other-pull-secret"},
@@ -752,7 +751,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should create single-node SA with empty imagePullSecrets when default SA has none", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-ips-sn-empty"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -795,7 +794,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create routes pointing to the default gateway when both are managed", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-create-http-route"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				llmSvc := LLMInferenceService(svcName,
 					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -871,7 +870,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should use referenced external InferencePool", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-create-http-route-inf-pool-ref"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				infPoolName := kmeta.ChildName(svcName, "-my-inf-pool")
 
@@ -928,7 +927,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should refresh InferencePoolReady when referenced external InferencePool status changes", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-inf-pool-ref-status-watch"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				infPoolName := kmeta.ChildName(svcName, "-my-inf-pool")
 
@@ -984,7 +983,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create routes pointing to workload service when no scheduler is configured", func(ctx SpecContext) {
 				// given
 				llmSvcName := "test-llm-create-http-route-no-scheduler"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(llmSvcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				llmSvc := LLMInferenceService(llmSvcName,
 					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1043,7 +1042,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create HTTPRoute with defined spec", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-defined-http-route"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				llmSvc := LLMInferenceService(svcName,
 					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1088,7 +1087,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should delete managed HTTPRoute when ref is defined", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-update-http-route"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				// Create the Gateway that the router-managed preset references
 				gateway := Gateway("my-ingress-gateway",
@@ -1166,7 +1165,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should evaluate HTTPRoute readiness conditions", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-httproute-conditions"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				ingressGateway := DefaultGateway(testNs.Name)
 				Expect(envTest.Client.Create(ctx, ingressGateway)).To(Succeed())
@@ -1221,7 +1220,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should expand HTTPRoute with LoRA adapter header matches", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-lora-routing"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				llmSvc := LLMInferenceService(svcName,
 					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1266,7 +1265,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				func(ctx SpecContext, testName string, initialRouterSpec *v1alpha2.RouterSpec, specMutation func(*v1alpha2.LLMInferenceService)) {
 					// given
 					svcName := "test-llm-" + testName
-					testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+					testNs := NewTestNamespace(ctx, envTest)
 
 					llmSvc := LLMInferenceService(svcName,
 						InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1374,7 +1373,6 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				},
 			}
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
 				envTest.DeleteAll(ctx, namespace)
 			}()
@@ -1442,7 +1440,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should propagate SectionName to managed HTTPRoute ParentRef", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-section-name"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			gatewayName := "my-sectioned-gateway"
 			listenerName := "https"
@@ -1506,7 +1504,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should not set SectionName on managed HTTPRoute ParentRef when unspecified", func(ctx SpecContext) {
 			// given - backward compatibility: no SectionName means ParentRef.SectionName is nil
 			svcName := "test-llm-no-section"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			gatewayName := "my-plain-gateway"
 			gateway := Gateway(gatewayName,
@@ -1894,7 +1892,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should clear SchedulerWorkloadReady condition when scheduler is no longer configured", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-stale-scheduler-condition"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 
 				// Create LLMInferenceService with scheduler
 				llmSvc := LLMInferenceService(svcName,
@@ -1951,7 +1949,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should update InferencePoolReady when the referenced pool becomes ready", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-stale-inferencepool-condition"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+				testNs := NewTestNamespace(ctx, envTest)
 				infPoolName := kmeta.ChildName(svcName, "-my-inf-pool")
 
 				infPool := InferencePool(infPoolName,
@@ -2017,7 +2015,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 	Context("Readiness Event Emission", func() {
 		It("should emit a Normal LLMInferenceServiceReady Event when transitioning NotReady to Ready", func(ctx SpecContext) {
 			svcName := "test-llm-event-ready"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -2047,7 +2045,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 		It("should emit a Warning LLMInferenceServiceNotReady Event with MainWorkloadReady when transitioning Ready to NotReady", func(ctx SpecContext) {
 			svcName := "test-llm-event-notready"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -2086,7 +2084,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 		It("should not emit a readiness Event when status is unchanged", func(ctx SpecContext) {
 			svcName := "test-llm-event-noop"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_tls_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_tls_test.go
@@ -35,7 +35,7 @@ var _ = Describe("LLMInferenceService TLS Toggle", func() {
 	Context("When enableLLMInferenceServiceTLS is false in ConfigMap", func() {
 		It("should keep cert secret and should use HTTP port name", func(ctx SpecContext) {
 			svcName := "test-llm-tls-off"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Patch the global ConfigMap to disable TLS
 			cfgMap := &corev1.ConfigMap{}

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_tokenizer_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_tokenizer_test.go
@@ -41,7 +41,7 @@ var _ = Describe("LLMInferenceService Controller — Standalone Tokenizer", func
 	Context("When standalone tokenizer should be deployed", func() {
 		It("should create tokenizer Deployment and Service from well-known config", func(ctx SpecContext) {
 			svcName := "test-llm-tokenizer-explicit"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -91,7 +91,7 @@ var _ = Describe("LLMInferenceService Controller — Standalone Tokenizer", func
 
 		It("should deploy tokenizer when token-producer plugin is in inline config", func(ctx SpecContext) {
 			svcName := "test-llm-tok-3plugin"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -176,7 +176,7 @@ schedulingProfiles:
 
 		It("should report TokenizerReady status condition", func(ctx SpecContext) {
 			svcName := "test-llm-tok-status"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -205,7 +205,7 @@ schedulingProfiles:
 	Context("When tokenizer is not configured", func() {
 		It("should not create tokenizer resources", func(ctx SpecContext) {
 			svcName := "test-llm-no-tokenizer"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -245,7 +245,7 @@ schedulingProfiles:
 	Context("Legacy migration — precise-prefix-cache-scorer triggers tokenizer", func() {
 		It("should create tokenizer Deployment when precise-prefix-cache-scorer is in inline config", func(ctx SpecContext) {
 			svcName := "test-llm-tok-legacy"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			legacyConfig := `
 apiVersion: inference.networking.x-k8s.io/v1alpha1
@@ -312,7 +312,7 @@ schedulingProfiles:
 	Context("Tokenizer cleanup on spec change", func() {
 		It("should delete tokenizer resources when tokenizer field is removed from spec", func(ctx SpecContext) {
 			svcName := "test-llm-tok-cleanup"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -384,7 +384,7 @@ schedulingProfiles:
 
 		It("should delete tokenizer resources when token-producer plugin is removed from inline config", func(ctx SpecContext) {
 			svcName := "test-llm-tok-cleanup-plugin"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -479,7 +479,7 @@ schedulingProfiles:
 	Context("ForceStop handling", func() {
 		It("should set TokenizerReady to False with reason Stopped when force-stop is applied", func(ctx SpecContext) {
 			svcName := "test-llm-tok-forcestop"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -550,7 +550,7 @@ schedulingProfiles:
 	Context("External InferencePool ref", func() {
 		It("should not create tokenizer when scheduler has external pool ref", func(ctx SpecContext) {
 			svcName := "test-llm-tok-extpool"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/controller_latency_predictor_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_latency_predictor_int_test.go
@@ -34,7 +34,7 @@ var _ = Describe("LLMInferenceService Controller — Latency Predictor", func() 
 	Context("When predicted-latency-producer plugin is in the scheduler config", func() {
 		It("should inject training and prediction sidecar containers into the scheduler deployment", func(ctx SpecContext) {
 			svcName := "test-llm-lp-sidecars"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -76,7 +76,7 @@ var _ = Describe("LLMInferenceService Controller — Latency Predictor", func() 
 	Context("When predicted-latency-producer plugin is NOT in the scheduler config", func() {
 		It("should not inject sidecar containers", func(ctx SpecContext) {
 			svcName := "test-llm-no-lp"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Model Based Routing", func() {
 	Context("Default mode (enabled)", func() {
 		It("should include both path-based and model-routing rules", func(ctx SpecContext) {
 			svcName := "test-mbr-default"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := createModelRoutingTestService(ctx, svcName, testNs)
 			defer func() {
@@ -157,7 +157,7 @@ var _ = Describe("Model Based Routing", func() {
 			DeferCleanup(restoreIngressModelBasedRoutingMode)
 
 			svcName := "test-mbr-config-update"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := createModelRoutingTestService(ctx, svcName, testNs)
 			defer func() {
@@ -188,7 +188,7 @@ var _ = Describe("Model Based Routing", func() {
 			DeferCleanup(restoreIngressModelBasedRoutingMode)
 
 			svcName := "test-mbr-disabled"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := createModelRoutingTestService(ctx, svcName, testNs)
 			defer func() {
@@ -219,7 +219,7 @@ var _ = Describe("Model Based Routing", func() {
 			DeferCleanup(restoreIngressModelBasedRoutingMode)
 
 			svcName := "test-mbr-forced"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			customGatewayName := "mbr-forced-gw"
 			customGateway := Gateway(customGatewayName,
@@ -266,7 +266,7 @@ var _ = Describe("Model Based Routing", func() {
 	Context("Enabled with Gateway opt-out annotation", func() {
 		It("should strip model-routing rules when Gateway opts out", func(ctx SpecContext) {
 			svcName := "test-mbr-gw-optout"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			customGatewayName := "mbr-optout-gw"
 			customGateway := Gateway(customGatewayName,
@@ -313,7 +313,7 @@ var _ = Describe("Model Based Routing", func() {
 	Context("Disabled via explicit Spec annotation override", func() {
 		It("should strip model-routing rules when Spec.Annotations overrides the annotation to false", func(ctx SpecContext) {
 			svcName := "test-mbr-no-annotation"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/controller_workload_storage_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_workload_storage_int_test.go
@@ -69,7 +69,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should configure direct PVC mount when model uri starts with pvc://", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-pvc"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("pvc://facebook-models/opt-125m")
 			Expect(err).ToNot(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should configure a modelcar when model uri starts with oci://", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-oci"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("oci://registry.io/user-id/repo-id:tag")
 			Expect(err).ToNot(HaveOccurred())
@@ -1051,7 +1051,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should NOT create storage-initializer when explicitly disabled for s3:// URI", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-s3-disabled"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("s3://user-id/repo-id:tag")
 			Expect(err).ToNot(HaveOccurred())
@@ -1110,7 +1110,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should NOT create storage-initializer when explicitly disabled for hf:// URI", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-hf-disabled"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("hf://meta-llama/Llama-3.2-1B-Instruct")
 			Expect(err).ToNot(HaveOccurred())
@@ -1169,7 +1169,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should NOT configure PVC storage when storage-initializer is disabled", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-pvc-si-disabled"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("pvc://facebook-models/opt-125m")
 			Expect(err).ToNot(HaveOccurred())
@@ -1231,7 +1231,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should NOT configure OCI storage when storage-initializer is disabled", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-oci-si-disabled"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("oci://registry.io/user-id/repo-id:tag")
 			Expect(err).ToNot(HaveOccurred())
@@ -1293,7 +1293,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should rewrite model URI to PVC when local model cache labels are present", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-local-cache"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			sourceUri := "hf://meta-llama/Llama-3.2-1B"
 			modelURL, err := apis.ParseURL(sourceUri)
@@ -1368,7 +1368,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should configure direct PVC mount when model uri starts with pvc://", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-pvc-mn"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("pvc://facebook-models/opt-125m")
 			Expect(err).ToNot(HaveOccurred())
@@ -1435,7 +1435,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should configure a modelcar when model uri starts with oci://", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-oci-mn"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("oci://registry.io/user-id/repo-id:tag")
 			Expect(err).ToNot(HaveOccurred())
@@ -1504,7 +1504,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("should use storage-initializer to download model when uri starts with hf://", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-storage-hf-mn"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("hf://user-id/repo-id:tag")
 			Expect(err).ToNot(HaveOccurred())
@@ -1573,7 +1573,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 		It("multi node should use storage-initializer and set proper env variables when uri starts with hf:// and credentials are configured", func(ctx SpecContext) {
 			// setup test dependencies
 			svcName := "test-llm-storage-hf-mn-with-credentials"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			secretName := kmeta.ChildName(svcName, "-secret")
 			hfTokenValue := "test-token"
@@ -1718,7 +1718,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-mn"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			modelURL, err := apis.ParseURL("s3://user-id/repo-id:tag")
 			Expect(err).ToNot(HaveOccurred())
@@ -1838,7 +1838,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-config-mn"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			localCaBundleConfigMapName := "local-s3-custom-certs"
 			localCaBundleconfigMap := &corev1.ConfigMap{
@@ -2027,7 +2027,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-mn-with-credentials"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			s3CaBundleConfigMapName := "s3-custom-certs"
 			s3CaBundleconfigMap := &corev1.ConfigMap{
@@ -2219,7 +2219,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 
 			// setup test dependencies
 			svcName := "test-llm-storage-s3-mn-with-iam-credentials"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			s3CaBundleConfigMapName := "s3-custom-certs"
 			s3CaBundleconfigMap := &corev1.ConfigMap{

--- a/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
@@ -25,8 +25,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"knative.dev/pkg/kmeta"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
@@ -59,32 +57,6 @@ func RequiredResources(ctx context.Context, c client.Client, ns string) {
 
 	gomega.Expect(c.Create(ctx, DefaultGateway(ns))).To(gomega.Succeed())
 	gomega.Expect(c.Create(ctx, DefaultGatewayClass())).To(gomega.Succeed())
-}
-
-func IstioShadowService(name, ns string) *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kmeta.ChildName(name, "istio-shadow"),
-			Namespace: ns,
-			Labels: map[string]string{
-				"istio.io/inferencepool-name": kmeta.ChildName(name, "-inference-pool"),
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "http",
-					Port:       80,
-					TargetPort: intstr.IntOrString{IntVal: 8000},
-				},
-				{
-					Name:       "https",
-					Port:       443,
-					TargetPort: intstr.IntOrString{IntVal: 8001},
-				},
-			},
-		},
-	}
 }
 
 func DefaultGateway(ns string) *gwapiv1.Gateway {

--- a/pkg/controller/v1alpha2/llmisvc/fixture/test_namespace.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/test_namespace.go
@@ -46,16 +46,6 @@ type TestNamespace struct {
 // TestNamespaceOption configures a TestNamespace during creation
 type TestNamespaceOption func(ctx context.Context, tn *TestNamespace)
 
-// WithIstioShadowService creates an Istio shadow service in the namespace.
-// This is required for tests that verify Istio integration.
-func WithIstioShadowService(svcName string) TestNamespaceOption {
-	return func(ctx context.Context, tn *TestNamespace) {
-		svc := IstioShadowService(svcName, tn.Name)
-		gomega.Expect(tn.client.Create(ctx, svc)).To(gomega.Succeed())
-		tn.resources = append(tn.resources, svc)
-	}
-}
-
 // WithDefaultServiceAccount creates the default ServiceAccount.
 // This is automatically applied but can be explicitly added for clarity.
 // Note: envtest doesn't run kube-controller-manager, so default SA isn't auto-created.
@@ -117,9 +107,7 @@ func WithServiceAccount(name string) TestNamespaceOption {
 //
 // Example usage:
 //
-//	testNs := NewTestNamespace(ctx, envTest,
-//	    WithIstioShadowService("my-service"),
-//	)
+//	testNs := NewTestNamespace(ctx, envTest)
 func NewTestNamespace(ctx context.Context, c *pkgtest.Client, opts ...TestNamespaceOption) *TestNamespace {
 	nsName := generateNamespaceName(ginkgo.CurrentSpecReport())
 

--- a/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_int_test.go
@@ -72,7 +72,7 @@ var _ = Describe("LLMInferenceServiceConfig Controller", func() {
 		It("should block deletion when config is referenced via spec.baseRefs", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-cfg-protect-baserefs"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			config := LLMInferenceServiceConfig("referenced-config",
 				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
@@ -133,7 +133,7 @@ var _ = Describe("LLMInferenceServiceConfig Controller", func() {
 			// given — create config and service, let the reconciler pin the config
 			// in status.annotations via versioned config resolution
 			svcName := "test-llm-cfg-protect-annot"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			config := LLMInferenceServiceConfig("pinned-cfg",
 				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
@@ -221,7 +221,7 @@ var _ = Describe("LLMInferenceServiceConfig Controller", func() {
 		It("should unblock deletion after referencing service is deleted", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-cfg-unblock"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			config := LLMInferenceServiceConfig("blocking-config",
 				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),

--- a/pkg/controller/v1alpha2/llmisvc/scaling_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling_int_test.go
@@ -44,7 +44,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("HPA scaling", func() {
 		It("should create HPA with WVA annotations when HPA scaling is configured", func(ctx SpecContext) {
 			svcName := "test-hpa-scaling"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -86,7 +86,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should update HPA when scaling spec changes", func(ctx SpecContext) {
 			svcName := "test-hpa-update"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -132,7 +132,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("KEDA scaling", func() {
 		It("should create ScaledObject with WVA annotations when KEDA scaling is configured", func(ctx SpecContext) {
 			svcName := "test-keda-scaling"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -173,7 +173,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should update ScaledObject when scaling spec changes", func(ctx SpecContext) {
 			svcName := "test-keda-update"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -216,7 +216,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Scaling cleanup", func() {
 		It("should delete HPA when scaling is removed", func(ctx SpecContext) {
 			svcName := "test-hpa-cleanup"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -255,7 +255,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should delete ScaledObject when scaling is removed", func(ctx SpecContext) {
 			svcName := "test-keda-cleanup"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -296,7 +296,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Prefill scaling", func() {
 		It("should create separate HPA scaling resources for decode and prefill workloads", func(ctx SpecContext) {
 			svcName := "test-prefill-hpa"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -337,7 +337,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should create separate KEDA scaling resources for decode and prefill workloads", func(ctx SpecContext) {
 			svcName := "test-prefill-keda"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -380,7 +380,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Actuator switch", func() {
 		It("should delete HPA and create ScaledObject when switching from HPA to KEDA", func(ctx SpecContext) {
 			svcName := "test-hpa-to-keda"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -423,7 +423,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should delete ScaledObject and create HPA when switching from KEDA to HPA", func(ctx SpecContext) {
 			svcName := "test-keda-to-hpa"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -468,7 +468,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Accelerator label on HPA/ScaledObject", func() {
 		It("should propagate accelerator label from workload labels to HPA", func(ctx SpecContext) {
 			svcName := "test-va-accel"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -496,7 +496,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should set accelerator label to unknown when workload has no accelerator label", func(ctx SpecContext) {
 			svcName := "test-va-no-accel"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -523,7 +523,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("No scaling configured", func() {
 		It("should not create any scaling resources when scaling is nil", func(ctx SpecContext) {
 			svcName := "test-no-scaling"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -552,7 +552,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Scaling with stop annotation", func() {
 		It("should delete HPA scaling resources when stop annotation is set", func(ctx SpecContext) {
 			svcName := "test-hpa-stop"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -592,7 +592,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should delete KEDA scaling resources when stop annotation is set", func(ctx SpecContext) {
 			svcName := "test-keda-stop"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -634,7 +634,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("HPA Behavior propagation", func() {
 		It("should propagate HPA behavior from scaling spec to the HPA resource", func(ctx SpecContext) {
 			svcName := "test-hpa-behavior"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			behavior := &autoscalingv2.HorizontalPodAutoscalerBehavior{
 				ScaleUp: &autoscalingv2.HPAScalingRules{
@@ -684,7 +684,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("VariantCost annotation propagation", func() {
 		It("should propagate variantCost from scaling spec to HPA annotation", func(ctx SpecContext) {
 			svcName := "test-va-cost"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -711,7 +711,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("KEDA Prometheus auth propagation", func() {
 		It("should include auth config on ScaledObject trigger when configured", func(ctx SpecContext) {
 			svcName := "test-keda-auth"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			cfgMap := &corev1.ConfigMap{}
 			cfgMapKey := types.NamespacedName{
@@ -784,7 +784,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Multi-node (LWS) HPA scaling", func() {
 		It("should create HPA with WVA annotations targeting LeaderWorkerSet when worker is set", func(ctx SpecContext) {
 			svcName := "test-lws-hpa"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -825,7 +825,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Multi-node (LWS) KEDA scaling", func() {
 		It("should create ScaledObject with WVA annotations targeting LeaderWorkerSet when worker is set", func(ctx SpecContext) {
 			svcName := "test-lws-keda"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -863,7 +863,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Multi-node P/D scaling", func() {
 		It("should create separate LWS-targeting scaling resources for decode and prefill", func(ctx SpecContext) {
 			svcName := "test-lws-pd"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -916,7 +916,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("Multi-node scaling with stop annotation", func() {
 		It("should delete LWS-targeting scaling resources when stop annotation is set", func(ctx SpecContext) {
 			svcName := "test-lws-stop"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -968,7 +968,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 	Context("ScalingReady condition propagation", func() {
 		It("should set ScalingReady=False (progressing) when HPA has no status conditions", func(ctx SpecContext) {
 			svcName := "test-hpa-cond-prog"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -995,7 +995,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should set ScalingReady=True when HPA reports healthy conditions", func(ctx SpecContext) {
 			svcName := "test-hpa-cond-ready"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1043,7 +1043,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should set ScalingReady=False when HPA ScalingActive is False", func(ctx SpecContext) {
 			svcName := "test-hpa-cond-fail"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1091,7 +1091,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should clear ScalingReady when scaling is removed", func(ctx SpecContext) {
 			svcName := "test-scaling-clear"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1134,7 +1134,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should not have ScalingReady when no scaling is configured", func(ctx SpecContext) {
 			svcName := "test-no-scaling-cond"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1165,7 +1165,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should set ScalingReady=False when KEDA ScaledObject is not yet ready", func(ctx SpecContext) {
 			svcName := "test-keda-cond-prog"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1192,7 +1192,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should set ScalingReady=True when KEDA ScaledObject reports Ready", func(ctx SpecContext) {
 			svcName := "test-keda-cond-ok"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1241,7 +1241,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should transition ScalingReady from True to False when HPA degrades", func(ctx SpecContext) {
 			svcName := "test-hpa-true-false"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1312,7 +1312,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should transition ScalingReady from True to False when KEDA ScaledObject degrades", func(ctx SpecContext) {
 			svcName := "test-keda-true-false"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
@@ -1387,7 +1387,7 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 
 		It("should set PrefillScalingReady when prefill scaling is configured", func(ctx SpecContext) {
 			svcName := "test-prefill-scale"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the `WithIstioShadowService` fixture from all LLMISVC envtest suites. No production code in the controller watches, reads, or references this service - it was a left-over from midstream contributions and quietly carried across every new test since. Cleaning it up reduces noise and makes the test setup reflect what the controller actually needs.

**Feature/Issue validation/testing**:

- [x] Full LLMISVC envtest suite passes without the fixture

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```