### PR TITLE
feat: add canary traffic splitting to RawDeployment HTTPRoutes

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -263,13 +263,16 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 		})
 		return nil, nil
 	}
+	// The route name and hostname use a stable name (without predictor.name) so
+	// they don't change on canary promotion. Backend refs use the actual service name.
+	routeName := constants.PredictorServiceName(isvc.Name)
 	predictorName := constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name)
 
 	// Add isvc name and namespace headers
 	filters := []gwapiv1.HTTPRouteFilter{addIsvcHeaders(isvc.Name, isvc.Namespace)}
 
 	// Add predictor host rules
-	predictorHost, err := GenerateDomainName(predictorName, isvc.ObjectMeta, ingressConfig)
+	predictorHost, err := GenerateDomainName(routeName, isvc.ObjectMeta, ingressConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate predictor ingress host: %w", err)
 	}
@@ -306,7 +309,7 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 	gatewaySlice := strings.Split(ingressConfig.KserveIngressGateway, "/")
 	httpRoute := gwapiv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name),
+			Name:        routeName,
 			Namespace:   isvc.Namespace,
 			Annotations: annotations,
 			Labels:      labels,
@@ -325,6 +328,9 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 				},
 			},
 		},
+	}
+	if len(isvc.Spec.Canary) > 0 {
+		applyCanaryWeights(isvc, &httpRoute)
 	}
 	return &httpRoute, nil
 }
@@ -669,13 +675,77 @@ func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc 
 			},
 		},
 	}
+	if len(isvc.Spec.Canary) > 0 {
+		applyCanaryWeights(isvc, &httpRoute)
+	}
 	return &httpRoute, nil
 }
 
+// applyCanaryWeights modifies the HTTPRoute's backend refs to include weighted
+// backends for canary traffic splitting.
+func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPRoute) {
+	var totalCanaryPercent int32
+	for _, canary := range isvc.Spec.Canary {
+		totalCanaryPercent += canary.TrafficPercent
+	}
+	stableWeight := int32(100) - totalCanaryPercent
+
+	for i := range httpRoute.Spec.Rules {
+		rule := &httpRoute.Spec.Rules[i]
+		if len(rule.BackendRefs) == 0 {
+			continue
+		}
+
+		template := rule.BackendRefs[0]
+		weightedBackends := make([]gwapiv1.HTTPBackendRef, 0, 1+len(isvc.Spec.Canary))
+
+		sw := stableWeight
+		stable := gwapiv1.HTTPBackendRef{
+			BackendRef: gwapiv1.BackendRef{
+				BackendObjectReference: template.BackendObjectReference,
+				Weight:                 &sw,
+			},
+		}
+		weightedBackends = append(weightedBackends, stable)
+
+		for _, canary := range isvc.Spec.Canary {
+			canaryServiceName := constants.PredictorServiceName(isvc.Name, canary.Predictor.Name)
+			cw := canary.TrafficPercent
+			backend := gwapiv1.HTTPBackendRef{
+				BackendRef: gwapiv1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{
+						Kind:      template.Kind,
+						Name:      gwapiv1.ObjectName(canaryServiceName),
+						Namespace: template.Namespace,
+						Port:      template.Port,
+					},
+					Weight: &cw,
+				},
+			}
+			weightedBackends = append(weightedBackends, backend)
+		}
+
+		rule.BackendRefs = weightedBackends
+	}
+}
+
 func semanticHttpRouteEquals(desired, existing *gwapiv1.HTTPRoute) bool {
-	return equality.Semantic.DeepDerivative(desired.Spec, existing.Spec) &&
-		equality.Semantic.DeepDerivative(desired.Labels, existing.Labels) &&
-		equality.Semantic.DeepDerivative(desired.Annotations, existing.Annotations)
+	if !equality.Semantic.DeepDerivative(desired.Labels, existing.Labels) ||
+		!equality.Semantic.DeepDerivative(desired.Annotations, existing.Annotations) {
+		return false
+	}
+	// DeepDerivative treats missing fields as matching, so a single unweighted
+	// backend is seen as a subset of two weighted backends. Compare backend ref
+	// counts explicitly to detect canary addition/removal.
+	if len(desired.Spec.Rules) != len(existing.Spec.Rules) {
+		return false
+	}
+	for i := range desired.Spec.Rules {
+		if len(desired.Spec.Rules[i].BackendRefs) != len(existing.Spec.Rules[i].BackendRefs) {
+			return false
+		}
+	}
+	return equality.Semantic.DeepDerivative(desired.Spec, existing.Spec)
 }
 
 // isHTTPRouteReady checks if the HTTPRoute is ready. If not, returns the reason and message.
