### PR TITLE
ci(e2e): isolate conversion tests and fix result file clobbering

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -9,8 +9,8 @@ inputs:
     description: 'Glob or path list for result files'
     required: false
     default: |
-      /tmp/junit_e2e.xml
-      /tmp/e2e_results.json
+      /tmp/junit_e2e*.xml
+      /tmp/e2e_results*.json
 
 runs:
   using: "composite"

--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -311,6 +311,15 @@ jobs:
           export PYTEST_MAXFAIL=3
           ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and llmisvc_core and cluster_cpu" 0 "envoy-gateway"
 
+      - name: Run conversion & storage-migration E2E tests
+        id: conversion-e2e-tests
+        if: always() && steps.llmisvc-e2e-tests.conclusion != 'cancelled'
+        timeout-minutes: 90
+        env:
+          OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
+        run: |
+          ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and conversion and cluster_cpu" 1 "envoy-gateway"
+
       - name: Check system status
         if: always()
         run: |

--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -38,7 +38,11 @@ _AUTOSCALING_STEM_PREFIX = "test_llm_autoscaling_"
 # Files that should NOT receive ``llmisvc_core`` automatically.
 # Autoscaling files (``test_llm_autoscaling_<variant>.py``) are handled
 # separately below; add other special-case filenames here.
-_LLMISVC_CORE_EXCLUDED = {"test_llm_tracing.py"}
+_LLMISVC_CORE_EXCLUDED = {
+    "test_llm_tracing.py",
+    "test_llm_inference_service_conversion.py",
+    "test_storage_version_migration.py",
+}
 
 
 @pytest.fixture

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -54,7 +54,17 @@ source python/kserve/.venv/bin/activate
 REPORT_DIR="${ARTIFACT_DIR:-/tmp}"
 mkdir -p "$REPORT_DIR"
 
-PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" --maxfail="$MAXFAIL" -vv --tb=long -s --junitxml="$REPORT_DIR/junit_e2e.xml" --json-report --json-report-file="$REPORT_DIR/e2e_results.json" --json-report-omit=log)
+# Derive a filesystem-safe slug from the marker expression so that multiple
+# invocations within the same job produce distinct result files instead of
+# clobbering each other.  When no marker is given the suffix is empty,
+# preserving the original filenames for single-invocation jobs.
+if [[ -n "$MARKER" ]]; then
+  REPORT_SUFFIX="-$(echo "$MARKER" | tr ' ()' '_' | tr -cs '[:alnum:]_-' '_' | sed 's/_$//')"
+else
+  REPORT_SUFFIX=""
+fi
+
+PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" --maxfail="$MAXFAIL" -vv --tb=long -s --junitxml="$REPORT_DIR/junit_e2e${REPORT_SUFFIX}.xml" --json-report --json-report-file="$REPORT_DIR/e2e_results${REPORT_SUFFIX}.json" --json-report-omit=log)
 
 MARKER_ARGS=()
 if [[ -n "$MARKER" ]]; then


### PR DESCRIPTION
## Summary

- Exclude `test_storage_version_migration.py` and `test_llm_inference_service_conversion.py` from `llmisvc_core` auto-marker. The storage migration test restarts the controller deployment, which interferes with other tests running in parallel via xdist.
- Run conversion tests serially (`-n 1`) as a separate step after the core suite in the `test-llmisvc` CI job.
- Derive per-invocation result file suffixes from the marker expression in `run-e2e-tests.sh`, fixing a pre-existing bug where jobs that call the script multiple times (`test-raw`, `test-transformer-explainer-mms`, `test-path-based-routing`) silently overwrite each other's `junit_e2e.xml` and `e2e_results.json`.

## Test plan

- [ ] `test-llmisvc` job runs core tests, then conversion tests serially
- [ ] Conversion test results appear in uploaded artifacts with distinct filenames
- [ ] Multi-call jobs in `e2e-test.yml` produce separate result files per invocation
- [ ] No conversion/migration tests collected during `llmisvc_core` marker selection