### PR TITLE
feat(llmisvc): migrate remaining --model-server-metrics-* flags for llm-d

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1440,16 +1440,26 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alp
 	if v.Compare(*metricsDataSourceMinVersion) >= 0 {
 		if params := extractModelServerMetricsFlags(ctx, d); len(params) > 0 {
 			if !writable {
+				flags := make([]string, 0, len(params))
+				for name := range params {
+					flags = append(flags, "--"+name)
+				}
+				sort.Strings(flags)
 				return fmt.Errorf(
-					"scheduler deployment %s/%s sets deprecated "+
-						"--model-server-metrics-{scheme,path,https-insecure-skip-verify} "+
+					"scheduler deployment %s/%s sets deprecated %s "+
 						"but has no inline --config-text; automatic migration to the "+
 						"metrics-data-source plugin is not possible — convert to --config-text "+
 						"or remove the flags manually",
-					d.GetNamespace(), d.GetName(),
+					d.GetNamespace(), d.GetName(), strings.Join(flags, ", "),
 				)
 			}
-			opts = append(opts, withMetricsDataSourceParams(params))
+			parameters, err := metricsDataSourceParameters(params)
+			if err != nil {
+				return err
+			}
+			if len(parameters) > 0 {
+				opts = append(opts, withMetricsDataSourceParams(parameters))
+			}
 		}
 	}
 
@@ -1944,27 +1954,40 @@ func withCoreMetricsExtractorPlugin(extracted map[string]string) mutateScheduler
 	}
 }
 
