### PR TITLE
feat(llmisvc): migrate deprecated flag to metrics-data-source plugin

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -62,6 +62,7 @@ const (
 	loraAffinityScorerPlugin          = "lora-affinity-scorer"
 	coreMetricsExtractorPlugin        = "model-server-protocol-metrics"
 	coreMetricsExtractorPluginRenamed = "core-metrics-extractor"
+	metricsDataSourcePlugin           = "metrics-data-source"
 	udsTokenizerBaseModelName         = "base"
 	udsTokenizerSocketFile            = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
 	tokenizerModelName                = "/mnt/models/base"                    // matches the vLLM render --model arg in config-llm-tokenizer.yaml
@@ -1295,6 +1296,16 @@ var deprecatedMetricFlagNames = map[string]bool{
 	"cache-info-metric":                true,
 }
 
+// modelServerMetricsSchemeFlag is the deprecated EPP CLI flag (without leading
+// dashes) removed in llm-d-router 0.10, superseded by the metrics-data-source
+// data layer plugin's scheme parameter in EndpointPickerConfig.
+const modelServerMetricsSchemeFlag = "model-server-metrics-scheme"
+
+// metricsDataSourceSchemeMinVersion is the first llm-d-router version that
+// removes --model-server-metrics-scheme; from this version the scrape scheme
+// must be supplied via the metrics-data-source plugin parameters.
+var metricsDataSourceSchemeMinVersion = semver.New("0.10.0")
+
 // hasDeprecatedMetricFlags reports whether any container in the pod spec
 // carries one of the 5 deprecated metric CLI flags, without modifying args.
 func hasDeprecatedMetricFlags(d *appsv1.Deployment) bool {
@@ -1333,6 +1344,8 @@ func hasDeprecatedMetricFlags(d *appsv1.Deployment) bool {
 //  5. withCoreMetricsExtractorPlugin – inject core-metrics-extractor with extracted flag values
 //  6. withMigrateCoreMetricsExtractor – rename model-server-protocol-metrics → core-metrics-extractor
 //     (v0.8.0 only, runs after injection so freshly injected plugins are also renamed)
+//  7. withMetricsDataSourceScheme – move --model-server-metrics-scheme into the
+//     metrics-data-source plugin parameters (v0.10.0+, flag removed upstream)
 func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alpha2.LLMInferenceService, enableTLS bool) error {
 	version, ok := d.Spec.Template.Annotations["app.kubernetes.io/version"]
 	if !ok || version == "" {
@@ -1387,6 +1400,24 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alp
 			tokURL := tokenizerServiceURL(llmSvc, enableTLS)
 			opts = append(opts, withDecomposePrecisePrefixCacheScorer(tokURL))
 			opts = append(opts, withInjectTokenProducerConfig(tokURL))
+		}
+	}
+
+	// llm-d-router v0.10.0 removes "--model-server-metrics-scheme"
+	// the function had been moved into metrics-data-source plugin parameters.
+	if v.Compare(*metricsDataSourceSchemeMinVersion) >= 0 {
+		if !writable {
+			if hasModelServerMetricsSchemeFlag(d) {
+				return fmt.Errorf(
+					"scheduler deployment %s/%s sets --%s but has no inline "+
+						"--config-text; automatic migration to the metrics-data-source "+
+						"plugin is not possible — convert to --config-text or remove the "+
+						"flag manually",
+					d.GetNamespace(), d.GetName(), modelServerMetricsSchemeFlag,
+				)
+			}
+		} else if scheme := extractModelServerMetricsScheme(d); scheme != "" {
+			opts = append(opts, withMetricsDataSourceScheme(scheme))
 		}
 	}
 
@@ -1768,6 +1799,35 @@ func extractDeprecatedMetricFlags(d *appsv1.Deployment) map[string]string {
 	return allExtracted
 }
 
+// extractModelServerMetricsScheme strips the deprecated --model-server-metrics-scheme
+// flag from every container's Command and returns its value (empty if absent).
+// The scheduler preset carries the flag on Command.
+func extractModelServerMetricsScheme(d *appsv1.Deployment) string {
+	names := map[string]bool{modelServerMetricsSchemeFlag: true}
+	scheme := ""
+	for ci := range d.Spec.Template.Spec.Containers {
+		c := &d.Spec.Template.Spec.Containers[ci]
+		if filtered, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
+			c.Command = filtered
+			scheme = extracted[modelServerMetricsSchemeFlag]
+		}
+	}
+	return scheme
+}
+
+// hasModelServerMetricsSchemeFlag reports whether any container carries the
+// --model-server-metrics-scheme flag on Command, without modifying it.
+func hasModelServerMetricsSchemeFlag(d *appsv1.Deployment) bool {
+	names := map[string]bool{modelServerMetricsSchemeFlag: true}
+	for ci := range d.Spec.Template.Spec.Containers {
+		c := &d.Spec.Template.Spec.Containers[ci]
+		if _, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // filterArgs removes matching flags from args and returns their values.
 // It handles both --flag=value and --flag value forms.
 func filterArgs(args []string, names map[string]bool) (filtered []string, extracted map[string]string) {
@@ -1842,6 +1902,38 @@ func withCoreMetricsExtractorPlugin(extracted map[string]string) mutateScheduler
 				"engineConfigs": []interface{}{
 					engineConfig,
 				},
+			},
+		}
+
+		plugins = append(plugins, pluginEntry)
+		return unstructured.SetNestedSlice(u.Object, plugins, "plugins")
+	}
+}
+
+// withMetricsDataSourceScheme returns a mutateSchedulerConfigFunc that injects a
+// metrics-data-source plugin carrying the scheme previously passed via the
+// --model-server-metrics-scheme CLI flag. EPP data layer defaulting wires the
+// declared source to core-metrics-extractor automatically, so only the plugin
+// entry is needed. Callers pass a non-empty scheme; no-op if a metrics-data-source
+// plugin is already declared.
+func withMetricsDataSourceScheme(scheme string) mutateSchedulerConfigFunc {
+	return func(_ context.Context, u *unstructured.Unstructured) error {
+		val, _, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+		if err != nil {
+			return err
+		}
+		plugins, _ := val.([]interface{})
+
+		for _, plugin := range plugins {
+			if pluginMap, ok := plugin.(map[string]interface{}); ok && pluginMap["type"] == metricsDataSourcePlugin {
+				return nil
+			}
+		}
+
+		pluginEntry := map[string]interface{}{
+			"type": metricsDataSourcePlugin,
+			"parameters": map[string]interface{}{
+				"scheme": scheme,
 			},
 		}
 

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -19,6 +19,7 @@ package llmisvc
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -2222,6 +2223,177 @@ plugins:
 			}
 			if tt.validateConfig != nil {
 				tt.validateConfig(g, resultArgs)
+			}
+		})
+	}
+}
+
+func TestWithMetricsDataSourceScheme(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		scheme     string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "injects plugin with scheme",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			scheme: "https",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(2))
+				pluginMap := plugins[1].(map[string]interface{})
+				g.Expect(pluginMap["type"]).To(Equal(metricsDataSourcePlugin))
+				params := pluginMap["parameters"].(map[string]interface{})
+				g.Expect(params["scheme"]).To(Equal("https"))
+			},
+		},
+		{
+			name: "skips when metrics-data-source already exists",
+			configYAML: `
+plugins:
+- type: metrics-data-source
+  parameters:
+    scheme: http
+`,
+			scheme: "https",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+				pluginMap := plugins[0].(map[string]interface{})
+				params := pluginMap["parameters"].(map[string]interface{})
+				g.Expect(params["scheme"]).To(Equal("http"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			fn := withMetricsDataSourceScheme(tt.scheme)
+			g.Expect(fn(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
+func TestExtractModelServerMetricsScheme(t *testing.T) {
+	tests := []struct {
+		name            string
+		command         []string
+		expectedCommand []string
+		expectedScheme  string
+	}{
+		{
+			name:            "extracts from command with equals form",
+			command:         []string{"/app/epp", "--model-server-metrics-scheme=https", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
+			expectedScheme:  "https",
+		},
+		{
+			name:            "no flag returns empty scheme",
+			command:         []string{"/app/epp", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
+			expectedScheme:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			d := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Command: tt.command},
+							},
+						},
+					},
+				},
+			}
+			scheme := extractModelServerMetricsScheme(d)
+			g.Expect(scheme).To(Equal(tt.expectedScheme))
+			if tt.expectedCommand != nil {
+				g.Expect(d.Spec.Template.Spec.Containers[0].Command).To(Equal(tt.expectedCommand))
+			}
+		})
+	}
+}
+
+func TestSchedulerTransformMigratesMetricsScheme(t *testing.T) {
+	configYAML := `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: queue-scorer
+`
+
+	tests := []struct {
+		name         string
+		version      string
+		expectFlag   bool
+		expectPlugin bool
+	}{
+		{
+			name:         "0.9.0 leaves flag and config untouched",
+			version:      "0.9.0",
+			expectFlag:   true,
+			expectPlugin: false,
+		},
+		{
+			name:         "0.10.0 strips flag and injects plugin",
+			version:      "0.10.0",
+			expectFlag:   false,
+			expectPlugin: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			d := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-scheduler", Namespace: "test-ns"},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"app.kubernetes.io/version": tt.version},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "main",
+									Command: []string{"/app/epp", "--model-server-metrics-scheme=https"},
+									Args:    []string{"--config-text", configYAML},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			g.Expect(schedulerTransform(context.Background(), d, &v1alpha2.LLMInferenceService{}, true)).To(Succeed())
+
+			command := d.Spec.Template.Spec.Containers[0].Command
+			g.Expect(slices.Contains(command, "--model-server-metrics-scheme=https")).To(Equal(tt.expectFlag))
+
+			args := d.Spec.Template.Spec.Containers[0].Args
+			configText := ""
+			for i, a := range args {
+				if a == "--config-text" && i+1 < len(args) {
+					configText = args[i+1]
+				}
+			}
+			if tt.expectPlugin {
+				g.Expect(configText).To(ContainSubstring("metrics-data-source"))
+				g.Expect(configText).To(ContainSubstring("scheme: https"))
+			} else {
+				g.Expect(configText).NotTo(ContainSubstring("metrics-data-source"))
 			}
 		})
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2337,20 +2337,44 @@ plugins:
 	tests := []struct {
 		name         string
 		version      string
+		command      []string
+		args         []string
+		expectErr    bool
+		errSubstring string
 		expectFlag   bool
 		expectPlugin bool
 	}{
 		{
 			name:         "0.9.0 leaves flag and config untouched",
 			version:      "0.9.0",
+			command:      []string{"/app/epp", "--model-server-metrics-scheme=https"},
+			args:         []string{"--config-text", configYAML},
 			expectFlag:   true,
 			expectPlugin: false,
 		},
 		{
 			name:         "0.10.0 strips flag and injects plugin",
 			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-scheme=https"},
+			args:         []string{"--config-text", configYAML},
 			expectFlag:   false,
 			expectPlugin: true,
+		},
+		{
+			name:         "0.10.0 without flag leaves config untouched",
+			version:      "0.10.0",
+			command:      []string{"/app/epp"},
+			args:         []string{"--config-text", configYAML},
+			expectFlag:   false,
+			expectPlugin: false,
+		},
+		{
+			name:         "0.10.0 with flag but non-writable config-file returns error",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-scheme=https"},
+			args:         []string{"--config-file", "/etc/scheduler/config.yaml"},
+			expectErr:    true,
+			errSubstring: "no inline --config-text",
 		},
 	}
 
@@ -2368,8 +2392,8 @@ plugins:
 							Containers: []corev1.Container{
 								{
 									Name:    "main",
-									Command: []string{"/app/epp", "--model-server-metrics-scheme=https"},
-									Args:    []string{"--config-text", configYAML},
+									Command: tt.command,
+									Args:    tt.args,
 								},
 							},
 						},
