### PR TITLE
fix(llmisvc): migrate --model-server-metrics-scheme when set on Args

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1800,8 +1800,11 @@ func extractDeprecatedMetricFlags(d *appsv1.Deployment) map[string]string {
 }
 
 // extractModelServerMetricsScheme strips the deprecated --model-server-metrics-scheme
-// flag from every container's Command and returns its value (empty if absent).
-// The scheduler preset carries the flag on Command.
+// flag from every container's Command and Args and returns its value (empty if
+// absent). The scheduler preset carries the flag on Command, but a user-supplied
+// SchedulerSpec.Template may place it on Args instead; both work on the old image
+// (kube concatenates Command+Args) but are rejected by llm-d-router v0.10.0, so
+// both lists must be scrubbed.
 func extractModelServerMetricsScheme(d *appsv1.Deployment) string {
 	names := map[string]bool{modelServerMetricsSchemeFlag: true}
 	scheme := ""
@@ -1811,17 +1814,24 @@ func extractModelServerMetricsScheme(d *appsv1.Deployment) string {
 			c.Command = filtered
 			scheme = extracted[modelServerMetricsSchemeFlag]
 		}
+		if filtered, extracted := filterArgs(c.Args, names); len(extracted) > 0 {
+			c.Args = filtered
+			scheme = extracted[modelServerMetricsSchemeFlag]
+		}
 	}
 	return scheme
 }
 
 // hasModelServerMetricsSchemeFlag reports whether any container carries the
-// --model-server-metrics-scheme flag on Command, without modifying it.
+// --model-server-metrics-scheme flag on Command or Args, without modifying it.
 func hasModelServerMetricsSchemeFlag(d *appsv1.Deployment) bool {
 	names := map[string]bool{modelServerMetricsSchemeFlag: true}
 	for ci := range d.Spec.Template.Spec.Containers {
 		c := &d.Spec.Template.Spec.Containers[ci]
 		if _, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
+			return true
+		}
+		if _, extracted := filterArgs(c.Args, names); len(extracted) > 0 {
 			return true
 		}
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2287,13 +2287,23 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 	tests := []struct {
 		name            string
 		command         []string
+		args            []string
 		expectedCommand []string
+		expectedArgs    []string
 		expectedScheme  string
 	}{
 		{
 			name:            "extracts from command with equals form",
 			command:         []string{"/app/epp", "--model-server-metrics-scheme=https", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
+			expectedScheme:  "https",
+		},
+		{
+			name:            "extracts from args with equals form",
+			command:         []string{"/app/epp"},
+			args:            []string{"--model-server-metrics-scheme=https", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp"},
+			expectedArgs:    []string{"--grpc-port=9002"},
 			expectedScheme:  "https",
 		},
 		{
@@ -2312,7 +2322,7 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Name: "main", Command: tt.command},
+								{Name: "main", Command: tt.command, Args: tt.args},
 							},
 						},
 					},
@@ -2322,6 +2332,9 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 			g.Expect(scheme).To(Equal(tt.expectedScheme))
 			if tt.expectedCommand != nil {
 				g.Expect(d.Spec.Template.Spec.Containers[0].Command).To(Equal(tt.expectedCommand))
+			}
+			if tt.expectedArgs != nil {
+				g.Expect(d.Spec.Template.Spec.Containers[0].Args).To(Equal(tt.expectedArgs))
 			}
 		})
 	}
@@ -2353,10 +2366,18 @@ plugins:
 			expectPlugin: false,
 		},
 		{
-			name:         "0.10.0 strips flag and injects plugin",
+			name:         "0.10.0 strips flag from command and injects plugin",
 			version:      "0.10.0",
 			command:      []string{"/app/epp", "--model-server-metrics-scheme=https"},
 			args:         []string{"--config-text", configYAML},
+			expectFlag:   false,
+			expectPlugin: true,
+		},
+		{
+			name:         "0.10.0 strips flag from args and injects plugin",
+			version:      "0.10.0",
+			command:      []string{"/app/epp"},
+			args:         []string{"--model-server-metrics-scheme=https", "--config-text", configYAML},
 			expectFlag:   false,
 			expectPlugin: true,
 		},
@@ -2413,6 +2434,8 @@ plugins:
 			g.Expect(slices.Contains(command, "--model-server-metrics-scheme=https")).To(Equal(tt.expectFlag))
 
 			args := d.Spec.Template.Spec.Containers[0].Args
+			// The flag must never survive on Args either, regardless of where it started.
+			g.Expect(slices.Contains(args, "--model-server-metrics-scheme=https")).To(BeFalse())
 			configText := ""
 			for i, a := range args {
 				if a == "--config-text" && i+1 < len(args) {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2442,11 +2442,25 @@ plugins:
 					configText = args[i+1]
 				}
 			}
+			var cfg map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(configText), &cfg)).To(Succeed())
+			plugins, _ := cfg["plugins"].([]interface{})
+
+			var metricsPlugin map[string]interface{}
+			for _, p := range plugins {
+				if pm, ok := p.(map[string]interface{}); ok && pm["type"] == "metrics-data-source" {
+					metricsPlugin = pm
+					break
+				}
+			}
+
 			if tt.expectPlugin {
-				g.Expect(configText).To(ContainSubstring("metrics-data-source"))
-				g.Expect(configText).To(ContainSubstring("scheme: https"))
+				g.Expect(metricsPlugin).NotTo(BeNil(), "expected a metrics-data-source plugin to be injected")
+				params, ok := metricsPlugin["parameters"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "metrics-data-source plugin must carry parameters")
+				g.Expect(params).To(HaveKeyWithValue("scheme", "https"))
 			} else {
-				g.Expect(configText).NotTo(ContainSubstring("metrics-data-source"))
+				g.Expect(metricsPlugin).To(BeNil(), "did not expect a metrics-data-source plugin")
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to a code-review comment on #5877: https://github.com/kserve/kserve/pull/5877/changes#r3624965271

The `--model-server-metrics-scheme` migration added in #5877 scanned only the container's `Command`. The scheduler preset does carry the flag on `Command`, but a user-supplied ` .spec.router.scheduler.template` can place it on `Args` instead. the flag works either way on pre-v0.10.0 images  but llm-d-router v0.10.0 will rejects it. A flag set on `Args` therefore survived the migration and would crash-loop the EPP pod after an upgrade.

`extractModelServerMetricsScheme` and `hasModelServerMetricsSchemeFlag` now scan both `Command` and `Args`. Scope is limited to this flag; the other deprecated-flag migrations are unchanged.

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [x] `TestExtractModelServerMetricsScheme` — added a case with the flag on `Args` (equals form)
- [x] `TestSchedulerTransformMigratesMetricsScheme` — added a v0.10.0 case where the flag starts on `Args`, plus an assertion that the flag never survives on `Args`

```
go test ./pkg/controller/v1alpha2/llmisvc/ \
  -run 'TestExtractModelServerMetricsScheme|TestSchedulerTransformMigratesMetricsScheme' -v
```

**Special notes for your reviewer**:

Addresses @bartoszmajsak's question on #5877 about whether operating on `c.Command` (rather than `c.Args`, as the other deprecated-flag migrations do) was intentional — it was, for the preset, but a user-authored template can use `Args`, so both lists are now handled.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
None
```
release notes has been handled in PR 5877