### PR TITLE
fix: check ServingRuntime WorkerSpec for nil before dereferencing it

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -538,9 +538,16 @@ func (p *Predictor) buildObjectMeta(isvc *v1beta1.InferenceService, predictorNam
 	}
 }
 
-// validateRuntimeWorkerSpec reports an error when the InferenceService requests a
-// worker but the selected ServingRuntime has no WorkerSpec. It must be called
-// before any field access on sRuntime.WorkerSpec, which is an optional pointer.
+// validateRuntimeWorkerSpec reports an error when the selected ServingRuntime has no
+// WorkerSpec. It must be called before any field access on sRuntime.WorkerSpec, which
+// is an optional pointer.
+//
+// The check is deliberately unconditional on isvc.Spec.Predictor.WorkerSpec: this is
+// the nil guard protecting every subsequent sRuntime.WorkerSpec dereference, so gating
+// it on the InferenceService would reopen the panic it exists to prevent. The message
+// still speaks in terms of the InferenceService because the sole caller,
+// reconcileWorker, runs only on the multi-node path, which Reconcile enters just when
+// isvc.Spec.Predictor.WorkerSpec != nil.
 func validateRuntimeWorkerSpec(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService) error {
 	if sRuntime.WorkerSpec != nil {
 		return nil

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -518,7 +518,24 @@ func (p *Predictor) buildObjectMeta(isvc *v1beta1.InferenceService, predictorNam
 	}
 }
 
+// validateRuntimeWorkerSpec reports an error when the InferenceService requests a
+// worker but the selected ServingRuntime has no WorkerSpec. It must be called
+// before any field access on sRuntime.WorkerSpec, which is an optional pointer.
+func validateRuntimeWorkerSpec(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService) error {
+	if sRuntime.WorkerSpec != nil {
+		return nil
+	}
+	errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
+	isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
+	return errors.New(errMsg)
+}
+
 func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, annotations, predictorAnnotations map[string]string, isvcGeneration string) (metav1.ObjectMeta, *corev1.PodSpec, error) {
+	// Must precede any access to sRuntime.WorkerSpec below.
+	if err := validateRuntimeWorkerSpec(sRuntime, isvc); err != nil {
+		return metav1.ObjectMeta{}, nil, err
+	}
+
 	var workerObjectMeta metav1.ObjectMeta
 	var workerPodSpec *corev1.PodSpec
 	var err error
@@ -554,6 +571,11 @@ func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *
 }
 
 func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, annotations map[string]string, isvcGeneration string) (*corev1.PodSpec, error) {
+	// Must precede any access to sRuntime.WorkerSpec below.
+	if err := validateRuntimeWorkerSpec(sRuntime, isvc); err != nil {
+		return nil, err
+	}
+
 	var workerContainer *corev1.Container
 	var mergedWorkerPodSpec *corev1.PodSpec
 	var err error
@@ -575,11 +597,6 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		sRuntime.WorkerSpec.TensorParallelSize = isvc.Spec.Predictor.WorkerSpec.TensorParallelSize
 	}
 
-	if sRuntime.WorkerSpec == nil {
-		errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
-		isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
-		return nil, errors.New(errMsg)
-	}
 	// Check if workerSpec in ServingRuntime does not have worker containers information, it should return errors
 	if len(sRuntime.WorkerSpec.Containers) == 0 {
 		errMsg := "No workerSpec container configuration found in selected serving runtime"

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -538,7 +538,24 @@ func (p *Predictor) buildObjectMeta(isvc *v1beta1.InferenceService, predictorNam
 	}
 }
 
