### PR TITLE
fix(llmisvc): escape quotes in generated --kv-transfer-config

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -682,9 +682,10 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 				if err != nil {
 					return ""
 				}
-				// Escape " as \" so the value embeds safely in a bash double-quoted
-				// assignment and in the JSON template string that ReplaceVariables renders.
-				return "--kv-transfer-config '" + strings.ReplaceAll(string(b), `"`, `\"`) + "'"
+				// \\\" decodes to \" after ReplaceVariables re-unmarshals this as JSON, and
+				// the \" then survives the KV_TRANSFER_ARGS="..." bash assignment in the
+				// template. Plain " would be eaten by the shell and vLLM would get invalid JSON.
+				return "--kv-transfer-config '" + strings.ReplaceAll(string(b), `"`, `\\\"`) + "'"
 			},
 			// shutdownTimeout computes the vLLM --shutdown-timeout value from a *corev1.PodSpec
 			// (or nil): max(0, tgps - preStop - min(5, tgps)), defaulting tgps to 60 when unset.

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package llmisvc_test
 
 import (
+	"encoding/json"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -2109,9 +2111,9 @@ func TestReplaceVariables(t *testing.T) {
 					WorkloadSpec: v1alpha2.WorkloadSpec{
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{
-								// json.Marshal sorts map keys alphabetically: kv_connector < kv_connector_extra_config < kv_role
-								// Internally " is escaped to \" for JSON-safe template rendering; JSON unmarshal restores plain ".
-								{Args: []string{`--kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_connector_extra_config":{"cpu_bytes_to_use":10737418240,"spec_name":"TieringOffloadingSpec"},"kv_role":"kv_both"}'`}},
+								// Keys are alphabetical (json.Marshal on a map); quotes stay escaped as \"
+								// so the value is safe in the KV_TRANSFER_ARGS="..." bash assignment.
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":10737418240,\"spec_name\":\"TieringOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
 							},
 						},
 					},
@@ -2147,7 +2149,7 @@ func TestReplaceVariables(t *testing.T) {
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{
 								// json.Marshal sorts map keys alphabetically: cpu_bytes_to_use < eviction_policy < spec_name
-								{Args: []string{`--kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_connector_extra_config":{"cpu_bytes_to_use":5368709120,"eviction_policy":"arc","spec_name":"TieringOffloadingSpec"},"kv_role":"kv_both"}'`}},
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":5368709120,\"eviction_policy\":\"arc\",\"spec_name\":\"TieringOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
 							},
 						},
 					},
@@ -2187,7 +2189,7 @@ func TestReplaceVariables(t *testing.T) {
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{
 								// secondary_tiers[0]: root_dir defaults to /mnt/kv-cache-0
-								{Args: []string{`--kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_connector_extra_config":{"cpu_bytes_to_use":10737418240,"secondary_tiers":[{"root_dir":"/mnt/kv-cache-0","type":"fs"}],"spec_name":"TieringOffloadingSpec"},"kv_role":"kv_both"}'`}},
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":10737418240,\"secondary_tiers\":[{\"root_dir\":\"/mnt/kv-cache-0\",\"type\":\"fs\"}],\"spec_name\":\"TieringOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
 							},
 						},
 					},
@@ -2229,7 +2231,7 @@ func TestReplaceVariables(t *testing.T) {
 					WorkloadSpec: v1alpha2.WorkloadSpec{
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Args: []string{`--kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_connector_extra_config":{"cpu_bytes_to_use":10737418240,"secondary_tiers":[{"root_dir":"/mnt/kv-cache-0","type":"fs"},{"root_dir":"/mnt/kv-cache-1","type":"fs"}],"spec_name":"TieringOffloadingSpec"},"kv_role":"kv_both"}'`}},
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":10737418240,\"secondary_tiers\":[{\"root_dir\":\"/mnt/kv-cache-0\",\"type\":\"fs\"},{\"root_dir\":\"/mnt/kv-cache-1\",\"type\":\"fs\"}],\"spec_name\":\"TieringOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
 							},
 						},
 					},
