### PR TITLE
fix(llmisvc): replace version gating with --help detection and fail-fast

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -134,28 +134,45 @@ spec:
           fi
         fi
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -470,28 +487,45 @@ spec:
 
         START_RANK=0
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -810,28 +844,45 @@ spec:
 
         START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -1056,28 +1107,45 @@ spec:
             fi
           fi
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve /mnt/models \
@@ -1333,28 +1401,45 @@ spec:
 
           START_RANK=0
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -1612,28 +1697,45 @@ spec:
 
           START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} ))
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -2470,28 +2572,45 @@ spec:
           fi
         fi
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -2836,28 +2955,45 @@ spec:
 
         START_RANK=0
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3115,28 +3251,45 @@ spec:
 
         START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -153,26 +153,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -506,26 +498,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -863,26 +847,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -1126,26 +1102,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve /mnt/models \
@@ -1420,26 +1388,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -1716,26 +1676,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -2591,26 +2543,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -2974,26 +2918,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3270,26 +3206,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -139,28 +139,45 @@ spec:
               fi
             fi
 
+            # Detect flags from `vllm serve --help` rather than the version string: patched
+            # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+            VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
             # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
             # Older versions still need the blanket --disable-uvicorn-access-log.
             ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-            VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-            echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
               ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
             fi
             echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
             # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
             SHUTDOWN_TIMEOUT_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
             fi
+            echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # --kv-transfer-config exists on all supported vLLM versions and even the
+            # OffloadingConnector predates them, but the TieringOffloadingSpec that
+            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+            # Neither is listed in --help output, so probe the installed package source.
+            vllm_supports_tiering_offloading() {
+              local pkg_dir
+              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+            }
+
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-              fi
+            if vllm_supports_tiering_offloading; then
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                *--kv-transfer-config*|*--kv_transfer_config*)
+                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              esac
+            else
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve /mnt/models \

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -158,26 +158,18 @@ spec:
             fi
             echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config exists on all supported vLLM versions and even the
-            # OffloadingConnector predates them, but the TieringOffloadingSpec that
-            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-            # Neither is listed in --help output, so probe the installed package source.
-            vllm_supports_tiering_offloading() {
-              local pkg_dir
-              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-            }
-
-            KV_TRANSFER_ARGS=""
-            if vllm_supports_tiering_offloading; then
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+            # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+            # and version strings are unusable (patched builds report 0.1.devN placeholders).
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+            if [ -n "$KV_TRANSFER_ARGS" ]; then
               case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                 *--kv-transfer-config*|*--kv_transfer_config*)
-                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+                  echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                  KV_TRANSFER_ARGS="" ;;
+                *)
+                  echo "[kv-transfer] injecting --kv-transfer-config" ;;
               esac
-            else
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve /mnt/models \

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -222,28 +222,45 @@ spec:
 
             START_RANK=0
 
+            # Detect flags from `vllm serve --help` rather than the version string: patched
+            # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+            VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
             # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
             # Older versions still need the blanket --disable-uvicorn-access-log.
             ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-            VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-            echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
               ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
             fi
             echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
             # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
             SHUTDOWN_TIMEOUT_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
             fi
+            echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # --kv-transfer-config exists on all supported vLLM versions and even the
+            # OffloadingConnector predates them, but the TieringOffloadingSpec that
+            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+            # Neither is listed in --help output, so probe the installed package source.
+            vllm_supports_tiering_offloading() {
+              local pkg_dir
+              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+            }
+
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-              fi
+            if vllm_supports_tiering_offloading; then
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                *--kv-transfer-config*|*--kv_transfer_config*)
+                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              esac
+            else
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve \
@@ -504,28 +521,45 @@ spec:
 
             START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
 
+            # Detect flags from `vllm serve --help` rather than the version string: patched
+            # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+            VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
             # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
             # Older versions still need the blanket --disable-uvicorn-access-log.
             ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-            VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-            echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
               ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
             fi
             echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
             # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
             SHUTDOWN_TIMEOUT_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
             fi
