### PR TITLE
fix(e2e): default GITHUB_SHA to 'latest' for test collection

### DIFF
--- a/test/e2e/custom/test_custom_model_grpc.py
+++ b/test/e2e/custom/test_custom_model_grpc.py
@@ -144,7 +144,7 @@ async def test_predictor_grpc_with_transformer_grpc():
             V1Container(
                 name="kserve-container",
                 image="kserve/custom-image-transformer-grpc:"
-                + os.environ.get("GITHUB_SHA"),
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},
@@ -398,7 +398,8 @@ async def test_predictor_grpc_with_transformer_grpc_raw(network_layer):
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image="kserve/custom-model-grpc:"
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},
@@ -418,7 +419,7 @@ async def test_predictor_grpc_with_transformer_grpc_raw(network_layer):
             V1Container(
                 name="kserve-container",
                 image="kserve/custom-image-transformer-grpc:"
-                + os.environ.get("GITHUB_SHA"),
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},

--- a/test/e2e/graph/test_inference_graph.py
+++ b/test/e2e/graph/test_inference_graph.py
@@ -39,7 +39,7 @@ from httpx import HTTPStatusError
 
 from ..common.utils import KSERVE_TEST_NAMESPACE, predict_ig
 
-img_version = os.environ.get("GITHUB_SHA", "latest")
+img_version = os.environ.get("GITHUB_SHA") or "latest"
 
 SUCCESS_ISVC_IMAGE = f"kserve/success-200-isvc:{img_version}"
 ERROR_ISVC_IMAGE = f"kserve/error-404-isvc:{img_version}"

--- a/test/e2e/predictor/test_response_headers.py
+++ b/test/e2e/predictor/test_response_headers.py
@@ -61,7 +61,7 @@ def test_predictor_headers_v1():
             V1Container(
                 name="kserve-container",
                 image="kserve/custom-image-transformer-grpc:"
-                + os.environ.get("GITHUB_SHA"),
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 # Override the entrypoint to run the custom transformer rest server
                 command=["python", "-m", "custom_transformer.model"],
                 resources=V1ResourceRequirements(
@@ -146,7 +146,7 @@ def test_predictor_headers_v2():
             V1Container(
                 name="kserve-container",
                 image="kserve/custom-image-transformer-grpc:"
-                + os.environ.get("GITHUB_SHA"),
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 # Override the entrypoint to run the custom transformer rest server
                 command=["python", "-m", "custom_transformer.model"],
                 resources=V1ResourceRequirements(


### PR DESCRIPTION
**What this PR does / why we need it**:

Defaults `GITHUB_SHA` to `"latest"` in the remaining e2e test files that still concatenate it bare. Without this, `pytest --collect-only` raises a `TypeError` outside CI, breaking `make precommit` and any local test discovery.

Follow-up on #4620 where we missed it.

**Which issue(s) this PR fixes**:

N/A

**Feature/Issue validation/testing**:

- [x] `pytest --collect-only test/e2e/` passes locally without `GITHUB_SHA` set
- [x] `make precommit` completes successfully

**Special notes for your reviewer**:

Identical pattern to the existing fix in `test_inference_graph.py`  introduced in #4620.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```