### PR TITLE
fix(llmisvc): skip v1alpha2 InfPool reconcile when CRD absent

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -240,8 +240,17 @@ func (r *LLMISVCReconciler) reconcileV1InferencePool(ctx context.Context, llmSvc
 	return Reconcile(ctx, r, llmSvc, &igwapi.InferencePool{}, expected, semanticInferencePoolIsEqual)
 }
 
-// reconcileV1Alpha2InferencePool reconciles the v1alpha2 InferencePool if the CRD is available.
+// reconcileV1Alpha2InferencePool reconciles the v1alpha2 InferencePool.
+// It is a no-op when the v1alpha2 InferencePool CRD is not installed on the cluster.
 func (r *LLMISVCReconciler) reconcileV1Alpha2InferencePool(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, shouldDelete bool) error {
+	ok, err := utils.IsCrdAvailable(r.Config, igwapiv1alpha2.GroupVersion.String(), "InferencePool")
+	if err != nil {
+		return fmt.Errorf("checking v1alpha2 InferencePool CRD availability: %w", err)
+	}
+	if !ok {
+		log.FromContext(ctx).V(2).Info("v1alpha2 InferencePool CRD not installed, skipping")
+		return nil
+	}
 	expected := r.expectedSchedulerInferencePoolV1Alpha2(ctx, llmSvc)
 	if shouldDelete {
 		return Delete(ctx, r, llmSvc, expected)


### PR DESCRIPTION
**What this PR does / why we need it**:

The scheduler reconciliation loop fails entirely when the v1alpha2 InferencePool CRD is not installed on the cluster. The generic `Reconcile()` helper only filters `apierrors.IsNotFound` via `client.IgnoreNotFound`, but a missing CRD produces `meta.NoKindMatchError` - a distinct error type that propagates unhandled.

This adds a CRD availability pre-check using the cached discovery API (already warmed by `SetupWithManager` at startup) so the reconcile-time cost is a map lookup. Discovery errors are propagated to trigger controller-runtime retry backoff rather than being silently swallowed.

v1 InferencePool is left unchanged - it is the stable API and is expected to always be present.

Based on the work in #5710 by @Fahmid-Arman - simplified to avoid the ConfigMap feature flag by reusing the discovery cache that `SetupWithManager` already populates.

**Which issue(s) this PR fixes**:
Fixes #5708

**Feature/Issue validation/testing**:

- [x] `reconcileV1Alpha2InferencePool` skips gracefully when CRD is absent (create path)
- [x] `reconcileV1Alpha2InferencePool` skips gracefully when CRD is absent (delete path)
- [x] Discovery errors propagate for controller-runtime retry

**Special notes for your reviewer**:

The `Delete()` helper in `lifecycle_crud.go` already handles `meta.IsNoMatchError` (lines 65, 89). The router readiness path in `router.go:744-817` also handles it correctly. The only gap was the create/update path through `Reconcile()`, which uses `client.IgnoreNotFound` and doesn't catch `NoKindMatchError`.

The CRD availability check uses the same `gvResourcesCache` that `SetupWithManager` populates at startup. If the CRD is absent at startup, watches aren't registered either - so the cache-based pre-check matches the existing contract (a restart is required if a CRD is installed later).

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fix: LLMInferenceService scheduling proceeds gracefully when v1alpha2 InferencePool CRD is not installed on the cluster.
```