+            echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # --kv-transfer-config exists on all supported vLLM versions and even the
+            # OffloadingConnector predates them, but the TieringOffloadingSpec that
+            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+            # Neither is listed in --help output, so probe the installed package source.
+            vllm_supports_tiering_offloading() {
+              local pkg_dir
+              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+            }
+
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-              fi
+            if vllm_supports_tiering_offloading; then
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                *--kv-transfer-config*|*--kv_transfer_config*)
+                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              esac
+            else
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve \

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -241,26 +241,18 @@ spec:
             fi
             echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config exists on all supported vLLM versions and even the
-            # OffloadingConnector predates them, but the TieringOffloadingSpec that
-            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-            # Neither is listed in --help output, so probe the installed package source.
-            vllm_supports_tiering_offloading() {
-              local pkg_dir
-              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-            }
-
-            KV_TRANSFER_ARGS=""
-            if vllm_supports_tiering_offloading; then
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+            # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+            # and version strings are unusable (patched builds report 0.1.devN placeholders).
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+            if [ -n "$KV_TRANSFER_ARGS" ]; then
               case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                 *--kv-transfer-config*|*--kv_transfer_config*)
-                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+                  echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                  KV_TRANSFER_ARGS="" ;;
+                *)
+                  echo "[kv-transfer] injecting --kv-transfer-config" ;;
               esac
-            else
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve \
@@ -540,26 +532,18 @@ spec:
             fi
             echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config exists on all supported vLLM versions and even the
-            # OffloadingConnector predates them, but the TieringOffloadingSpec that
-            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-            # Neither is listed in --help output, so probe the installed package source.
-            vllm_supports_tiering_offloading() {
-              local pkg_dir
-              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-            }
-
-            KV_TRANSFER_ARGS=""
-            if vllm_supports_tiering_offloading; then
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+            # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+            # and version strings are unusable (patched builds report 0.1.devN placeholders).
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+            if [ -n "$KV_TRANSFER_ARGS" ]; then
               case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                 *--kv-transfer-config*|*--kv_transfer_config*)
-                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+                  echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                  KV_TRANSFER_ARGS="" ;;
+                *)
+                  echo "[kv-transfer] injecting --kv-transfer-config" ;;
               esac
-            else
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve \

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -140,28 +140,45 @@ spec:
                 fi
               fi
 
+              # Detect flags from `vllm serve --help` rather than the version string: patched
+              # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+              VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
               # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
               # Older versions still need the blanket --disable-uvicorn-access-log.
               ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-              VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-              echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+              if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
                 ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
               fi
               echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
               # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
               SHUTDOWN_TIMEOUT_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+              if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
                 SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
               fi
+              echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              # --kv-transfer-config exists on all supported vLLM versions and even the
+              # OffloadingConnector predates them, but the TieringOffloadingSpec that
+              # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+              # Neither is listed in --help output, so probe the installed package source.
+              vllm_supports_tiering_offloading() {
+                local pkg_dir
+                pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+                grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+              }
+
               KV_TRANSFER_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-                if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                  KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-                fi
+              if vllm_supports_tiering_offloading; then
+                echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+                case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                  *--kv-transfer-config*|*--kv_transfer_config*)
+                    echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                  *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                esac
+              else
+                echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
               fi
 
               eval "exec vllm serve /mnt/models \

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -159,26 +159,18 @@ spec:
               fi
               echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-              # --kv-transfer-config exists on all supported vLLM versions and even the
-              # OffloadingConnector predates them, but the TieringOffloadingSpec that
-              # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-              # Neither is listed in --help output, so probe the installed package source.
-              vllm_supports_tiering_offloading() {
-                local pkg_dir
-                pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-                grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-              }
-
-              KV_TRANSFER_ARGS=""
-              if vllm_supports_tiering_offloading; then
-                echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+              # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+              # and version strings are unusable (patched builds report 0.1.devN placeholders).
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+              if [ -n "$KV_TRANSFER_ARGS" ]; then
                 case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                   *--kv-transfer-config*|*--kv_transfer_config*)
-                    echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                  *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                    echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                    KV_TRANSFER_ARGS="" ;;
+                  *)
+                    echo "[kv-transfer] injecting --kv-transfer-config" ;;
                 esac
-              else
-                echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
               fi
 
               eval "exec vllm serve /mnt/models \

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -162,28 +162,45 @@ spec:
 
               START_RANK=0
 