@@ -2270,7 +2272,7 @@ func TestReplaceVariables(t *testing.T) {
 					WorkloadSpec: v1alpha2.WorkloadSpec{
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Args: []string{`--kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_connector_extra_config":{"cpu_bytes_to_use":10737418240,"secondary_tiers":[{"root_dir":"/mnt/kv-cache-0","type":"fs"}],"spec_name":"TieringOffloadingSpec"},"kv_role":"kv_both"}'`}},
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":10737418240,\"secondary_tiers\":[{\"root_dir\":\"/mnt/kv-cache-0\",\"type\":\"fs\"}],\"spec_name\":\"TieringOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
 							},
 						},
 					},
@@ -2292,6 +2294,67 @@ func TestReplaceVariables(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReplaceVariables_KVTransferConfigBashSafe guards against the shell eating the
+// quotes in the rendered --kv-transfer-config JSON. The config template assigns the
+// value with KV_TRANSFER_ARGS="..." and then eval's the command line; if the quotes
+// aren't escaped, vLLM receives invalid JSON. This runs that same shape and checks the
+// JSON that reaches vLLM still parses.
+func TestReplaceVariables_KVTransferConfigBashSafe(t *testing.T) {
+	g := NewWithT(t)
+
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+
+	// Same shape as the config template. After eval, $2 is the JSON argument that
+	// follows --kv-transfer-config, i.e. what vllm serve parses.
+	script := `KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+eval "set -- ${KV_TRANSFER_ARGS}"
+printf '%s' "$2"`
+
+	cfg := &v1alpha2.LLMInferenceServiceConfig{
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			WorkloadSpec: v1alpha2.WorkloadSpec{
+				Template: &corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Command: []string{"/bin/bash", "-c", script}},
+					},
+				},
+			},
+		},
+	}
+	llmSvc := &v1alpha2.LLMInferenceService{
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			WorkloadSpec: v1alpha2.WorkloadSpec{
+				KVCacheOffloading: &v1alpha2.KVCacheOffloadingSpec{
+					CPU:            resource.MustParse("10Gi"),
+					EvictionPolicy: "lru",
+				},
+			},
+		},
+	}
+
+	got, err := llmisvc.ReplaceVariables(llmSvc, cfg, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	renderedScript := got.Spec.Template.Containers[0].Command[2]
+	g.Expect(renderedScript).To(ContainSubstring(`--kv-transfer-config '`))
+
+	out, err := exec.Command(bashPath, "-c", renderedScript).CombinedOutput() // #nosec G204 -- test input, not user data
+	g.Expect(err).ToNot(HaveOccurred(), "bash execution failed: %s", string(out))
+
+	// vLLM parses this argument as JSON; it must be valid and preserve the keys.
+	var parsed map[string]any
+	g.Expect(json.Unmarshal(out, &parsed)).To(Succeed(), "vllm would reject: %q", string(out))
+	g.Expect(parsed).To(HaveKeyWithValue("kv_connector", "OffloadingConnector"))
+	g.Expect(parsed).To(HaveKeyWithValue("kv_role", "kv_both"))
+	extra, ok := parsed["kv_connector_extra_config"].(map[string]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(extra).To(HaveKeyWithValue("spec_name", "TieringOffloadingSpec"))
+	g.Expect(extra).To(HaveKeyWithValue("eviction_policy", "lru"))
 }
 
 func mustParseURL(s string) apis.URL {

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -2343,7 +2343,7 @@ printf '%s' "$2"`
 	renderedScript := got.Spec.Template.Containers[0].Command[2]
 	g.Expect(renderedScript).To(ContainSubstring(`--kv-transfer-config '`))
 
-	out, err := exec.Command(bashPath, "-c", renderedScript).CombinedOutput() // #nosec G204 -- test input, not user data
+	out, err := exec.CommandContext(t.Context(), bashPath, "-c", renderedScript).CombinedOutput() // #nosec G204 -- test input, not user data
 	g.Expect(err).ToNot(HaveOccurred(), "bash execution failed: %s", string(out))
 
 	// vLLM parses this argument as JSON; it must be valid and preserve the keys.
@@ -2351,10 +2351,12 @@ printf '%s' "$2"`
 	g.Expect(json.Unmarshal(out, &parsed)).To(Succeed(), "vllm would reject: %q", string(out))
 	g.Expect(parsed).To(HaveKeyWithValue("kv_connector", "OffloadingConnector"))
 	g.Expect(parsed).To(HaveKeyWithValue("kv_role", "kv_both"))
-	extra, ok := parsed["kv_connector_extra_config"].(map[string]any)
-	g.Expect(ok).To(BeTrue())
-	g.Expect(extra).To(HaveKeyWithValue("spec_name", "TieringOffloadingSpec"))
-	g.Expect(extra).To(HaveKeyWithValue("eviction_policy", "lru"))
+	g.Expect(parsed).To(HaveKey("kv_connector_extra_config"))
+	extra := parsed["kv_connector_extra_config"]
+	g.Expect(extra).To(And(
+		HaveKeyWithValue("spec_name", "TieringOffloadingSpec"),
+		HaveKeyWithValue("eviction_policy", "lru"),
+	))
 }
 
 func mustParseURL(s string) apis.URL {


### PR DESCRIPTION
**What this PR does / why we need it**:

When `spec.kvCacheOffloading` is set, the controller generates a `--kv-transfer-config` argument for the vLLM serve command. The generated JSON reached vLLM with its double quotes stripped (e.g. `{kv_connector:OffloadingConnector,...}`), so vLLM rejected it and the workload crash-looped:

`--kv-transfer-config: Invalid JSON: key must be a string at line 1 column 2`

The rendered value passes through two consumers in sequence: `ReplaceVariables` re-unmarshals the template output as JSON (which collapses one level of backslash escaping), and the config template then embeds the result inside a bash double-quoted assignment (`KV_TRANSFER_ARGS="…"`). The previous escaping only survived the first step, so by the time the shell evaluated the assignment the quotes were bare and got eaten, corrupting the JSON that vLLM parses.

This PR escapes the quotes so the value survives both the JSON round-trip and the bash double-quoted assignment, leaving the JSON intact when it reaches vLLM. This is a rendering-only fix — no API, behavior, or image changes.


**Feature/Issue validation/testing**:

- [x] Updated the existing `kvTransferConfig` rendering cases in `TestReplaceVariables` to assert the shell-safe (escaped) output.
- [x] Added `TestReplaceVariables_KVTransferConfigBashSafe`, which renders the value into the same `KV_TRANSFER_ARGS="…"` + `eval` shape used by the config template, runs it through `bash`, and asserts the argument vLLM receives is still parseable JSON with the expected keys.

- Before vs. after, feeding the rendered value through the real assignment + `eval`:
  ```
  # before: quotes stripped -> vLLM error "key must be a string"
  {kv_connector:OffloadingConnector,kv_role:kv_both}
  
  # after: valid JSON
  {"kv_connector":"OffloadingConnector","kv_role":"kv_both"}
  
  go test ./pkg/controller/v1alpha2/llmisvc/ -run 'TestReplaceVariables' -count=1
  ok  github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc
  ```

**Special notes for your reviewer**:

The fix is a single change to how quotes are escaped in the generated `--kv-transfer-config` value. It affects only services that set `spec.kvCacheOffloading`; services without it render no such argument and are unaffected. 

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Fixed KV cache offloading so the generated --kv-transfer-config argument is passed to vLLM as valid JSON. Previously vLLM rejected it with "Invalid JSON: key must be a string" and the workload failed to start.
```
