### PR TITLE
feat(localmodelcache): add printer columns for cache resources

### DIFF
--- a/charts/kserve-localmodel-crd-minimal/templates/serving.kserve.io_localmodelcaches.yaml
+++ b/charts/kserve-localmodel-crd-minimal/templates/serving.kserve.io_localmodelcaches.yaml
@@ -13,7 +13,25 @@ spec:
     singular: localmodelcache
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/charts/kserve-localmodel-crd-minimal/templates/serving.kserve.io_localmodelnamespacecaches.yaml
+++ b/charts/kserve-localmodel-crd-minimal/templates/serving.kserve.io_localmodelnamespacecaches.yaml
@@ -13,7 +13,25 @@ spec:
     singular: localmodelnamespacecache
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/charts/kserve-localmodel-crd/templates/serving.kserve.io_localmodelcaches.yaml
+++ b/charts/kserve-localmodel-crd/templates/serving.kserve.io_localmodelcaches.yaml
@@ -14,7 +14,25 @@ spec:
     singular: localmodelcache
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/charts/kserve-localmodel-crd/templates/serving.kserve.io_localmodelnamespacecaches.yaml
+++ b/charts/kserve-localmodel-crd/templates/serving.kserve.io_localmodelnamespacecaches.yaml
@@ -14,7 +14,25 @@ spec:
     singular: localmodelnamespacecache
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/config/crd/full/localmodel/serving.kserve.io_localmodelcaches.yaml
+++ b/config/crd/full/localmodel/serving.kserve.io_localmodelcaches.yaml
@@ -14,7 +14,25 @@ spec:
     singular: localmodelcache
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/config/crd/full/localmodel/serving.kserve.io_localmodelnamespacecaches.yaml
+++ b/config/crd/full/localmodel/serving.kserve.io_localmodelnamespacecaches.yaml
@@ -14,7 +14,25 @@ spec:
     singular: localmodelnamespacecache
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/config/crd/minimal/localmodel/serving.kserve.io_localmodelcaches.yaml
+++ b/config/crd/minimal/localmodel/serving.kserve.io_localmodelcaches.yaml
@@ -13,7 +13,25 @@ spec:
     singular: localmodelcache
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/config/crd/minimal/localmodel/serving.kserve.io_localmodelnamespacecaches.yaml
+++ b/config/crd/minimal/localmodel/serving.kserve.io_localmodelnamespacecaches.yaml
@@ -13,7 +13,25 @@ spec:
     singular: localmodelnamespacecache
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/pkg/apis/serving/v1alpha1/local_model_cache_types.go
+++ b/pkg/apis/serving/v1alpha1/local_model_cache_types.go
@@ -67,6 +67,11 @@ type LocalModelCacheSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope="Cluster"
+// +kubebuilder:printcolumn:name="Available",type="integer",JSONPath=".status.copies.available"
+// +kubebuilder:printcolumn:name="Total",type="integer",JSONPath=".status.copies.total"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="NodeGroups",type="string",JSONPath=".spec.nodeGroups",priority=1
+// +kubebuilder:printcolumn:name="ModelSize",type="string",JSONPath=".spec.modelSize",priority=1
 type LocalModelCache struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/serving/v1alpha1/local_model_namespace_cache_types.go
+++ b/pkg/apis/serving/v1alpha1/local_model_namespace_cache_types.go
@@ -46,6 +46,11 @@ type LocalModelNamespaceCacheSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope="Namespaced"
+// +kubebuilder:printcolumn:name="Available",type="integer",JSONPath=".status.copies.available"
+// +kubebuilder:printcolumn:name="Total",type="integer",JSONPath=".status.copies.total"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="NodeGroups",type="string",JSONPath=".spec.nodeGroups",priority=1
+// +kubebuilder:printcolumn:name="ModelSize",type="string",JSONPath=".spec.modelSize",priority=1
 type LocalModelNamespaceCache struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/test/crds/serving.kserve.io_all_crds.yaml
+++ b/test/crds/serving.kserve.io_all_crds.yaml
@@ -149775,7 +149775,25 @@ spec:
     singular: localmodelcache
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:
@@ -149881,7 +149899,25 @@ spec:
     singular: localmodelnamespacecache
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.copies.available
+      name: Available
+      type: integer
+    - jsonPath: .status.copies.total
+      name: Total
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.nodeGroups
+      name: NodeGroups
+      priority: 1
+      type: string
+    - jsonPath: .spec.modelSize
+      name: ModelSize
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `kubectl` printer columns for `LocalModelCache` and `LocalModelNamespaceCache` resources.

The default output now shows:
- `Available`
- `Total`
- `Age`

The wide output additionally shows:
- `NodeGroups`
- `ModelSize`

`NodeGroups` uses `.spec.nodeGroups` so that all configured node groups are rendered. Using `.spec.nodeGroups[*]` only rendered the first array element.

**Which issue(s) this PR fixes**:

N/A

**Feature/Issue validation/testing**:

- [x] `make precommit`
- [x] `go test ./pkg/apis/serving/v1alpha1/...`
- [x] `helm lint charts/kserve-localmodel-crd`
- [x] `helm lint charts/kserve-localmodel-crd-minimal`
- [x] `git diff --check`
- [x] Verified the generated CRD columns on Kubernetes v1.35.2

```text
$ kubectl get localmodelcaches.serving.kserve.io -o wide
NAME        AVAILABLE   TOTAL   AGE     NODEGROUPS     MODELSIZE
tiny-gpt2               1       3m29s   ["dev-a100"]   100Mi
```

Also verified that multiple node groups render as a complete JSON array:

```text
["rtx2080ti-workers","a100-workers"]
```

**Special notes for your reviewer**:

This changes CRD presentation metadata only. It does not change controller behavior.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works? (Not applicable: CRD printer metadata only; validated against a live cluster.)
- [ ] Has code been commented, particularly in hard-to-understand areas? (Not applicable.)
- [ ] Have you made corresponding changes to the documentation? (Not applicable.)

**Release note**:

```release-note
Add kubectl printer columns for LocalModelCache and LocalModelNamespaceCache resources.
```