+              # Detect flags from `vllm serve --help` rather than the version string: patched
+              # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+              VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
               # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
               # Older versions still need the blanket --disable-uvicorn-access-log.
               ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-              VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-              echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+              if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
                 ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
               fi
               echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
               # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
               SHUTDOWN_TIMEOUT_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+              if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
                 SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
               fi
+              echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              # --kv-transfer-config exists on all supported vLLM versions and even the
+              # OffloadingConnector predates them, but the TieringOffloadingSpec that
+              # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+              # Neither is listed in --help output, so probe the installed package source.
+              vllm_supports_tiering_offloading() {
+                local pkg_dir
+                pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+                grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+              }
+
               KV_TRANSFER_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-                if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                  KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-                fi
+              if vllm_supports_tiering_offloading; then
+                echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+                case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                  *--kv-transfer-config*|*--kv_transfer_config*)
+                    echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                  *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                esac
+              else
+                echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
               fi
 
               eval "exec vllm serve \
@@ -444,28 +461,45 @@ spec:
 
               START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} ))
 
+              # Detect flags from `vllm serve --help` rather than the version string: patched
+              # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+              VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
               # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
               # Older versions still need the blanket --disable-uvicorn-access-log.
               ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-              VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-              echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+              if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
                 ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
               fi
               echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
               # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
               SHUTDOWN_TIMEOUT_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+              if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
                 SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
               fi
+              echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              # --kv-transfer-config exists on all supported vLLM versions and even the
+              # OffloadingConnector predates them, but the TieringOffloadingSpec that
+              # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+              # Neither is listed in --help output, so probe the installed package source.
+              vllm_supports_tiering_offloading() {
+                local pkg_dir
+                pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+                grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+              }
+
               KV_TRANSFER_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-                if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                  KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-                fi
+              if vllm_supports_tiering_offloading; then
+                echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+                case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                  *--kv-transfer-config*|*--kv_transfer_config*)
+                    echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                  *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                esac
+              else
+                echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
               fi
 
               eval "exec vllm serve \

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -181,26 +181,18 @@ spec:
               fi
               echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-              # --kv-transfer-config exists on all supported vLLM versions and even the
-              # OffloadingConnector predates them, but the TieringOffloadingSpec that
-              # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-              # Neither is listed in --help output, so probe the installed package source.
-              vllm_supports_tiering_offloading() {
-                local pkg_dir
-                pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-                grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-              }
-
-              KV_TRANSFER_ARGS=""
-              if vllm_supports_tiering_offloading; then
-                echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+              # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+              # and version strings are unusable (patched builds report 0.1.devN placeholders).
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+              if [ -n "$KV_TRANSFER_ARGS" ]; then
                 case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                   *--kv-transfer-config*|*--kv_transfer_config*)
-                    echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                  *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                    echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                    KV_TRANSFER_ARGS="" ;;
+                  *)
+                    echo "[kv-transfer] injecting --kv-transfer-config" ;;
                 esac
-              else
-                echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
               fi
 
               eval "exec vllm serve \
@@ -480,26 +472,18 @@ spec:
               fi
               echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-              # --kv-transfer-config exists on all supported vLLM versions and even the
-              # OffloadingConnector predates them, but the TieringOffloadingSpec that
-              # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-              # Neither is listed in --help output, so probe the installed package source.
-              vllm_supports_tiering_offloading() {
-                local pkg_dir
-                pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-                grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-              }
-
-              KV_TRANSFER_ARGS=""
-              if vllm_supports_tiering_offloading; then
-                echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+              # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+              # and version strings are unusable (patched builds report 0.1.devN placeholders).
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+              if [ -n "$KV_TRANSFER_ARGS" ]; then
                 case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                   *--kv-transfer-config*|*--kv_transfer_config*)
-                    echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                  *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                    echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                    KV_TRANSFER_ARGS="" ;;
+                  *)
+                    echo "[kv-transfer] injecting --kv-transfer-config" ;;
                 esac
-              else
-                echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
               fi
 
               eval "exec vllm serve \

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -139,28 +139,45 @@ spec:
               fi
             fi
 
