### PR TITLE
fix(llmisvc): detect scheduler plugins from template args

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1490,6 +1490,136 @@ plugins:
 	}
 }
 
+// TestSchedulerTransformDecomposesPrecisePrefixCacheFromTemplateArgs verifies
+// the >=0.9.0 decompose migration applies when the scheduler config is
+// supplied via spec.router.scheduler.template.containers[].args (a literal
+// "--config-text <yaml>" pair) instead of spec.router.scheduler.config.inline.
+func TestSchedulerTransformDecomposesPrecisePrefixCacheFromTemplateArgs(t *testing.T) {
+	legacyConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- parameters:
+    indexerConfig:
+      kvBlockIndexConfig:
+        enableMetrics: true
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      tokenizersPoolConfig:
+        hf:
+          tokenizersCacheDir: /mnt/tokenizers
+    kvEventsConfig:
+      topicFilter: kv
+      zmqEndpoint: tcp://*:5557
+  type: precise-prefix-cache-scorer
+- type: load-aware-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: precise-prefix-cache-scorer
+    weight: 2.0
+  - pluginRef: load-aware-scorer
+    weight: 1.0
+  - pluginRef: max-score-picker
+`
+
+	g := NewGomegaWithT(t)
+
+	mainContainer := corev1.Container{
+		Name: "main",
+		Args: []string{
+			"--v=4",
+			"--secure-serving",
+			"--config-text",
+			legacyConfigYAML,
+		},
+	}
+
+	// The Deployment being reconciled: its pod template spec is a verbatim
+	// copy of llmSvc.Spec.Router.Scheduler.Template, exactly as
+	// expectedSchedulerDeployment builds it.
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"app.kubernetes.io/version": "0.10.0",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{mainContainer},
+				},
+			},
+		},
+	}
+
+	// The LLMInferenceService carries the config only via
+	// spec.router.scheduler.template.containers[].args; spec.router.scheduler.config
+	// is intentionally left unset.
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llmisvc-precise-prefix-scorer",
+			Namespace: "llmd-singlenode-precise-prefix-cache",
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{
+				Scheduler: &v1alpha2.SchedulerSpec{
+					Template: &corev1.PodSpec{
+						Containers: []corev1.Container{mainContainer},
+					},
+				},
+			},
+		},
+	}
+
+	g.Expect(hasPrecisePrefixCachePlugin(llmSvc.Spec)).To(BeTrue(),
+		"plugin detection must see the legacy plugin declared in template args, not just config.inline")
+	g.Expect(isTokenizerEnabled(llmSvc.Spec)).To(BeTrue())
+
+	g.Expect(schedulerTransform(context.Background(), d, llmSvc, false)).To(Succeed())
+
+	configText := d.Spec.Template.Spec.Containers[0].Args[3]
+
+	// The legacy monolithic plugin must be fully decomposed.
+	g.Expect(configText).NotTo(ContainSubstring(precisePrefixCacheScorerPlugin))
+	g.Expect(configText).To(ContainSubstring(tokenProducerPlugin))
+	g.Expect(configText).To(ContainSubstring(precisePrefixCacheProducerPlugin))
+	g.Expect(configText).To(ContainSubstring(prefixCacheScorerPlugin))
+	g.Expect(configText).To(ContainSubstring("prefixMatchInfoProducerName"))
+
+	// apiVersion must be migrated to the current llm-d.ai group.
+	g.Expect(configText).To(ContainSubstring("apiVersion: llm-d.ai/v1alpha1"))
+	g.Expect(configText).NotTo(ContainSubstring("inference.networking.x-k8s.io/v1alpha1"))
+
+	// tokenProcessorConfig must be promoted to the producer's top-level
+	// parameters, not left nested inside indexerConfig.
+	u := unstructured.Unstructured{}
+	g.Expect(yaml.Unmarshal([]byte(configText), &u)).To(Succeed())
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue())
+	plugins := val.([]interface{})
+
+	var producerPlugin map[string]interface{}
+	for _, p := range plugins {
+		pm := p.(map[string]interface{})
+		if pm["type"] == precisePrefixCacheProducerPlugin {
+			producerPlugin = pm
+		}
+	}
+	g.Expect(producerPlugin).NotTo(BeNil(), "expected a precise-prefix-cache-producer plugin in the decomposed pipeline")
+
+	params, _ := producerPlugin["parameters"].(map[string]interface{})
+	g.Expect(params).To(HaveKey("tokenProcessorConfig"), "tokenProcessorConfig must be promoted to top-level parameters")
+
+	if indexerConfig, ok := params["indexerConfig"].(map[string]interface{}); ok {
+		g.Expect(indexerConfig).NotTo(HaveKey("tokenProcessorConfig"), "tokenProcessorConfig must no longer be nested inside indexerConfig")
+		g.Expect(indexerConfig).NotTo(HaveKey("tokenizersPoolConfig"), "tokenizersPoolConfig is replaced by the standalone token-producer")
+	}
+}
+
 // TestSchedulerTransformMigratesLLMDAPIVersion verifies the version-gated
 // (>=0.9.0) EndpointPickerConfig apiVersion rewrite in isolation:
 //   - 0.9.0: inference.networking.x-k8s.io/v1alpha1 -> llm-d.ai/v1alpha1

--- a/pkg/controller/v1alpha2/llmisvc/tokenizer.go
+++ b/pkg/controller/v1alpha2/llmisvc/tokenizer.go
@@ -91,15 +91,42 @@ func isTokenizerEnabled(spec v1alpha2.LLMInferenceServiceSpec) bool {
 	return hasTokenProducerPlugin(spec) || hasPrecisePrefixCachePlugin(spec)
 }
 
+// inlineSchedulerConfigBytes returns the raw EndpointPickerConfig YAML/JSON for
+// this LLMInferenceService. The scheduler config can be supplied two ways:
+//
+//  1. spec.router.scheduler.config.inline — the dedicated, structured field.
+//  2. spec.router.scheduler.template.containers[].args — a user-authored pod
+//     template that embeds a literal "--config-text <yaml>" argument pair.
+//
+// Only "--config-text" (inline YAML) is supported for (2), not "--config-file"
+// (a path to a mounted file), since file contents aren't available at this point.
+func inlineSchedulerConfigBytes(spec v1alpha2.LLMInferenceServiceSpec) ([]byte, bool) {
+	if spec.Router == nil || spec.Router.Scheduler == nil {
+		return nil, false
+	}
+	if spec.Router.Scheduler.Config != nil && spec.Router.Scheduler.Config.Inline != nil {
+		return spec.Router.Scheduler.Config.Inline.Raw, true
+	}
+	if spec.Router.Scheduler.Template != nil {
+		if pair := configFlagFromContainers(spec.Router.Scheduler.Template.Containers); pair != nil {
+			if _, ok := inlineConfigTextFlags[pair[0]]; ok {
+				return []byte(pair[1]), true
+			}
+		}
+	}
+	return nil, false
+}
+
 // hasTokenProducerPlugin checks if the scheduler config contains the token-producer
 // plugin, which requires a standalone tokenizer deployment to serve tokenization
 // requests over HTTP (vLLM render endpoint).
 func hasTokenProducerPlugin(spec v1alpha2.LLMInferenceServiceSpec) bool {
-	if spec.Router == nil || spec.Router.Scheduler == nil || spec.Router.Scheduler.Config == nil || spec.Router.Scheduler.Config.Inline == nil {
+	raw, ok := inlineSchedulerConfigBytes(spec)
+	if !ok {
 		return false
 	}
 	u := unstructured.Unstructured{}
-	if err := yaml.Unmarshal(spec.Router.Scheduler.Config.Inline.Raw, &u.Object); err != nil {
+	if err := yaml.Unmarshal(raw, &u.Object); err != nil {
 		return false
 	}
 	return hasPluginType(u.Object, tokenProducerPlugin)
@@ -108,11 +135,12 @@ func hasTokenProducerPlugin(spec v1alpha2.LLMInferenceServiceSpec) bool {
 // hasPrecisePrefixCachePlugin checks if the scheduler config contains the legacy
 // precise-prefix-cache-scorer plugin (migration trigger).
 func hasPrecisePrefixCachePlugin(spec v1alpha2.LLMInferenceServiceSpec) bool {
-	if spec.Router == nil || spec.Router.Scheduler == nil || spec.Router.Scheduler.Config == nil || spec.Router.Scheduler.Config.Inline == nil {
+	raw, ok := inlineSchedulerConfigBytes(spec)
+	if !ok {
 		return false
 	}
 	u := unstructured.Unstructured{}
-	if err := yaml.Unmarshal(spec.Router.Scheduler.Config.Inline.Raw, &u.Object); err != nil {
+	if err := yaml.Unmarshal(raw, &u.Object); err != nil {
 		return false
 	}
 	return hasPluginType(u.Object, precisePrefixCacheScorerPlugin)

--- a/pkg/controller/v1alpha2/llmisvc/tokenizer_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/tokenizer_test.go
@@ -107,6 +107,99 @@ func TestIsTokenizerEnabled(t *testing.T) {
 			want: false,
 		},
 		{
+			// Config supplied via spec.router.scheduler.template.containers[].args
+			// (a literal "--config-text <yaml>" pair) rather than the dedicated
+			// spec.router.scheduler.config.inline field. Both are valid ways to
+			// configure the scheduler, and plugin detection must work for either.
+			name: "token-producer plugin present via template args, no config.inline set",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--config-text",
+										`{"plugins":[{"type":"token-producer"}]}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "legacy precise-prefix-cache-scorer present via template args, no config.inline set",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--config-text",
+										`{"plugins":[{"type":"precise-prefix-cache-scorer"}]}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "config.inline takes priority over template args when both are present",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Config: &v1alpha2.SchedulerConfigSpec{
+							Inline: &runtime.RawExtension{
+								Raw: []byte(`{"plugins":[{"type":"prefix-cache-scorer"}]}`),
+							},
+						},
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--config-text",
+										`{"plugins":[{"type":"token-producer"}]}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			// --config-file points at a mounted file whose contents aren't
+			// available at reconcile time, so it can't be inspected for
+			// plugin detection. This is a known, documented limitation.
+			name: "config-file flag in template args is not treated as inline plugin source",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-file", "/etc/epp/config.yaml"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "nil scheduler",
 			spec: v1alpha2.LLMInferenceServiceSpec{
 				Router: &v1alpha2.RouterSpec{},

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -764,6 +764,58 @@ LLMINFERENCESERVICE_CONFIGS = {
             },
         },
     },
