### PR TITLE
fix(infer_type): honor binary_data_output for requested outputs

### DIFF
--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -1349,7 +1349,11 @@ class InferResponse:
                 else output
             )
             if self._requested_outputs:
-                use_binary_data = output.binary_data
+                use_binary_data = (
+                    self._use_binary_outputs
+                    if output.binary_data is None
+                    else output.binary_data
+                )
             if infer_output is None:
                 raise InvalidInput(
                     f"Unexpected inference output '{output.name}' for model '{self.model_name}'"

--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -1366,7 +1366,7 @@ class InferResponse:
                 infer_output.set_data_from_numpy(
                     infer_output.data, binary_data=use_binary_data
                 )
-            elif infer_output.data or infer_output._raw_data:
+            elif infer_output.data is not None or infer_output._raw_data is not None:
                 infer_output.set_data_from_numpy(
                     infer_output.as_numpy(), binary_data=use_binary_data
                 )

--- a/python/kserve/test/test_infer_type.py
+++ b/python/kserve/test/test_infer_type.py
@@ -1025,6 +1025,29 @@ class TestInferResponse:
         )
         assert json_length == 215
 
+    def test_infer_response_to_rest_with_empty_output_as_binary_data(self):
+        infer_output = InferOutput(
+            name="output1",
+            shape=[0],
+            datatype="INT32",
+            data=[],
+            parameters=None,
+        )
+        infer_response = InferResponse(
+            response_id="1",
+            model_name="test_model",
+            infer_outputs=[infer_output],
+            use_binary_outputs=True,
+            requested_outputs=[RequestedOutput(name="output1")],
+        )
+        result, json_length = infer_response.to_rest()
+        assert isinstance(result, bytes)
+        assert (
+            result
+            == b'{"id":"1","model_name":"test_model","model_version":null,"outputs":[{"name":"output1","shape":[0],"datatype":"INT32","parameters":{"binary_data_size":0}}]}'
+        )
+        assert json_length == len(result)
+
     def test_infer_response_to_rest_with_raw_data_with_binary_data_false(
         self,
     ):

--- a/python/kserve/test/test_infer_type.py
+++ b/python/kserve/test/test_infer_type.py
@@ -949,6 +949,82 @@ class TestInferResponse:
         )
         assert json_length == 301
 
+    def test_infer_response_to_rest_with_requested_outputs_without_binary_data(
+        self,
+    ):
+        infer_output1 = InferOutput(
+            name="output1",
+            shape=[1],
+            datatype="FP16",
+            data=None,
+            parameters=None,
+        )
+        infer_output1.set_data_from_numpy(
+            np.array([1], dtype=np.float16), binary_data=True
+        )
+        infer_output2 = InferOutput(
+            name="output2",
+            shape=[1],
+            datatype="INT32",
+            data=[1],
+            parameters=None,
+        )
+        infer_response = InferResponse(
+            response_id="1",
+            model_name="test_model",
+            infer_outputs=[infer_output1, infer_output2],
+            use_binary_outputs=True,
+            requested_outputs=[
+                RequestedOutput(name="output1"),
+                RequestedOutput(name="output2"),
+            ],
+        )
+        result, json_length = infer_response.to_rest()
+        assert isinstance(result, bytes)
+        assert (
+            result
+            == b'{"id":"1","model_name":"test_model","model_version":null,"outputs":[{"name":"output1","shape":[1],"datatype":"FP16","parameters":{"binary_data_size":2}},{"name":"output2","shape":[1],"datatype":"INT32","parameters":{"binary_data_size":4}}]}\x00<\x01\x00\x00\x00'
+        )
+        assert json_length == 240
+
+    def test_infer_response_to_rest_with_requested_outputs_binary_data_false(
+        self,
+    ):
+        infer_output1 = InferOutput(
+            name="output1",
+            shape=[1],
+            datatype="FP16",
+            data=None,
+            parameters=None,
+        )
+        infer_output1.set_data_from_numpy(
+            np.array([1], dtype=np.float16), binary_data=True
+        )
+        infer_output2 = InferOutput(
+            name="output2",
+            shape=[1],
+            datatype="INT32",
+            data=[1],
+            parameters=None,
+        )
+        infer_response = InferResponse(
+            response_id="1",
+            model_name="test_model",
+            infer_outputs=[infer_output1, infer_output2],
+            use_binary_outputs=True,
+            requested_outputs=[
+                RequestedOutput(name="output1"),
+                RequestedOutput(name="output2", parameters={"binary_data": False}),
+            ],
+        )
+        result, json_length = infer_response.to_rest()
+        assert isinstance(result, bytes)
+        assert (
+            result
+            == b'{"id":"1","model_name":"test_model","model_version":null,"outputs":[{"name":"output1","shape":[1],"datatype":"FP16","parameters":{"binary_data_size":2}},{"name":"output2","shape":[1],"datatype":"INT32","data":[1]}]}\x00<'
+        )
+        assert json_length == 215
+
     def test_infer_response_to_rest_with_raw_data_with_binary_data_false(
         self,
     ):


### PR DESCRIPTION
**What this PR does / why we need it**:

A v2 request that sets `binary_data_output: true` and also lists its `outputs` got a JSON
response instead of a binary one, and FP16 outputs failed outright with "Sending FP16 data via
JSON is not supported" even though the request had asked for binary.

`RequestedOutput.binary_data` returns `None` when the client did not set a per-output
`binary_data` parameter. `InferResponse.to_rest()` assigned that value unconditionally, so the
`None` overwrote the request-level flag stored in `_use_binary_outputs` and everything fell
back to JSON.

This makes the per-output value override the request-level one only when it is actually set,
which is the behaviour the `InferResponse` docstring already describes. An explicit per-output
`binary_data: false` still wins.

It affects every predictor that responds through `get_predict_response()`, so sklearn,
xgboost, lightgbm, pmml, paddle and custom predictors.

**Which issue(s) this PR fixes**:
Fixes #NNNN

**Feature/Issue validation/testing**:

Two tests added to `python/kserve/test/test_infer_type.py`. Both fail on master and pass with
this change.

- [x] `test_infer_response_to_rest_with_requested_outputs_without_binary_data` - request-level
  `binary_data_output` with requested outputs that set no `binary_data`. On master this raises
  `InvalidInput: Sending FP16 data via JSON is not supported`, now it returns the binary
  payload with the correct header length.
- [x] `test_infer_response_to_rest_with_requested_outputs_binary_data_false` - same, but one
  output sets `binary_data: false` explicitly. That output stays JSON while the others go
  binary, confirming the per-output override still takes precedence.

- Logs

Before the change:

```
FAILED test_infer_type.py::TestInferResponse::test_infer_response_to_rest_with_requested_outputs_without_binary_data
FAILED test_infer_type.py::TestInferResponse::test_infer_response_to_rest_with_requested_outputs_binary_data_false
E   kserve.errors.InvalidInput: Sending FP16 data via JSON is not supported. Please use the binary data format for output output1
2 failed
```

After:

```
$ pytest -W ignore kserve/test/test_infer_type.py -q
35 passed
```

Also ran the wider unit suite (265 passed) and re-ran `test_infer_type.py` against
numpy 1.26.4 for the numpy 1.x job (35 passed). `ruff format --check` and `ruff check` are
clean.

**Special notes for your reviewer**:

The existing `to_rest` tests all set an explicit `binary_data` on every requested output, which
is why the unset case slipped through. None of them change with this fix.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
Fixed v2 REST responses ignoring the request-level `binary_data_output` parameter when the request also listed `outputs` without a per-output `binary_data` value.
```