@@ -700,7 +770,7 @@ func (r *RawHTTPRouteReconciler) reconcilePredictorHTTPRoute(ctx context.Context
 	}
 
 	// reconcile httpRoute
-	httpRouteName := constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name)
+	httpRouteName := constants.PredictorServiceName(isvc.Name)
 	existingHttpRoute := &gwapiv1.HTTPRoute{}
 	getExistingErr := r.client.Get(ctx, types.NamespacedName{
 		Namespace: isvc.Namespace,
@@ -955,7 +1025,7 @@ func (r *RawHTTPRouteReconciler) reconcileHTTPRouteStatus(ctx context.Context, i
 
 	checks := []httpRouteCheck{
 		{
-			name:      constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name),
+			name:      constants.PredictorServiceName(isvc.Name),
 			component: "Predictor",
 		},
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -3461,3 +3461,179 @@ func TestCreateRawPredictorHTTPRouteDisableTimeout(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyCanaryWeights(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	t.Run("single canary", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{
+						TrafficPercent: 20,
+						Predictor:      v1beta1.PredictorSpec{Name: "v2"},
+					},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Kind:      ptr.To(gwapiv1.Kind(constants.ServiceKind)),
+										Name:      "my-model-predictor",
+										Namespace: (*gwapiv1.Namespace)(ptr.To("default")),
+										Port:      ptr.To(int32(80)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		backends := httpRoute.Spec.Rules[0].BackendRefs
+		g.Expect(backends).To(HaveLen(2))
+		g.Expect(*backends[0].Weight).To(Equal(int32(80)))
+		g.Expect(string(backends[0].Name)).To(Equal("my-model-predictor"))
+		g.Expect(*backends[1].Weight).To(Equal(int32(20)))
+		g.Expect(string(backends[1].Name)).To(Equal("my-model-v2-predictor"))
+	})
+
+	t.Run("multiple canaries", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+					{TrafficPercent: 30, Predictor: v1beta1.PredictorSpec{Name: "v3"}},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{BackendRef: gwapiv1.BackendRef{
+								BackendObjectReference: gwapiv1.BackendObjectReference{
+									Kind: ptr.To(gwapiv1.Kind(constants.ServiceKind)),
+									Name: "my-model-predictor",
+									Port: ptr.To(int32(80)),
+								},
+							}},
+						},
+					},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		backends := httpRoute.Spec.Rules[0].BackendRefs
+		g.Expect(backends).To(HaveLen(3))
+		g.Expect(*backends[0].Weight).To(Equal(int32(50)))
+		g.Expect(*backends[1].Weight).To(Equal(int32(20)))
+		g.Expect(string(backends[1].Name)).To(Equal("my-model-v2-predictor"))
+		g.Expect(*backends[2].Weight).To(Equal(int32(30)))
+		g.Expect(string(backends[2].Name)).To(Equal("my-model-v3-predictor"))
+	})
+
+	t.Run("dual-protocol rules", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 25, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{BackendRefs: []gwapiv1.HTTPBackendRef{
+						{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+							Name: "my-model-predictor", Port: ptr.To(int32(9090)),
+						}}},
+					}},
+					{BackendRefs: []gwapiv1.HTTPBackendRef{
+						{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+							Name: "my-model-predictor", Port: ptr.To(int32(80)),
+						}}},
+					}},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		// Both rules should get canary backends
+		for _, rule := range httpRoute.Spec.Rules {
+			g.Expect(rule.BackendRefs).To(HaveLen(2))
+			g.Expect(*rule.BackendRefs[0].Weight).To(Equal(int32(75)))
+			g.Expect(*rule.BackendRefs[1].Weight).To(Equal(int32(25)))
+		}
+	})
+
+	t.Run("skips rules with no backends", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 10, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{BackendRefs: nil},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(BeNil())
+	})
+}
+
+func TestSemanticHttpRouteEquals_BackendRefCount(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	makeRoute := func(backendCount int) *gwapiv1.HTTPRoute {
+		backends := make([]gwapiv1.HTTPBackendRef, backendCount)
+		for i := range backends {
+			w := int32(100 / backendCount) //nolint:gosec // test-only, backendCount is always small
+			backends[i] = gwapiv1.HTTPBackendRef{
+				BackendRef: gwapiv1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{
+						Name: gwapiv1.ObjectName("svc"),
+						Port: ptr.To(int32(80)),
+					},
+					Weight: &w,
+				},
+			}
+		}
+		return &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{{BackendRefs: backends}},
+			},
+		}
+	}
+
+	t.Run("different backend count is not equal", func(t *testing.T) {
+		g.Expect(semanticHttpRouteEquals(makeRoute(1), makeRoute(2))).To(BeFalse())
+	})
+
+	t.Run("same backend count is equal", func(t *testing.T) {
+		g.Expect(semanticHttpRouteEquals(makeRoute(2), makeRoute(2))).To(BeTrue())
+	})
+}