+            # Detect flags from `vllm serve --help` rather than the version string: patched
+            # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+            VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
             # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
             # Older versions still need the blanket --disable-uvicorn-access-log.
             ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-            VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-            echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
               ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
             fi
             echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
             # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
             SHUTDOWN_TIMEOUT_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
             fi
+            echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # --kv-transfer-config exists on all supported vLLM versions and even the
+            # OffloadingConnector predates them, but the TieringOffloadingSpec that
+            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+            # Neither is listed in --help output, so probe the installed package source.
+            vllm_supports_tiering_offloading() {
+              local pkg_dir
+              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+            }
+
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-              fi
+            if vllm_supports_tiering_offloading; then
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                *--kv-transfer-config*|*--kv_transfer_config*)
+                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              esac
+            else
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve /mnt/models \

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -158,26 +158,18 @@ spec:
             fi
             echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config exists on all supported vLLM versions and even the
-            # OffloadingConnector predates them, but the TieringOffloadingSpec that
-            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-            # Neither is listed in --help output, so probe the installed package source.
-            vllm_supports_tiering_offloading() {
-              local pkg_dir
-              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-            }
-
-            KV_TRANSFER_ARGS=""
-            if vllm_supports_tiering_offloading; then
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+            # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+            # and version strings are unusable (patched builds report 0.1.devN placeholders).
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+            if [ -n "$KV_TRANSFER_ARGS" ]; then
               case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                 *--kv-transfer-config*|*--kv_transfer_config*)
-                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+                  echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                  KV_TRANSFER_ARGS="" ;;
+                *)
+                  echo "[kv-transfer] injecting --kv-transfer-config" ;;
               esac
-            else
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve /mnt/models \

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -161,28 +161,45 @@ spec:
 
             START_RANK=0
 
+            # Detect flags from `vllm serve --help` rather than the version string: patched
+            # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+            VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
             # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
             # Older versions still need the blanket --disable-uvicorn-access-log.
             ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-            VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-            echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
               ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
             fi
             echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
             # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
             SHUTDOWN_TIMEOUT_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
             fi
+            echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # --kv-transfer-config exists on all supported vLLM versions and even the
+            # OffloadingConnector predates them, but the TieringOffloadingSpec that
+            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+            # Neither is listed in --help output, so probe the installed package source.
+            vllm_supports_tiering_offloading() {
+              local pkg_dir
+              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+            }
+
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-              fi
+            if vllm_supports_tiering_offloading; then
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                *--kv-transfer-config*|*--kv_transfer_config*)
+                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              esac
+            else
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve \
@@ -443,28 +460,45 @@ spec:
 
             START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
 
+            # Detect flags from `vllm serve --help` rather than the version string: patched
+            # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+            VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
             # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
             # Older versions still need the blanket --disable-uvicorn-access-log.
             ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-            VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-            echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
               ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
             fi
             echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
             # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
             SHUTDOWN_TIMEOUT_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
             fi
+            echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # --kv-transfer-config exists on all supported vLLM versions and even the
+            # OffloadingConnector predates them, but the TieringOffloadingSpec that
+            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+            # Neither is listed in --help output, so probe the installed package source.
+            vllm_supports_tiering_offloading() {
+              local pkg_dir
+              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+            }
+
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-                KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-              fi
+            if vllm_supports_tiering_offloading; then
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+              case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+                *--kv-transfer-config*|*--kv_transfer_config*)
+                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              esac
+            else
+              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve \

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -180,26 +180,18 @@ spec:
             fi
             echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config exists on all supported vLLM versions and even the
-            # OffloadingConnector predates them, but the TieringOffloadingSpec that
-            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-            # Neither is listed in --help output, so probe the installed package source.
-            vllm_supports_tiering_offloading() {
-              local pkg_dir
-              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-            }
-
-            KV_TRANSFER_ARGS=""
-            if vllm_supports_tiering_offloading; then
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+            # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+            # and version strings are unusable (patched builds report 0.1.devN placeholders).
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+            if [ -n "$KV_TRANSFER_ARGS" ]; then
               case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                 *--kv-transfer-config*|*--kv_transfer_config*)