-// withMetricsDataSourceParams returns a mutateSchedulerConfigFunc that injects a
-// metrics-data-source plugin carrying the scheme, path, and insecureSkipVerify
-// previously passed via the --model-server-metrics-* CLI flags.
-// No-op if a metrics-data-source plugin is already declared or if no re-injectable parameters were extracted.
-func withMetricsDataSourceParams(extracted map[string]string) mutateSchedulerConfigFunc {
-	return func(_ context.Context, u *unstructured.Unstructured) error {
-		parameters := map[string]interface{}{}
-		if scheme := extracted[modelServerMetricsSchemeFlag]; scheme != "" {
-			parameters["scheme"] = scheme
+// metricsDataSourceParameters converts the extracted --model-server-metrics-*
+// flag values into metrics-data-source plugin parameters, validating them.
+// A bare --model-server-metrics-https-insecure-skip-verify (empty value) means true;
+// any other value must parse as a boolean, matching the router's flag parsing.
+// Empty scheme/path values are dropped; the returned map may be empty.
+func metricsDataSourceParameters(extracted map[string]string) (map[string]interface{}, error) {
+	parameters := map[string]interface{}{}
+	if scheme := extracted[modelServerMetricsSchemeFlag]; scheme != "" {
+		parameters["scheme"] = scheme
+	}
+	if p := extracted[modelServerMetricsPathFlag]; p != "" {
+		parameters["path"] = p
+	}
+	if v, ok := extracted[modelServerMetricsInsecureSkipVerifyFlag]; ok {
+		if v == "" {
+			parameters["insecureSkipVerify"] = true
+		} else {
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value %q for --%s: %w", v, modelServerMetricsInsecureSkipVerifyFlag, err)
+			}
+			parameters["insecureSkipVerify"] = b
 		}
-		if p := extracted[modelServerMetricsPathFlag]; p != "" {
-			parameters["path"] = p
-		}
-		// empty string means true
-		if v, ok := extracted[modelServerMetricsInsecureSkipVerifyFlag]; ok {
-			parameters["insecureSkipVerify"] = v == "" || parseBoolDefaultTrue(v)
-		}
-		if len(parameters) == 0 {
-			return nil
-		}
+	}
+	return parameters, nil
+}
 
+// withMetricsDataSourceParams returns a mutateSchedulerConfigFunc that injects a
+// metrics-data-source plugin carrying the given parameters (scheme, path, and
+// insecureSkipVerify) previously passed via the --model-server-metrics-* CLI flags.
+// Callers pass a non-empty, already-validated parameter map (see
+// metricsDataSourceParameters). No-op if a metrics-data-source plugin is already declared.
+func withMetricsDataSourceParams(parameters map[string]interface{}) mutateSchedulerConfigFunc {
+	return func(_ context.Context, u *unstructured.Unstructured) error {
 		val, _, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 		if err != nil {
 			return err
@@ -1985,16 +2008,6 @@ func withMetricsDataSourceParams(extracted map[string]string) mutateSchedulerCon
 		plugins = append(plugins, pluginEntry)
 		return unstructured.SetNestedSlice(u.Object, plugins, "plugins")
 	}
-}
-
-// parseBoolDefaultTrue parses a bool flag value, falling back to true (the router
-// insecureSkipVerify default) when the value is not a recognized boolean.
-func parseBoolDefaultTrue(v string) bool {
-	b, err := strconv.ParseBool(v)
-	if err != nil {
-		return true
-	}
-	return b
 }
 
 func semanticServiceIsEqual(expected *corev1.Service, current *corev1.Service) bool {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
@@ -1305,15 +1306,29 @@ var deprecatedMetricFlagNames = map[string]bool{
 	"cache-info-metric":                true,
 }
 
-// modelServerMetricsSchemeFlag is the deprecated EPP CLI flag (without leading
-// dashes) removed in llm-d-router 0.10, superseded by the metrics-data-source
-// data layer plugin's scheme parameter in EndpointPickerConfig.
-const modelServerMetricsSchemeFlag = "model-server-metrics-scheme"
+// Deprecated EPP CLI flags (without leading dashes) removed in llm-d-router 0.10.
+// --model-server-metrics-scheme, --model-server-metrics-path, and --model-server-metrics-https-insecure-skip-verify
+// are superseded in EndpointPickerConfig's metrics-data-source plugin, by scheme, path, and insecureSkipVerify parameters
+// --model-server-metrics-port has no plugin parameter: the scrape port is always the InferencePool target port,
+// so the flag is only stripped, never re-injected.
+const (
+	modelServerMetricsSchemeFlag             = "model-server-metrics-scheme"
+	modelServerMetricsPathFlag               = "model-server-metrics-path"
+	modelServerMetricsPortFlag               = "model-server-metrics-port"
+	modelServerMetricsInsecureSkipVerifyFlag = "model-server-metrics-https-insecure-skip-verify"
+)
 
-// metricsDataSourceSchemeMinVersion is the first llm-d-router version that
-// removes --model-server-metrics-scheme; from this version the scrape scheme
+var deprecatedModelServerMetricFlagNames = map[string]bool{
+	modelServerMetricsSchemeFlag:             true,
+	modelServerMetricsPathFlag:               true,
+	modelServerMetricsPortFlag:               true,
+	modelServerMetricsInsecureSkipVerifyFlag: true,
+}
+
+// metricsDataSourceMinVersion is the first llm-d-router version that removes
+// the --model-server-metrics-* flags; from this version their surviving equivalents
 // must be supplied via the metrics-data-source plugin parameters.
-var metricsDataSourceSchemeMinVersion = semver.New("0.10.0")
+var metricsDataSourceMinVersion = semver.New("0.10.0")
 
 // hasDeprecatedMetricFlags reports whether any container in the pod spec
 // carries one of the 5 deprecated metric CLI flags, without modifying args.
@@ -1353,8 +1368,9 @@ func hasDeprecatedMetricFlags(d *appsv1.Deployment) bool {
 //  5. withCoreMetricsExtractorPlugin – inject core-metrics-extractor with extracted flag values
 //  6. withMigrateCoreMetricsExtractor – rename model-server-protocol-metrics → core-metrics-extractor
 //     (v0.8.0 only, runs after injection so freshly injected plugins are also renamed)
-//  7. withMetricsDataSourceScheme – move --model-server-metrics-scheme into the
-//     metrics-data-source plugin parameters (v0.10.0+, flag removed upstream)
+//  7. withMetricsDataSourceParams – move --model-server-metrics-{scheme,path,
+//     https-insecure-skip-verify} into the metrics-data-source plugin parameters
+//     and strip --model-server-metrics-port (v0.10.0+, flags removed in llm-d-router)
 func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alpha2.LLMInferenceService, enableTLS bool) error {
 	version, ok := d.Spec.Template.Annotations["app.kubernetes.io/version"]
 	if !ok || version == "" {
@@ -1412,21 +1428,28 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alp
 		}
 	}
 
-	// llm-d-router v0.10.0 removes "--model-server-metrics-scheme"
-	// the function had been moved into metrics-data-source plugin parameters.
-	if v.Compare(*metricsDataSourceSchemeMinVersion) >= 0 {
-		if !writable {
-			if hasModelServerMetricsSchemeFlag(d) {
+	// llm-d-router v0.10.0 removes the --model-server-metrics-* flags. Stripping
+	// them from Command/Args never touches the config, so it is always safe;
+	// extractModelServerMetricsFlags does that and returns only the
+	// re-injectable values (scheme, path, insecureSkipVerify). --model-server-metrics-port
+	// has no plugin parameter, so it is dropped in place and never appears here.
+	// Re-injecting the surviving values requires a writable inline config-text;
+	// abort only in that case so their values are not silently lost.
+	// Extraction runs before the writable check so --model-server-metrics-port is
+	// always stripped; on the error path d is discarded, so the early mutation is safe.
+	if v.Compare(*metricsDataSourceMinVersion) >= 0 {
+		if params := extractModelServerMetricsFlags(ctx, d); len(params) > 0 {
+			if !writable {
 				return fmt.Errorf(
-					"scheduler deployment %s/%s sets --%s but has no inline "+
-						"--config-text; automatic migration to the metrics-data-source "+
-						"plugin is not possible — convert to --config-text or remove the "+
-						"flag manually",
-					d.GetNamespace(), d.GetName(), modelServerMetricsSchemeFlag,
+					"scheduler deployment %s/%s sets deprecated "+
+						"--model-server-metrics-{scheme,path,https-insecure-skip-verify} "+
+						"but has no inline --config-text; automatic migration to the "+
+						"metrics-data-source plugin is not possible — convert to --config-text "+
+						"or remove the flags manually",
+					d.GetNamespace(), d.GetName(),
 				)
 			}
-		} else if scheme := extractModelServerMetricsScheme(d); scheme != "" {
-			opts = append(opts, withMetricsDataSourceScheme(scheme))
+			opts = append(opts, withMetricsDataSourceParams(params))
 		}
 	}
 
@@ -1808,51 +1831,60 @@ func extractDeprecatedMetricFlags(d *appsv1.Deployment) map[string]string {
 	return allExtracted
 }
 
-// extractModelServerMetricsScheme strips the deprecated --model-server-metrics-scheme
-// flag from every container's Command and Args and returns its value (empty if
-// absent). The scheduler preset carries the flag on Command, but a user-supplied
-// SchedulerSpec.Template may place it on Args instead; both work on the old image
-// (kube concatenates Command+Args) but are rejected by llm-d-router v0.10.0, so
-// both lists must be scrubbed.
-func extractModelServerMetricsScheme(d *appsv1.Deployment) string {
-	names := map[string]bool{modelServerMetricsSchemeFlag: true}
-	scheme := ""
+// extractModelServerMetricsFlags strips the deprecated
+// --model-server-metrics-* flags from every container's Command and Args
+// (scrubbing both, since kube concatenates them and either may carry a flag) and
+// returns the re-injectable values keyed by flag name. --model-server-metrics-port
+// has no plugin parameter: it is stripped and logged, never returned.
+func extractModelServerMetricsFlags(ctx context.Context, d *appsv1.Deployment) map[string]string {
+	params := map[string]string{}
 	for ci := range d.Spec.Template.Spec.Containers {
 		c := &d.Spec.Template.Spec.Containers[ci]
-		if filtered, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
-			c.Command = filtered
-			scheme = extracted[modelServerMetricsSchemeFlag]
-		}
-		if filtered, extracted := filterArgs(c.Args, names); len(extracted) > 0 {
-			c.Args = filtered
-			scheme = extracted[modelServerMetricsSchemeFlag]
+		if fc, fa, extracted := filterCommandArgs(c.Command, c.Args, deprecatedModelServerMetricFlagNames); len(extracted) > 0 {
+			c.Command = fc
+			c.Args = fa
+			maps.Copy(params, extracted)
 		}
 	}
-	return scheme
-}
-
-// hasModelServerMetricsSchemeFlag reports whether any container carries the
-// --model-server-metrics-scheme flag on Command or Args, without modifying it.
-func hasModelServerMetricsSchemeFlag(d *appsv1.Deployment) bool {
-	names := map[string]bool{modelServerMetricsSchemeFlag: true}
-	for ci := range d.Spec.Template.Spec.Containers {
-		c := &d.Spec.Template.Spec.Containers[ci]
-		if _, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
-			return true
-		}
-		if _, extracted := filterArgs(c.Args, names); len(extracted) > 0 {
-			return true
-		}
+	// remove port flag to keep other 3 flags if were set
+	if port, ok := params[modelServerMetricsPortFlag]; ok {
+		log.FromContext(ctx).Info(
+			"Dropped --model-server-metrics-port; llm-d-router v0.10.0 scrapes metrics "+
+				"on the InferencePool target port", "droppedPort", port,
+		)
+		delete(params, modelServerMetricsPortFlag)
 	}
-	return false
+	return params
 }
 
-// filterArgs removes matching flags from args and returns their values.
+// filterArgs removes matching flags from args and returns final values.
 // It handles both --flag=value and --flag value forms.
 func filterArgs(args []string, names map[string]bool) (filtered []string, extracted map[string]string) {
+	_, filtered, extracted = filterCommandArgs(nil, args, names)
+	return filtered, extracted
+}
+
+// filterCommandArgs removes matching flags from the concatenated command+args,
+// then re-splits the surviving tokens into their original command and args
+// halves, and returns them along with the extracted flag values. It handles
+// both --flag=value and --flag value forms.
+func filterCommandArgs(command, args []string, names map[string]bool) (filteredCommand, filteredArgs []string, extracted map[string]string) {
 	extracted = make(map[string]string)
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
+	combined := make([]string, 0, len(command)+len(args))
+	combined = append(combined, command...)
+	combined = append(combined, args...)
+	boundary := len(command)
+
+	emit := func(idx int) {
+		if idx < boundary {
+			filteredCommand = append(filteredCommand, combined[idx])
+		} else {
+			filteredArgs = append(filteredArgs, combined[idx])
+		}
+	}
+
+	for i := 0; i < len(combined); i++ {
+		arg := combined[i]
 		name := strings.TrimLeft(arg, "-")
 		value := ""
 		if eqIdx := strings.Index(name, "="); eqIdx != -1 {
@@ -1860,16 +1892,16 @@ func filterArgs(args []string, names map[string]bool) (filtered []string, extrac
 			name = name[:eqIdx]
 		}
 		if !names[name] {
-			filtered = append(filtered, args[i])
+			emit(i)
 			continue
 		}
-		if value == "" && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-			value = args[i+1]
+		if value == "" && i+1 < len(combined) && !strings.HasPrefix(combined[i+1], "-") {
+			value = combined[i+1]
 			i++
 		}
 		extracted[name] = value
 	}
-	return filtered, extracted
+	return filteredCommand, filteredArgs, extracted
 }
 
 // withCoreMetricsExtractorPlugin returns a mutateSchedulerConfigFunc that
@@ -1929,14 +1961,27 @@ func withCoreMetricsExtractorPlugin(extracted map[string]string) mutateScheduler
 	}
 }
 
-// withMetricsDataSourceScheme returns a mutateSchedulerConfigFunc that injects a
-// metrics-data-source plugin carrying the scheme previously passed via the
-// --model-server-metrics-scheme CLI flag. EPP data layer defaulting wires the
-// declared source to core-metrics-extractor automatically, so only the plugin
-// entry is needed. Callers pass a non-empty scheme; no-op if a metrics-data-source
-// plugin is already declared.
-func withMetricsDataSourceScheme(scheme string) mutateSchedulerConfigFunc {
+// withMetricsDataSourceParams returns a mutateSchedulerConfigFunc that injects a
+// metrics-data-source plugin carrying the scheme, path, and insecureSkipVerify
+// previously passed via the --model-server-metrics-* CLI flags.
+// No-op if a metrics-data-source plugin is already declared or if no re-injectable parameters were extracted.
+func withMetricsDataSourceParams(extracted map[string]string) mutateSchedulerConfigFunc {
 	return func(_ context.Context, u *unstructured.Unstructured) error {
+		parameters := map[string]interface{}{}
+		if scheme := extracted[modelServerMetricsSchemeFlag]; scheme != "" {
+			parameters["scheme"] = scheme
+		}
+		if p := extracted[modelServerMetricsPathFlag]; p != "" {
+			parameters["path"] = p
+		}
+		// empty string means true
+		if v, ok := extracted[modelServerMetricsInsecureSkipVerifyFlag]; ok {
+			parameters["insecureSkipVerify"] = v == "" || parseBoolDefaultTrue(v)
+		}
+		if len(parameters) == 0 {
+			return nil
+		}
+
 		val, _, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 		if err != nil {
 			return err
@@ -1950,15 +1995,23 @@ func withMetricsDataSourceScheme(scheme string) mutateSchedulerConfigFunc {
 		}
 
 		pluginEntry := map[string]interface{}{
-			"type": metricsDataSourcePlugin,
-			"parameters": map[string]interface{}{
-				"scheme": scheme,
-			},
+			"type":       metricsDataSourcePlugin,
+			"parameters": parameters,
 		}
 
 		plugins = append(plugins, pluginEntry)
 		return unstructured.SetNestedSlice(u.Object, plugins, "plugins")
 	}
+}
+
+// parseBoolDefaultTrue parses a bool flag value, falling back to true (the router
+// insecureSkipVerify default) when the value is not a recognized boolean.
+func parseBoolDefaultTrue(v string) bool {
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return true
+	}
+	return b
 }
 
 func semanticServiceIsEqual(expected *corev1.Service, current *corev1.Service) bool {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1831,18 +1831,23 @@ func extractDeprecatedMetricFlags(d *appsv1.Deployment) map[string]string {
 	return allExtracted
 }
 
-// extractModelServerMetricsFlags strips the deprecated
-// --model-server-metrics-* flags from every container's Command and Args
-// (scrubbing both, since kube concatenates them and either may carry a flag) and
-// returns the re-injectable values keyed by flag name. --model-server-metrics-port
+// extractModelServerMetricsFlags strips the deprecated --model-server-metrics-*
+// flags from every container's Command and Args and returns the re-injectable
+// values keyed by flag name. The scheduler preset carries the flags on Command,
+// but a user-supplied SchedulerSpec.Template may place them on Args instead;
+// both work on the old image (kube concatenates Command+Args) but are rejected
+// by llm-d-router v0.10.0, so both lists must be scrubbed. --model-server-metrics-port
 // has no plugin parameter: it is stripped and logged, never returned.
 func extractModelServerMetricsFlags(ctx context.Context, d *appsv1.Deployment) map[string]string {
 	params := map[string]string{}
 	for ci := range d.Spec.Template.Spec.Containers {
 		c := &d.Spec.Template.Spec.Containers[ci]
-		if fc, fa, extracted := filterCommandArgs(c.Command, c.Args, deprecatedModelServerMetricFlagNames); len(extracted) > 0 {
-			c.Command = fc
-			c.Args = fa
+		if filtered, extracted := filterArgs(c.Command, deprecatedModelServerMetricFlagNames); len(extracted) > 0 {
+			c.Command = filtered
+			maps.Copy(params, extracted)
+		}
+		if filtered, extracted := filterArgs(c.Args, deprecatedModelServerMetricFlagNames); len(extracted) > 0 {
+			c.Args = filtered
 			maps.Copy(params, extracted)
 		}
 	}
@@ -1857,34 +1862,12 @@ func extractModelServerMetricsFlags(ctx context.Context, d *appsv1.Deployment) m
 	return params
 }
 
-// filterArgs removes matching flags from args and returns final values.
+// filterArgs removes matching flags from args and returns their values.
 // It handles both --flag=value and --flag value forms.
 func filterArgs(args []string, names map[string]bool) (filtered []string, extracted map[string]string) {
-	_, filtered, extracted = filterCommandArgs(nil, args, names)
-	return filtered, extracted
-}
-
-// filterCommandArgs removes matching flags from the concatenated command+args,
-// then re-splits the surviving tokens into their original command and args
-// halves, and returns them along with the extracted flag values. It handles
-// both --flag=value and --flag value forms.
-func filterCommandArgs(command, args []string, names map[string]bool) (filteredCommand, filteredArgs []string, extracted map[string]string) {
 	extracted = make(map[string]string)
-	combined := make([]string, 0, len(command)+len(args))
-	combined = append(combined, command...)
-	combined = append(combined, args...)
-	boundary := len(command)
-
-	emit := func(idx int) {
-		if idx < boundary {
-			filteredCommand = append(filteredCommand, combined[idx])
-		} else {
-			filteredArgs = append(filteredArgs, combined[idx])
-		}
-	}
-
-	for i := 0; i < len(combined); i++ {
-		arg := combined[i]
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		name := strings.TrimLeft(arg, "-")
 		value := ""
 		if eqIdx := strings.Index(name, "="); eqIdx != -1 {
@@ -1892,16 +1875,16 @@ func filterCommandArgs(command, args []string, names map[string]bool) (filteredC
 			name = name[:eqIdx]
 		}
 		if !names[name] {
-			emit(i)
+			filtered = append(filtered, args[i])
 			continue
 		}
-		if value == "" && i+1 < len(combined) && !strings.HasPrefix(combined[i+1], "-") {
-			value = combined[i+1]
+		if value == "" && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			value = args[i+1]
 			i++
 		}
 		extracted[name] = value
 	}
-	return filteredCommand, filteredArgs, extracted
+	return filtered, extracted
 }
 
 // withCoreMetricsExtractorPlugin returns a mutateSchedulerConfigFunc that

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -518,62 +518,6 @@ func TestFilterArgs(t *testing.T) {
 	}
 }
 
-func TestFilterCommandArgs(t *testing.T) {
-	names := map[string]bool{"model-server-metrics-scheme": true}
-	tests := []struct {
-		name              string
-		command           []string
-		args              []string
-		expectedCommand   []string
-		expectedArgs      []string
-		expectedExtracted map[string]string
-	}{
-		{
-			name:              "flag and value both in command",
-			command:           []string{"/app/epp", "--model-server-metrics-scheme", "https"},
-			args:              []string{"--grpc-port", "9002"},
-			expectedCommand:   []string{"/app/epp"},
-			expectedArgs:      []string{"--grpc-port", "9002"},
-			expectedExtracted: map[string]string{"model-server-metrics-scheme": "https"},
-		},
-		{
-			// #5902: terminal flag in command consumes its value from the start of args.
-			name:              "flag in command value spilling into args",
-			command:           []string{"/app/epp", "--model-server-metrics-scheme"},
-			args:              []string{"https", "--grpc-port", "9002"},
-			expectedCommand:   []string{"/app/epp"},
-			expectedArgs:      []string{"--grpc-port", "9002"},
-			expectedExtracted: map[string]string{"model-server-metrics-scheme": "https"},
-		},
-		{
-			name:              "terminal flag in command with no value in args",
-			command:           []string{"/app/epp", "--model-server-metrics-scheme"},
-			args:              []string{"--grpc-port", "9002"},
-			expectedCommand:   []string{"/app/epp"},
-			expectedArgs:      []string{"--grpc-port", "9002"},
-			expectedExtracted: map[string]string{"model-server-metrics-scheme": ""},
-		},
-		{
-			name:              "flag and value both in args",
-			command:           []string{"/app/epp"},
-			args:              []string{"--model-server-metrics-scheme", "https", "--grpc-port", "9002"},
-			expectedCommand:   []string{"/app/epp"},
-			expectedArgs:      []string{"--grpc-port", "9002"},
-			expectedExtracted: map[string]string{"model-server-metrics-scheme": "https"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-			fc, fa, extracted := filterCommandArgs(tt.command, tt.args, names)
-			g.Expect(fc).To(Equal(tt.expectedCommand))
-			g.Expect(fa).To(Equal(tt.expectedArgs))
-			g.Expect(extracted).To(Equal(tt.expectedExtracted))
-		})
-	}
-}
-
 // pluginRefWeight is an ordered (pluginRef, weight) pair from a scheduling
 // profile. Weight is 0 when unset; the P/D baseline only uses weights 2 and 3,
 // so 0 unambiguously means "no weight".
@@ -2410,17 +2354,6 @@ func TestExtractModelServerMetricsFlags(t *testing.T) {
 			command:         []string{"/app/epp", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
 			expectedParams:  map[string]string{},
-		},
-		{
-			// Regression for #5902: the flag sits at the end of Command and its
-			// value is the first element of Args. The value must be consumed, not
-			// left dangling as a positional argument.
-			name:            "flag on command with value spilling into args",
-			command:         []string{"/app/epp", "--model-server-metrics-scheme"},
-			args:            []string{"https", "--grpc-port=9002"},
-			expectedCommand: []string{"/app/epp"},
-			expectedArgs:    []string{"--grpc-port=9002"},
-			expectedParams:  map[string]string{modelServerMetricsSchemeFlag: "https"},
 		},
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2228,23 +2228,85 @@ plugins:
 	}
 }
 
-func TestWithMetricsDataSourceParams(t *testing.T) {
+func TestMetricsDataSourceParameters(t *testing.T) {
 	tests := []struct {
-		name       string
-		configYAML string
-		extracted  map[string]string
-		validate   func(g Gomega, obj map[string]interface{})
+		name         string
+		extracted    map[string]string
+		expectErr    bool
+		errSubstring string
+		expected     map[string]interface{}
 	}{
 		{
-			name: "injects plugin with scheme, path and insecureSkipVerify",
-			configYAML: `
-plugins:
-- type: queue-scorer
-`,
+			name: "converts scheme, path and insecureSkipVerify",
 			extracted: map[string]string{
 				modelServerMetricsSchemeFlag:             "https",
 				modelServerMetricsPathFlag:               "/custom/metrics",
 				modelServerMetricsInsecureSkipVerifyFlag: "false",
+			},
+			expected: map[string]interface{}{
+				"scheme":             "https",
+				"path":               "/custom/metrics",
+				"insecureSkipVerify": false,
+			},
+		},
+		{
+			name:      "bare insecureSkipVerify flag means true",
+			extracted: map[string]string{modelServerMetricsInsecureSkipVerifyFlag: ""},
+			expected:  map[string]interface{}{"insecureSkipVerify": true},
+		},
+		{
+			name: "empty scheme and path values are dropped",
+			extracted: map[string]string{
+				modelServerMetricsSchemeFlag: "",
+				modelServerMetricsPathFlag:   "",
+			},
+			expected: map[string]interface{}{},
+		},
+		{
+			name:      "no flags returns empty parameters",
+			extracted: map[string]string{},
+			expected:  map[string]interface{}{},
+		},
+		{
+			name:         "invalid insecureSkipVerify value returns error",
+			extracted:    map[string]string{modelServerMetricsInsecureSkipVerifyFlag: "notabool"},
+			expectErr:    true,
+			errSubstring: "invalid value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			parameters, err := metricsDataSourceParameters(tt.extracted)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errSubstring))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(parameters).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestWithMetricsDataSourceParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		parameters map[string]interface{}
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "injects plugin with the given parameters",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			parameters: map[string]interface{}{
+				"scheme":             "https",
+				"path":               "/custom/metrics",
+				"insecureSkipVerify": false,
 			},
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
@@ -2258,33 +2320,6 @@ plugins:
 			},
 		},
 		{
-			name: "bare insecureSkipVerify flag means true",
-			configYAML: `
-plugins:
-- type: queue-scorer
-`,
-			extracted: map[string]string{modelServerMetricsInsecureSkipVerifyFlag: ""},
-			validate: func(g Gomega, obj map[string]interface{}) {
-				plugins := obj["plugins"].([]interface{})
-				g.Expect(plugins).To(HaveLen(2))
-				params := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
-				g.Expect(params).To(HaveKeyWithValue("insecureSkipVerify", true))
-				g.Expect(params).NotTo(HaveKey("scheme"))
-			},
-		},
-		{
-			name: "no re-injectable params leaves plugins untouched",
-			configYAML: `
-plugins:
-- type: queue-scorer
-`,
-			extracted: map[string]string{},
-			validate: func(g Gomega, obj map[string]interface{}) {
-				plugins := obj["plugins"].([]interface{})
-				g.Expect(plugins).To(HaveLen(1))
-			},
-		},
-		{
 			name: "skips when metrics-data-source already exists",
 			configYAML: `
 plugins:
@@ -2292,7 +2327,7 @@ plugins:
   parameters:
     scheme: http
 `,
-			extracted: map[string]string{modelServerMetricsSchemeFlag: "https"},
+			parameters: map[string]interface{}{"scheme": "https"},
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
 				g.Expect(plugins).To(HaveLen(1))
@@ -2309,7 +2344,7 @@ plugins:
 			var obj map[string]interface{}
 			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
 			u := unstructured.Unstructured{Object: obj}
-			fn := withMetricsDataSourceParams(tt.extracted)
+			fn := withMetricsDataSourceParams(tt.parameters)
 			g.Expect(fn(context.Background(), &u)).To(Succeed())
 			tt.validate(g, u.Object)
 		})
@@ -2464,6 +2499,32 @@ plugins:
 			args:         []string{"--config-file", "/etc/scheduler/config.yaml"},
 			expectErr:    true,
 			errSubstring: "no inline --config-text",
+		},
+		{
+			// multiple flags on a non-writable config: the error must list the
+			// actual flags that were set, in a deterministic (sorted) order.
+			name:    "0.10.0 non-writable config-file lists the set flags sorted",
+			version: "0.10.0",
+			command: []string{
+				"/app/epp",
+				"--model-server-metrics-scheme=https",
+				"--model-server-metrics-path=/metrics",
+				"--model-server-metrics-https-insecure-skip-verify=true",
+			},
+			args:      []string{"--config-file", "/etc/scheduler/config.yaml"},
+			expectErr: true,
+			errSubstring: "--model-server-metrics-https-insecure-skip-verify, " +
+				"--model-server-metrics-path, --model-server-metrics-scheme",
+		},
+		{
+			// an invalid boolean fails the reconcile up front (with a writable
+			// config-text), before any config mutation happens.
+			name:         "0.10.0 invalid insecureSkipVerify value returns error",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-https-insecure-skip-verify=notabool"},
+			args:         []string{"--config-text", configYAML},
+			expectErr:    true,
+			errSubstring: "invalid value",
 		},
 		{
 			// port has no plugin parameter, so stripping it needs no config

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -518,6 +518,62 @@ func TestFilterArgs(t *testing.T) {
 	}
 }
 
+func TestFilterCommandArgs(t *testing.T) {
+	names := map[string]bool{"model-server-metrics-scheme": true}
+	tests := []struct {
+		name              string
+		command           []string
+		args              []string
+		expectedCommand   []string
+		expectedArgs      []string
+		expectedExtracted map[string]string
+	}{
+		{
+			name:              "flag and value both in command",
+			command:           []string{"/app/epp", "--model-server-metrics-scheme", "https"},
+			args:              []string{"--grpc-port", "9002"},
+			expectedCommand:   []string{"/app/epp"},
+			expectedArgs:      []string{"--grpc-port", "9002"},
+			expectedExtracted: map[string]string{"model-server-metrics-scheme": "https"},
+		},
+		{
+			// #5902: terminal flag in command consumes its value from the start of args.
+			name:              "flag in command value spilling into args",
+			command:           []string{"/app/epp", "--model-server-metrics-scheme"},
+			args:              []string{"https", "--grpc-port", "9002"},
+			expectedCommand:   []string{"/app/epp"},
+			expectedArgs:      []string{"--grpc-port", "9002"},
+			expectedExtracted: map[string]string{"model-server-metrics-scheme": "https"},
+		},
+		{
+			name:              "terminal flag in command with no value in args",
+			command:           []string{"/app/epp", "--model-server-metrics-scheme"},
+			args:              []string{"--grpc-port", "9002"},
+			expectedCommand:   []string{"/app/epp"},
+			expectedArgs:      []string{"--grpc-port", "9002"},
+			expectedExtracted: map[string]string{"model-server-metrics-scheme": ""},
+		},
+		{
+			name:              "flag and value both in args",
+			command:           []string{"/app/epp"},
+			args:              []string{"--model-server-metrics-scheme", "https", "--grpc-port", "9002"},
+			expectedCommand:   []string{"/app/epp"},
+			expectedArgs:      []string{"--grpc-port", "9002"},
+			expectedExtracted: map[string]string{"model-server-metrics-scheme": "https"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			fc, fa, extracted := filterCommandArgs(tt.command, tt.args, names)
+			g.Expect(fc).To(Equal(tt.expectedCommand))
+			g.Expect(fa).To(Equal(tt.expectedArgs))
+			g.Expect(extracted).To(Equal(tt.expectedExtracted))
+		})
+	}
+}
+
 // pluginRefWeight is an ordered (pluginRef, weight) pair from a scheduling
 // profile. Weight is 0 when unset; the P/D baseline only uses weights 2 and 3,
 // so 0 unambiguously means "no weight".
@@ -2228,27 +2284,60 @@ plugins:
 	}
 }
 
-func TestWithMetricsDataSourceScheme(t *testing.T) {
+func TestWithMetricsDataSourceParams(t *testing.T) {
 	tests := []struct {
 		name       string
 		configYAML string
-		scheme     string
+		extracted  map[string]string
 		validate   func(g Gomega, obj map[string]interface{})
 	}{
 		{
-			name: "injects plugin with scheme",
+			name: "injects plugin with scheme, path and insecureSkipVerify",
 			configYAML: `
 plugins:
 - type: queue-scorer
 `,
-			scheme: "https",
+			extracted: map[string]string{
+				modelServerMetricsSchemeFlag:             "https",
+				modelServerMetricsPathFlag:               "/custom/metrics",
+				modelServerMetricsInsecureSkipVerifyFlag: "false",
+			},
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
 				g.Expect(plugins).To(HaveLen(2))
 				pluginMap := plugins[1].(map[string]interface{})
 				g.Expect(pluginMap["type"]).To(Equal(metricsDataSourcePlugin))
 				params := pluginMap["parameters"].(map[string]interface{})
-				g.Expect(params["scheme"]).To(Equal("https"))
+				g.Expect(params).To(HaveKeyWithValue("scheme", "https"))
+				g.Expect(params).To(HaveKeyWithValue("path", "/custom/metrics"))
+				g.Expect(params).To(HaveKeyWithValue("insecureSkipVerify", false))
+			},
+		},
+		{
+			name: "bare insecureSkipVerify flag means true",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			extracted: map[string]string{modelServerMetricsInsecureSkipVerifyFlag: ""},
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(2))
+				params := plugins[1].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).To(HaveKeyWithValue("insecureSkipVerify", true))
+				g.Expect(params).NotTo(HaveKey("scheme"))
+			},
+		},
+		{
+			name: "no re-injectable params leaves plugins untouched",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			extracted: map[string]string{},
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
 			},
 		},
 		{
@@ -2259,7 +2348,7 @@ plugins:
   parameters:
     scheme: http
 `,
-			scheme: "https",
+			extracted: map[string]string{modelServerMetricsSchemeFlag: "https"},
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
 				g.Expect(plugins).To(HaveLen(1))
@@ -2276,27 +2365,31 @@ plugins:
 			var obj map[string]interface{}
 			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
 			u := unstructured.Unstructured{Object: obj}
-			fn := withMetricsDataSourceScheme(tt.scheme)
+			fn := withMetricsDataSourceParams(tt.extracted)
 			g.Expect(fn(context.Background(), &u)).To(Succeed())
 			tt.validate(g, u.Object)
 		})
 	}
 }
 
-func TestExtractModelServerMetricsScheme(t *testing.T) {
+func TestExtractModelServerMetricsFlags(t *testing.T) {
 	tests := []struct {
 		name            string
 		command         []string
 		args            []string
 		expectedCommand []string
 		expectedArgs    []string
-		expectedScheme  string
+		expectedParams  map[string]string
 	}{
 		{
-			name:            "extracts from command with equals form",
-			command:         []string{"/app/epp", "--model-server-metrics-scheme=https", "--grpc-port=9002"},
+			name:            "extracts scheme, path and insecureSkipVerify from command",
+			command:         []string{"/app/epp", "--model-server-metrics-scheme=https", "--model-server-metrics-path=/custom/metrics", "--model-server-metrics-https-insecure-skip-verify=false", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
-			expectedScheme:  "https",
+			expectedParams: map[string]string{
+				modelServerMetricsSchemeFlag:             "https",
+				modelServerMetricsPathFlag:               "/custom/metrics",
+				modelServerMetricsInsecureSkipVerifyFlag: "false",
+			},
 		},
 		{
 			name:            "extracts from args with equals form",
@@ -2304,13 +2397,30 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 			args:            []string{"--model-server-metrics-scheme=https", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp"},
 			expectedArgs:    []string{"--grpc-port=9002"},
-			expectedScheme:  "https",
+			expectedParams:  map[string]string{modelServerMetricsSchemeFlag: "https"},
 		},
 		{
-			name:            "no flag returns empty scheme",
+			name:            "strips port without returning it",
+			command:         []string{"/app/epp", "--model-server-metrics-port=8000", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
+			expectedParams:  map[string]string{},
+		},
+		{
+			name:            "no flag returns empty params",
 			command:         []string{"/app/epp", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
-			expectedScheme:  "",
+			expectedParams:  map[string]string{},
+		},
+		{
+			// Regression for #5902: the flag sits at the end of Command and its
+			// value is the first element of Args. The value must be consumed, not
+			// left dangling as a positional argument.
+			name:            "flag on command with value spilling into args",
+			command:         []string{"/app/epp", "--model-server-metrics-scheme"},
+			args:            []string{"https", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp"},
+			expectedArgs:    []string{"--grpc-port=9002"},
+			expectedParams:  map[string]string{modelServerMetricsSchemeFlag: "https"},
 		},
 	}
 
@@ -2328,8 +2438,8 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 					},
 				},
 			}
-			scheme := extractModelServerMetricsScheme(d)
-			g.Expect(scheme).To(Equal(tt.expectedScheme))
+			params := extractModelServerMetricsFlags(context.Background(), d)
+			g.Expect(params).To(Equal(tt.expectedParams))
 			if tt.expectedCommand != nil {
 				g.Expect(d.Spec.Template.Spec.Containers[0].Command).To(Equal(tt.expectedCommand))
 			}
@@ -2354,40 +2464,65 @@ plugins:
 		args         []string
 		expectErr    bool
 		errSubstring string
-		expectFlag   bool
-		expectPlugin bool
+		flag         string                 // the deprecated flag literal to check on Command/Args
+		expectFlag   bool                   // whether flag still survives on Command
+		expectParams map[string]interface{} // nil => no metrics-data-source plugin
 	}{
 		{
 			name:         "0.9.0 leaves flag and config untouched",
 			version:      "0.9.0",
 			command:      []string{"/app/epp", "--model-server-metrics-scheme=https"},
 			args:         []string{"--config-text", configYAML},
+			flag:         "--model-server-metrics-scheme=https",
 			expectFlag:   true,
-			expectPlugin: false,
+			expectParams: nil,
 		},
 		{
-			name:         "0.10.0 strips flag from command and injects plugin",
+			name:         "0.10.0 strips scheme from command and injects plugin",
 			version:      "0.10.0",
 			command:      []string{"/app/epp", "--model-server-metrics-scheme=https"},
 			args:         []string{"--config-text", configYAML},
-			expectFlag:   false,
-			expectPlugin: true,
+			flag:         "--model-server-metrics-scheme=https",
+			expectParams: map[string]interface{}{"scheme": "https"},
 		},
 		{
-			name:         "0.10.0 strips flag from args and injects plugin",
+			name:         "0.10.0 strips scheme from args and injects plugin",
 			version:      "0.10.0",
 			command:      []string{"/app/epp"},
 			args:         []string{"--model-server-metrics-scheme=https", "--config-text", configYAML},
-			expectFlag:   false,
-			expectPlugin: true,
+			flag:         "--model-server-metrics-scheme=https",
+			expectParams: map[string]interface{}{"scheme": "https"},
+		},
+		{
+			name:         "0.10.0 strips path and injects plugin",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-path=/custom/metrics"},
+			args:         []string{"--config-text", configYAML},
+			flag:         "--model-server-metrics-path=/custom/metrics",
+			expectParams: map[string]interface{}{"path": "/custom/metrics"},
+		},
+		{
+			name:         "0.10.0 strips insecureSkipVerify and injects plugin",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-https-insecure-skip-verify=false"},
+			args:         []string{"--config-text", configYAML},
+			flag:         "--model-server-metrics-https-insecure-skip-verify=false",
+			expectParams: map[string]interface{}{"insecureSkipVerify": false},
+		},
+		{
+			name:         "0.10.0 strips port without injecting a plugin",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-port=8000"},
+			args:         []string{"--config-text", configYAML},
+			flag:         "--model-server-metrics-port=8000",
+			expectParams: nil,
 		},
 		{
 			name:         "0.10.0 without flag leaves config untouched",
 			version:      "0.10.0",
 			command:      []string{"/app/epp"},
 			args:         []string{"--config-text", configYAML},
-			expectFlag:   false,
-			expectPlugin: false,
+			expectParams: nil,
 		},
 		{
 			name:         "0.10.0 with flag but non-writable config-file returns error",
@@ -2396,6 +2531,17 @@ plugins:
 			args:         []string{"--config-file", "/etc/scheduler/config.yaml"},
 			expectErr:    true,
 			errSubstring: "no inline --config-text",
+		},
+		{
+			// port has no plugin parameter, so stripping it needs no config
+			// rewrite: a non-writable config-file must not block its removal.
+			name:         "0.10.0 strips port even with non-writable config-file",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-port=8000"},
+			args:         []string{"--config-file", "/etc/scheduler/config.yaml"},
+			flag:         "--model-server-metrics-port=8000",
+			expectFlag:   false,
+			expectParams: nil,
 		},
 	}
 
@@ -2431,11 +2577,13 @@ plugins:
 			g.Expect(err).NotTo(HaveOccurred())
 
 			command := d.Spec.Template.Spec.Containers[0].Command
-			g.Expect(slices.Contains(command, "--model-server-metrics-scheme=https")).To(Equal(tt.expectFlag))
-
 			args := d.Spec.Template.Spec.Containers[0].Args
-			// The flag must never survive on Args either, regardless of where it started.
-			g.Expect(slices.Contains(args, "--model-server-metrics-scheme=https")).To(BeFalse())
+			if tt.flag != "" {
+				g.Expect(slices.Contains(command, tt.flag)).To(Equal(tt.expectFlag))
+				// The flag must never survive on Args, regardless of where it started.
+				g.Expect(slices.Contains(args, tt.flag)).To(BeFalse())
+			}
+
 			configText := ""
 			for i, a := range args {
 				if a == "--config-text" && i+1 < len(args) {
@@ -2454,11 +2602,13 @@ plugins:
 				}
 			}
 
-			if tt.expectPlugin {
+			if tt.expectParams != nil {
 				g.Expect(metricsPlugin).NotTo(BeNil(), "expected a metrics-data-source plugin to be injected")
 				params, ok := metricsPlugin["parameters"].(map[string]interface{})
 				g.Expect(ok).To(BeTrue(), "metrics-data-source plugin must carry parameters")
-				g.Expect(params).To(HaveKeyWithValue("scheme", "https"))
+				for k, v := range tt.expectParams {
+					g.Expect(params).To(HaveKeyWithValue(k, v))
+				}
 			} else {
 				g.Expect(metricsPlugin).To(BeNil(), "did not expect a metrics-data-source plugin")
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
llm-d-router v0.10.0 removes the `--model-server-metrics-*` CLI flags. A prior change migrated only `--model-server-metrics-scheme` into the EndpointPickerConfig `metrics-data-source` plugin. This PR completes the migration for the rest of the flag family so v0.10.0+ schedulers don't fail on startup:

- `--model-server-metrics-scheme`, `--model-server-metrics-path`, and `--model-server-metrics-https-insecure-skip-verify` are moved into the `metrics-data-source` plugin as the `scheme`, `path`, and `insecureSkipVerify` parameters.
- `--model-server-metrics-port` has no plugin equivalent (the router always scrapes the InferencePool target port), so it is stripped in place and logged — this works even without a writable inline `--config-text`.
- The `insecureSkipVerify` value is validated up front: a bare flag means `true`, any other value must parse as a boolean, otherwise the reconcile fails before the scheduler config is mutated.
- When the scheduler has no writable inline `--config-text`, the migration aborts with an error that lists the exact deprecated flags that were set.


**Feature/Issue validation/testing**:
- [x] Unit tests for `extractModelServerMetricsFlags`, `metricsDataSourceParameters`, `withMetricsDataSourceParams`, and the version-gated `schedulerTransform` migration:
  - 0.9.0 leaves flags and config untouched; 0.10.0 strips scheme/path/insecureSkipVerify from `Command`/`Args` and injects the plugin.
  - `--model-server-metrics-port` is stripped with and without a writable config, and never injects a plugin.
  - Non-writable inline config aborts with an error listing the set flags in sorted order.
  - An invalid `insecureSkipVerify` value is rejected before any config mutation.


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
llmisvc: migrate the remaining `--model-server-metrics-*` scheduler flags (path, https-insecure-skip-verify, and port) for llm-d-router v0.10.0, which removes them.
```
