### PR TITLE
fix(llmisvc): migrate metrics-scheme across split Command/Args

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1819,12 +1819,15 @@ func extractModelServerMetricsScheme(d *appsv1.Deployment) string {
 	scheme := ""
 	for ci := range d.Spec.Template.Spec.Containers {
 		c := &d.Spec.Template.Spec.Containers[ci]
-		if filtered, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
-			c.Command = filtered
-			scheme = extracted[modelServerMetricsSchemeFlag]
-		}
-		if filtered, extracted := filterArgs(c.Args, names); len(extracted) > 0 {
-			c.Args = filtered
+		// Filter Command and Args as one concatenated token stream. Kubernetes
+		// runs Command+Args together, so a preset may legitimately carry the
+		// flag at the end of Command with its value at the start of Args.
+		// Filtering the two lists independently would strip the flag but leave
+		// its value behind as a dangling positional argument.
+		newCommand, newArgs, extracted := filterArgsAcross(c.Command, c.Args, names)
+		if len(extracted) > 0 {
+			c.Command = newCommand
+			c.Args = newArgs
 			scheme = extracted[modelServerMetricsSchemeFlag]
 		}
 	}
@@ -1845,6 +1848,49 @@ func hasModelServerMetricsSchemeFlag(d *appsv1.Deployment) bool {
 		}
 	}
 	return false
+}
+
+// filterArgsAcross removes matching flags from the concatenated Command+Args
+// token stream and returns the rebuilt Command and Args slices along with the
+// extracted flag values. Unlike filtering each slice independently, it handles
+// the split form where a flag sits at the end of Command and its value at the
+// start of Args (Kubernetes concatenates the two): the value is consumed
+// instead of being left behind as a stray positional argument. The Command/Args
+// boundary is preserved — every kept token is returned in the slice it
+// originally came from.
+func filterArgsAcross(command, args []string, names map[string]bool) (newCommand, newArgs []string, extracted map[string]string) {
+	extracted = make(map[string]string)
+	combined := make([]string, 0, len(command)+len(args))
+	combined = append(combined, command...)
+	combined = append(combined, args...)
+	boundary := len(command)
+
+	keep := func(idx int) {
+		if idx < boundary {
+			newCommand = append(newCommand, combined[idx])
+		} else {
+			newArgs = append(newArgs, combined[idx])
+		}
+	}
+
+	for i := 0; i < len(combined); i++ {
+		name := strings.TrimLeft(combined[i], "-")
+		value := ""
+		if eqIdx := strings.Index(name, "="); eqIdx != -1 {
+			value = name[eqIdx+1:]
+			name = name[:eqIdx]
+		}
+		if !names[name] {
+			keep(i)
+			continue
+		}
+		if value == "" && i+1 < len(combined) && !strings.HasPrefix(combined[i+1], "-") {
+			value = combined[i+1]
+			i++
+		}
+		extracted[name] = value
+	}
+	return newCommand, newArgs, extracted
 }
 
 // filterArgs removes matching flags from args and returns their values.

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2312,6 +2312,18 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
 			expectedScheme:  "",
 		},
+		{
+			// A template may split the space form so the flag ends Command and
+			// its value starts Args; kube concatenates the two. Filtering each
+			// slice independently strips the flag but leaves "https" behind as a
+			// dangling positional argument.
+			name:            "extracts flag and value split across command and args",
+			command:         []string{"/app/epp", "--model-server-metrics-scheme"},
+			args:            []string{"https", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp"},
+			expectedArgs:    []string{"--grpc-port=9002"},
+			expectedScheme:  "https",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it:**

`extractModelServerMetricsScheme` runs `filterArgs` independently on each container's `Command` and `Args`. `filterArgs` only consumes a space-form flag's value when that value lives in the same slice, so when the deprecated `--model-server-metrics-scheme` flag sits at the end of `Command` and its value (`https`) is the first element of `Args`:

- filtering `Command` strips the flag but extracts an empty value (there is no next token in that slice), and
- filtering `Args` sees `https` as an ordinary positional and keeps it.

The migration therefore leaves `https` behind as a dangling positional argument, e.g. `Command=[/app/epp, --model-server-metrics-scheme]` + `Args=[https, --grpc-port=9002]` becomes `[/app/epp, https, --grpc-port=9002]` — an invalid command that prevents the EPP container from starting. Templates that keep the flag and value in one list are unaffected.

**Fix:** filter `Command` and `Args` as one concatenated token stream (Kubernetes runs `Command`+`Args` together anyway) via a new `filterArgsAcross` helper that consumes the value across the boundary while preserving the two Kubernetes fields — each kept token is returned in the slice it originally came from. Same-slice behavior is unchanged, so `hasModelServerMetricsSchemeFlag` and the existing extraction cases are untouched.

Added a `TestExtractModelServerMetricsScheme` case reproducing the split Command/Args scenario (fails before the fix: `https` is left as a positional).

**Which issue(s) this PR fixes:**

Fixes #5902

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Special notes for your reviewer:**

I don't have a local Go toolchain here, so the new table case is written to mirror the existing `TestExtractModelServerMetricsScheme` cases exactly; please run `go test ./pkg/controller/v1alpha2/llmisvc/ -run TestExtractModelServerMetricsScheme` to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
