### PR TITLE
fix(e2e): poll for CanaryPredictorReady condition

### DIFF
--- a/test/e2e/predictor/test_canary_raw_deployment.py
+++ b/test/e2e/predictor/test_canary_raw_deployment.py
@@ -178,15 +178,12 @@ def test_canary_create():
         assert stable_dep is not None
         assert canary_dep is not None
 
-        got = kserve.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
-
-        conditions = got.get("status", {}).get("conditions", [])
-        canary_condition = next(
-            (c for c in conditions if c["type"] == "CanaryPredictorReady"), None
+        canary_condition = _wait_for_condition(
+            kserve, service_name, "CanaryPredictorReady", "AllCanariesReady"
         )
-        assert canary_condition is not None, "CanaryPredictorReady condition missing"
         assert canary_condition["status"] == "True"
 
+        got = kserve.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
         canary_status = got.get("status", {}).get("canaryStatuses", [])
         assert len(canary_status) > 0, "canary status should be populated"
         assert canary_status[0]["name"] == "v2"


### PR DESCRIPTION
**What this PR does / why we need it**:

`test_canary_create` is flaky because it does a one-shot read of `CanaryPredictorReady` immediately after `wait_isvc_ready` returns. Since `CanaryPredictorReady` is an informational condition outside the readiness gate (`PredictorReady` + `IngressReady`), the ISVC can be `Ready=True` before the controller has reconciled the canary deployment's availability into the condition.

This replaces the point-in-time assertion with the existing `_wait_for_condition` helper, which polls until the controller sets `CanaryPredictorReady` with reason `AllCanariesReady`.

**Which issue(s) this PR fixes**:

Fixes flaky `test_canary_create` in `test_canary_raw_deployment.py`.

**Feature/Issue validation/testing**:

- [x] Existing `_wait_for_condition` helper already used by `test_canary_force_stop` in same file
- [x] 60s timeout with descriptive `TimeoutError` on failure

**Special notes for your reviewer**:

The race window: `wait_isvc_ready` → deployment watch event → controller reconcile → status write. Under CI load this gap is large enough to trigger the flake.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```