### PR TITLE
fix(e2e): add gateway convergence wait to canary llmisvc test

### DIFF
--- a/test/e2e/llmisvc/test_llm_canary_lifecycle.py
+++ b/test/e2e/llmisvc/test_llm_canary_lifecycle.py
@@ -1027,10 +1027,19 @@ class TestCanaryLifecycle:
         wait_for_member_count(api, v1.name, ns, 3)
 
         gateway = get_gateway_base_url(api, v1.name, ns)
+        route_headers = {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"}
+        route_payload = {"model": MODEL, "prompt": "Hello", "max_tokens": 5}
+
+        wait_for_healthy_route(
+            f"{gateway}/v1/completions",
+            route_headers,
+            route_payload,
+        )
+
         driver = traffic_driver(
             url=f"{gateway}/v1/completions",
-            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            headers=route_headers,
+            payload=route_payload,
             rate=2,
             timeout=15.0,
             warmup=True,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a flaky `test_three_member_group` canary lifecycle test that was failing in CI with ~5% error rate (3/61 requests returning 500). Traffic measurement started before the gateway finished reprogramming routes for all three weighted backendRefs - the controller status converged but the data plane hadn't caught up.

Adds `wait_for_healthy_route` convergence poll (3 consecutive 2xx) before starting traffic, matching the pattern already used in the canary lifecycle, rollback, late-join, and force-stop tests.

**Special notes for your reviewer**:

The `wait_for_healthy_route` polls for 3 consecutive 2xx responses before marking the route as converged. This avoids false positives from stale pre-mutation routes that return 200 but haven't been reprogrammed yet.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```