### PR TITLE
fix(test): assert worker count via exec not log PIDs

### DIFF
--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -15,6 +15,7 @@
 import asyncio
 import json
 import os
+import time
 from concurrent import futures
 from typing import Union, List, Dict
 from urllib.parse import urlparse
@@ -22,6 +23,7 @@ from urllib.parse import urlparse
 import portforward
 import requests
 from kubernetes import client as k8s_client
+from kubernetes.stream import stream as k8s_stream
 from orjson import orjson
 
 from httpx import HTTPStatusError
@@ -670,14 +672,47 @@ def is_model_ready(
     return rest_client.is_model_ready(base_url, model_name, headers=headers)
 
 
-def extract_process_ids_from_logs(logs: str) -> set[int]:
-    process_ids = set()
-    for line in logs.splitlines():
-        tokens = line.strip().split()
-        if len(tokens) >= 5 and tokens[3] == "kserve.trace":
-            process_ids.add(int(tokens[2]))
-    logger.info("Extracted process ids: %s", process_ids)
-    return process_ids
+_WORKER_COUNT_SCRIPT = (
+    "import glob\n"
+    "print(sum(1 for f in glob.glob('/proc/[0-9]*/cmdline')"
+    " if b'spawn_main' in open(f,'rb').read()))"
+)
+
+
+def get_container_worker_count(
+    core_api: k8s_client.CoreV1Api,
+    pod_name: str,
+    namespace: str,
+    container: str = INFERENCESERVICE_CONTAINER,
+    timeout: int = 30,
+    interval: int = 2,
+) -> int:
+    """Count multiprocessing worker processes inside a running container via /proc."""
+    cmd = ["python", "-c", _WORKER_COUNT_SCRIPT]
+    deadline = time.monotonic() + timeout
+    last_count = 0
+    while True:
+        resp = k8s_stream(
+            core_api.connect_get_namespaced_pod_exec,
+            pod_name,
+            namespace,
+            container=container,
+            command=cmd,
+            stderr=True,
+            stdout=True,
+            stdin=False,
+            tty=False,
+        )
+        try:
+            last_count = int(resp.strip())
+        except ValueError:
+            logger.warning("Unexpected worker-count output: %r", resp)
+            last_count = 0
+        if last_count > 0 or time.monotonic() >= deadline:
+            break
+        time.sleep(interval)
+    logger.info("Worker process count in %s/%s: %d", namespace, pod_name, last_count)
+    return last_count
 
 
 async def wait_for_pod_logs(

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -672,21 +672,23 @@ def is_model_ready(
     return rest_client.is_model_ready(base_url, model_name, headers=headers)
 
 
-_WORKER_COUNT_SCRIPT = "\n".join([
-    "import glob, os, sys",
-    "count = 0",
-    "for f in glob.glob('/proc/[0-9]*/cmdline'):",
-    "    try:",
-    "        data = open(f, 'rb').read()",
-    "        if b'spawn_main' not in data: continue",
-    "        status = open(os.path.join(os.path.dirname(f), 'status')).read()",
-    "        ppid = status.split('PPid:\\t')[1].split()[0]",
-    "        pid = f.split('/')[2]",
-    "        if ppid == '1': count += 1",
-    "        else: print(f'skip pid={pid} ppid={ppid}', file=sys.stderr)",
-    "    except (OSError, IndexError): pass",
-    "print(count)",
-])
+_WORKER_COUNT_SCRIPT = "\n".join(
+    [
+        "import glob, os, sys",
+        "count = 0",
+        "for f in glob.glob('/proc/[0-9]*/cmdline'):",
+        "    try:",
+        "        data = open(f, 'rb').read()",
+        "        if b'spawn_main' not in data: continue",
+        "        status = open(os.path.join(os.path.dirname(f), 'status')).read()",
+        "        ppid = status.split('PPid:\\t')[1].split()[0]",
+        "        pid = f.split('/')[2]",
+        "        if ppid == '1': count += 1",
+        "        else: print(f'skip pid={pid} ppid={ppid}', file=sys.stderr)",
+        "    except (OSError, IndexError): pass",
+        "print(count)",
+    ]
+)
 
 
 def get_container_worker_count(

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -672,21 +672,19 @@ def is_model_ready(
     return rest_client.is_model_ready(base_url, model_name, headers=headers)
 
 
-_WORKER_COUNT_SCRIPT = "\n".join(
-    [
-        "import glob, os",
-        "count = 0",
-        "for f in glob.glob('/proc/[0-9]*/cmdline'):",
-        "    try:",
-        "        data = open(f, 'rb').read()",
-        "        if b'spawn_main' not in data: continue",
-        "        status = open(os.path.join(os.path.dirname(f), 'status')).read()",
-        "        ppid = status.split('PPid:\\t')[1].split()[0]",
-        "        if ppid == '1': count += 1",
-        "    except (OSError, IndexError): pass",
-        "print(count)",
-    ]
-)
+_WORKER_COUNT_SCRIPT = """\
+import glob, os
+count = 0
+for f in glob.glob("/proc/[0-9]*/cmdline"):
+    try:
+        data = open(f, "rb").read()
+        if b"spawn_main" not in data: continue
+        status = open(os.path.join(os.path.dirname(f), "status")).read()
+        ppid = status.split("PPid:\\t")[1].split()[0]
+        if ppid == "1": count += 1
+    except (OSError, IndexError): pass
+print(count)
+"""
 
 
 def get_container_worker_count(

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -674,7 +674,7 @@ def is_model_ready(
 
 _WORKER_COUNT_SCRIPT = "\n".join(
     [
-        "import glob, os, sys",
+        "import glob, os",
         "count = 0",
         "for f in glob.glob('/proc/[0-9]*/cmdline'):",
         "    try:",
@@ -682,9 +682,7 @@ _WORKER_COUNT_SCRIPT = "\n".join(
         "        if b'spawn_main' not in data: continue",
         "        status = open(os.path.join(os.path.dirname(f), 'status')).read()",
         "        ppid = status.split('PPid:\\t')[1].split()[0]",
-        "        pid = f.split('/')[2]",
         "        if ppid == '1': count += 1",
-        "        else: print(f'skip pid={pid} ppid={ppid}', file=sys.stderr)",
         "    except (OSError, IndexError): pass",
         "print(count)",
     ]
@@ -710,7 +708,7 @@ def get_container_worker_count(
             namespace,
             container=container,
             command=cmd,
-            stderr=True,
+            stderr=False,
             stdout=True,
             stdin=False,
             tty=False,

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -672,11 +672,21 @@ def is_model_ready(
     return rest_client.is_model_ready(base_url, model_name, headers=headers)
 
 
-_WORKER_COUNT_SCRIPT = (
-    "import glob\n"
-    "print(sum(1 for f in glob.glob('/proc/[0-9]*/cmdline')"
-    " if b'spawn_main' in open(f,'rb').read()))"
-)
+_WORKER_COUNT_SCRIPT = "\n".join([
+    "import glob, os, sys",
+    "count = 0",
+    "for f in glob.glob('/proc/[0-9]*/cmdline'):",
+    "    try:",
+    "        data = open(f, 'rb').read()",
+    "        if b'spawn_main' not in data: continue",
+    "        status = open(os.path.join(os.path.dirname(f), 'status')).read()",
+    "        ppid = status.split('PPid:\\t')[1].split()[0]",
+    "        pid = f.split('/')[2]",
+    "        if ppid == '1': count += 1",
+    "        else: print(f'skip pid={pid} ppid={ppid}', file=sys.stderr)",
+    "    except (OSError, IndexError): pass",
+    "print(count)",
+])
 
 
 def get_container_worker_count(

--- a/test/e2e/predictor/test_sklearn.py
+++ b/test/e2e/predictor/test_sklearn.py
@@ -50,8 +50,7 @@ from ..common.utils import (
     KSERVE_TEST_NAMESPACE,
     predict_isvc,
     predict_grpc,
-    extract_process_ids_from_logs,
-    wait_for_pod_logs,
+    get_container_worker_count,
 )
 
 
@@ -179,6 +178,20 @@ async def test_sklearn_runtime_kserve(rest_v1_client, network_layer):
 
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+    pods = kserve_client.core_api.list_namespaced_pod(
+        KSERVE_TEST_NAMESPACE,
+        label_selector="serving.kserve.io/inferenceservice={}".format(service_name),
+    )
+    worker_count = get_container_worker_count(
+        kserve_client.core_api,
+        pods.items[0].metadata.name,
+        KSERVE_TEST_NAMESPACE,
+    )
+    assert worker_count == 2, (
+        f"Expected 2 multiprocessing workers but found {worker_count}"
+    )
+
     tasks = [
         predict_isvc(
             rest_v1_client,
@@ -192,19 +205,6 @@ async def test_sklearn_runtime_kserve(rest_v1_client, network_layer):
     for res in responses:
         assert res["predictions"] == [19]
 
-    pods = kserve_client.core_api.list_namespaced_pod(
-        KSERVE_TEST_NAMESPACE,
-        label_selector="serving.kserve.io/inferenceservice={}".format(service_name),
-    )
-    logs = await wait_for_pod_logs(
-        kserve_client.core_api,
-        pods.items[0].metadata.name,
-        pods.items[0].metadata.namespace,
-        expected_substring="kserve.trace",
-        timeout_s=30,
-    )
-    process_ids = extract_process_ids_from_logs(logs)
-    assert len(process_ids) == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 


### PR DESCRIPTION
## Summary

- `test_sklearn_runtime_kserve` verifies `--workers=2` by checking how many worker processes are running. Previously it sent 25 concurrent requests and extracted unique PIDs from `kserve.trace` log lines — but httpx connection pooling can funnel all requests through a single TCP connection, so only one worker handles traffic and `assert len(process_ids) == 2` flakes.
- Replace with a deterministic in-container process check via `kubectl exec` that scans `/proc/*/cmdline` for multiprocessing `spawn_main` children. This is network-layer agnostic and works on slim Debian images that lack `pgrep`.
- Remove the now-unused `extract_process_ids_from_logs` utility and the post-predict log fetch (the worker count check runs before predictions, immediately after ISVC readiness).

Supersedes #5357 (same fix, closed before CI validation, now confirmed flaking again).

## Test plan

- [ ] Verify `test_sklearn_runtime_kserve` passes in `test-predictor` (istio) CI job
- [ ] Verify `test_sklearn_runtime_kserve` passes in `test-kourier` CI job
- [ ] Confirm no regressions in other predictor E2E tests