### PR TITLE
fix(webhook): validate oci+<mode>:// storageUris against OCI limits

### DIFF
--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -326,19 +328,35 @@ func CommonStorageInitialization(ctx context.Context, params *StorageInitializer
 			}
 
 			ociIndex := 0
-			// Collect OCI mount paths for collision check and count validation
-			var ociMountPaths []string
+			// Collect OCI mount paths for collision check and count validation.
+			// The mode resolution here mirrors the dispatch loop below so that every URI
+			// that gets mounted is also counted and validated, including oci+<mode>:// URIs.
+			// Mount paths are grouped by effective mode because the collision rules differ
+			// between native ImageVolumes and modelcar emptyDir sidecars.
+			ociCount := 0
+			mountPathsByMode := map[string][]string{}
 			for _, storageUri := range params.StorageURIs {
-				if strings.HasPrefix(storageUri.Uri, constants.OciURIPrefix) {
-					ociMountPaths = append(ociMountPaths, storageUri.MountPath)
+				parsedMode, _, isOci := utils.ParseOciScheme(storageUri.Uri)
+				if !isOci {
+					continue
 				}
+				effectiveMode := parsedMode
+				if effectiveMode == "" {
+					effectiveMode = types.ResolveOciModelMode(params.Config)
+				}
+				if effectiveMode == "" {
+					continue
+				}
+				ociCount++
+				mountPathsByMode[effectiveMode] = append(mountPathsByMode[effectiveMode], storageUri.MountPath)
 			}
-			if len(ociMountPaths) > utils.MaxOCISourcesPerPod {
-				return fmt.Errorf("too many OCI sources (%d); maximum is %d per pod", len(ociMountPaths), utils.MaxOCISourcesPerPod)
+			if ociCount > utils.MaxOCISourcesPerPod {
+				return fmt.Errorf("too many OCI sources (%d); maximum is %d per pod", ociCount, utils.MaxOCISourcesPerPod)
 			}
-			configMode := types.ResolveOciModelMode(params.Config)
-			if err := utils.ValidateOCIMountPaths(ociMountPaths, configMode); err != nil {
-				return err
+			for _, mode := range slices.Sorted(maps.Keys(mountPathsByMode)) {
+				if err := utils.ValidateOCIMountPaths(mountPathsByMode[mode], mode); err != nil {
+					return err
+				}
 			}
 
 			for _, storageUri := range params.StorageURIs {

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -5821,4 +5822,98 @@ func TestCommonStorageInitializationSkipsOciNativeURI(t *testing.T) {
 		}
 	}
 	require.NotNil(t, imgVol, "oci+native:// must produce an ImageVolume on the pod spec")
+}
+
+// TestCommonStorageInitializationOciSchemeValidation verifies that the OCI source
+// limit and mount path collision checks apply to oci+<mode>:// URIs, not just to
+// bare oci:// URIs. These URIs are dispatched via ParseOciScheme, so skipping them
+// during validation would let them exceed MaxOCISourcesPerPod and mount over each other.
+func TestCommonStorageInitializationOciSchemeValidation(t *testing.T) {
+	const modelcarURIPrefix = "oci+" + kserveTypes.OciModelModeModelcar + "://"
+
+	newPodSpec := func() *corev1.PodSpec {
+		return &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: constants.InferenceServiceContainerName}},
+		}
+	}
+	ociURIs := func(prefix string, mountPaths ...string) []v1beta1.StorageUri {
+		uris := make([]v1beta1.StorageUri, 0, len(mountPaths))
+		for i, mountPath := range mountPaths {
+			uris = append(uris, v1beta1.StorageUri{
+				Uri:       fmt.Sprintf("%sregistry.io/model-%d:v1", prefix, i),
+				MountPath: mountPath,
+			})
+		}
+		return uris
+	}
+	mountPaths := func(count int) []string {
+		paths := make([]string, 0, count)
+		for i := range count {
+			paths = append(paths, fmt.Sprintf("/mnt/models/m%d", i))
+		}
+		return paths
+	}
+
+	tests := []struct {
+		name        string
+		storageURIs []v1beta1.StorageUri
+		configMode  string
+		expectedErr string
+	}{
+		{
+			name:        "oci+native:// exceeding the per-pod limit is rejected",
+			storageURIs: ociURIs(constants.OciNativeURIPrefix, mountPaths(utils.MaxOCISourcesPerPod+1)...),
+			configMode:  kserveTypes.OciModelModeNative,
+			expectedErr: "too many OCI sources",
+		},
+		{
+			name:        "oci+native:// reusing a mount path is rejected",
+			storageURIs: ociURIs(constants.OciNativeURIPrefix, "/mnt/models/shared", "/mnt/models/shared"),
+			configMode:  kserveTypes.OciModelModeNative,
+			expectedErr: "specified more than once",
+		},
+		{
+			name:        "oci+modelcar:// sharing a parent directory is rejected",
+			storageURIs: ociURIs(modelcarURIPrefix, "/mnt/models/a", "/mnt/models/b"),
+			configMode:  kserveTypes.OciModelModeModelcar,
+			expectedErr: "share parent directory",
+		},
+		{
+			name: "mount paths are validated against the per-URI mode, not the config mode",
+			// Native URIs may share a parent directory, so these are only a collision
+			// under modelcar rules. The config mode must not be applied to them.
+			storageURIs: ociURIs(constants.OciNativeURIPrefix, "/mnt/models/a", "/mnt/models/b"),
+			configMode:  kserveTypes.OciModelModeModelcar,
+		},
+		{
+			name:        "oci+native:// with distinct mount paths under the limit is accepted",
+			storageURIs: ociURIs(constants.OciNativeURIPrefix, mountPaths(utils.MaxOCISourcesPerPod)...),
+			configMode:  kserveTypes.OciModelModeNative,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CommonStorageInitialization(t.Context(), &StorageInitializerParams{
+				Namespace:   "default",
+				StorageURIs: tt.storageURIs,
+				PodSpec:     newPodSpec(),
+				Config: &kserveTypes.StorageInitializerConfig{
+					Image:         "kserve/storage-initializer:latest",
+					CpuRequest:    StorageInitializerDefaultCPURequest,
+					CpuLimit:      StorageInitializerDefaultCPULimit,
+					MemoryRequest: StorageInitializerDefaultMemoryRequest,
+					MemoryLimit:   StorageInitializerDefaultMemoryLimit,
+					OciModelMode:  tt.configMode,
+				},
+				IsvcAnnotations: map[string]string{},
+			})
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In `CommonStorageInitialization`, the loop that collects OCI mount paths for validation matched URIs with `strings.HasPrefix(storageUri.Uri, constants.OciURIPrefix)`, while the dispatch loop below it uses `utils.ParseOciScheme`. Because `constants.OciURIPrefix` is `"oci://"`, the `oci+native://` and `oci+modelcar://` forms were mounted but never counted against `MaxOCISourcesPerPod` and never passed to `ValidateOCIMountPaths`.

The most damaging case is two distinct images requested at the same mount path: instead of the validation error the same input produces under `oci://`, the pod is admitted with a single volume and the second artifact is silently dropped, so the workload comes up healthy while serving the wrong set of files.

This change makes the validation loop resolve the effective mode exactly the way the dispatch loop does, so every URI that gets mounted is also counted and validated. Mount paths are grouped by effective mode before validation because the collision rules differ between the two: native mounts the image directly at the requested path, so only exact duplicates collide, whereas modelcar mounts an emptyDir at the parent directory of the model path, so siblings under one parent shadow each other. Validating every path against a single cluster-wide mode would be wrong in both directions.

**Which issue(s) this PR fixes**:

Fixes #5928

**Feature/Issue validation/testing**:

- [x] Added `TestCommonStorageInitializationOciSchemeValidation`, a table-driven test with five cases: the three previously unvalidated scenarios (source count over the limit, duplicate native mount path, modelcar siblings sharing a parent directory) plus two that must still be accepted (native siblings under one parent, and a full complement of distinct paths at the limit). The last two guard against over-correcting into a stricter rule than intended.

```
$ KUBEBUILDER_ASSETS=... go test ./pkg/webhook/admission/pod/ \
    -run TestCommonStorageInitializationOciSchemeValidation -v

--- PASS: TestCommonStorageInitializationOciSchemeValidation
    --- PASS: .../oci+native://_exceeding_the_per-pod_limit_is_rejected
    --- PASS: .../oci+native://_reusing_a_mount_path_is_rejected
    --- PASS: .../oci+modelcar://_sharing_a_parent_directory_is_rejected
    --- PASS: .../mount_paths_are_validated_against_the_per-URI_mode,_not_the_config_mode
    --- PASS: .../oci+native://_with_distinct_mount_paths_under_the_limit_is_accepted
PASS
```

- [x] Confirmed the test actually pins the regression: with the source change reverted, the three bug cases fail with "An error is expected but got nil" while the two acceptance cases still pass; with the change applied, all five pass.

- [x] `go test ./pkg/webhook/... ./pkg/utils/...` passes with no regressions.

**Special notes for your reviewer**:

The mode resolution added to the validation loop is deliberately a line-for-line mirror of the dispatch loop below it, including the early `continue` when no effective mode can be resolved, so the two cannot drift apart again in the same way.

Map iteration order is normalised with `slices.Sorted(maps.Keys(...))` so that a pod violating the rules under more than one mode always reports the same error.

Overlap with #5739: that PR touches the same collection loop, switching it to `utils.ParseOciScheme` while keeping the single cluster-wide `ValidateOCIMountPaths` call. I checked out that version and ran the tests added here against it — the source count case and the two same-mode collision cases pass, but `mount paths are validated against the per-URI mode, not the config mode` fails: with `ociModelMode: modelcar`, two `oci+native://` entries at `/mnt/models/a` and `/mnt/models/b` are rejected for sharing a parent directory, which is a legal layout for native ImageVolumes and the one the oci-image-volume sample recommends. Grouping by effective mode covers both rules and needs no further change for `fetch`, since `ValidateOCIMountPaths` already applies the stricter parent-directory rule to any non-native mode. The two changes are not mutually exclusive — this one is small and independent of the `oci+fetch://` work, and I am happy to rebase whichever way round they land.

Not addressed here: nesting *across* modes, e.g. a native ImageVolume at `/mnt/models/a` alongside a modelcar emptyDir at `/mnt/models`. That is a broader question about the interaction of the two mounting strategies and seemed out of scope for this fix — happy to file a follow-up if you would like it tracked.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Fixed `oci+native://` and `oci+modelcar://` storageUris bypassing the per-pod OCI source limit and the mount path collision checks, which could silently drop a model artifact when two entries resolved to colliding mount paths.
```