--- a/test/e2e/predictor/test_canary_raw_deployment.py
+++ b/test/e2e/predictor/test_canary_raw_deployment.py
@@ -151,6 +151,10 @@ def _get_httproute_backend_refs(name, namespace):
     return [(ref["name"], ref.get("weight")) for ref in rules[0].get("backendRefs", [])]
 
 
+def _is_gatewayapi(network_layer):
+    return network_layer is not None and "gatewayapi" in network_layer
+
+
 def _get_pod_uids(apps_v1, deployment_name, namespace):
     core_v1 = client.CoreV1Api()
     dep = apps_v1.read_namespaced_deployment(deployment_name, namespace)
@@ -162,7 +166,7 @@ def _get_pod_uids(apps_v1, deployment_name, namespace):
 
 @pytest.mark.predictor
 @pytest.mark.raw
-def test_canary_create():
+def test_canary_create(network_layer):
     service_name = "isvc-canary-create"
     kserve = _kserve_client()
     apps = _apps_v1()
@@ -203,30 +207,26 @@ def test_canary_create():
         assert len(canary_status) > 0, "canary status should be populated"
         assert canary_status[0]["name"] == "v2"
 
-        # Verify HTTPRoute has weighted backend refs for stable and canary
-        backends = _get_httproute_backend_refs(
-            f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
-        )
-        assert len(backends) == 2, (
-            f"Expected 2 backends (stable + canary), got {backends}"
-        )
-        names = {name for name, _ in backends}
-        assert f"{service_name}-predictor" in names, (
-            "Stable backend missing from HTTPRoute"
-        )
-        assert f"{service_name}-v2-predictor" in names, (
-            "Canary backend missing from HTTPRoute"
-        )
-        weights = {name: weight for name, weight in backends}
-        assert weights[f"{service_name}-predictor"] == 80
-        assert weights[f"{service_name}-v2-predictor"] == 20
+        if _is_gatewayapi(network_layer):
+            backends = _get_httproute_backend_refs(
+                f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+            )
+            assert len(backends) == 2, (
+                f"Expected 2 backends (stable + canary), got {backends}"
+            )
+            names = {name for name, _ in backends}
+            assert f"{service_name}-predictor" in names
+            assert f"{service_name}-v2-predictor" in names
+            weights = {name: weight for name, weight in backends}
+            assert weights[f"{service_name}-predictor"] == 80
+            assert weights[f"{service_name}-v2-predictor"] == 20
     finally:
         _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
 @pytest.mark.raw
