### PR TITLE
fix(llmisvc): skip pod spec build when tokenizer disabled

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_tokenizer_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_tokenizer_test.go
@@ -240,6 +240,62 @@ schedulingProfiles:
 				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "tokenizer Deployment should not exist")
 			}).WithContext(ctx).Should(Succeed())
 		})
+
+		// Uses oci:// because, unlike hf://, it requires a "main" container to
+		// already exist in the pod spec -- the case that must not break the scheduler.
+		It("should reconcile the scheduler successfully for an OCI modelcar model URI", func(ctx SpecContext) {
+			svcName := "test-llm-no-tokenizer-oci"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("oci://registry.io/user-id/repo-id:tag"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// Scheduler Deployment must still get created.
+			Eventually(func(g Gomega, ctx context.Context) {
+				dep := &appsv1.Deployment{}
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, dep)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Tokenizer Deployment should not exist
+			tokenizerName := kmeta.ChildName(svcName, "-tokenizer")
+			Consistently(func(g Gomega, ctx context.Context) {
+				dep := &appsv1.Deployment{}
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      tokenizerName,
+					Namespace: testNs.Name,
+				}, dep)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "tokenizer Deployment should not exist")
+			}).WithContext(ctx).Should(Succeed())
+
+			// Must never fail with reason SchedulerReconcileError (may still be False
+			// for other reasons, e.g. not yet Available).
+			Consistently(func(g Gomega, ctx context.Context) {
+				updated := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: testNs.Name,
+				}, updated)).To(Succeed())
+
+				cond := updated.Status.GetCondition(v1alpha2.SchedulerWorkloadReady)
+				if cond != nil {
+					g.Expect(cond.Reason).ToNot(Equal("SchedulerReconcileError"),
+						"scheduler reconcile must not fail when no tokenizer is needed: %+v", cond)
+				}
+			}).WithContext(ctx).Should(Succeed())
+		})
 	})
 
 	Context("Legacy migration — precise-prefix-cache-scorer triggers tokenizer", func() {

--- a/pkg/controller/v1alpha2/llmisvc/tokenizer.go
+++ b/pkg/controller/v1alpha2/llmisvc/tokenizer.go
@@ -184,6 +184,12 @@ func (r *LLMISVCReconciler) expectedTokenizerDeployment(ctx context.Context, llm
 		},
 	}
 
+	// If the tokenizer isn't enabled, reconcileTokenizerDeployment only needs `d`'s
+	// identity to Delete it -- skip building a pod spec with no container to attach to.
+	if shouldDeleteTokenizer(llmSvc) {
+		return d, nil
+	}
+
 	// Build the pod spec from the merged tokenizer template
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil && llmSvc.Spec.Router.Scheduler.Tokenizer != nil &&
 		llmSvc.Spec.Router.Scheduler.Tokenizer.Template != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

`expectedTokenizerDeployment` unconditionally built a full pod spec and called `attachModelArtifacts` on it, even when the tokenizer Deployment was not needed (e.g. `spec.router.scheduler: {}` with no tokenizer-triggering plugins configured). Attaching model artifacts requires a "main" container, which is never added to the pod spec in this case, so building the expected Deployment failed with:

    failed to attach model artifacts to tokenizer deployment: no container found with name main

This error propagated up through `reconcileScheduler`, setting `SchedulerReconcileError` on the LLMInferenceService and putting the controller into an infinite reconcile-error loop — the Scheduler Deployment, Services, and routing resources were never created and the resource never reached `READY=True`.

The fix adds an early return in `expectedTokenizerDeployment`: when `shouldDeleteTokenizer` is true, the caller only needs the Deployment's identity to delete it, so we skip building the pod spec entirely.

**Feature/Issue validation/testing**:

- [x] Added a new integration test (`controller_int_tokenizer_test.go`) covering an LLMInferenceService with a managed scheduler and an `oci://` modelcar model URI (no tokenizer-triggering plugins). This reproduces the bug because, unlike `hf://`, the OCI code path requires a "main" container to already exist in the pod spec.
  - Verified the new test fails on the unpatched code with the exact reported error (`no container found with name main`) and passes with the fix applied.
  - Verified the Scheduler Deployment is still created, the tokenizer Deployment is correctly never created, and the `SchedulerWorkloadReady` condition never reports `SchedulerReconcileError`.
- [x] `make precommit` passes (vet, go-lint, tests).

**Special notes for your reviewer**:

Root cause is isolated to `expectedTokenizerDeployment` in `tokenizer.go`; audited nearby callers (`reconcileTokenizerDeployment`, `shouldDeleteTokenizer`) and found no other code paths with the same unconditional-build pattern.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:

Fixed a bug where LLMInferenceService resources without a tokenizer (e.g. `spec.router.scheduler: {}` with no tokenizer-triggering plugins) could get stuck in `READY=False` with `SchedulerReconcileError` due to an unconditional pod spec build in the tokenizer Deployment reconciler.
