### PR TITLE
fix: handle metrics scheme split across command args

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1944,8 +1944,21 @@ func extractModelServerMetricsFlags(ctx context.Context, d *appsv1.Deployment) m
 	params := map[string]string{}
 	for ci := range d.Spec.Template.Spec.Containers {
 		c := &d.Spec.Template.Spec.Containers[ci]
+		crossBoundaryFlag := ""
+		if len(c.Command) > 0 {
+			name := strings.TrimLeft(c.Command[len(c.Command)-1], "-")
+			if deprecatedModelServerMetricFlagNames[name] {
+				crossBoundaryFlag = name
+			}
+		}
 		if filtered, extracted := filterArgs(c.Command, deprecatedModelServerMetricFlagNames); len(extracted) > 0 {
 			c.Command = filtered
+			// Kubernetes appends Args to Command, so a standalone terminal flag
+			// may take its value from the first Args token.
+			if crossBoundaryFlag != "" && extracted[crossBoundaryFlag] == "" && len(c.Args) > 0 && !strings.HasPrefix(c.Args[0], "-") {
+				extracted[crossBoundaryFlag] = c.Args[0]
+				c.Args = c.Args[1:]
+			}
 			maps.Copy(params, extracted)
 		}
 		if filtered, extracted := filterArgs(c.Args, deprecatedModelServerMetricFlagNames); len(extracted) > 0 {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1819,9 +1819,17 @@ func extractModelServerMetricsScheme(d *appsv1.Deployment) string {
 	scheme := ""
 	for ci := range d.Spec.Template.Spec.Containers {
 		c := &d.Spec.Template.Spec.Containers[ci]
+		flagEndsCommand := len(c.Command) > 0 &&
+			strings.TrimLeft(c.Command[len(c.Command)-1], "-") == modelServerMetricsSchemeFlag
 		if filtered, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
 			c.Command = filtered
 			scheme = extracted[modelServerMetricsSchemeFlag]
+			// Kubernetes appends Args to Command, so a standalone terminal flag
+			// may take its value from the first Args token.
+			if flagEndsCommand && len(c.Args) > 0 && !strings.HasPrefix(c.Args[0], "-") {
+				scheme = c.Args[0]
+				c.Args = c.Args[1:]
+			}
 		}
 		if filtered, extracted := filterArgs(c.Args, names); len(extracted) > 0 {
 			c.Args = filtered

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2634,6 +2634,14 @@ func TestExtractModelServerMetricsFlags(t *testing.T) {
 			expectedParams:  map[string]string{modelServerMetricsSchemeFlag: "https"},
 		},
 		{
+			name:            "extracts value split across command and args",
+			command:         []string{"/app/epp", "--model-server-metrics-scheme"},
+			args:            []string{"https", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp"},
+			expectedArgs:    []string{"--grpc-port=9002"},
+			expectedParams:  map[string]string{modelServerMetricsSchemeFlag: "https"},
+		},
+		{
 			name:            "strips port without returning it",
 			command:         []string{"/app/epp", "--model-server-metrics-port=8000", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2307,6 +2307,14 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 			expectedScheme:  "https",
 		},
 		{
+			name:            "extracts value split across command and args",
+			command:         []string{"/app/epp", "--model-server-metrics-scheme"},
+			args:            []string{"https", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp"},
+			expectedArgs:    []string{"--grpc-port=9002"},
+			expectedScheme:  "https",
+		},
+		{
 			name:            "no flag returns empty scheme",
 			command:         []string{"/app/epp", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Handles deprecated model-server metrics flags when a custom scheduler template places a standalone flag at the end of `Command` and its value at the start of `Args`.

Kubernetes executes the two fields as one command line, but the migration filtered them independently. It removed the flag while leaving the value as a positional argument, which could prevent the scheduler container from starting. The extraction now consumes a recognized cross-boundary value while preserving the remaining tokens in both fields.

**Which issue(s) this PR fixes**:

Fixes #5902

**Feature/Issue validation/testing**:

- [x] `go test -p 2 ./pkg/controller/v1alpha2/llmisvc -run "^TestExtractModelServerMetricsFlags$" -count=1`
- [x] `KUBEBUILDER_ASSETS=... go test -p 2 ./pkg/controller/v1alpha2/llmisvc -count=1` (279 specs, Kubernetes 1.34.1 envtest)
- [x] Repository precommit targets: Go vet/lint, Python format/lint, 245-test e2e collection, code/OpenAPI generation, tidy, manifests, lockfiles, 15 quick-install generators, Helm chart lint, helper consistency, minimal-CRD sync, pinned actions, and boilerplate
- [x] `gofmt -d` on the changed files and `git diff --check`

The regression test was verified to fail before the production change. The Makefile skipped the documented `kernelcache/mcv` CGO vet/lint checks because this Linux host does not provide the required system libraries; upstream CI covers that unrelated module.

**Special notes for your reviewer**:

The behavior change is limited to a recognized standalone deprecated metrics flag at the final `Command` position followed by a non-flag first `Args` token.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

No documentation change is needed for this migration correctness fix.

**Release note**:

```release-note
Fix scheduler metrics migration when a deprecated flag and value are split across container Command and Args.
```