-def test_canary_promote():
+def test_canary_promote(network_layer):
     service_name = "isvc-canary-promote"
     kserve = _kserve_client()
     apps = _apps_v1()
@@ -282,19 +282,21 @@ def test_canary_promote():
             f"Canary pods were restarted during promotion: canary={canary_pod_uids}, post_promote={post_promote_uids}"
         )
 
-        # After promotion, HTTPRoute name stays stable, backend points to promoted service
-        backends = _get_httproute_backend_refs(
-            f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
-        )
-        assert len(backends) == 1, f"Expected 1 backend after promotion, got {backends}"
-        assert backends[0][0] == f"{service_name}-v2-predictor"
+        if _is_gatewayapi(network_layer):
+            backends = _get_httproute_backend_refs(
+                f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+            )
+            assert len(backends) == 1, (
+                f"Expected 1 backend after promotion, got {backends}"
+            )
+            assert backends[0][0] == f"{service_name}-v2-predictor"
     finally:
         _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
 @pytest.mark.raw
-def test_canary_rollback():
+def test_canary_rollback(network_layer):
     service_name = "isvc-canary-rollback"
     kserve = _kserve_client()
     apps = _apps_v1()
@@ -345,12 +347,14 @@ def test_canary_rollback():
             "CanaryPredictorReady should be cleared after rollback"
         )
 
-        # After rollback, HTTPRoute should have a single stable backend
-        backends = _get_httproute_backend_refs(
-            f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
-        )
-        assert len(backends) == 1, f"Expected 1 backend after rollback, got {backends}"
-        assert backends[0][0] == f"{service_name}-predictor"
+        if _is_gatewayapi(network_layer):
+            backends = _get_httproute_backend_refs(
+                f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+            )
+            assert len(backends) == 1, (
+                f"Expected 1 backend after rollback, got {backends}"
+            )
+            assert backends[0][0] == f"{service_name}-predictor"
     finally:
         _safe_delete(kserve, service_name)
 

