### PR TITLE
fix(python): map numpy unicode string dtype to BYTES in from_np_dtype

### DIFF
--- a/python/kserve/kserve/utils/numpy_codec.py
+++ b/python/kserve/kserve/utils/numpy_codec.py
@@ -62,6 +62,7 @@ def from_np_dtype(np_dtype):
     elif (
         np_dtype == np.object_
         or np_dtype.type == np.bytes_
+        or np_dtype.type == np.str_
         or np.issubdtype(np_dtype, np.datetime64)
     ):
         return "BYTES"

--- a/python/kserve/test/test_numpy_codec.py
+++ b/python/kserve/test/test_numpy_codec.py
@@ -1,0 +1,58 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from kserve.utils.numpy_codec import from_np_dtype, to_np_dtype
+
+
+@pytest.mark.parametrize(
+    "array, expected",
+    [
+        (np.array([True, False]), "BOOL"),
+        (np.array([1, 2], dtype=np.int8), "INT8"),
+        (np.array([1, 2], dtype=np.int16), "INT16"),
+        (np.array([1, 2], dtype=np.int32), "INT32"),
+        (np.array([1, 2], dtype=np.int64), "INT64"),
+        (np.array([1, 2], dtype=np.uint8), "UINT8"),
+        (np.array([1, 2], dtype=np.float32), "FP32"),
+        (np.array([1, 2], dtype=np.float64), "FP64"),
+        (np.array(["a", "bb"]), "BYTES"),  # unicode string dtype (kind "U")
+        (np.array([b"a", b"bb"]), "BYTES"),  # byte string dtype (kind "S")
+        (np.array(["a"], dtype=object), "BYTES"),  # object dtype
+        (np.array(["2020-01-01"], dtype="datetime64[s]"), "BYTES"),
+    ],
+)
+def test_from_np_dtype(array, expected):
+    assert from_np_dtype(array.dtype) == expected
+
+
+def test_from_np_dtype_unicode_is_bytes():
+    """Regression: numpy unicode string dtype must map to BYTES, not None.
+
+    ``np.array(["a", "b"])`` yields a ``<U`` (unicode) dtype. Previously only
+    byte-string (``|S``) and object dtypes were recognised, so a unicode string
+    array produced ``None`` and an InferOutput with ``datatype=None``.
+    """
+    assert from_np_dtype(np.array(["cat", "dog"]).dtype) == "BYTES"
+
+
+@pytest.mark.parametrize(
+    "datatype",
+    ["BOOL", "INT8", "INT16", "INT32", "INT64", "UINT8", "FP16", "FP32", "FP64"],
+)
+def test_np_dtype_round_trip(datatype):
+    """Numeric datatypes round-trip through to_np_dtype / from_np_dtype."""
+    assert from_np_dtype(np.dtype(to_np_dtype(datatype))) == datatype


### PR DESCRIPTION
**What this PR does / why we need it**:

`kserve.utils.numpy_codec.from_np_dtype` maps a numpy dtype to a KServe/V2 datatype string. It recognised byte-string (`|S`, `np.bytes_`) and object dtypes as `"BYTES"`, but **not** the numpy unicode-string dtype (`<U`, `np.str_`). As a result a perfectly valid string prediction result:

```python
from kserve.utils.numpy_codec import from_np_dtype
import numpy as np

from_np_dtype(np.array(["cat", "dog"]).dtype)   # -> None   (should be "BYTES")
from_np_dtype(np.array([b"cat", b"dog"]).dtype)  # -> "BYTES"
```

returned `None`, which then flows into `get_predict_response` and produces an `InferOutput` with `datatype=None`. `np.array([...])` of Python strings yields a `<U` dtype, so this is the common case for string outputs, while only the byte-string form was handled.

This adds `np_dtype.type == np.str_` alongside the existing `np.bytes_` check so unicode string dtypes map to `"BYTES"`.

**Which issue(s) this PR fixes**:

(No existing issue — found while reading the codec.)

**Feature/Issue validation/testing**:

Added `python/kserve/test/test_numpy_codec.py`:

- [x] `test_from_np_dtype` — parametrized over every dtype kind (bool/int/uint/float/unicode/bytes/object/datetime64); the unicode case fails on `main` (`None`) and passes here (`BYTES`).
- [x] `test_from_np_dtype_unicode_is_bytes` — focused regression for the `<U` case.
- [x] `test_np_dtype_round_trip` — numeric datatypes round-trip through `to_np_dtype` / `from_np_dtype`.

- Logs

```
kind=U <U2  -> 'BYTES'   (was None on main)
kind=S |S2  -> 'BYTES'
kind=O object -> 'BYTES'
all dtype kinds map as expected; numeric round-trip holds
```

**Special notes for your reviewer**:

Scoped to `from_np_dtype`; existing behaviour for all other dtypes is unchanged (covered by the parametrized test). `black`-clean.