-                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+                  echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                  KV_TRANSFER_ARGS="" ;;
+                *)
+                  echo "[kv-transfer] injecting --kv-transfer-config" ;;
               esac
-            else
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve \
@@ -479,26 +471,18 @@ spec:
             fi
             echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-            # --kv-transfer-config exists on all supported vLLM versions and even the
-            # OffloadingConnector predates them, but the TieringOffloadingSpec that
-            # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-            # Neither is listed in --help output, so probe the installed package source.
-            vllm_supports_tiering_offloading() {
-              local pkg_dir
-              pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-              grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-            }
-
-            KV_TRANSFER_ARGS=""
-            if vllm_supports_tiering_offloading; then
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+            # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+            # and version strings are unusable (patched builds report 0.1.devN placeholders).
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+            if [ -n "$KV_TRANSFER_ARGS" ]; then
               case "${VLLM_ADDITIONAL_ARGS:-} $*" in
                 *--kv-transfer-config*|*--kv_transfer_config*)
-                  echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-                *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+                  echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                  KV_TRANSFER_ARGS="" ;;
+                *)
+                  echo "[kv-transfer] injecting --kv-transfer-config" ;;
               esac
-            else
-              echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
             fi
 
             eval "exec vllm serve \

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2740,28 +2740,45 @@ spec:
           fi
         fi
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -3076,28 +3093,45 @@ spec:
 
         START_RANK=0
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3416,28 +3450,45 @@ spec:
 
         START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3662,28 +3713,45 @@ spec:
             fi
           fi
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve /mnt/models \
@@ -3939,28 +4007,45 @@ spec:
 
           START_RANK=0
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -4218,28 +4303,45 @@ spec:
 
           START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} ))
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -5076,28 +5178,45 @@ spec:
           fi
         fi
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -5442,28 +5561,45 @@ spec:
 
         START_RANK=0
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -5721,28 +5857,45 @@ spec:
 
         START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2759,26 +2759,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -3112,26 +3104,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3469,26 +3453,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3732,26 +3708,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve /mnt/models \
@@ -4026,26 +3994,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -4322,26 +4282,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -5197,26 +5149,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -5580,26 +5524,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -5876,26 +5812,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2326,28 +2326,45 @@ spec:
           fi
         fi
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -2662,28 +2679,45 @@ spec:
 
         START_RANK=0
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3002,28 +3036,45 @@ spec:
 
         START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3248,28 +3299,45 @@ spec:
             fi
           fi
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve /mnt/models \
@@ -3525,28 +3593,45 @@ spec:
 
           START_RANK=0
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -3804,28 +3889,45 @@ spec:
 
           START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} ))
 
+          # Detect flags from `vllm serve --help` rather than the version string: patched
+          # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+          VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
           # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
           # Older versions still need the blanket --disable-uvicorn-access-log.
           ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
             ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
           fi
           echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
           # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
           SHUTDOWN_TIMEOUT_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
+          echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # --kv-transfer-config exists on all supported vLLM versions and even the
+          # OffloadingConnector predates them, but the TieringOffloadingSpec that
+          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+          # Neither is listed in --help output, so probe the installed package source.
+          vllm_supports_tiering_offloading() {
+            local pkg_dir
+            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+          }
+
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
-            fi
+          if vllm_supports_tiering_offloading; then
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+            case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+              *--kv-transfer-config*|*--kv_transfer_config*)
+                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+            esac
+          else
+            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -4662,28 +4764,45 @@ spec:
           fi
         fi
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -5028,28 +5147,45 @@ spec:
 
         START_RANK=0
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -5307,28 +5443,45 @@ spec:
 
         START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
 
+        # Detect flags from `vllm serve --help` rather than the version string: patched
+        # builds report a placeholder version (0.1.devN+g<hash>) unrelated to the real one.
+        VLLM_SERVE_HELP="$( { vllm serve --help=all || vllm serve --help; } 2>/dev/null || true )"
+
         # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
         # Older versions still need the blanket --disable-uvicorn-access-log.
         ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