--- a/test/e2e/predictor/test_canary_raw_deployment.py
+++ b/test/e2e/predictor/test_canary_raw_deployment.py
@@ -179,13 +179,13 @@ def _verify_traffic_split(
 
     In this test setup:
     - Stable predictor uses STABLE_MODEL_URI which returns 200 (successful)
-    - Canary predictor uses CANARY_MODEL_URI which returns 503 (bad model path)
+    - Canary predictor uses CANARY_MODEL_URI which returns 500 (bad model path)
 
     Args:
         kserve: KServeClient instance
         service_name: Name of the InferenceService
         namespace: Kubernetes namespace
-        expected_pcts: Dict mapping status code to expected percentage, e.g., {200: 80, 503: 20}
+        expected_pcts: Dict mapping status code to expected percentage, e.g., {200: 80, 500: 20}
         network_layer: Network layer type (e.g., "istio-gatewayapi")
         num_requests: Total number of requests to send
         tolerance: Allowed deviation in percentage points
@@ -210,13 +210,13 @@ def _verify_traffic_split(
 
     for i in range(num_requests):
         try:
-            # Don't retry on 503 since we expect it from canary (bad model path)
-            # Only retry on network errors and 502/504 gateway errors
+            # Don't retry on 500 since we expect it from canary (bad model path)
+            # Only retry on network errors and 502/503/504 gateway errors
             response = post_with_retry(
                 url,
                 headers=headers,
                 json_data=input_data,
-                retry_status_codes=(502, 504),
+                retry_status_codes=(502, 503, 504),
             )
             status_counts[response.status_code] = (
                 status_counts.get(response.status_code, 0) + 1
@@ -304,12 +304,12 @@ def test_canary_create(network_layer):
             assert weights[f"{service_name}-v2-predictor"] == 20
 
             # Verify actual traffic split by sending requests
-            # Stable (STABLE_MODEL_URI) returns 200, canary (CANARY_MODEL_URI) returns 503
+            # Stable (STABLE_MODEL_URI) returns 200, canary (CANARY_MODEL_URI) returns 500
             _verify_traffic_split(
                 kserve,
                 service_name,
                 KSERVE_TEST_NAMESPACE,
-                expected_pcts={200: 80, 503: 20},
+                expected_pcts={200: 80, 500: 20},
                 network_layer=network_layer,
                 num_requests=100,
                 tolerance=10,
@@ -386,12 +386,12 @@ def test_canary_promote(network_layer):
             assert backends[0][0] == f"{service_name}-v2-predictor"
 
             # Verify 100% traffic goes to promoted canary (v2)
-            # The promoted v2 uses CANARY_MODEL_URI which returns 503
+            # The promoted v2 uses CANARY_MODEL_URI which returns 500
             _verify_traffic_split(
                 kserve,
                 service_name,
                 KSERVE_TEST_NAMESPACE,
-                expected_pcts={503: 100},
+                expected_pcts={500: 100},
                 network_layer=network_layer,
                 num_requests=50,
                 tolerance=10,

--- a/test/e2e/predictor/test_canary_raw_deployment.py
+++ b/test/e2e/predictor/test_canary_raw_deployment.py
@@ -135,6 +135,25 @@ def _wait_for_condition(
     )
 
 
+def _get_httproute(name, namespace):
+    api = client.CustomObjectsApi()
+    return api.get_namespaced_custom_object(
+        "gateway.networking.k8s.io", "v1", namespace, "httproutes", name
+    )
+
+
+def _get_httproute_backend_refs(name, namespace):
+    """Return a list of (service_name, weight) tuples from the first rule's backendRefs."""
+    route = _get_httproute(name, namespace)
+    rules = route.get("spec", {}).get("rules", [])
+    if not rules:
+        return []
+    return [
+        (ref["backendRef"]["name"], ref["backendRef"].get("weight"))
+        for ref in rules[0].get("backendRefs", [])
+    ]
+
+
 def _get_pod_uids(apps_v1, deployment_name, namespace):
     core_v1 = client.CoreV1Api()
     dep = apps_v1.read_namespaced_deployment(deployment_name, namespace)
@@ -187,6 +206,24 @@ def test_canary_create():
         canary_status = got.get("status", {}).get("canaryStatuses", [])
         assert len(canary_status) > 0, "canary status should be populated"
         assert canary_status[0]["name"] == "v2"
+
+        # Verify HTTPRoute has weighted backend refs for stable and canary
+        backends = _get_httproute_backend_refs(
+            f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+        )
+        assert len(backends) == 2, (
+            f"Expected 2 backends (stable + canary), got {backends}"
+        )
+        names = {name for name, _ in backends}
+        assert f"{service_name}-predictor" in names, (
+            "Stable backend missing from HTTPRoute"
+        )
+        assert f"{service_name}-v2-predictor" in names, (
+            "Canary backend missing from HTTPRoute"
+        )
+        weights = {name: weight for name, weight in backends}
+        assert weights[f"{service_name}-predictor"] == 80
+        assert weights[f"{service_name}-v2-predictor"] == 20
     finally:
         _safe_delete(kserve, service_name)
 
@@ -249,6 +286,14 @@ def test_canary_promote():
         assert canary_pod_uids.issubset(post_promote_uids), (
             f"Canary pods were restarted during promotion: canary={canary_pod_uids}, post_promote={post_promote_uids}"
         )
+
+        # After promotion, HTTPRoute should have a single unweighted backend
+        backends = _get_httproute_backend_refs(
+            f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+        )
+        assert len(backends) == 1, f"Expected 1 backend after promotion, got {backends}"
+        assert backends[0][0] == f"{service_name}-v2-predictor"
+        assert backends[0][1] is None, "Backend should be unweighted after promotion"
     finally:
         _safe_delete(kserve, service_name)
 
@@ -306,6 +351,14 @@ def test_canary_rollback():
         assert canary_condition is None, (
             "CanaryPredictorReady should be cleared after rollback"
         )
+
+        # After rollback, HTTPRoute should have a single unweighted stable backend
+        backends = _get_httproute_backend_refs(
+            f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+        )
+        assert len(backends) == 1, f"Expected 1 backend after rollback, got {backends}"
+        assert backends[0][0] == f"{service_name}-predictor"
+        assert backends[0][1] is None, "Backend should be unweighted after rollback"
     finally:
         _safe_delete(kserve, service_name)
 
@@ -360,6 +413,3 @@ def test_canary_force_stop():
         _wait_for_condition(kserve, service_name, "CanaryPredictorReady", "Stopped")
     finally:
         _safe_delete(kserve, service_name)
-
-
-# TODO: Add testing for routing after HTTPRoute support is added to the raw deployment mode.

--- a/test/e2e/predictor/test_canary_raw_deployment.py
+++ b/test/e2e/predictor/test_canary_raw_deployment.py
@@ -148,10 +148,7 @@ def _get_httproute_backend_refs(name, namespace):
     rules = route.get("spec", {}).get("rules", [])
     if not rules:
         return []
-    return [
-        (ref["backendRef"]["name"], ref["backendRef"].get("weight"))
-        for ref in rules[0].get("backendRefs", [])
-    ]
+    return [(ref["name"], ref.get("weight")) for ref in rules[0].get("backendRefs", [])]
 
 
 def _get_pod_uids(apps_v1, deployment_name, namespace):
@@ -165,7 +162,6 @@ def _get_pod_uids(apps_v1, deployment_name, namespace):
 
 @pytest.mark.predictor
 @pytest.mark.raw
-@pytest.mark.asyncio(scope="session")
 def test_canary_create():
     service_name = "isvc-canary-create"
     kserve = _kserve_client()
@@ -230,7 +226,6 @@ def test_canary_create():
 
 @pytest.mark.predictor
 @pytest.mark.raw
-@pytest.mark.asyncio(scope="session")
 def test_canary_promote():
     service_name = "isvc-canary-promote"
     kserve = _kserve_client()
@@ -287,20 +282,18 @@ def test_canary_promote():
             f"Canary pods were restarted during promotion: canary={canary_pod_uids}, post_promote={post_promote_uids}"
         )
 
-        # After promotion, HTTPRoute should have a single unweighted backend
+        # After promotion, HTTPRoute name stays stable, backend points to promoted service
         backends = _get_httproute_backend_refs(
-            f"{service_name}-v2-predictor", KSERVE_TEST_NAMESPACE
+            f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
         )
         assert len(backends) == 1, f"Expected 1 backend after promotion, got {backends}"
         assert backends[0][0] == f"{service_name}-v2-predictor"
-        assert backends[0][1] is None, "Backend should be unweighted after promotion"
     finally:
         _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
 @pytest.mark.raw
-@pytest.mark.asyncio(scope="session")
 def test_canary_rollback():
     service_name = "isvc-canary-rollback"
     kserve = _kserve_client()
@@ -352,20 +345,18 @@ def test_canary_rollback():
             "CanaryPredictorReady should be cleared after rollback"
         )
 
-        # After rollback, HTTPRoute should have a single unweighted stable backend
+        # After rollback, HTTPRoute should have a single stable backend
         backends = _get_httproute_backend_refs(
             f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
         )
         assert len(backends) == 1, f"Expected 1 backend after rollback, got {backends}"
         assert backends[0][0] == f"{service_name}-predictor"
-        assert backends[0][1] is None, "Backend should be unweighted after rollback"
     finally:
         _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
 @pytest.mark.raw
-@pytest.mark.asyncio(scope="session")
 def test_canary_force_stop():
     service_name = "isvc-canary-stop"
     kserve = _kserve_client()

--- a/test/e2e/predictor/test_canary_raw_deployment.py
+++ b/test/e2e/predictor/test_canary_raw_deployment.py
@@ -31,7 +31,8 @@ from kubernetes import client
 from kubernetes.client import V1ResourceRequirements
 from kubernetes.client.rest import ApiException
 
-from ..common.utils import KSERVE_TEST_NAMESPACE
+from ..common.http_retry import post_with_retry
+from ..common.utils import KSERVE_TEST_NAMESPACE, get_isvc_endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +165,87 @@ def _get_pod_uids(apps_v1, deployment_name, namespace):
     return {pod.metadata.uid for pod in pods.items}
 
 
+def _verify_traffic_split(
+    kserve,
+    service_name,
+    namespace,
+    expected_pcts,
+    network_layer,
+    num_requests=100,
+    tolerance=10,
+):
+    """
+    Verify traffic split by sending requests and counting responses by status code.
+
+    In this test setup:
+    - Stable predictor uses STABLE_MODEL_URI which returns 200 (successful)
+    - Canary predictor uses CANARY_MODEL_URI which returns 503 (bad model path)
+
+    Args:
+        kserve: KServeClient instance
+        service_name: Name of the InferenceService
+        namespace: Kubernetes namespace
+        expected_pcts: Dict mapping status code to expected percentage, e.g., {200: 80, 503: 20}
+        network_layer: Network layer type (e.g., "istio-gatewayapi")
+        num_requests: Total number of requests to send
+        tolerance: Allowed deviation in percentage points
+
+    Returns:
+        dict: {status_code: (count, percentage)}
+    """
+    isvc = kserve.get(service_name, namespace=namespace)
+    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc, network_layer)
+
+    url = f"{scheme}://{cluster_ip}{path}/v1/models/{service_name}:predict"
+    headers = {"Host": host, "Content-Type": "application/json"}
+
+    # Simple prediction input for sklearn model
+    input_data = {"instances": [[1, 2, 3, 4]]}
+
+    status_counts = {}
+
+    logger.info(
+        f"Sending {num_requests} requests to verify traffic split: {expected_pcts}"
+    )
+
+    for i in range(num_requests):
+        try:
+            # Don't retry on 503 since we expect it from canary (bad model path)
+            # Only retry on network errors and 502/504 gateway errors
+            response = post_with_retry(
+                url,
+                headers=headers,
+                json_data=input_data,
+                retry_status_codes=(502, 504),
+            )
+            status_counts[response.status_code] = (
+                status_counts.get(response.status_code, 0) + 1
+            )
+        except Exception as e:
+            logger.warning(f"Request {i + 1} failed: {e}")
+
+    total = sum(status_counts.values())
+    results = {}
+
+    logger.info("Traffic split results:")
+    for status_code, count in sorted(status_counts.items()):
+        pct = (count / total * 100) if total > 0 else 0
+        results[status_code] = (count, pct)
+        logger.info(f"  {status_code}: {count}/{total} ({pct:.1f}%)")
+
+    # Verify each expected status code is within tolerance
+    for status_code, expected_pct in expected_pcts.items():
+        assert status_code in results, (
+            f"Expected status code {status_code} not seen in responses"
+        )
+        _, actual_pct = results[status_code]
+        assert abs(actual_pct - expected_pct) <= tolerance, (
+            f"Status {status_code} traffic {actual_pct:.1f}% outside expected {expected_pct}% ±{tolerance}%"
+        )
+
+    return results
+
+
 @pytest.mark.predictor
 @pytest.mark.raw
 def test_canary_create(network_layer):
@@ -220,6 +302,18 @@ def test_canary_create(network_layer):
             weights = {name: weight for name, weight in backends}
             assert weights[f"{service_name}-predictor"] == 80
             assert weights[f"{service_name}-v2-predictor"] == 20
+
+            # Verify actual traffic split by sending requests
+            # Stable (STABLE_MODEL_URI) returns 200, canary (CANARY_MODEL_URI) returns 503
+            _verify_traffic_split(
+                kserve,
+                service_name,
+                KSERVE_TEST_NAMESPACE,
+                expected_pcts={200: 80, 503: 20},
+                network_layer=network_layer,
+                num_requests=100,
+                tolerance=10,
+            )
     finally:
         _safe_delete(kserve, service_name)
 
@@ -290,6 +384,18 @@ def test_canary_promote(network_layer):
                 f"Expected 1 backend after promotion, got {backends}"
             )
             assert backends[0][0] == f"{service_name}-v2-predictor"
+
+            # Verify 100% traffic goes to promoted canary (v2)
+            # The promoted v2 uses CANARY_MODEL_URI which returns 503
+            _verify_traffic_split(
+                kserve,
+                service_name,
+                KSERVE_TEST_NAMESPACE,
+                expected_pcts={503: 100},
+                network_layer=network_layer,
+                num_requests=50,
+                tolerance=10,
+            )
     finally:
         _safe_delete(kserve, service_name)
 
@@ -355,6 +461,18 @@ def test_canary_rollback(network_layer):
                 f"Expected 1 backend after rollback, got {backends}"
             )
             assert backends[0][0] == f"{service_name}-predictor"