@@ -2377,7 +2401,13 @@ plugins:
 				},
 			}
 
-			g.Expect(schedulerTransform(context.Background(), d, &v1alpha2.LLMInferenceService{}, true)).To(Succeed())
+			err := schedulerTransform(context.Background(), d, &v1alpha2.LLMInferenceService{}, true)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errSubstring))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
 
 			command := d.Spec.Template.Spec.Containers[0].Command
 			g.Expect(slices.Contains(command, "--model-server-metrics-scheme=https")).To(Equal(tt.expectFlag))


### PR DESCRIPTION
**What this PR does / why we need it**:

llm-d-router 0.10 removes the `--model-server-metrics-scheme` EPP CLI flag; the scrape scheme now lives in the `metrics-data-source` data-layer plugin parameters of the `EndpointPickerConfig`. This adds a version-gated scheduler config migration that, once the scheduler deployment's `app.kubernetes.io/version` annotation reaches `0.10.0`, strips the flag and injects a `metrics-data-source` plugin carrying the scheme into the inline `--config-text`. EPP data-layer defaulting then wires the declared source to `core-metrics-extractor` automatically.

The migration is dormant at the preset's current `0.9.0` annotation and activates only when the EPP image and version are bumped to `0.10`. It mirrors the existing version-gated metric-flag migrations already in the scheduler transform (the `0.8.0` rename and `0.9.0` changes), and reuses the shared `filterArgs` flag parser.

