### PR TITLE
fix(reconcilers): set owner refs inside RawKubeReconciler.Reconcile

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -157,28 +157,15 @@ func handleInferenceGraphRawDeployment(ctx context.Context, cl client.Client, cl
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "fails to create NewRawKubeReconciler for inference graph")
 	}
-	// set Deployment Controller
-	if err := reconciler.Workload.SetControllerReferences(graph, scheme); err != nil {
-		return nil, reconciler.URL, errors.Wrapf(err, "fails to set deployment owner reference for inference graph")
-	}
-	// set Service Controller
-	if err := reconciler.Service.SetControllerReferences(graph, scheme); err != nil {
-		return nil, reconciler.URL, errors.Wrapf(err, "fails to set service owner reference for inference graph")
-	}
-
-	// set autoscaler Controller
-	if err := reconciler.Scaler.Autoscaler.SetControllerReferences(graph, scheme); err != nil {
-		return nil, reconciler.URL, errors.Wrapf(err, "fails to set autoscaler owner references for inference graph")
-	}
-
 	// reconcile
-	deployment, err := reconciler.Reconcile(ctx)
-	logger.Info("Result of inference graph raw reconcile", "deployment", deployment[0]) // only 1 deployment exist (default deployment)
-	logger.Info("Result of reconcile", "err", err)
-
+	deployment, err := reconciler.Reconcile(ctx, graph)
 	if err != nil {
-		return deployment[0], reconciler.URL, errors.Wrapf(err, "fails to reconcile inference graph raw")
+		return nil, reconciler.URL, errors.Wrapf(err, "fails to reconcile inference graph raw")
 	}
+	if len(deployment) == 0 {
+		return nil, reconciler.URL, errors.New("no deployment returned from inference graph raw reconcile")
+	}
+	logger.Info("Result of inference graph raw reconcile", "deployment", deployment[0]) // only 1 deployment exist (default deployment)
 
 	return deployment[0], reconciler.URL, nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/canary_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/canary_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -365,6 +366,44 @@ var _ = Describe("Canary deployment controller", func() {
 				}
 				return *deploy.Spec.Replicas
 			}, timeout, interval).Should(Equal(int32(1)))