+
+            # Verify 100% traffic goes to stable after rollback
+            # Stable uses STABLE_MODEL_URI which returns 200
+            _verify_traffic_split(
+                kserve,
+                service_name,
+                KSERVE_TEST_NAMESPACE,
+                expected_pcts={200: 100},
+                network_layer=network_layer,
+                num_requests=50,
+                tolerance=10,
+            )
     finally:
         _safe_delete(kserve, service_name)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds canary traffic splitting to HTTPRoutes in RawDeployment mode. When an InferenceService has canary specs, the predictor and top-level HTTPRoutes get weighted backend refs — stable gets the remaining weight after all canary percentages are subtracted.

Also decouples the HTTPRoute name and hostname from the predictor `name` field so they remain stable through canary promotion. Only the backend refs change to point at the promoted service.

### Before (no canary support)
```
HTTPRoute: my-model-predictor
  backendRefs:
    - name: my-model-predictor  # unweighted
```

### With canary (20% traffic)
```
HTTPRoute: my-model-predictor
  backendRefs:
    - name: my-model-predictor     weight: 80
    - name: my-model-v2-predictor  weight: 20
```

### After promotion (predictor.name = "v2", canary removed)
```
HTTPRoute: my-model-predictor  # name unchanged
  hostname: my-model-predictor-default.example.com  # unchanged
  backendRefs:
    - name: my-model-v2-predictor  # points to promoted service
```