+// validateRuntimeWorkerSpec reports an error when the InferenceService requests a
+// worker but the selected ServingRuntime has no WorkerSpec. It must be called
+// before any field access on sRuntime.WorkerSpec, which is an optional pointer.
+func validateRuntimeWorkerSpec(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService) error {
+	if sRuntime.WorkerSpec != nil {
+		return nil
+	}
+	errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
+	isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
+	return errors.New(errMsg)
+}
+
 func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, annotations, predictorAnnotations map[string]string, isvcGeneration string) (metav1.ObjectMeta, *corev1.PodSpec, error) {
+	// Must precede any access to sRuntime.WorkerSpec below.
+	if err := validateRuntimeWorkerSpec(sRuntime, isvc); err != nil {
+		return metav1.ObjectMeta{}, nil, err
+	}
+
 	var workerObjectMeta metav1.ObjectMeta
 	var workerPodSpec *corev1.PodSpec
 	var err error
@@ -574,6 +591,11 @@ func (p *Predictor) reconcileWorker(sRuntime v1alpha1.ServingRuntimeSpec, isvc *
 }
 
 func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.InferenceService, podSpec *corev1.PodSpec, annotations map[string]string, isvcGeneration string) (*corev1.PodSpec, error) {
+	// Must precede any access to sRuntime.WorkerSpec below.
+	if err := validateRuntimeWorkerSpec(sRuntime, isvc); err != nil {
+		return nil, err
+	}
+
 	var workerContainer *corev1.Container
 	var mergedWorkerPodSpec *corev1.PodSpec
 	var err error
@@ -595,11 +617,6 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		sRuntime.WorkerSpec.TensorParallelSize = isvc.Spec.Predictor.WorkerSpec.TensorParallelSize
 	}
 
-	if sRuntime.WorkerSpec == nil {
-		errMsg := "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
-		isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, v1beta1.InvalidWorkerSpecNotSet, errMsg, corev1.ConditionFalse)
-		return nil, errors.New(errMsg)
-	}
 	// Check if workerSpec in ServingRuntime does not have worker containers information, it should return errors
 	if len(sRuntime.WorkerSpec.Containers) == 0 {
 		errMsg := "No workerSpec container configuration found in selected serving runtime"

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -235,4 +238,44 @@ func TestAdjustStableMinReplicasForCanaries(t *testing.T) {
 			assert.Equal(t, tt.expectedStable, *componentExt.MinReplicas)
 		})
 	}