-        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
-        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --disable-access-log-for-endpoints; then
           ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
         fi
         echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
 
         # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
         SHUTDOWN_TIMEOUT_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+        if printf '%s' "$VLLM_SERVE_HELP" | grep -q -- --shutdown-timeout; then
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
+        echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # --kv-transfer-config exists on all supported vLLM versions and even the
+        # OffloadingConnector predates them, but the TieringOffloadingSpec that
+        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
+        # Neither is listed in --help output, so probe the installed package source.
+        vllm_supports_tiering_offloading() {
+          local pkg_dir
+          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
+          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
+        }
+
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-          fi
+        if vllm_supports_tiering_offloading; then
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          case "${VLLM_ADDITIONAL_ARGS:-} $*" in
+            *--kv-transfer-config*|*--kv_transfer_config*)
+              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
+            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+          esac
+        else
+          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2345,26 +2345,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -2698,26 +2690,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3055,26 +3039,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3318,26 +3294,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve /mnt/models \
@@ -3612,26 +3580,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -3908,26 +3868,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -4783,26 +4735,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -5166,26 +5110,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -5462,26 +5398,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -2737,26 +2737,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -3090,26 +3082,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3447,26 +3431,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -3710,26 +3686,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve /mnt/models \
@@ -4004,26 +3972,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -4300,26 +4260,18 @@ spec:
           fi
           echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-          # --kv-transfer-config exists on all supported vLLM versions and even the
-          # OffloadingConnector predates them, but the TieringOffloadingSpec that
-          # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-          # Neither is listed in --help output, so probe the installed package source.
-          vllm_supports_tiering_offloading() {
-            local pkg_dir
-            pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-            grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-          }
-
-          KV_TRANSFER_ARGS=""
-          if vllm_supports_tiering_offloading; then
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+          # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+          # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+          # and version strings are unusable (patched builds report 0.1.devN placeholders).
+          KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+          if [ -n "$KV_TRANSFER_ARGS" ]; then
             case "${VLLM_ADDITIONAL_ARGS:-} $*" in
               *--kv-transfer-config*|*--kv_transfer_config*)
-                echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-              *) KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}" ;;
+                echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+                KV_TRANSFER_ARGS="" ;;
+              *)
+                echo "[kv-transfer] injecting --kv-transfer-config" ;;
             esac
-          else
-            echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
           fi
 
           eval "exec vllm serve \
@@ -5175,26 +5127,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve /mnt/models \
@@ -5558,26 +5502,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \
@@ -5854,26 +5790,18 @@ spec:
         fi
         echo "[shutdown-timeout-detect] selected SHUTDOWN_TIMEOUT_ARGS='${SHUTDOWN_TIMEOUT_ARGS}'"
 
-        # --kv-transfer-config exists on all supported vLLM versions and even the
-        # OffloadingConnector predates them, but the TieringOffloadingSpec that
-        # kvTransferConfig generates only landed in vLLM 0.22.0 (vllm-project/vllm#40020).
-        # Neither is listed in --help output, so probe the installed package source.
-        vllm_supports_tiering_offloading() {
-          local pkg_dir
-          pkg_dir="$(python3 -c 'import importlib.util, os; print(os.path.dirname(importlib.util.find_spec("vllm").origin))' 2>/dev/null)" || return 1
-          grep -rqsI "TieringOffloadingSpec" "$pkg_dir"
-        }
-
-        KV_TRANSFER_ARGS=""
-        if vllm_supports_tiering_offloading; then
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='1'"
+        # TieringOffloadingSpec requires vLLM >= 0.22.0 (vllm-project/vllm#40020). No upfront
+        # check: older vLLM fast-fails with "Unsupported spec type: TieringOffloadingSpec",
+        # and version strings are unusable (patched builds report 0.1.devN placeholders).
+        KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+        if [ -n "$KV_TRANSFER_ARGS" ]; then
           case "${VLLM_ADDITIONAL_ARGS:-} $*" in
             *--kv-transfer-config*|*--kv_transfer_config*)
-              echo "[kv-transfer-detect] user-supplied --kv-transfer-config, skipping injection" ;;
-            *) KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}" ;;
+              echo "[kv-transfer] user-supplied --kv-transfer-config, skipping injection"
+              KV_TRANSFER_ARGS="" ;;
+            *)
+              echo "[kv-transfer] injecting --kv-transfer-config" ;;
           esac
