### PR TITLE
fix(modelserver): reject instances mixing numeric and string values

### DIFF
--- a/python/kserve/kserve/utils/utils.py
+++ b/python/kserve/kserve/utils/utils.py
@@ -166,7 +166,20 @@ def get_predict_input(
         else:
             if isinstance(instances[0], str):
                 return instances
-            return np.array(instances)
+            np_array = np.array(instances)
+            # numpy silently casts every element to a string when the instances
+            # hold both numeric and string values, corrupting the numeric fields.
+            if np_array.dtype.kind in ("U", "S") and any(
+                not isinstance(value, str)
+                for value in np.array(instances, dtype=object).ravel()
+            ):
+                raise InvalidInput(
+                    "instances mix numeric and string values, which would be coerced "
+                    "to strings. Send each instance as named fields to preserve the "
+                    'type of each field, e.g. {"instances": [{"col1": [1.0], '
+                    '"col2": ["abc"]}]}'
+                )
+            return np_array
     elif isinstance(payload, InferRequest):
         content_type = ""
         parameters = payload.parameters

--- a/python/kserve/kserve/utils/utils.py
+++ b/python/kserve/kserve/utils/utils.py
@@ -170,7 +170,7 @@ def get_predict_input(
             # numpy silently casts every element to a string when the instances
             # hold both numeric and string values, corrupting the numeric fields.
             if np_array.dtype.kind in ("U", "S") and any(
-                not isinstance(value, str)
+                not isinstance(value, (str, bytes))
                 for value in np.array(instances, dtype=object).ravel()
             ):
                 raise InvalidInput(

--- a/python/kserve/test/test_utils.py
+++ b/python/kserve/test/test_utils.py
@@ -51,6 +51,21 @@ class TestGetPredictInput:
         assert result.dtype.kind == "U"
         assert result.tolist() == [["PPC", "OSIOS"], ["SEO", "DESKTOP"]]
 
+    def test_all_bytes_instances_are_not_rejected(self):
+        payload = {"instances": [[b"PPC", b"OSIOS"]]}
+
+        result = get_predict_input(payload)
+
+        assert isinstance(result, np.ndarray)
+        assert result.dtype.kind == "S"
+        assert result.tolist() == [[b"PPC", b"OSIOS"]]
+
+    def test_bytes_mixed_with_numbers_raises(self):
+        payload = {"instances": [[b"PPC", 1.0]]}
+
+        with pytest.raises(InvalidInput, match="mix numeric and string values"):
+            get_predict_input(payload)
+
     def test_list_of_strings_is_returned_unchanged(self):
         payload = {"instances": ["first text", "second text"]}
 

--- a/python/kserve/test/test_utils.py
+++ b/python/kserve/test/test_utils.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from kserve.errors import InvalidInput
+from kserve.utils.utils import get_predict_input
+
+
+class TestGetPredictInput:
+    def test_mixed_types_in_instances_raises(self):
+        payload = {"instances": [[0.0, 141.0, "PPC", "US-MD", 0.14]]}
+
+        with pytest.raises(InvalidInput, match="mix numeric and string values"):
+            get_predict_input(payload)
+
+    def test_mixed_types_in_flat_instances_raises(self):
+        payload = {"instances": [1.0, "PPC", 2.0]}
+
+        with pytest.raises(InvalidInput, match="mix numeric and string values"):
+            get_predict_input(payload)
+
+    def test_numeric_instances_keep_their_dtype(self):
+        payload = {"instances": [[0.0, 141.0, 4.0], [1.0, 2.0, 3.0]]}
+
+        result = get_predict_input(payload)
+
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float64
+        assert result.tolist() == [[0.0, 141.0, 4.0], [1.0, 2.0, 3.0]]
+
+    def test_all_string_instances_are_not_rejected(self):
+        payload = {"instances": [["PPC", "OSIOS"], ["SEO", "DESKTOP"]]}
+
+        result = get_predict_input(payload)
+
+        assert isinstance(result, np.ndarray)
+        assert result.dtype.kind == "U"
+        assert result.tolist() == [["PPC", "OSIOS"], ["SEO", "DESKTOP"]]
+
+    def test_list_of_strings_is_returned_unchanged(self):
+        payload = {"instances": ["first text", "second text"]}
+
+        assert get_predict_input(payload) == ["first text", "second text"]
+
+    def test_dict_instances_preserve_per_field_types(self):
+        payload = {"instances": [{"age": [25], "channel": ["PPC"]}]}
+
+        result = get_predict_input(payload)
+
+        assert isinstance(result, pd.DataFrame)
+        assert result["age"].dtype == np.int64
+        assert result["channel"].dtype == object
+
+    def test_empty_instances(self):
+        result = get_predict_input({"instances": []})
+
+        assert isinstance(result, np.ndarray)
+        assert result.size == 0


### PR DESCRIPTION
**What this PR does / why we need it**:

`get_predict_input` passed list-form instances straight to `np.array(instances)`. When an
instance holds both numbers and strings, numpy has to settle on one dtype and picks a string
one, so every numeric field was silently rewritten as text before the model ever saw it:

```python
>>> get_predict_input({"instances": [[0.0, 141.0, "PPC", 0.14]]})
array([['0.0', '141.0', 'PPC', '0.14']], dtype='<U32')
```

With xgboost that surfaced as the `XGBoostError: Unicode-3 is not supported` from the issue.
The quieter case is worse: a model that accepts string input returns predictions computed on
stringified numbers, with no error at all.

This keeps the existing requirement that mixed field types are sent as named fields, and just
stops the silent coercion, raising `InvalidInput` that names the shape that works. The
function is shared by the sklearn, xgboost, lightgbm, pmml and paddle servers, so all five get
the check.

Homogeneous input is untouched: all-numeric instances keep their numeric dtype, all-string
instances are still accepted, and a plain list of strings is still returned as-is.

**Which issue(s) this PR fixes**:
Fixes #2381

**Feature/Issue validation/testing**:

New file `python/kserve/test/test_utils.py`, since `get_predict_input` had no direct coverage.
The two mixed-type tests fail on master and pass with this change, the rest pin the existing
behaviour so the guard cannot regress it.

- [x] `test_mixed_types_in_instances_raises` and `test_mixed_types_in_flat_instances_raises` -
  the reported case, nested and flat.
- [x] `test_numeric_instances_keep_their_dtype` - all-numeric still returns float64, not strings.
- [x] `test_all_string_instances_are_not_rejected` - all-string input is not caught by the guard.
- [x] `test_list_of_strings_is_returned_unchanged` - text models are unaffected.
- [x] `test_dict_instances_preserve_per_field_types` - the named-field form still yields a
  DataFrame with per-column dtypes.
- [x] `test_empty_instances` - empty input still returns an empty array.

- Logs

The payload from the issue, before and after:

```
# before
>>> get_predict_input({"instances": [[0.0, 141.0, 4.0, "PPC", "US-MD", 0.14]]})
array([['0.0', '141.0', '4.0', 'PPC', 'US-MD', '0.14']], dtype='<U32')

# after
kserve.errors.InvalidInput: instances mix numeric and string values, which would be
coerced to strings. Send each instance as named fields to preserve the type of each
field, e.g. {"instances": [{"col1": [1.0], "col2": ["abc"]}]}
```

Test runs:

```
$ pytest -W ignore kserve/test/test_utils.py -v
7 passed

$ pytest -W ignore sklearnserver -q
10 passed

$ pytest -W ignore xgbserver -q
6 passed
```

Also ran the wider kserve unit suite (274 passed) and re-ran the new tests against numpy 1.26.4
for the numpy 1.x job (7 passed). `ruff format --check` and `ruff check` are clean.

**Special notes for your reviewer**:

The alternative would be to build a DataFrame for the mixed case so the numeric fields survive,
which is what the named-field path already does. I went with the explicit error because it
matches the guidance already given on the issue and does not change what any currently working
request returns. Happy to switch to the DataFrame behaviour if you would rather have that.

The object-array scan only runs when numpy has already chosen a string dtype, so the normal
numeric path is unaffected.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

```release-note
Requests whose `instances` mix numeric and string values now fail with a clear error instead of silently coercing every numeric field to a string.
```