+}
+
+// TestWorkerSpecNilReturnsErrorInsteadOfPanicking covers the case where an
+// InferenceService sets predictor.workerSpec but the selected ServingRuntime has
+// no workerSpec. Both entry points dereferenced sRuntime.WorkerSpec before the
+// nil check that is meant to catch this, so the controller panicked instead of
+// surfacing the intended error.
+func TestWorkerSpecNilReturnsErrorInsteadOfPanicking(t *testing.T) {
+	const wantMsg = "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
+
+	newISVC := func() *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "isvc", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Predictor: v1beta1.PredictorSpec{
+					WorkerSpec: &v1beta1.WorkerSpec{},
+				},
+			},
+		}
+	}
+
+	// ServingRuntime deliberately has no WorkerSpec.
+	sRuntime := v1alpha1.ServingRuntimeSpec{}
+
+	t.Run("multiNodeProcess", func(t *testing.T) {
+		isvc := newISVC()
+		podSpec, err := multiNodeProcess(sRuntime, isvc, &corev1.PodSpec{}, map[string]string{}, "1")
+		require.Error(t, err)
+		assert.Equal(t, wantMsg, err.Error())
+		assert.Nil(t, podSpec)
+	})
+
+	t.Run("reconcileWorker", func(t *testing.T) {
+		isvc := newISVC()
+		p := &Predictor{}
+		_, podSpec, err := p.reconcileWorker(sRuntime, isvc, &corev1.PodSpec{}, map[string]string{}, map[string]string{}, "1")
+		require.Error(t, err)
+		assert.Equal(t, wantMsg, err.Error())
+		assert.Nil(t, podSpec)
+	})
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -104,4 +107,44 @@ func TestAddStorageInitializerAnnotationsOciNative(t *testing.T) {
 	annotationVal, hasAnnotation := annotations[constants.StorageInitializerSourceUriInternalAnnotationKey]
 	assert.True(t, hasAnnotation, "oci+native:// must set StorageInitializerSourceUriInternalAnnotationKey so InjectModelcar can inject the ImageVolume")
 	assert.Equal(t, ociNativeURI, annotationVal)
+}
+
+// TestWorkerSpecNilReturnsErrorInsteadOfPanicking covers the case where an
+// InferenceService sets predictor.workerSpec but the selected ServingRuntime has
+// no workerSpec. Both entry points dereferenced sRuntime.WorkerSpec before the
+// nil check that is meant to catch this, so the controller panicked instead of
+// surfacing the intended error.
+func TestWorkerSpecNilReturnsErrorInsteadOfPanicking(t *testing.T) {
+	const wantMsg = "you cannot set WorkerSpec in the InferenceService if the ServingRuntime does not have a WorkerSpec"
+
+	newISVC := func() *v1beta1.InferenceService {
+		return &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "isvc", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Predictor: v1beta1.PredictorSpec{
+					WorkerSpec: &v1beta1.WorkerSpec{},
+				},
+			},
+		}
+	}
+
+	// ServingRuntime deliberately has no WorkerSpec.
+	sRuntime := v1alpha1.ServingRuntimeSpec{}
+
+	t.Run("multiNodeProcess", func(t *testing.T) {
+		isvc := newISVC()
+		podSpec, err := multiNodeProcess(sRuntime, isvc, &corev1.PodSpec{}, map[string]string{}, "1")
+		require.Error(t, err)
+		assert.Equal(t, wantMsg, err.Error())
+		assert.Nil(t, podSpec)
+	})
+
+	t.Run("reconcileWorker", func(t *testing.T) {
+		isvc := newISVC()
+		p := &Predictor{}
+		_, podSpec, err := p.reconcileWorker(sRuntime, isvc, &corev1.PodSpec{}, map[string]string{}, map[string]string{}, "1")
+		require.Error(t, err)
+		assert.Equal(t, wantMsg, err.Error())
+		assert.Nil(t, podSpec)
+	})
 }


### PR DESCRIPTION
## What this PR does / why we need it

`WorkerSpec` is an optional pointer on `ServingRuntimeSpec`, but both multi-node entry points in `pkg/controller/v1beta1/inferenceservice/components/predictor.go` dereferenced it before the nil check that exists to reject exactly this case:

- `reconcileWorker` read `sRuntime.WorkerSpec.Annotations` and `.Labels` as its first two statements.
- `multiNodeProcess` then set `PipelineParallelSize` and `TensorParallelSize` on it, and read `isvc.Spec.Predictor.WorkerSpec` into it, before reaching the `if sRuntime.WorkerSpec == nil` guard further down.

So an InferenceService that sets `predictor.workerSpec` while referencing a ServingRuntime with no `workerSpec` panics the controller instead of returning the clean error the guard was written to produce.

This is a reordering: the error message, the status propagation, and the control flow already existed and are unchanged — they just ran too late. The check is shared through a small `validateRuntimeWorkerSpec` helper so it stays in one place across both entry points.

## Which issue(s) this PR fixes

Fixes #5805

## Testing

Added `TestWorkerSpecNilReturnsErrorInsteadOfPanicking`, covering both `multiNodeProcess` and `reconcileWorker` with a ServingRuntime that has no `WorkerSpec`. Against the previous ordering the test panics:

```
--- FAIL: TestWorkerSpecNilReturnsErrorInsteadOfPanicking/multiNodeProcess
panic: runtime error: invalid memory address or nil pointer dereference
```

With the fix both subtests return the expected error. `go build`, `go vet`, `gofmt`, and the full `components` package suite are clean.

## Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, fix, and tests were verified against the source and the existing test suite before submitting.