### Key changes
- `applyCanaryWeights()` modifies HTTPRoute backend refs to include weighted canary backends
- Predictor HTTPRoute name and hostname use `PredictorServiceName(isvc.Name)` (stable) instead of `PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name)` (changes on promotion)
- `semanticHttpRouteEquals` now compares backend ref counts to detect canary addition/removal, since `DeepDerivative` treats a single unweighted backend as a subset of two weighted backends

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] Unit tests for `applyCanaryWeights` (single canary, multiple canaries, dual-protocol rules, empty backends)
- [x] Unit tests for `semanticHttpRouteEquals` backend ref count detection
- [x] E2E test assertions for HTTPRoute backend refs on create, promote, and rollback
- [x] Manual verification on CRC: HTTPRoute name and hostname stable through canary promotion
- [x] `go build ./...` and `go vet ./...` pass

**Special notes for your reviewer**:

The predictor HTTPRoute name change (from including `predictor.name` to excluding it) is technically a breaking change for existing ISVCs that already set `predictor.name`. On reconcile, the controller would create a new HTTPRoute with the stable name and leave the old one orphaned. However, `predictor.name` was not usable before the canary feature (introduced in #5672), so no existing ISVCs should have it set.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Add canary traffic splitting to RawDeployment HTTPRoutes with stable route names through promotion.
```