+		})
+	})
+
+	Context("When the canary uses an HPA autoscaler", func() {
+		It("Should set an owner reference on the canary HPA so it is garbage-collected with the ISVC", func() {
+			configMap := createInferenceServiceConfigMap(configs)
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			servingRuntime := getServingRuntime("tf-canary-hpa", "default")
+			Expect(k8sClient.Create(context.TODO(), &servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), &servingRuntime)
+
+			serviceName := "canary-hpa-test"
+			ctx := context.Background()
+
+			isvc := makeCanaryISVC(serviceName, "default", "s3://test/model-v1", 4,
+				[]v1beta1.CanarySpec{makeCanary("v2", 25, "s3://test/model-v2")})
+			// Use the HPA autoscaler class so an HPA is actually created for the canary.
+			isvc.Annotations = getDefaultAnnotations(constants.AutoscalerClassHPA)
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			canaryHPAKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceName, "v2"), Namespace: "default"}
+
+			// Wait for the canary HPA to be created.
+			actualHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, canaryHPAKey, actualHPA)
+			}, timeout, interval).Should(Succeed())
+
+			// The canary HPA must be owned by the InferenceService; otherwise it is
+			// orphaned and never garbage-collected when the ISVC is deleted.
+			controllerRef := metav1.GetControllerOf(actualHPA)
+			Expect(controllerRef).NotTo(BeNil(), "canary HPA has no controller owner reference (orphaned)")
+			Expect(controllerRef.Kind).To(Equal("InferenceService"))
+			Expect(controllerRef.Name).To(Equal(serviceName))
 		})
 	})
 

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -191,21 +191,7 @@ func (e *Explainer) reconcileExplainerRawDeployment(ctx context.Context, isvc *v
 	if err != nil {
 		return errors.Wrapf(err, "fails to create NewRawKubeReconciler for explainer")
 	}
-	// set Workload Controller
-	if err := r.Workload.SetControllerReferences(isvc, e.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set workload owner reference for explainer")
-	}
-
-	// set Service Controller
-	if err := r.Service.SetControllerReferences(isvc, e.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set service owner reference for explainer")
-	}
-	// set autoscaler Controller
-	if err := r.Scaler.Autoscaler.SetControllerReferences(isvc, e.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set autoscaler owner references for explainer")
-	}
-
-	deployment, err := r.Reconcile(ctx)
+	deployment, err := r.Reconcile(ctx, isvc)
 	if err != nil {
 		return errors.Wrapf(err, "fails to reconcile explainer")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -808,27 +808,7 @@ func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.In
 		return errors.Wrapf(err, "fails to create NewRawKubeReconciler for predictor")
 	}
 
-	// set Workload Controller
-	if err := r.Workload.SetControllerReferences(isvc, p.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set workload owner reference for predictor")
-	}
-
-	// set Service Controller
-	if err := r.Service.SetControllerReferences(isvc, p.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set service owner reference for predictor")
-	}
-	// set Otel Controller
-	if r.OtelCollector != nil {
-		if err := r.OtelCollector.SetControllerReferences(isvc, p.scheme); err != nil {
-			return errors.Wrapf(err, "fails to set otel owner references for predictor")
-		}
-	}
-	// set autoscaler Controller
-	if err := r.Scaler.Autoscaler.SetControllerReferences(isvc, p.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set autoscaler owner references for predictor")
-	}
-
-	deploymentList, err := r.Reconcile(ctx)
+	deploymentList, err := r.Reconcile(ctx, isvc)
 	if err != nil {
 		return errors.Wrapf(err, "fails to reconcile predictor")
 	}
@@ -943,14 +923,7 @@ func (p *Predictor) reconcileCanaryDeployments(ctx context.Context, isvc *v1beta
 			return errors.Wrapf(err, "fails to create canary reconciler for %s", canary.Predictor.Name)
 		}
 
-		if err := r.Workload.SetControllerReferences(isvc, p.scheme); err != nil {
-			return errors.Wrapf(err, "fails to set canary workload owner reference for %s", canary.Predictor.Name)
-		}
-		if err := r.Service.SetControllerReferences(isvc, p.scheme); err != nil {
-			return errors.Wrapf(err, "fails to set canary service owner reference for %s", canary.Predictor.Name)
-		}
-
-		if _, err := r.Reconcile(ctx); err != nil {
+		if _, err := r.Reconcile(ctx, isvc); err != nil {
 			return errors.Wrapf(err, "fails to reconcile canary %s", canary.Predictor.Name)
 		}
 		p.Log.Info("Reconciled canary deployment", "canary", canary.Predictor.Name, "trafficPercent", canary.TrafficPercent)

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -227,21 +227,7 @@ func (p *Transformer) reconcileTransformerRawDeployment(ctx context.Context, isv
 	if err != nil {
 		return errors.Wrapf(err, "fails to create NewRawKubeReconciler for transformer")
 	}
-	// set Workload Controller
-	if err := r.Workload.SetControllerReferences(isvc, p.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set workload owner reference for transformer")
-	}
-
-	// set Service Controller
-	if err := r.Service.SetControllerReferences(isvc, p.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set service owner reference for transformer")
-	}
-	// set autoscaler Controller
-	if err := r.Scaler.Autoscaler.SetControllerReferences(isvc, p.scheme); err != nil {
-		return errors.Wrapf(err, "fails to set autoscaler owner references for transformer")
-	}
-
-	deployment, err := r.Reconcile(ctx)
+	deployment, err := r.Reconcile(ctx, isvc)
 	if err != nil {
 		return errors.Wrapf(err, "fails to reconcile transformer")
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -18,6 +18,7 @@ package raw
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -234,8 +235,32 @@ func createRawURL(ingressConfig *v1beta1.IngressConfig, metadata metav1.ObjectMe
 	return url, nil
 }
 
-// Reconcile ...
-func (r *RawKubeReconciler) Reconcile(ctx context.Context) ([]*appsv1.Deployment, error) {
+// Reconcile stamps owner references (with owner as the controller) on every
+// desired resource and then applies them. Setting refs here rather than in each
+// caller means a component can never accidentally create an orphaned resource.
+func (r *RawKubeReconciler) Reconcile(ctx context.Context, owner metav1.Object) ([]*appsv1.Deployment, error) {
+	// Set owner references on all desired objects before applying them, so nothing
+	// is orphaned if a caller forgets a separate call. Each sub-reconciler stamps
+	// refs on its own resource type (Deployment/Rollout CR, Service, HPA, ...), so
+	// this stays polymorphic across workload types.
+	if owner == nil {
+		return nil, errors.New("owner must not be nil: raw resources would be created orphaned")
+	}
+	if err := r.Service.SetControllerReferences(owner, r.scheme); err != nil {
+		return nil, fmt.Errorf("fails to set service owner reference: %w", err)
+	}
+	if r.OtelCollector != nil {
+		if err := r.OtelCollector.SetControllerReferences(owner, r.scheme); err != nil {
+			return nil, fmt.Errorf("fails to set otel owner reference: %w", err)
+		}
+	}
+	if err := r.Workload.SetControllerReferences(owner, r.scheme); err != nil {
+		return nil, fmt.Errorf("fails to set workload owner reference: %w", err)
+	}
+	if err := r.Scaler.Autoscaler.SetControllerReferences(owner, r.scheme); err != nil {
+		return nil, fmt.Errorf("fails to set autoscaler owner reference: %w", err)
+	}
+
 	// reconcile Service first to avoid transient pod startup delays when
 	// platform-specific service annotations (e.g. serving-cert) trigger
 	// secret creation that the deployment's pods mount.


### PR DESCRIPTION
**What this PR does / why we need it**:

Owner-reference setting for raw-deployment resources was a separate call each component made before `RawKubeReconciler.Reconcile`. Over time the callers drifted apart: canary never set the autoscaler ref, and transformer/explainer never set the OTel ref, so those resources were created orphaned and never garbage-collected with the InferenceService.

This moves `SetControllerReferences` into `Reconcile(ctx, owner)`. Each sub-reconciler still stamps refs on its own resource type, so it stays polymorphic for alternative workload reconcilers (e.g. Argo Rollouts). Callers just pass the owner, so the orphan footgun is gone, and a nil owner is rejected instead of creating orphaned resources. Also guards the inference-graph raw reconcile against indexing an empty deployment slice on error.

This pr help the gap of  this old pr: https://github.com/kserve/kserve/pull/4922

**Which issue(s) this PR fixes**:
NONE

**Feature/Issue validation/testing**:

- [x] New canary HPA owner-reference envtest — fails (orphaned HPA) before the change, passes after
- [x] Full `inferenceservice` and `inferencegraph` envtest suites pass
- [x] `make precommit` passes

**Special notes for your reviewer**:

A follow-up PR adds per-caller owner-reference regression tests (transformer OTel collector, predictor, explainer, inference graph). It is kept separate to keep this PR focused on the fix.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
Fix raw-deployment HPA and OpenTelemetry collector being created without an owner reference for canary/transformer/explainer components, which left them orphaned when the InferenceService was deleted.
```