### PR TITLE
fix(e2e): update stale apiVersion in fixture

### DIFF
--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -772,7 +772,7 @@ LLMINFERENCESERVICE_CONFIGS = {
             "scheduler": {
                 "config": {
                     "inline": {
-                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "apiVersion": "llm-d.ai/v1alpha1",
                         "kind": "EndpointPickerConfig",
                         "plugins": [
                             {"type": "single-profile-handler"},


### PR DESCRIPTION
## Summary

- The `scheduler-with-tokenizer-kvcache` fixture added in #5712 used the old `inference.networking.x-k8s.io/v1alpha1` apiVersion, but #5774 (merged earlier) migrated all `EndpointPickerConfig` apiVersions to `llm-d.ai/v1alpha1`
- The controller auto-migrates at runtime (`withMigrateLLMDAPIVersion`), so tests pass regardless, but the fixture should match the canonical version for consistency
- Only fixture still using the old apiVersion

Closes #5871

## Test plan

- [ ] Existing e2e tests pass (no behavioral change — auto-migration already handled this)