### PR TITLE
fix(samples): remove NixlConnector from prefix cache routing e2e sample

### DIFF
--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -199,7 +199,7 @@ kubectl apply -f llmisvc_config_prefix_cache.yaml -n kserve-lab
 
 This creates `llmisvc-prefix-caching`. It adds:
 
-- vLLM args: `--prefix-caching-hash-algo sha256_cbor`, `--block-size 64`, `--kv_transfer_config`, `--kv-events-config` (ZMQ to EPP)
+- vLLM args: `--prefix-caching-hash-algo sha256_cbor`, `--block-size 64`, `--kv-events-config` (ZMQ to EPP)
 - Router scheduler with `token-producer`, `precise-prefix-cache-producer`, `prefix-cache-scorer`, `queue-scorer`, `kv-cache-utilization-scorer`, and `active-request-scorer`
 - Standalone tokenizer deployment (auto-deployed from `token-producer` plugin presence)
 - Scheduler needs `hf-token` secret for tokenizer download (already created above)

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
@@ -18,7 +18,6 @@ spec:
             --disable-log-requests
             --prefix-caching-hash-algo sha256_cbor
             --block-size 64
-            --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
             --kv-events-config "$KV_EVENTS_CONFIG"
             $VLLM_ADDITIONAL_ARGS
         env:


### PR DESCRIPTION
## What this PR does / why we need it

Removes `--kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'` from the prefix cache routing sample (`e2e-gpt-oss/llmisvc_config_prefix_cache.yaml`) and updates the README to match.

NixlConnector enables **cross-pod KV cache transfer** used in prefill/decode disaggregation (`kv_producer`/`kv_consumer` roles). Prefix cache-aware routing is a different mechanism — it **routes requests to the pod that already has the cached blocks** via ZMQ event tracking. No KV transfer between pods occurs.

## Validation

- The [upstream llm-d canonical config](https://github.com/llm-d/llm-d/blob/main/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml) for precise-prefix-cache-routing does NOT use `--kv_transfer_config`
- The kserve automated e2e test fixtures (`test/e2e/llmisvc/fixtures.py`) for prefix cache routing do not use NixlConnector
- The P/D disaggregation sample (section 9, `llmisvc_config_pd_disagg.yaml`) correctly retains NixlConnector with `kv_producer`/`kv_consumer` roles
- PR #5804 already removed NixlConnector from the standalone prefix cache routing sample (`precise-prefix-kv-cache-routing/`)

## Files changed

| File | Change |
|------|--------|
| `docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml` | Remove `--kv_transfer_config` line from vLLM args |
| `docs/samples/llmisvc/e2e-gpt-oss/README.md` | Remove `--kv_transfer_config` from section 8.1 description |

## Release note
NONE