### PR TITLE
fix(python): return valid cpu count when os.cpu_count() is None

### DIFF
--- a/python/kserve/kserve/utils/utils.py
+++ b/python/kserve/kserve/utils/utils.py
@@ -61,7 +61,10 @@ def cpu_count():
     - CPU Affinity (if set)
     - Cgroups limit (if set)
     """
-    count = os.cpu_count()
+    # os.cpu_count() may return None when the count is undetermined; fall back
+    # to 1 so the min() comparisons below (with affinity / cgroups limits) don't
+    # raise TypeError on such hosts.
+    count = os.cpu_count() or 1
 
     # Check CPU affinity if available
     try:

--- a/python/kserve/test/test_cpu_count.py
+++ b/python/kserve/test/test_cpu_count.py
@@ -1,0 +1,47 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import psutil
+
+from kserve.utils.utils import cpu_count
+
+
+def test_cpu_count_handles_none_from_os(monkeypatch):
+    """os.cpu_count() may return None; cpu_count() must still return a valid int.
+
+    Regression: with os.cpu_count() == None the ``min(count, affinity_count)``
+    comparison raised TypeError, which was swallowed by the surrounding
+    ``except Exception``, so cpu_count() returned None instead of a usable
+    worker count (and the affinity/cgroups limits were silently ignored).
+    """
+    monkeypatch.setattr("os.cpu_count", lambda: None)
+    # cpu_affinity is not defined on every platform (e.g. macOS), so add it.
+    monkeypatch.setattr(
+        psutil.Process, "cpu_affinity", lambda self: [0, 1, 2, 3], raising=False
+    )
+
+    result = cpu_count()
+    assert isinstance(result, int)
+    assert result >= 1
+
+
+def test_cpu_count_respects_affinity(monkeypatch):
+    """When affinity is smaller than the host CPU count, it wins."""
+    monkeypatch.setattr("os.cpu_count", lambda: 8)
+    monkeypatch.setattr(
+        psutil.Process, "cpu_affinity", lambda self: [0, 1], raising=False
+    )
+    assert cpu_count() == 2

--- a/python/kserve/test/test_cpu_count.py
+++ b/python/kserve/test/test_cpu_count.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import mock
-
 import psutil
 
 from kserve.utils.utils import cpu_count


### PR DESCRIPTION
**What this PR does / why we need it**:

`kserve.utils.utils.cpu_count()` starts from `os.cpu_count()`, which is documented to return `None` when the CPU count is undetermined. When it is `None`, the `min(count, affinity_count)` / `min(count, cgroups_count)` refinements raise `TypeError: '<' not supported between instances of 'int' and 'NoneType'`. That exception is swallowed by the surrounding `except Exception`, so `cpu_count()` returns `None` and the CPU-affinity / cgroups limits are silently ignored.

Callers use the result as a worker / thread count (e.g. server worker sizing), so a `None` return propagates into places that expect a positive int.

This defaults to `1` when `os.cpu_count()` is `None`, so `cpu_count()` always returns a valid positive int and the affinity/cgroups minimums apply as intended. Normal hosts (where `os.cpu_count()` returns a number) are unaffected.

**Which issue(s) this PR fixes**:

(No existing issue — found while reading the utility.)

**Feature/Issue validation/testing**:

Added `python/kserve/test/test_cpu_count.py`:

- [x] `test_cpu_count_handles_none_from_os` — with `os.cpu_count()` mocked to `None` and an affinity set, `cpu_count()` returns a positive int. Fails on `master` (returns `None`); passes with this change.
- [x] `test_cpu_count_respects_affinity` — a smaller affinity still wins over the host CPU count.

```
$ pytest test/test_cpu_count.py
2 passed
# on master (without the fix): test_cpu_count_handles_none_from_os fails (returns None)
```

**Special notes for your reviewer**:

One-line behavioural change (`os.cpu_count()` → `os.cpu_count() or 1`); the affinity/cgroups logic is unchanged. `black`-clean.