Behavior notes:
- The migration is flag-driven: when the deprecated flag is present it is stripped and translated; when absent, nothing is injected and EPP falls back to its default scheme.
- If a scheduler deployment sets the flag but has no inline `--config-text` (e.g. a mounted config-file), the transform returns an actionable error rather than silently dropping the flag — mirroring the existing guard for the other deprecated metric flags.

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [x] Unit test for the plugin injector (`TestWithMetricsDataSourceScheme`) — injects the plugin with the scheme, and is a no-op when a `metrics-data-source` plugin already exists.
- [x] Unit test for the flag extractor (`TestExtractModelServerMetricsScheme`) — strips the flag from the container command and returns its value; returns empty when absent.
- [x] Integration test for the version gate (`TestSchedulerTransformMigratesMetricsScheme`) — dormant at `0.9.0` (flag kept, no plugin), active at `0.10.0` (flag stripped, plugin injected).

**Special notes for your reviewer**:

The migration assumes the llm-d-router 0.10 contract: the plugin type is `metrics-data-source`, and EPP data-layer defaulting auto-wires the declared source to `core-metrics-extractor` (no explicit `source` reference needed). Please confirm against the 0.10 EPP schema.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
Scheduler config now migrates the deprecated `--model-server-metrics-scheme` EPP flag into the `metrics-data-source` plugin when the EPP version is >= 0.10.0.
```
