### PR TITLE
fix(utils): eliminate data race in API resource discovery cache

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
@@ -39,7 +40,7 @@ import (
  * Please add functional style container operations sparingly and intentionally.
  */
 
-var gvResourcesCache map[string]*metav1.APIResourceList
+var gvResourcesCache sync.Map
 
 // Errors
 const (
@@ -238,23 +239,21 @@ func IsCrdAvailable(config *rest.Config, groupVersion, kind string) (bool, error
 // resources will be cached and returned to subsequent invocations to prevent additional
 // queries to the API server.
 func GetAvailableResourcesForApi(config *rest.Config, groupVersion string) (*metav1.APIResourceList, error) {
-	var gvResources *metav1.APIResourceList
-	var ok bool
-
-	if gvResources, ok = gvResourcesCache[groupVersion]; !ok {
-		discoveryClient, newClientErr := discovery.NewDiscoveryClientForConfig(config)
-		if newClientErr != nil {
-			return nil, newClientErr
-		}
-
-		var getGvResourcesErr error
-		gvResources, getGvResourcesErr = discoveryClient.ServerResourcesForGroupVersion(groupVersion)
-		if getGvResourcesErr != nil && !apierr.IsNotFound(getGvResourcesErr) {
-			return nil, getGvResourcesErr
-		}
-
-		SetAvailableResourcesForApi(groupVersion, gvResources)
+	if cached, ok := gvResourcesCache.Load(groupVersion); ok {
+		return cached.(*metav1.APIResourceList), nil
 	}
+
+	discoveryClient, newClientErr := discovery.NewDiscoveryClientForConfig(config)
+	if newClientErr != nil {
+		return nil, newClientErr
+	}
+
+	gvResources, getGvResourcesErr := discoveryClient.ServerResourcesForGroupVersion(groupVersion)
+	if getGvResourcesErr != nil && !apierr.IsNotFound(getGvResourcesErr) {
+		return nil, getGvResourcesErr
+	}
+
+	SetAvailableResourcesForApi(groupVersion, gvResources)
 
 	return gvResources, nil
 }
@@ -263,11 +262,7 @@ func GetAvailableResourcesForApi(config *rest.Config, groupVersion string) (*met
 // of discovered API resources. This function should never be called directly. It is exported
 // for usage in tests.
 func SetAvailableResourcesForApi(groupVersion string, resources *metav1.APIResourceList) {
-	if gvResourcesCache == nil {
-		gvResourcesCache = make(map[string]*metav1.APIResourceList)
-	}
-
-	gvResourcesCache[groupVersion] = resources
+	gvResourcesCache.Store(groupVersion, resources)
 }
 
 func GetEnvVarValue(envVars []corev1.EnvVar, key string) (string, bool) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -929,12 +929,13 @@ func TestSetAvailableResourcesForApi(t *testing.T) {
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
 			// Reset the cache before each test
-			gvResourcesCache = nil
+			gvResourcesCache.Clear()
 
 			SetAvailableResourcesForApi(scenario.groupVersion, scenario.resources)
 
-			g.Expect(gvResourcesCache).ToNot(gomega.BeNil())
-			g.Expect(gvResourcesCache[scenario.groupVersion]).To(gomega.BeComparableTo(scenario.resources))
+			cached, ok := gvResourcesCache.Load(scenario.groupVersion)
+			g.Expect(ok).To(gomega.BeTrue())
+			g.Expect(cached.(*metav1.APIResourceList)).To(gomega.BeComparableTo(scenario.resources))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The package-level `gvResourcesCache` map has no synchronization, creating a data race when controllers read the cache concurrently with a first reconcile writing a cache-miss entry. The nil-check-then-init pattern for the map itself is also racy under concurrent access.

Replaces the unprotected map with `sync.Map`, which is optimized for the write-once-read-many access pattern this cache follows - keys are written once on first discovery and read many times by reconcilers.

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/utils/... -race -count=1` passes
- [x] `go vet ./pkg/utils/...` clean

**Special notes for your reviewer**:

The TOCTOU window where two goroutines both miss the cache and both run discovery is pre-existing and benign - `ServerResourcesForGroupVersion` returns the same result for the same cluster state, and `sync.Map.Store` is atomic. Not worth adding `singleflight` complexity for a cache that stabilizes immediately after startup.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
NONE
```