### PR TITLE
fix(predictor): skip MMS when model-dir VolumeMount already exists

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -70,6 +70,19 @@ func IsMMSPredictor(predictor *v1beta1.PredictorSpec) bool {
 		hasStorageSpec := impl.GetStorageSpec() != nil
 		hasStorageUris := len(predictor.StorageUris) > 0
 
+		// If the container already has a "/mnt/models" then the model download is being handled outside of KServe and
+		// we should not enable MMS.
+		//
+		// Without this KServe will attempt to inject its own emptydir volume at /mnt/models for MMS, which would
+		// conflict with the existing one, producing an invalid pod.
+		if predictor.Model != nil {
+			for _, volumeMount := range predictor.Model.VolumeMounts {
+				if volumeMount.MountPath == constants.ModelDir || strings.HasPrefix(volumeMount.MountPath, constants.ModelDir+"/") {
+					return false
+				}
+			}
+		}
+
 		// HuggingFace supports model ID without storage initializer, but it should not be a multi-model server.
 		if predictor.HuggingFace != nil || (predictor.Model != nil && predictor.Model.ModelFormat.Name == "huggingface") {
 			return false

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -116,6 +116,64 @@ func TestIsMMSPredictor(t *testing.T) {
 			},
 			expected: false,
 		},
+		"ModelSpecWithModelDirVolumeMount": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sklearnWithModelDirMount",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{
+								Name: "sklearn",
+							},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								Container: corev1.Container{
+									Image:     "customImage:0.1.0",
+									Resources: requestedResource,
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "my-csi-vol",
+											MountPath: constants.ModelDir,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"ModelSpecWithModelDirSubdirVolumeMount": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sklearnWithModelDirSubdirMount",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{
+								Name: "sklearn",
+							},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								Container: corev1.Container{
+									Image:     "customImage:0.1.0",
+									Resources: requestedResource,
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "my-csi-vol",
+											MountPath: constants.ModelDir + "/base",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
 		"CustomSpec": {
 			isvc: InferenceService{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

When `spec.predictor.model` is used without a `storageUri`/`storageUris`, `IsMMSPredictor` returns `true` and the MMS agent injector mounts an `EmptyDir` volume at `/mnt/models` inside `kserve-container`. If the user has also specified a `VolumeMount` at `/mnt/models` (e.g. to bring their own inline CSI volume containing the models), the pod ends up with two `VolumeMounts` at the same `mountPath`, which Kubernetes rejects as invalid.

This PR makes `IsMMSPredictor` return `false` when `spec.predictor.model` already has a `VolumeMount` at `constants.ModelDir` (`/mnt/models`), treating it as a signal that model storage is being handled externally. This allows users to mount a CSI volume (or any other volume type) directly at `/mnt/models` without KServe interfering.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] Unit test added: `TestIsMMSPredictor/ModelSpecWithModelDirVolumeMount` — verifies `IsMMSPredictor` returns `false` when a `VolumeMount` at `/mnt/models` is present on the `ModelSpec` container
- [x] Manually verified on a local KIND cluster with `RawDeployment` mode

Applied the following `InferenceService` — no `storageUri`, emptyDir mounted at `/mnt/models` to simulate an external volume:

```yaml
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: test-csi-fix
  namespace: kserve-test
spec:
  predictor:
    volumes:
      - name: model-vol
        emptyDir: {}
    model:
      modelFormat:
        name: sklearn
      volumeMounts:
        - name: model-vol
          mountPath: /mnt/models
```

Verified the pod is valid and running, with no agent sidecar injected and a single `/mnt/models` mount:

```
$ kubectl get pod -n kserve-test -o jsonpath='{.items[0].spec.containers[*].name}'
kserve-container

$ kubectl get pod -n kserve-test -o jsonpath='{.items[0].spec.containers[0].volumeMounts}'
[{"mountPath":"/mnt/models","name":"model-vol"},{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"kube-api-access-9vflq","readOnly":true}]
```

**Special notes for your reviewer**:

The check is scoped to the `else` branch of `IsMMSPredictor` (framework predictors using `spec.predictor.model`). The custom predictor path (`spec.predictor.containers`) is unaffected — it already returns `false` unless `CUSTOM_SPEC_MULTI_MODEL_SERVER=true` is explicitly set.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fixed invalid pod configuration when spec.predictor.model specifies a VolumeMount at /mnt/models without a storageUri. Multi-model serving is now disabled in this case, preventing injection of a conflicting EmptyDir at the same path.
```