+    # Same plugin config as "scheduler-with-precise-prefix-cache-inline-config"
+    # above, but supplied as literal YAML via
+    # spec.router.scheduler.template.containers[].args (a "--config-text
+    # <yaml>" pair) instead of spec.router.scheduler.config.inline.
+    "scheduler-with-precise-prefix-cache-template-args-config": {
+        "router": {
+            "scheduler": {
+                "template": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "args": [
+                                "--config-text",
+                                (
+                                    "apiVersion: llm-d.ai/v1alpha1\n"
+                                    "kind: EndpointPickerConfig\n"
+                                    "plugins:\n"
+                                    "- type: single-profile-handler\n"
+                                    "- type: precise-prefix-cache-scorer\n"
+                                    "  parameters:\n"
+                                    "    tokenProcessorConfig:\n"
+                                    "      blockSize: 16\n"
+                                    '      hashSeed: "42"\n'
+                                    "    kvEventsConfig:\n"
+                                    "      zmqEndpoint: tcp://*:5557\n"
+                                    "    indexerConfig:\n"
+                                    "      tokenizersPoolConfig:\n"
+                                    "        modelName: facebook/opt-125m\n"
+                                    "      kvBlockIndexConfig:\n"
+                                    "        enableMetrics: true\n"
+                                    "        metricsLoggingInterval: 60000000000\n"
+                                    "- type: queue-scorer\n"
+                                    "- type: kv-cache-utilization-scorer\n"
+                                    "- type: max-score-picker\n"
+                                    "schedulingProfiles:\n"
+                                    "- name: default\n"
+                                    "  plugins:\n"
+                                    "  - pluginRef: queue-scorer\n"
+                                    "    weight: 2\n"
+                                    "  - pluginRef: kv-cache-utilization-scorer\n"
+                                    "    weight: 2\n"
+                                    "  - pluginRef: precise-prefix-cache-scorer\n"
+                                    "    weight: 3\n"
+                                    "  - pluginRef: max-score-picker\n"
+                                ),
+                            ],
+                        }
+                    ],
+                },
+            },
+        },
+    },
     # Clean-path: token-producer in inline config triggers standalone tokenizer
     # deployment automatically. The controller injects modelName and vllm.url
     # into the token-producer plugin parameters.

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -629,6 +629,25 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 pytest.mark.llmd_simulator,
             ],
         ),
