### PR TITLE
docs(llmisvc): agentic tool calling guide and samples

### DIFF
--- a/docs/samples/llmisvc/agentic-tool-calling/README.md
+++ b/docs/samples/llmisvc/agentic-tool-calling/README.md
@@ -1,0 +1,227 @@
+# Agentic Tool Calling — E2E Test Guide
+
+This guide validates that tool calling parameters pass through the full KServe LLMInferenceService serving stack unaltered, on both the **OpenAI Chat Completions API** (`/v1/chat/completions`) and the **Anthropic Messages API** (`/v1/messages`).
+
+The request path under test:
+
+```
+Client → Gateway → HTTPRoute → InferencePool → EPP → pd-sidecar → vLLM
+```
+
+## What This Tests
+
+- Tool definitions (`tools` array) arrive at the model server intact
+- Tool call responses (`tool_calls` / `tool_use`) reach the client unaltered
+- Streaming tool call deltas assemble correctly
+- Multi-turn tool use (tool results in conversation history) works
+- Multiple tool definitions and parallel tool calls are preserved
+- `tool_choice` field (auto, specific function) passes through
+- Complex nested parameter schemas survive serialization
+- Non-tool-calling requests are not degraded
+
+## Deployment Options
+
+Two LLMInferenceService manifests are provided:
+
+| Manifest | Model | GPUs | Topology | Use Case |
+|----------|-------|------|----------|----------|
+| [`nemotron-3-ultra-pd.yaml`](nemotron-3-ultra-pd.yaml) | Nemotron-3-Ultra-550B | 2x 8-GPU nodes | P/D disaggregated | Production reference, tests pd-sidecar passthrough |
+| [`llmisvc-single-gpu.yaml`](llmisvc-single-gpu.yaml) | Qwen3-Coder-30B-A3B-Instruct-FP8 | 1 GPU | Single node | Fast iteration, CI testing |
+
+## Prerequisites
+
+- KServe with LLMInferenceService controller installed ([quick-install script](../../../../hack/setup/quick-install/llmisvc-full-install-with-manifests.sh))
+- Gateway API Inference Extension CRDs (v1 + v1alpha2 InferencePool)
+- `kubectl`, `jq`, `curl`
+- HuggingFace token with model access
+
+### Known Issues
+
+1. **v1alpha2 InferencePool CRD**: The quick-install script may not install the `inferencepools.inference.networking.x-k8s.io` CRD, causing the controller to fail. Fix: [kserve#5751](https://github.com/kserve/kserve/pull/5751).
+
+2. **Hybrid model prefix caching**: Nemotron-3-Ultra (Mamba+Attention hybrid) requires `--enable-prefix-caching` for KV offloading. Without it, vLLM fails with `gpu_block_size not divisible by hash_block_size`.
+
+3. **Storage-initializer memory**: The default 1Gi memory limit for the storage-initializer is too small for large models (~530GB for Nemotron). Increase it:
+   ```bash
+   kubectl get configmap inferenceservice-config -n kserve -o json | \
+     python3 -c "
+   import json, sys
+   cm = json.load(sys.stdin)
+   si = json.loads(cm['data']['storageInitializer'])
+   si['memoryLimit'] = '8Gi'
+   si['memoryRequest'] = '2Gi'
+   cm['data']['storageInitializer'] = json.dumps(si)
+   json.dump(cm, sys.stdout)
+   " | kubectl apply -f -
+   ```
+
+## Setup
+
+```bash
+export NAMESPACE=tool-calling-test
+export MODEL=<model-name>  # e.g., Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8
+
+kubectl create namespace ${NAMESPACE}
+kubectl create secret generic hf-token \
+  --from-literal="HF_TOKEN=${HF_TOKEN}" \
+  --namespace "${NAMESPACE}"
+```
+
+## Deploy
+
+### Option A: Single GPU (Qwen3-Coder-30B)
+
+```bash
+kubectl apply -n ${NAMESPACE} -f llmisvc-single-gpu.yaml
+kubectl wait --for=condition=Ready llminferenceservice/qwen3-coder-tool-calling \
+  -n ${NAMESPACE} --timeout=1800s
+```
+
+### Option B: P/D Disaggregated (Nemotron-3-Ultra-550B)
+
+```bash
+kubectl apply -n ${NAMESPACE} -f nemotron-3-ultra-pd.yaml
+kubectl rollout status deployment/nemotron-ultra-pd-kserve -n ${NAMESPACE} --timeout=3600s
+kubectl rollout status deployment/nemotron-ultra-pd-kserve-prefill -n ${NAMESPACE} --timeout=3600s
+```
+
+## Get the Endpoint
+
+### Via Gateway (full stack path — recommended)
+
+```bash
+GATEWAY_IP=$(kubectl get gateway kserve-ingress-gateway -n kserve \
+  -o jsonpath='{.status.addresses[0].value}')
+export BASE_URL="http://${GATEWAY_IP}/${NAMESPACE}/<llmisvc-name>"
+```
+
+To access from outside the cluster, port-forward the Gateway's Envoy proxy:
+
+```bash
+kubectl port-forward -n envoy-gateway-system \
+  svc/$(kubectl get svc -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-name=kserve-ingress-gateway -o name | head -1 | sed 's|service/||') \
+  8080:80 &
+export BASE_URL="http://localhost:8080/${NAMESPACE}/<llmisvc-name>"
+```
+
+### Via workload service (bypasses Gateway/EPP — for debugging)
+
+```bash
+kubectl port-forward -n ${NAMESPACE} svc/<llmisvc-name>-kserve-workload-svc 8000:8000 &
+export BASE_URL="http://localhost:8000"
+```
+
+## Run Tests
+
+### Automated (all 19 tests)
+
+```bash
+MODEL=${MODEL} LLMISVC_NAME=<llmisvc-name> NAMESPACE=${NAMESPACE} ./run-tests.sh
+```
+
+Or pass the base URL directly:
+
+```bash
+./run-tests.sh "${BASE_URL}"
+```
+
+For full response body logging:
+
+```bash
+VERBOSE=true MODEL=${MODEL} LLMISVC_NAME=<llmisvc-name> ./run-tests.sh 2>&1 | tee test-results.log
+```
+
+### Manual (individual requests)
+
+See [`test-requests.md`](test-requests.md) for all curl commands with expected responses.
+
+Quick smoke test:
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {"role": "user", "content": "What is the weather in San Francisco?"}
+    ],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get weather for a location",
+        "parameters": {
+          "type": "object",
+          "properties": {"location": {"type": "string"}},
+          "required": ["location"]
+        }
+      }
+    }],
+    "tool_choice": "auto"
+  }' | jq '.choices[0].message.tool_calls'
+```
+
+## Verify Stack Passthrough
+
+The LLMInferenceService manifests include `--enable-log-requests` and `--enable-log-outputs` flags. After running tests, check vLLM logs to verify tool calling parameters arrived at the model server and tool call responses were produced:
+
+```bash
+# Decode pod — check response contains tool calls
+kubectl logs -n ${NAMESPACE} -l app.kubernetes.io/name=<llmisvc-name>,kserve.io/component=workload \
+  -c main --tail=100 | grep -i "Generated response\|tool_calls\|tool_use\|get_weather"
+
+# Prefill pod (P/D mode only) — check request arrived
+kubectl logs -n ${NAMESPACE} -l app.kubernetes.io/name=<llmisvc-name>,kserve.io/component=workload \
+  -c main --tail=100 | grep -i "Received request"
+
+# pd-sidecar (P/D mode only) — check request forwarding
+kubectl logs -n ${NAMESPACE} -l app.kubernetes.io/name=<llmisvc-name>,kserve.io/component=workload \
+  -c llm-d-routing-sidecar --tail=100 | grep -i "forward\|error"
+```
+
+## Test Matrix
+
+| # | Test | API | What it validates |
+|---|------|-----|-------------------|
+| 1 | Tool calling (non-streaming) | Chat Completions | Basic tool call passthrough |
+| 2 | Tool calling (streaming) | Chat Completions | SSE delta assembly |
+| 3 | Tool calling (non-streaming) | Messages API | Anthropic format passthrough |
+| 4 | Tool calling (streaming) | Messages API | Anthropic SSE events |
+| 5 | Multi-turn tool use | Chat Completions | Tool result in message history |
+| 6 | Multi-turn tool use | Messages API | tool_result block passthrough |
+| 7 | Multiple tools (2 definitions) | Chat Completions | Multiple tool defs preserved |
+| 8 | Multiple tools (2 definitions) | Messages API | Multiple tool defs preserved |
+| 9 | 5 tools, use all | Chat Completions | Large tools array not truncated |
+| 10 | 5 tools, use all | Messages API | Large tools array not truncated |
+| 11 | tool_choice specific function | Chat Completions | tool_choice field preserved |
+| 12 | tool_choice specific tool | Messages API | Anthropic tool_choice preserved |
+| 13 | Complex nested parameters | Chat Completions | Nested objects/arrays/enums in schema |
+| 14 | Tool with no parameters | Chat Completions | Empty params edge case |
+| 15 | Multiple calls same tool | Chat Completions | Repeated tool_calls indexing |
+| 16 | Verify all tools reach model | Chat Completions | Tool definitions not truncated |
+| 17 | Verify all tools reach model | Messages API | Tool definitions not truncated |
+| 18 | Regression (no tools) | Chat Completions | Non-tool requests unaffected |
+| 19 | Regression (no tools) | Messages API | Non-tool requests unaffected |
+
+## Scale Down
+
+To release GPUs while preserving the LLMInferenceService CR:
+
+```bash
+kubectl patch llminferenceservice <name> -n ${NAMESPACE} --type merge \
+  -p '{"spec":{"replicas":0,"prefill":{"replicas":0}}}'
+```
+
+Scale back up:
+
+```bash
+kubectl patch llminferenceservice <name> -n ${NAMESPACE} --type merge \
+  -p '{"spec":{"replicas":1,"prefill":{"replicas":1}}}'
+```
+
+## Cleanup
+
+```bash
+kubectl delete llminferenceservice --all -n ${NAMESPACE}
+kubectl delete namespace ${NAMESPACE}
+```

--- a/docs/samples/llmisvc/agentic-tool-calling/README.md
+++ b/docs/samples/llmisvc/agentic-tool-calling/README.md
@@ -142,6 +142,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {"role": "user", "content": "What is the weather in San Francisco?"}
     ],

--- a/docs/samples/llmisvc/agentic-tool-calling/llmisvc-single-gpu.yaml
+++ b/docs/samples/llmisvc/agentic-tool-calling/llmisvc-single-gpu.yaml
@@ -1,0 +1,38 @@
+---
+# LLMInferenceService for tool calling validation on a single GPU
+# Model: Qwen3-Coder-30B-A3B-Instruct-FP8 (supports tool calling via qwen3_coder parser)
+# Topology: Single node, no P/D disaggregation
+# Requires: 1x GPU node, HF token secret
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: qwen3-coder-tool-calling
+spec:
+  model:
+    uri: "hf://Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8"
+    name: Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8
+  replicas: 1
+  router:
+    route: {}
+    scheduler: {}
+  template:
+    containers:
+      - name: main
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.1
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-token
+                key: HF_TOKEN
+          - name: VLLM_ADDITIONAL_ARGS
+            value: >-
+              --enable-auto-tool-choice
+              --tool-call-parser=qwen3_coder
+              --enable-log-requests
+              --enable-log-outputs
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+          requests:
+            nvidia.com/gpu: "1"

--- a/docs/samples/llmisvc/agentic-tool-calling/nemotron-3-ultra-pd.yaml
+++ b/docs/samples/llmisvc/agentic-tool-calling/nemotron-3-ultra-pd.yaml
@@ -1,0 +1,119 @@
+---
+# LLMInferenceService for e2e tool calling validation
+# Model: NVIDIA Nemotron-3-Ultra-550B (hybrid Mamba+Attention)
+# Topology: P/D disaggregated (1 prefill + 1 decode, 8 GPUs each)
+# Requires: 2x H200 nodes, HF token secret
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: nemotron-ultra-pd
+spec:
+  model:
+    uri: "hf://RedHatAI/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8-block"
+    name: RedHatAI/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8-block
+  replicas: 1
+  router:
+    route: {}
+    scheduler: {}
+  template:
+    containers:
+      - name: main
+        image: ghcr.io/llm-d/llm-d-cuda:v0.8.1
+        env:
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: hf-token
+                key: HF_TOKEN
+          - name: VLLM_SSM_CONV_STATE_LAYOUT
+            value: "DS"
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: VLLM_ADDITIONAL_ARGS
+            value: >-
+              --trust-remote-code
+              --tensor-parallel-size=8
+              --enable-expert-parallel
+              --kv-cache-dtype=fp8
+              --enable-prefix-caching
+              --enable-auto-tool-choice
+              --tool-call-parser=qwen3_coder
+              --reasoning-parser=nemotron_v3
+              --enable-log-requests
+              --enable-log-outputs
+              --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 96}'
+              --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"bidirectional_kv_xfer":true}},{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":214748364800,"lazy_offload":true}}]}}'
+        resources:
+          limits:
+            cpu: "48"
+            memory: 600Gi
+            nvidia.com/gpu: "8"
+          requests:
+            cpu: "32"
+            memory: 300Gi
+            nvidia.com/gpu: "8"
+        startupProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 120
+    volumes:
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 40Gi
+  prefill:
+    replicas: 1
+    template:
+      containers:
+        - name: main
+          image: ghcr.io/llm-d/llm-d-cuda:v0.8.1
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: HF_TOKEN
+            - name: VLLM_SSM_CONV_STATE_LAYOUT
+              value: "DS"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+              value: "120"
+            - name: VLLM_ADDITIONAL_ARGS
+              value: >-
+                --trust-remote-code
+                --tensor-parallel-size=8
+                --enable-expert-parallel
+                --kv-cache-dtype=fp8
+                --enable-prefix-caching
+                --enable-auto-tool-choice
+                --tool-call-parser=qwen3_coder
+                --reasoning-parser=nemotron_v3
+                --enable-log-requests
+                --enable-log-outputs
+                --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 96}'
+                --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_connector_extra_config":{"bidirectional_kv_xfer":true}},{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":214748364800,"lazy_offload":true}}]}}'
+          resources:
+            limits:
+              cpu: "48"
+              memory: 600Gi
+              nvidia.com/gpu: "8"
+            requests:
+              cpu: "32"
+              memory: 300Gi
+              nvidia.com/gpu: "8"
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 40Gi

--- a/docs/samples/llmisvc/agentic-tool-calling/nemotron-3-ultra-pd.yaml
+++ b/docs/samples/llmisvc/agentic-tool-calling/nemotron-3-ultra-pd.yaml
@@ -25,6 +25,8 @@ spec:
               secretKeyRef:
                 name: hf-token
                 key: HF_TOKEN
+          - name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+            value: "0"
           - name: VLLM_SSM_CONV_STATE_LAYOUT
             value: "DS"
           - name: VLLM_NIXL_SIDE_CHANNEL_HOST
@@ -76,6 +78,8 @@ spec:
                 secretKeyRef:
                   name: hf-token
                   key: HF_TOKEN
+            - name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+              value: "0"
             - name: VLLM_SSM_CONV_STATE_LAYOUT
               value: "DS"
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST

--- a/docs/samples/llmisvc/agentic-tool-calling/run-tests.sh
+++ b/docs/samples/llmisvc/agentic-tool-calling/run-tests.sh
@@ -1,0 +1,710 @@
+#!/usr/bin/env bash
+# E2E tool calling tests for KServe LLMInferenceService
+# Tests Chat Completions and Anthropic Messages API tool-calling support
+# for any tool-calling-capable model deployed via LLMInferenceService.
+#
+# Usage:
+#   MODEL=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 LLMISVC_NAME=qwen-7b ./run-tests.sh
+#   ./run-tests.sh http://localhost:8080/my-namespace/my-llmisvc
+#
+# Environment variables:
+#   MODEL          - Model name (required unless endpoint URL is the only concern)
+#   LLMISVC_NAME   - Name of the LLMInferenceService resource (required when not passing a URL)
+#   NAMESPACE      - Kubernetes namespace (default: tool-calling-test)
+#   VERBOSE        - Set to "true" for full response output
+set -euo pipefail
+
+MODEL="${MODEL:-}"
+NAMESPACE="${NAMESPACE:-tool-calling-test}"
+LLMISVC_NAME="${LLMISVC_NAME:-}"
+
+if [ -n "${1:-}" ]; then
+    BASE_URL="$1"
+else
+    if [ -z "$LLMISVC_NAME" ]; then
+        echo "ERROR: LLMISVC_NAME must be set, or pass the base URL as an argument."
+        echo "  Example: LLMISVC_NAME=qwen-7b MODEL=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 $0"
+        echo "  Example: $0 http://localhost:8080/my-namespace/my-llmisvc"
+        exit 1
+    fi
+    GATEWAY_IP=$(kubectl get gateway kserve-ingress-gateway -n kserve -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)
+    if [ -z "$GATEWAY_IP" ]; then
+        echo "ERROR: Could not determine Gateway IP. Pass the base URL as an argument."
+        exit 1
+    fi
+    BASE_URL="http://${GATEWAY_IP}/${NAMESPACE}/${LLMISVC_NAME}"
+fi
+
+if [ -z "$MODEL" ]; then
+    echo "ERROR: MODEL must be set."
+    echo "  Example: MODEL=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 $0"
+    exit 1
+fi
+
+echo "Using endpoint: ${BASE_URL}"
+echo "Model: ${MODEL}"
+VERBOSE="${VERBOSE:-false}"
+PASS=0
+FAIL=0
+RESULTS=()
+
+run_test() {
+    local name="$1"
+    local cmd="$2"
+    local validate="$3"
+
+    echo ""
+    echo "============================================"
+    echo "TEST: ${name}"
+    echo "============================================"
+
+    local response
+    response=$(eval "$cmd" 2>&1) || true
+
+    if echo "$response" | eval "$validate" > /dev/null 2>&1; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+        RESULTS+=("PASS: ${name}")
+    else
+        echo "FAIL"
+        echo "Response:"
+        echo "$response" | head -50
+        FAIL=$((FAIL + 1))
+        RESULTS+=("FAIL: ${name}")
+    fi
+
+    if [ "$VERBOSE" = "true" ]; then
+        echo ""
+        echo "--- Full Response ---"
+        echo "$response" | python3 -m json.tool 2>/dev/null || echo "$response"
+        echo "--- End Response ---"
+    fi
+}
+
+# ============================================
+# Step 1.2: Chat Completions Tool Calling (non-streaming)
+# ============================================
+run_test "Chat Completions - tool calling (non-streaming)" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"system\", \"content\": \"You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather.\"},
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco?\"}
+            ],
+            \"tools\": [{
+                \"type\": \"function\",
+                \"function\": {
+                    \"name\": \"get_weather\",
+                    \"description\": \"Get the current weather in a given location\",
+                    \"parameters\": {
+                        \"type\": \"object\",
+                        \"properties\": {
+                            \"location\": {\"type\": \"string\", \"description\": \"City and state\"},
+                            \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}
+                        },
+                        \"required\": [\"location\"]
+                    }
+                }
+            }],
+            \"tool_choice\": \"auto\",
+            \"parallel_tool_calls\": true
+        }'" \
+    "jq -e '.choices[0].message.tool_calls[0].function.name == \"get_weather\"'"
+
+# ============================================
+# Step 1.3: Chat Completions Tool Calling (streaming)
+# ============================================
+run_test "Chat Completions - tool calling (streaming)" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"stream\": true,
+            \"messages\": [
+                {\"role\": \"system\", \"content\": \"You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather.\"},
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco?\"}
+            ],
+            \"tools\": [{
+                \"type\": \"function\",
+                \"function\": {
+                    \"name\": \"get_weather\",
+                    \"description\": \"Get the current weather in a given location\",
+                    \"parameters\": {
+                        \"type\": \"object\",
+                        \"properties\": {
+                            \"location\": {\"type\": \"string\", \"description\": \"City and state\"},
+                            \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}
+                        },
+                        \"required\": [\"location\"]
+                    }
+                }
+            }],
+            \"tool_choice\": \"auto\"
+        }'" \
+    "grep '^data: ' | grep -v '\\[DONE\\]' | sed 's/^data: //' | jq -s 'map(select(.choices[0].delta.tool_calls != null)) | length > 0 and (map(.choices[0].delta.tool_calls[0].function.arguments // empty) | join(\"\") | fromjson | .location != null)'"
+
+# ============================================
+# Step 1.4: Anthropic Messages API Tool Calling (non-streaming)
+# ============================================
+run_test "Messages API - tool calling (non-streaming)" \
+    "curl -s -X POST ${BASE_URL}/v1/messages \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: dummy' \
+        -H 'anthropic-version: 2023-06-01' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"max_tokens\": 1024,
+            \"system\": \"You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather.\",
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco?\"}
+            ],
+            \"tools\": [{
+                \"name\": \"get_weather\",
+                \"description\": \"Get the current weather in a given location\",
+                \"input_schema\": {
+                    \"type\": \"object\",
+                    \"properties\": {
+                        \"location\": {\"type\": \"string\", \"description\": \"City and state\"},
+                        \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}
+                    },
+                    \"required\": [\"location\"]
+                }
+            }],
+            \"tool_choice\": {\"type\": \"auto\"}
+        }'" \
+    "jq -e '.content[] | select(.type == \"tool_use\") | .name == \"get_weather\"'"
+
+# ============================================
+# Step 1.5: Anthropic Messages API Tool Calling (streaming)
+# ============================================
+run_test "Messages API - tool calling (streaming)" \
+    "curl -s -X POST ${BASE_URL}/v1/messages \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: dummy' \
+        -H 'anthropic-version: 2023-06-01' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"max_tokens\": 1024,
+            \"stream\": true,
+            \"system\": \"You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather.\",
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco?\"}
+            ],
+            \"tools\": [{
+                \"name\": \"get_weather\",
+                \"description\": \"Get the current weather in a given location\",
+                \"input_schema\": {
+                    \"type\": \"object\",
+                    \"properties\": {
+                        \"location\": {\"type\": \"string\", \"description\": \"City and state\"},
+                        \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}
+                    },
+                    \"required\": [\"location\"]
+                }
+            }],
+            \"tool_choice\": {\"type\": \"auto\"}
+        }'" \
+    "grep '^data: ' | grep -v '\\[DONE\\]' | sed 's/^data: //' | jq -s 'map(select(.type == \"content_block_start\" and .content_block.type == \"tool_use\")) | length > 0'"
+
+# ============================================
+# Step 1.6a: Chat Completions Multi-turn Tool Use
+# ============================================
+run_test "Chat Completions - multi-turn tool use" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"system\", \"content\": \"You are a helpful assistant with access to tools.\"},
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco?\"},
+                {\"role\": \"assistant\", \"content\": null, \"tool_calls\": [
+                    {\"id\": \"call_123\", \"type\": \"function\", \"function\": {\"name\": \"get_weather\", \"arguments\": \"{\\\"location\\\": \\\"San Francisco, CA\\\"}\"}}
+                ]},
+                {\"role\": \"tool\", \"tool_call_id\": \"call_123\", \"content\": \"{\\\"temperature\\\": 62, \\\"unit\\\": \\\"fahrenheit\\\", \\\"condition\\\": \\\"foggy\\\"}\"}
+            ],
+            \"tools\": [{
+                \"type\": \"function\",
+                \"function\": {
+                    \"name\": \"get_weather\",
+                    \"description\": \"Get the current weather in a given location\",
+                    \"parameters\": {
+                        \"type\": \"object\",
+                        \"properties\": {
+                            \"location\": {\"type\": \"string\"},
+                            \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}
+                        },
+                        \"required\": [\"location\"]
+                    }
+                }
+            }]
+        }'" \
+    "jq -e '.choices[0].message.content != null and (.choices[0].message.tool_calls | length == 0 or .choices[0].message.tool_calls == null)'"
+
+# ============================================
+# Step 1.6b: Anthropic Messages Multi-turn Tool Use
+# ============================================
+run_test "Messages API - multi-turn tool use" \
+    "curl -s -X POST ${BASE_URL}/v1/messages \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: dummy' \
+        -H 'anthropic-version: 2023-06-01' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"max_tokens\": 1024,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco?\"},
+                {\"role\": \"assistant\", \"content\": [
+                    {\"type\": \"tool_use\", \"id\": \"toolu_123\", \"name\": \"get_weather\", \"input\": {\"location\": \"San Francisco, CA\"}}
+                ]},
+                {\"role\": \"user\", \"content\": [
+                    {\"type\": \"tool_result\", \"tool_use_id\": \"toolu_123\", \"content\": \"{\\\"temperature\\\": 62, \\\"unit\\\": \\\"fahrenheit\\\", \\\"condition\\\": \\\"foggy\\\"}\"}
+                ]}
+            ],
+            \"tools\": [{
+                \"name\": \"get_weather\",
+                \"description\": \"Get the current weather in a given location\",
+                \"input_schema\": {
+                    \"type\": \"object\",
+                    \"properties\": {
+                        \"location\": {\"type\": \"string\"},
+                        \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}
+                    },
+                    \"required\": [\"location\"]
+                }
+            }]
+        }'" \
+    "jq -e '(.content | map(select(.type == \"text\")) | length > 0) and .stop_reason == \"end_turn\"'"
+
+# ============================================
+# Step 1.6c: Chat Completions Multiple Tools
+# ============================================
+run_test "Chat Completions - multiple tools" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"system\", \"content\": \"You are a helpful assistant with access to tools. Use the appropriate tool for each part of the request. Call multiple tools in parallel when needed.\"},
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco and what time is it in Tokyo?\"}
+            ],
+            \"tools\": [
+                {
+                    \"type\": \"function\",
+                    \"function\": {
+                        \"name\": \"get_weather\",
+                        \"description\": \"Get the current weather in a given location\",
+                        \"parameters\": {
+                            \"type\": \"object\",
+                            \"properties\": {
+                                \"location\": {\"type\": \"string\", \"description\": \"City and state or city and country\"}
+                            },
+                            \"required\": [\"location\"]
+                        }
+                    }
+                },
+                {
+                    \"type\": \"function\",
+                    \"function\": {
+                        \"name\": \"get_time\",
+                        \"description\": \"Get the current time in a given timezone or city\",
+                        \"parameters\": {
+                            \"type\": \"object\",
+                            \"properties\": {
+                                \"location\": {\"type\": \"string\", \"description\": \"City or timezone name\"}
+                            },
+                            \"required\": [\"location\"]
+                        }
+                    }
+                }
+            ],
+            \"tool_choice\": \"auto\",
+            \"parallel_tool_calls\": true
+        }'" \
+    "jq -e '.choices[0].message.tool_calls | length >= 1 and all(.[]; .function.name == \"get_weather\" or .function.name == \"get_time\")'"
+
+# ============================================
+# Step 1.6d: Messages API Multiple Tools
+# ============================================
+run_test "Messages API - multiple tools" \
+    "curl -s -X POST ${BASE_URL}/v1/messages \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: dummy' \
+        -H 'anthropic-version: 2023-06-01' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"max_tokens\": 1024,
+            \"system\": \"You are a helpful assistant with access to tools. Use the appropriate tool for each part of the request. Call multiple tools when needed.\",
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco and what time is it in Tokyo?\"}
+            ],
+            \"tools\": [
+                {
+                    \"name\": \"get_weather\",
+                    \"description\": \"Get the current weather in a given location\",
+                    \"input_schema\": {
+                        \"type\": \"object\",
+                        \"properties\": {
+                            \"location\": {\"type\": \"string\", \"description\": \"City and state or city and country\"}
+                        },
+                        \"required\": [\"location\"]
+                    }
+                },
+                {
+                    \"name\": \"get_time\",
+                    \"description\": \"Get the current time in a given timezone or city\",
+                    \"input_schema\": {
+                        \"type\": \"object\",
+                        \"properties\": {
+                            \"location\": {\"type\": \"string\", \"description\": \"City or timezone name\"}
+                        },
+                        \"required\": [\"location\"]
+                    }
+                }
+            ],
+            \"tool_choice\": {\"type\": \"auto\"}
+        }'" \
+    "jq -e '[.content[] | select(.type == \"tool_use\")] | length >= 1 and all(.[]; .name == \"get_weather\" or .name == \"get_time\")'"
+
+# ============================================
+# Step 1.6e: Chat Completions - 5 tools, use all
+# ============================================
+run_test "Chat Completions - 5 tools, use all" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"system\", \"content\": \"You are a travel planning assistant. You MUST call ALL relevant tools in parallel to answer the user. For this request, call get_weather for the destination, get_time for the destination, search_flights, get_exchange_rate, and translate_phrase.\"},
+                {\"role\": \"user\", \"content\": \"I want to travel from New York to Tokyo. What is the weather and time there, find me flights, what is the USD to JPY rate, and how do I say hello in Japanese?\"}
+            ],
+            \"tools\": [
+                {\"type\": \"function\", \"function\": {\"name\": \"get_weather\", \"description\": \"Get weather for a location\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\"}}, \"required\": [\"location\"]}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"get_time\", \"description\": \"Get current time in a city\", \"parameters\": {\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\"}}, \"required\": [\"city\"]}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"search_flights\", \"description\": \"Search for flights between cities\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\"}, \"destination\": {\"type\": \"string\"}, \"date\": {\"type\": \"string\", \"description\": \"YYYY-MM-DD\"}}, \"required\": [\"origin\", \"destination\"]}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"get_exchange_rate\", \"description\": \"Get exchange rate between currencies\", \"parameters\": {\"type\": \"object\", \"properties\": {\"from_currency\": {\"type\": \"string\"}, \"to_currency\": {\"type\": \"string\"}}, \"required\": [\"from_currency\", \"to_currency\"]}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"translate_phrase\", \"description\": \"Translate a phrase to another language\", \"parameters\": {\"type\": \"object\", \"properties\": {\"phrase\": {\"type\": \"string\"}, \"target_language\": {\"type\": \"string\"}}, \"required\": [\"phrase\", \"target_language\"]}}}
+            ],
+            \"tool_choice\": \"auto\",
+            \"parallel_tool_calls\": true
+        }'" \
+    "jq -e '.choices[0].message.tool_calls | length >= 5 and ([.[].function.name] | sort == [\"get_exchange_rate\", \"get_time\", \"get_weather\", \"search_flights\", \"translate_phrase\"])'"
+
+# ============================================
+# Step 1.6f: Messages API - 5 tools, use all
+# ============================================
+run_test "Messages API - 5 tools, use all" \
+    "curl -s -X POST ${BASE_URL}/v1/messages \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: dummy' \
+        -H 'anthropic-version: 2023-06-01' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"max_tokens\": 2048,
+            \"system\": \"You are a travel planning assistant. You MUST call ALL relevant tools to answer the user. For this request, call get_weather for the destination, get_time for the destination, search_flights, get_exchange_rate, and translate_phrase.\",
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"I want to travel from New York to Tokyo. What is the weather and time there, find me flights, what is the USD to JPY rate, and how do I say hello in Japanese?\"}
+            ],
+            \"tools\": [
+                {\"name\": \"get_weather\", \"description\": \"Get weather for a location\", \"input_schema\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\"}}, \"required\": [\"location\"]}},
+                {\"name\": \"get_time\", \"description\": \"Get current time in a city\", \"input_schema\": {\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\"}}, \"required\": [\"city\"]}},
+                {\"name\": \"search_flights\", \"description\": \"Search for flights between cities\", \"input_schema\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\"}, \"destination\": {\"type\": \"string\"}, \"date\": {\"type\": \"string\", \"description\": \"YYYY-MM-DD\"}}, \"required\": [\"origin\", \"destination\"]}},
+                {\"name\": \"get_exchange_rate\", \"description\": \"Get exchange rate between currencies\", \"input_schema\": {\"type\": \"object\", \"properties\": {\"from_currency\": {\"type\": \"string\"}, \"to_currency\": {\"type\": \"string\"}}, \"required\": [\"from_currency\", \"to_currency\"]}},
+                {\"name\": \"translate_phrase\", \"description\": \"Translate a phrase to another language\", \"input_schema\": {\"type\": \"object\", \"properties\": {\"phrase\": {\"type\": \"string\"}, \"target_language\": {\"type\": \"string\"}}, \"required\": [\"phrase\", \"target_language\"]}}
+            ],
+            \"tool_choice\": {\"type\": \"auto\"}
+        }'" \
+    "jq -e '[.content[] | select(.type == \"tool_use\")] | length >= 5 and ([.[].name] | sort == [\"get_exchange_rate\", \"get_time\", \"get_weather\", \"search_flights\", \"translate_phrase\"])'"
+
+# ============================================
+# Step 1.6g: Chat Completions - tool_choice forces specific function
+# ============================================
+run_test "Chat Completions - tool_choice specific function" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"Tell me a joke\"}
+            ],
+            \"tools\": [
+                {\"type\": \"function\", \"function\": {\"name\": \"get_weather\", \"description\": \"Get weather for a location\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\"}}, \"required\": [\"location\"]}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"get_time\", \"description\": \"Get current time\", \"parameters\": {\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\"}}, \"required\": [\"city\"]}}}
+            ],
+            \"tool_choice\": {\"type\": \"function\", \"function\": {\"name\": \"get_weather\"}}
+        }'" \
+    "jq -e '.choices[0].message.tool_calls[0].function.name == \"get_weather\"'"
+
+# ============================================
+# Step 1.6h: Messages API - tool_choice forces specific tool
+# ============================================
+run_test "Messages API - tool_choice specific tool" \
+    "curl -s -X POST ${BASE_URL}/v1/messages \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: dummy' \
+        -H 'anthropic-version: 2023-06-01' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"max_tokens\": 1024,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"Tell me a joke\"}
+            ],
+            \"tools\": [
+                {\"name\": \"get_weather\", \"description\": \"Get weather for a location\", \"input_schema\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\"}}, \"required\": [\"location\"]}},
+                {\"name\": \"get_time\", \"description\": \"Get current time\", \"input_schema\": {\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\"}}, \"required\": [\"city\"]}}
+            ],
+            \"tool_choice\": {\"type\": \"tool\", \"name\": \"get_weather\"}
+        }'" \
+    "jq -e '[.content[] | select(.type == \"tool_use\")] | length >= 1 and .[0].name == \"get_weather\"'"
+
+# ============================================
+# Step 1.6i: Chat Completions - complex nested parameters
+# ============================================
+run_test "Chat Completions - complex nested parameters" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"Create a meeting titled Team Standup for 2025-07-15T09:00:00 with alice@example.com and bob@example.com, set it as high priority with a 30 minute reminder.\"}
+            ],
+            \"tools\": [{
+                \"type\": \"function\",
+                \"function\": {
+                    \"name\": \"create_calendar_event\",
+                    \"description\": \"Create a calendar event with attendees and settings\",
+                    \"parameters\": {
+                        \"type\": \"object\",
+                        \"properties\": {
+                            \"title\": {\"type\": \"string\"},
+                            \"datetime\": {\"type\": \"string\", \"description\": \"ISO 8601 datetime\"},
+                            \"attendees\": {
+                                \"type\": \"array\",
+                                \"items\": {
+                                    \"type\": \"object\",
+                                    \"properties\": {
+                                        \"email\": {\"type\": \"string\"},
+                                        \"role\": {\"type\": \"string\", \"enum\": [\"required\", \"optional\"]}
+                                    },
+                                    \"required\": [\"email\"]
+                                }
+                            },
+                            \"settings\": {
+                                \"type\": \"object\",
+                                \"properties\": {
+                                    \"priority\": {\"type\": \"string\", \"enum\": [\"low\", \"medium\", \"high\"]},
+                                    \"reminders\": {
+                                        \"type\": \"array\",
+                                        \"items\": {\"type\": \"integer\", \"description\": \"Minutes before event\"}
+                                    }
+                                }
+                            }
+                        },
+                        \"required\": [\"title\", \"datetime\", \"attendees\"]
+                    }
+                }
+            }],
+            \"tool_choice\": \"auto\"
+        }'" \
+    "jq -e '.choices[0].message.tool_calls[0] | .function.name == \"create_calendar_event\" and (.function.arguments | fromjson | .attendees | length >= 2)'"
+
+# ============================================
+# Step 1.6j: Chat Completions - tool with no parameters
+# ============================================
+run_test "Chat Completions - tool with no parameters" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"What is the current server status?\"}
+            ],
+            \"tools\": [{
+                \"type\": \"function\",
+                \"function\": {
+                    \"name\": \"get_server_status\",
+                    \"description\": \"Returns the current server health status. Takes no arguments.\",
+                    \"parameters\": {\"type\": \"object\", \"properties\": {}}
+                }
+            }],
+            \"tool_choice\": \"auto\"
+        }'" \
+    "jq -e '.choices[0].message.tool_calls[0].function.name == \"get_server_status\"'"
+
+# ============================================
+# Step 1.6k: Chat Completions - multiple calls to same tool
+# ============================================
+run_test "Chat Completions - multiple calls same tool, different args" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"system\", \"content\": \"You are a helpful assistant. When asked about weather in multiple cities, make a separate get_weather call for EACH city.\"},
+                {\"role\": \"user\", \"content\": \"What is the weather in San Francisco, New York, and London?\"}
+            ],
+            \"tools\": [{
+                \"type\": \"function\",
+                \"function\": {
+                    \"name\": \"get_weather\",
+                    \"description\": \"Get weather for a location\",
+                    \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\"}}, \"required\": [\"location\"]}
+                }
+            }],
+            \"tool_choice\": \"auto\",
+            \"parallel_tool_calls\": true
+        }'" \
+    "jq -e '.choices[0].message.tool_calls | length >= 1 and all(.[]; .function.name == \"get_weather\")'"
+
+# ============================================
+# Step 1.6l: Chat Completions - verify all tools visible to model
+# ============================================
+run_test "Chat Completions - verify all tool definitions reach model" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"List the exact names of all tools available to you, one per line. Do not explain them.\"}
+            ],
+            \"tools\": [
+                {\"type\": \"function\", \"function\": {\"name\": \"tool_alpha\", \"description\": \"First tool\", \"parameters\": {\"type\": \"object\", \"properties\": {}}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"tool_beta\", \"description\": \"Second tool\", \"parameters\": {\"type\": \"object\", \"properties\": {}}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"tool_gamma\", \"description\": \"Third tool\", \"parameters\": {\"type\": \"object\", \"properties\": {}}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"tool_delta\", \"description\": \"Fourth tool\", \"parameters\": {\"type\": \"object\", \"properties\": {}}}},
+                {\"type\": \"function\", \"function\": {\"name\": \"tool_epsilon\", \"description\": \"Fifth tool\", \"parameters\": {\"type\": \"object\", \"properties\": {}}}}
+            ],
+            \"max_tokens\": 100
+        }'" \
+    "grep -o 'tool_alpha\|tool_beta\|tool_gamma\|tool_delta\|tool_epsilon' | sort -u | wc -l | xargs test 5 -eq"
+
+# ============================================
+# Step 1.6m: Messages API - verify all tools visible to model
+# ============================================
+run_test "Messages API - verify all tool definitions reach model" \
+    "curl -s -X POST ${BASE_URL}/v1/messages \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: dummy' \
+        -H 'anthropic-version: 2023-06-01' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"max_tokens\": 100,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"List the exact names of all tools available to you, one per line. Do not explain them.\"}
+            ],
+            \"tools\": [
+                {\"name\": \"tool_alpha\", \"description\": \"First tool\", \"input_schema\": {\"type\": \"object\", \"properties\": {}}},
+                {\"name\": \"tool_beta\", \"description\": \"Second tool\", \"input_schema\": {\"type\": \"object\", \"properties\": {}}},
+                {\"name\": \"tool_gamma\", \"description\": \"Third tool\", \"input_schema\": {\"type\": \"object\", \"properties\": {}}},
+                {\"name\": \"tool_delta\", \"description\": \"Fourth tool\", \"input_schema\": {\"type\": \"object\", \"properties\": {}}},
+                {\"name\": \"tool_epsilon\", \"description\": \"Fifth tool\", \"input_schema\": {\"type\": \"object\", \"properties\": {}}}
+            ]
+        }'" \
+    "grep -o 'tool_alpha\|tool_beta\|tool_gamma\|tool_delta\|tool_epsilon' | sort -u | wc -l | xargs test 5 -eq"
+
+# ============================================
+# Step 4.1a: Regression - Chat Completions without tools
+# ============================================
+run_test "Regression - Chat Completions without tools" \
+    "curl -s -X POST ${BASE_URL}/v1/chat/completions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"Explain how a simple agent loop works in 3 sentences.\"}
+            ]
+        }'" \
+    "jq -e '.choices[0].message.content != null'"
+
+# ============================================
+# Step 4.1b: Regression - Messages API without tools
+# ============================================
+run_test "Regression - Messages API without tools" \
+    "curl -s -X POST ${BASE_URL}/v1/messages \
+        -H 'Content-Type: application/json' \
+        -H 'x-api-key: dummy' \
+        -H 'anthropic-version: 2023-06-01' \
+        -d '{
+            \"model\": \"${MODEL}\",
+            \"temperature\": 0,
+            \"max_tokens\": 1024,
+            \"messages\": [
+                {\"role\": \"user\", \"content\": \"Explain how a simple agent loop works in 3 sentences.\"}
+            ]
+        }'" \
+    "jq -e '.content | map(select(.type == \"text\")) | length > 0'"
+
+# ============================================
+# Stack passthrough verification
+# ============================================
+echo ""
+echo "============================================"
+echo "STACK PASSTHROUGH VERIFICATION"
+echo "============================================"
+
+if [ -z "$LLMISVC_NAME" ]; then
+    echo "(Skipping stack passthrough -- LLMISVC_NAME not set)"
+else
+    WORKLOAD_PODS=$(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/name="${LLMISVC_NAME}" -o name 2>/dev/null || true)
+    EPP_POD=$(kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/name="${LLMISVC_NAME}",app.kubernetes.io/component=llminferenceservice-scheduler -o name 2>/dev/null | head -1)
+
+    echo ""
+    echo "--- Workload pod logs ---"
+    if [ -n "$WORKLOAD_PODS" ]; then
+        for POD in $WORKLOAD_PODS; do
+            echo "  [$POD]"
+            kubectl logs -n "${NAMESPACE}" "${POD}" --all-containers --tail=100 2>&1 \
+                | grep -i "tool\|auto_tool\|chat/completions\|/v1/messages\|get_weather\|error\|fail" \
+                | tail -20 || echo "  (no tool-related logs)"
+        done
+    else
+        echo "  (no workload pods found)"
+    fi
+
+    echo ""
+    echo "--- EPP logs ---"
+    if [ -n "$EPP_POD" ]; then
+        kubectl logs -n "${NAMESPACE}" "${EPP_POD}" -c main --tail=100 2>&1 \
+            | grep -i "tool\|message\|chat/completions\|/v1/messages\|request" \
+            | tail -20 || echo "  (no tool-related EPP logs)"
+    else
+        echo "  (no EPP pod found)"
+    fi
+fi
+
+# ============================================
+# Summary
+# ============================================
+echo ""
+echo "============================================"
+echo "SUMMARY"
+echo "============================================"
+for r in "${RESULTS[@]}"; do
+    echo "  $r"
+done
+echo ""
+echo "Total: $((PASS + FAIL))  Passed: ${PASS}  Failed: ${FAIL}"
+echo "============================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/docs/samples/llmisvc/agentic-tool-calling/run-tests.sh
+++ b/docs/samples/llmisvc/agentic-tool-calling/run-tests.sh
@@ -4,7 +4,7 @@
 # for any tool-calling-capable model deployed via LLMInferenceService.
 #
 # Usage:
-#   MODEL=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 LLMISVC_NAME=qwen-7b ./run-tests.sh
+#   MODEL=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 LLMISVC_NAME=qwen3-coder-tool-calling ./run-tests.sh
 #   ./run-tests.sh http://localhost:8080/my-namespace/my-llmisvc
 #
 # Environment variables:
@@ -23,7 +23,7 @@ if [ -n "${1:-}" ]; then
 else
     if [ -z "$LLMISVC_NAME" ]; then
         echo "ERROR: LLMISVC_NAME must be set, or pass the base URL as an argument."
-        echo "  Example: LLMISVC_NAME=qwen-7b MODEL=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 $0"
+        echo "  Example: LLMISVC_NAME=qwen3-coder-tool-calling MODEL=Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 $0"
         echo "  Example: $0 http://localhost:8080/my-namespace/my-llmisvc"
         exit 1
     fi

--- a/docs/samples/llmisvc/agentic-tool-calling/test-requests.md
+++ b/docs/samples/llmisvc/agentic-tool-calling/test-requests.md
@@ -1,0 +1,1062 @@
+# Tool Calling Test Requests
+
+Test requests for validating tool calling passthrough on both Chat Completions and Anthropic Messages API surfaces through KServe LLMInferenceService.
+
+## Setup
+
+Set these environment variables to point at your deployed LLMInferenceService endpoint and the model it serves.
+
+```bash
+export BASE_URL="<your-llminferenceservice-endpoint>"   # e.g. http://localhost:8080
+export MODEL="<your-model-name>"                         # e.g. the model identifier used at deploy time
+```
+
+---
+
+## 1. Chat Completions -- Tool Calling (non-streaming)
+
+Sends a request with a tool definition and expects the model to return a tool call.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather."
+      },
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco?"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get the current weather in a given location",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "City and state"
+              },
+              "unit": {
+                "type": "string",
+                "enum": ["celsius", "fahrenheit"]
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "parallel_tool_calls": true
+  }' | jq
+```
+
+**Expected:** `choices[].message.tool_calls` array with `function.name == "get_weather"` and `function.arguments` containing `"location"`.
+
+---
+
+## 2. Chat Completions -- Tool Calling (streaming)
+
+Same request with `"stream": true`.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "stream": true,
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather."
+      },
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco?"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get the current weather in a given location",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "City and state"
+              },
+              "unit": {
+                "type": "string",
+                "enum": ["celsius", "fahrenheit"]
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto"
+  }'
+```
+
+**Expected:** SSE stream with `choices[].delta.tool_calls` chunks. Concatenated `function.arguments` fragments form valid JSON containing `"location"`.
+
+---
+
+## 3. Messages API -- Tool Calling (non-streaming)
+
+Anthropic Messages format with `input_schema` instead of `parameters`, `tool_choice` as object.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{
+    "model": "'${MODEL}'",
+    "max_tokens": 1024,
+    "system": "You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather.",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco?"
+      }
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City and state"
+            },
+            "unit": {
+              "type": "string",
+              "enum": ["celsius", "fahrenheit"]
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "tool_choice": {"type": "auto"}
+  }' | jq
+```
+
+**Expected:** `content` array with a `tool_use` block containing `name: "get_weather"` and `input` with `"location"`. `stop_reason: "tool_use"`.
+
+---
+
+## 4. Messages API -- Tool Calling (streaming)
+
+Same request with `"stream": true`.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{
+    "model": "'${MODEL}'",
+    "max_tokens": 1024,
+    "stream": true,
+    "system": "You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather.",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco?"
+      }
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City and state"
+            },
+            "unit": {
+              "type": "string",
+              "enum": ["celsius", "fahrenheit"]
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "tool_choice": {"type": "auto"}
+  }'
+```
+
+**Expected:** SSE stream with `content_block_start` event containing `type: "tool_use"`. `content_block_delta` events with `partial_json` fragments that assemble into valid JSON with `"location"`.
+
+---
+
+## 5. Chat Completions -- Multi-turn Tool Use
+
+Simulates a complete tool use loop: user asks, model calls tool, tool returns result, model responds with text.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant with access to tools."
+      },
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco?"
+      },
+      {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_123",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\": \"San Francisco, CA\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "tool_call_id": "call_123",
+        "content": "{\"temperature\": 62, \"unit\": \"fahrenheit\", \"condition\": \"foggy\"}"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get the current weather in a given location",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {"type": "string"},
+              "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ]
+  }' | jq
+```
+
+**Expected:** `choices[].message.content` contains natural language referencing the weather data (62F, foggy). No additional tool calls.
+
+---
+
+## 6. Messages API -- Multi-turn Tool Use
+
+Same flow in Anthropic format: `tool_use` in assistant message, `tool_result` in user message.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{
+    "model": "'${MODEL}'",
+    "max_tokens": 1024,
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco?"
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_use",
+            "id": "toolu_123",
+            "name": "get_weather",
+            "input": {"location": "San Francisco, CA"}
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "toolu_123",
+            "content": "{\"temperature\": 62, \"unit\": \"fahrenheit\", \"condition\": \"foggy\"}"
+          }
+        ]
+      }
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string"},
+            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+          },
+          "required": ["location"]
+        }
+      }
+    ]
+  }' | jq
+```
+
+**Expected:** `content` array with a `text` block referencing the weather data. `stop_reason: "end_turn"`.
+
+---
+
+## 7. Chat Completions -- Multiple Tools (2 definitions)
+
+Provides two tool definitions (`get_weather` and `get_time`) and a prompt that requires both. Verifies the model can select from multiple available tools.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant with access to tools. Use the appropriate tool for each part of the request. Call multiple tools in parallel when needed."
+      },
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco and what time is it in Tokyo?"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get the current weather in a given location",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "City and state or city and country"
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "get_time",
+          "description": "Get the current time in a given timezone or city",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "City or timezone name"
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "parallel_tool_calls": true
+  }' | jq
+```
+
+**Expected:** `choices[].message.tool_calls` with at least one call. Each call's `function.name` is either `"get_weather"` or `"get_time"`.
+
+---
+
+## 8. Messages API -- Multiple Tools (2 definitions)
+
+Same two-tool scenario in Anthropic Messages format.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{
+    "model": "'${MODEL}'",
+    "max_tokens": 1024,
+    "system": "You are a helpful assistant with access to tools. Use the appropriate tool for each part of the request. Call multiple tools when needed.",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco and what time is it in Tokyo?"
+      }
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City and state or city and country"
+            }
+          },
+          "required": ["location"]
+        }
+      },
+      {
+        "name": "get_time",
+        "description": "Get the current time in a given timezone or city",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City or timezone name"
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "tool_choice": {"type": "auto"}
+  }' | jq
+```
+
+**Expected:** `content` array with at least one `tool_use` block. Each block's `name` is either `"get_weather"` or `"get_time"`.
+
+---
+
+## 9. Chat Completions -- 5 Tools
+
+Provides five tool definitions and a prompt designed to exercise all of them in parallel. Validates that the serving stack passes a larger tool set through correctly.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a travel planning assistant. You MUST call ALL relevant tools in parallel to answer the user. For this request, call get_weather for the destination, get_time for the destination, search_flights, get_exchange_rate, and translate_phrase."
+      },
+      {
+        "role": "user",
+        "content": "I want to travel from New York to Tokyo. What is the weather and time there, find me flights, what is the USD to JPY rate, and how do I say hello in Japanese?"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get weather for a location",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {"type": "string"}
+            },
+            "required": ["location"]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "get_time",
+          "description": "Get current time in a city",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "city": {"type": "string"}
+            },
+            "required": ["city"]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "search_flights",
+          "description": "Search for flights between cities",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "origin": {"type": "string"},
+              "destination": {"type": "string"},
+              "date": {"type": "string", "description": "YYYY-MM-DD"}
+            },
+            "required": ["origin", "destination"]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "get_exchange_rate",
+          "description": "Get exchange rate between currencies",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "from_currency": {"type": "string"},
+              "to_currency": {"type": "string"}
+            },
+            "required": ["from_currency", "to_currency"]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "translate_phrase",
+          "description": "Translate a phrase to another language",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "phrase": {"type": "string"},
+              "target_language": {"type": "string"}
+            },
+            "required": ["phrase", "target_language"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "parallel_tool_calls": true
+  }' | jq
+```
+
+**Expected:** `choices[].message.tool_calls` with 5 entries. The set of `function.name` values, sorted, equals `["get_exchange_rate", "get_time", "get_weather", "search_flights", "translate_phrase"]`.
+
+---
+
+## 10. Messages API -- 5 Tools
+
+Same five-tool scenario in Anthropic Messages format.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{
+    "model": "'${MODEL}'",
+    "max_tokens": 2048,
+    "system": "You are a travel planning assistant. You MUST call ALL relevant tools to answer the user. For this request, call get_weather for the destination, get_time for the destination, search_flights, get_exchange_rate, and translate_phrase.",
+    "messages": [
+      {
+        "role": "user",
+        "content": "I want to travel from New York to Tokyo. What is the weather and time there, find me flights, what is the USD to JPY rate, and how do I say hello in Japanese?"
+      }
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get weather for a location",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string"}
+          },
+          "required": ["location"]
+        }
+      },
+      {
+        "name": "get_time",
+        "description": "Get current time in a city",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "city": {"type": "string"}
+          },
+          "required": ["city"]
+        }
+      },
+      {
+        "name": "search_flights",
+        "description": "Search for flights between cities",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "origin": {"type": "string"},
+            "destination": {"type": "string"},
+            "date": {"type": "string", "description": "YYYY-MM-DD"}
+          },
+          "required": ["origin", "destination"]
+        }
+      },
+      {
+        "name": "get_exchange_rate",
+        "description": "Get exchange rate between currencies",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "from_currency": {"type": "string"},
+            "to_currency": {"type": "string"}
+          },
+          "required": ["from_currency", "to_currency"]
+        }
+      },
+      {
+        "name": "translate_phrase",
+        "description": "Translate a phrase to another language",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "phrase": {"type": "string"},
+            "target_language": {"type": "string"}
+          },
+          "required": ["phrase", "target_language"]
+        }
+      }
+    ],
+    "tool_choice": {"type": "auto"}
+  }' | jq
+```
+
+**Expected:** `content` array with 5 `tool_use` blocks. The sorted set of `name` values equals `["get_exchange_rate", "get_time", "get_weather", "search_flights", "translate_phrase"]`.
+
+---
+
+## 11. Chat Completions -- tool_choice Specific Function
+
+Sends a prompt unrelated to the tools but forces the model to call `get_weather` via `tool_choice`. Validates that `tool_choice` with a specific function name is honored.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Tell me a joke"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get weather for a location",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {"type": "string"}
+            },
+            "required": ["location"]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "get_time",
+          "description": "Get current time",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "city": {"type": "string"}
+            },
+            "required": ["city"]
+          }
+        }
+      }
+    ],
+    "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
+  }' | jq
+```
+
+**Expected:** `choices[].message.tool_calls[0].function.name == "get_weather"` regardless of the prompt content.
+
+---
+
+## 12. Messages API -- tool_choice Specific Tool
+
+Same forced-tool scenario in Anthropic Messages format.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{
+    "model": "'${MODEL}'",
+    "max_tokens": 1024,
+    "messages": [
+      {
+        "role": "user",
+        "content": "Tell me a joke"
+      }
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get weather for a location",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string"}
+          },
+          "required": ["location"]
+        }
+      },
+      {
+        "name": "get_time",
+        "description": "Get current time",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "city": {"type": "string"}
+          },
+          "required": ["city"]
+        }
+      }
+    ],
+    "tool_choice": {"type": "tool", "name": "get_weather"}
+  }' | jq
+```
+
+**Expected:** `content` array with at least one `tool_use` block where `name == "get_weather"`.
+
+---
+
+## 13. Chat Completions -- Complex Nested Parameters
+
+Sends a tool with deeply nested parameter schemas (arrays of objects, nested objects) and verifies the model populates them correctly.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Create a meeting titled Team Standup for 2025-07-15T09:00:00 with alice@example.com and bob@example.com, set it as high priority with a 30 minute reminder."
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "create_calendar_event",
+          "description": "Create a calendar event with attendees and settings",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "title": {"type": "string"},
+              "datetime": {
+                "type": "string",
+                "description": "ISO 8601 datetime"
+              },
+              "attendees": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "email": {"type": "string"},
+                    "role": {
+                      "type": "string",
+                      "enum": ["required", "optional"]
+                    }
+                  },
+                  "required": ["email"]
+                }
+              },
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "priority": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"]
+                  },
+                  "reminders": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "description": "Minutes before event"
+                    }
+                  }
+                }
+              }
+            },
+            "required": ["title", "datetime", "attendees"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto"
+  }' | jq
+```
+
+**Expected:** `choices[].message.tool_calls[0].function.name == "create_calendar_event"`. The parsed `function.arguments` contains an `attendees` array with at least 2 entries.
+
+---
+
+## 14. Chat Completions -- Tool with No Parameters
+
+Provides a tool that takes no arguments. Verifies the model can call it without generating spurious parameters.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is the current server status?"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_server_status",
+          "description": "Returns the current server health status. Takes no arguments.",
+          "parameters": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto"
+  }' | jq
+```
+
+**Expected:** `choices[].message.tool_calls[0].function.name == "get_server_status"`.
+
+---
+
+## 15. Chat Completions -- Multiple Calls to Same Tool
+
+Asks about weather in three cities with a single tool definition. Verifies the model issues multiple parallel calls to the same function with different arguments.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant. When asked about weather in multiple cities, make a separate get_weather call for EACH city."
+      },
+      {
+        "role": "user",
+        "content": "What is the weather in San Francisco, New York, and London?"
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get weather for a location",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {"type": "string"}
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ],
+    "tool_choice": "auto",
+    "parallel_tool_calls": true
+  }' | jq
+```
+
+**Expected:** `choices[].message.tool_calls` with at least one entry. Every entry has `function.name == "get_weather"`.
+
+---
+
+## 16. Chat Completions -- Verify All Tool Definitions Reach Model
+
+Registers five distinctly named tools and asks the model to list them. Confirms every definition is visible to the model through the serving stack.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "user",
+        "content": "List the exact names of all tools available to you, one per line. Do not explain them."
+      }
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "tool_alpha",
+          "description": "First tool",
+          "parameters": {"type": "object", "properties": {}}
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "tool_beta",
+          "description": "Second tool",
+          "parameters": {"type": "object", "properties": {}}
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "tool_gamma",
+          "description": "Third tool",
+          "parameters": {"type": "object", "properties": {}}
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "tool_delta",
+          "description": "Fourth tool",
+          "parameters": {"type": "object", "properties": {}}
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "tool_epsilon",
+          "description": "Fifth tool",
+          "parameters": {"type": "object", "properties": {}}
+        }
+      }
+    ],
+    "max_tokens": 100
+  }' | jq
+```
+
+**Expected:** `choices[].message.content` mentions all five names: `tool_alpha`, `tool_beta`, `tool_gamma`, `tool_delta`, `tool_epsilon`.
+
+---
+
+## 17. Messages API -- Verify All Tool Definitions Reach Model
+
+Same five-tool visibility test in Anthropic Messages format.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{
+    "model": "'${MODEL}'",
+    "max_tokens": 100,
+    "messages": [
+      {
+        "role": "user",
+        "content": "List the exact names of all tools available to you, one per line. Do not explain them."
+      }
+    ],
+    "tools": [
+      {
+        "name": "tool_alpha",
+        "description": "First tool",
+        "input_schema": {"type": "object", "properties": {}}
+      },
+      {
+        "name": "tool_beta",
+        "description": "Second tool",
+        "input_schema": {"type": "object", "properties": {}}
+      },
+      {
+        "name": "tool_gamma",
+        "description": "Third tool",
+        "input_schema": {"type": "object", "properties": {}}
+      },
+      {
+        "name": "tool_delta",
+        "description": "Fourth tool",
+        "input_schema": {"type": "object", "properties": {}}
+      },
+      {
+        "name": "tool_epsilon",
+        "description": "Fifth tool",
+        "input_schema": {"type": "object", "properties": {}}
+      }
+    ]
+  }' | jq
+```
+
+**Expected:** `content` text mentions all five names: `tool_alpha`, `tool_beta`, `tool_gamma`, `tool_delta`, `tool_epsilon`.
+
+---
+
+## 18. Chat Completions -- Regression (no tools)
+
+Verifies non-tool-calling requests still work.
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "'${MODEL}'",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Explain how a simple agent loop works in 3 sentences."
+      }
+    ]
+  }' | jq
+```
+
+**Expected:** `choices[].message.content` with a text response.
+
+---
+
+## 19. Messages API -- Regression (no tools)
+
+```bash
+curl -s -X POST ${BASE_URL}/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'x-api-key: dummy' \
+  -H 'anthropic-version: 2023-06-01' \
+  -d '{
+    "model": "'${MODEL}'",
+    "max_tokens": 1024,
+    "messages": [
+      {
+        "role": "user",
+        "content": "Explain how a simple agent loop works in 3 sentences."
+      }
+    ]
+  }' | jq
+```
+
+**Expected:** `content` array with a `text` block. `stop_reason: "end_turn"`.

--- a/docs/samples/llmisvc/agentic-tool-calling/test-requests.md
+++ b/docs/samples/llmisvc/agentic-tool-calling/test-requests.md
@@ -22,6 +22,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "system",
@@ -73,6 +74,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "stream": true,
     "messages": [
       {
@@ -126,6 +128,7 @@ curl -s -X POST ${BASE_URL}/v1/messages \
   -H 'anthropic-version: 2023-06-01' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "max_tokens": 1024,
     "system": "You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather.",
     "messages": [
@@ -173,6 +176,7 @@ curl -s -X POST ${BASE_URL}/v1/messages \
   -H 'anthropic-version: 2023-06-01' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "max_tokens": 1024,
     "stream": true,
     "system": "You are a helpful assistant with access to tools. Use the get_weather tool when asked about weather.",
@@ -219,6 +223,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "system",
@@ -283,6 +288,7 @@ curl -s -X POST ${BASE_URL}/v1/messages \
   -H 'anthropic-version: 2023-06-01' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "max_tokens": 1024,
     "messages": [
       {
@@ -341,6 +347,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "system",
@@ -407,6 +414,7 @@ curl -s -X POST ${BASE_URL}/v1/messages \
   -H 'anthropic-version: 2023-06-01' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "max_tokens": 1024,
     "system": "You are a helpful assistant with access to tools. Use the appropriate tool for each part of the request. Call multiple tools when needed.",
     "messages": [
@@ -462,6 +470,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "system",
@@ -568,6 +577,7 @@ curl -s -X POST ${BASE_URL}/v1/messages \
   -H 'anthropic-version: 2023-06-01' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "max_tokens": 2048,
     "system": "You are a travel planning assistant. You MUST call ALL relevant tools to answer the user. For this request, call get_weather for the destination, get_time for the destination, search_flights, get_exchange_rate, and translate_phrase.",
     "messages": [
@@ -654,6 +664,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "user",
@@ -709,6 +720,7 @@ curl -s -X POST ${BASE_URL}/v1/messages \
   -H 'anthropic-version: 2023-06-01' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "max_tokens": 1024,
     "messages": [
       {
@@ -757,6 +769,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "user",
@@ -830,6 +843,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "user",
@@ -866,6 +880,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "system",
@@ -910,6 +925,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "user",
@@ -977,6 +993,7 @@ curl -s -X POST ${BASE_URL}/v1/messages \
   -H 'anthropic-version: 2023-06-01' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "max_tokens": 100,
     "messages": [
       {
@@ -1027,6 +1044,7 @@ curl -s -X POST ${BASE_URL}/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "messages": [
       {
         "role": "user",
@@ -1049,6 +1067,7 @@ curl -s -X POST ${BASE_URL}/v1/messages \
   -H 'anthropic-version: 2023-06-01' \
   -d '{
     "model": "'${MODEL}'",
+    "temperature": 0,
     "max_tokens": 1024,
     "messages": [
       {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds LLMInferenceService samples and a manual test guide for validating tool calling passthrough on both Chat Completions and Anthropic Messages APIs. Includes:
- a P/D disaggregated deployment (Nemotron-3-Ultra-550B)
- a single-GPU deployment (Qwen3-Coder-30B)
- a 19-test script
- curl reference docs.


**Feature/Issue validation/testing**:

- [x] 19/19 tool calling tests passed on P/D disaggregated deployment (Nemotron-3-Ultra-550B, 2x H200 nodes) via LLMInferenceService on CoreWeave cluster
- [x] Both Chat Completions and Anthropic Messages API surfaces validated
- [x] Streaming, multi-turn, multiple tools, tool_choice, complex nested params, no-params edge case all covered

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
NONE.
```