-        else
-          echo "[kv-transfer-detect] TieringOffloadingSpec supported='0'"
         fi
 
         eval "exec vllm serve \


### PR DESCRIPTION
**What this PR does / why we need it**:

The generated vLLM serve command decided whether to add `--kv-transfer-config`, `--shutdown-timeout`, and `--disable-access-log-for-endpoints` by comparing the output of `vllm --version` against fixed thresholds (0.22.0 / 0.18.0 / 0.16.0).

This breaks on images whose vLLM is built from source / patched rather than installed from a tagged release, because `vllm --version` then reports a setuptools-scm placeholder instead of the real version. Concretely, `ghcr.io/llm-d/llm-d-cuda:v0.8.0` reports:

`0.1.dev1+g51f799c1a.precompiled`

The gate parses the leading `0.1`, ranks it below every threshold with `sort -V`, and silently drops all three flags — even though that build is actually newer than 0.22.0 and fully supports them. No version-string logic can fix this, because the placeholder carries no usable version information.

This PR replaces version parsing with a per-flag policy:

- **`--shutdown-timeout` and `--disable-access-log-for-endpoints`: capability detection.** The startup script queries `vllm serve --help=all` once (falling back to `vllm serve --help` for older vLLM) and enables each flag only if the binary advertises it. These are not user-requested features and both have safe fallbacks, so silently falling back is the right policy.
- **`--kv-transfer-config` (generated from `spec.kvCacheOffloading`): injected unconditionally, no gate.** The flag itself exists on every supported vLLM version, and testing on real images (see below) confirmed that vLLM validates the offloading spec at engine init and fails fast with `ValueError: Unsupported spec type: TieringOffloadingSpec` on versions without support (< 0.22.0). Silently skipping a feature the user explicitly set in the spec — while the LLMInferenceService reports Ready — is worse than a clear crash-loop, and any upfront capability probe is a proxy that can false-negative and block a working image (thanks @pierDipi for pushing on this). Injection is still skipped when the user supplies their own `--kv-transfer-config` via args or `VLLM_ADDITIONAL_ARGS`.

**Feature/Issue validation/testing**:

- [x] Verified the injected `--kv-transfer-config` end-to-end on real llm-d-cuda images:

| Image | Reported version |  Behavior with the flag injected |
|---|---|---|
| `ghcr.io/llm-d/llm-d-cuda:0.6.0` | `0.17.1+precompiled` | fast fail: `ValueError: Unsupported spec type: TieringOffloadingSpec` |
| `ghcr.io/llm-d/llm-d-cuda:0.7.0` | `0.1.dev1+g693c2d11e.precompiled` | fast fail: `ValueError: Unsupported spec type: TieringOffloadingSpec` |
| `ghcr.io/llm-d/llm-d-cuda:0.8.0` | `0.1.dev1+g51f799c1a.precompiled` | works: `Created TieringOffloadingManager`, server healthy |

- [x] Verified `vllm serve --help` detection flips `--shutdown-timeout` / `--disable-access-log-for-endpoints` exactly where each feature landed, independent of the reported version string.
- [x] Regenerated chart + quick-install manifests via `make generate-chart-manifests generate-quick-install-scripts`; `bash -n` passes on the rendered startup scripts.

**Special notes for your reviewer**:

Behavioral change: when `spec.kvCacheOffloading` is set and the image's vLLM lacks TieringOffloadingSpec (< 0.22.0), the workload now crash-loops with a clear, actionable error instead of starting without offloading. No API or image changes. Source of truth is `config/llmisvcconfig/*.yaml`; the chart `resources.yaml` and `hack/setup/quick-install/*-with-manifests.sh` are regenerated from it.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Fixed vLLM feature detection in LLMInferenceService. Flags with safe fallbacks (--shutdown-timeout, --disable-access-log-for-endpoints) are now gated by `vllm serve --help` capability detection instead of the version string, which is a meaningless placeholder on source-built images (e.g. llm-d-cuda reporting 0.1.devN+g<hash>). --kv-transfer-config generated from spec.kvCacheOffloading is now always injected: on images whose vLLM lacks TieringOffloadingSpec (< 0.22.0) the workload fails fast with a clear error instead of silently running without KV cache offloading.