+        # Same migration path, but with the legacy plugin config supplied via
+        # spec.router.scheduler.template.containers[].args instead of
+        # spec.router.scheduler.config.inline.
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-with-precise-prefix-cache-template-args-config",
+                    "workload-llmd-simulator-kvcache",
+                ],
+                prompt="KServe is a",
+                service_name="tokenizer-migration-path-template-args-test",
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+        ),
         # Models endpoint coverage
         pytest.param(
             TestCase(


### PR DESCRIPTION
## Summary
- `isTokenizerEnabled`, `hasTokenProducerPlugin`, and `hasPrecisePrefixCachePlugin` only looked at `spec.router.scheduler.config.inline` to detect scheduler plugins, so configs supplied instead via `spec.router.scheduler.template.containers[].args` (a literal `--config-text <yaml>` pair) were never inspected.
- As a result, services using the template-args form never got the standalone tokenizer/latency-predictor presets attached, and the legacy `precise-prefix-cache-scorer` plugin never went through the `>=0.9.0` decompose migration — leaving stale configs (e.g. `tokenProcessorConfig` nested under `indexerConfig`) that newer `llm-d-router` builds reject at startup.
- Added `inlineSchedulerConfigBytes` to read the raw `EndpointPickerConfig` from either source, and wired it into all three detection helpers so both configuration mechanisms behave consistently.

## Test plan
- [x] `TestIsTokenizerEnabled` — new cases for token-producer/precise-prefix-cache-scorer detection via template args, `config.inline` taking priority over template args when both are set, and confirming `--config-file` is correctly *not* treated as an inline plugin source.
- [x] `TestSchedulerTransformDecomposesPrecisePrefixCacheFromTemplateArgs` — end-to-end check that `schedulerTransform` fully decomposes the legacy plugin and migrates the `apiVersion` when the config arrives via template args.
- [x] New e2e test `tokenizer-migration-path-template-args-test` (mirrors the existing `tokenizer-migration-path-test`) exercising the same migration against a real cluster with the config supplied via `template.containers[].args`.