### PR TITLE
fix(llmisvc): detect latency-producer plugin from template args

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_latency_predictor_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_latency_predictor_int_test.go
@@ -73,6 +73,48 @@ var _ = Describe("LLMInferenceService Controller — Latency Predictor", func() 
 		})
 	})
 
+	Context("When predicted-latency-producer plugin is declared via template.containers[].args", func() {
+		It("should inject training and prediction sidecar containers into the scheduler deployment", func(ctx SpecContext) {
+			svcName := "test-llm-lp-sidecars-template-args"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigTemplateArgs(`plugins:
+- type: predicted-latency-producer
+- type: latency-scorer
+- type: weighted-random-picker
+`),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				deployments := &appsv1.DeploymentList{}
+				g.Expect(envTest.Client.List(ctx, deployments, &client.ListOptions{
+					Namespace:     testNs.Name,
+					LabelSelector: labels.SelectorFromSet(llmisvc.SchedulerLabels(llmSvc)),
+				})).To(Succeed())
+				g.Expect(deployments.Items).To(HaveLen(1))
+
+				dep := deployments.Items[0]
+				containerNames := make([]string, len(dep.Spec.Template.Spec.Containers))
+				for i, c := range dep.Spec.Template.Spec.Containers {
+					containerNames[i] = c.Name
+				}
+				g.Expect(containerNames).To(ContainElement("training-server"))
+				g.Expect(containerNames).To(ContainElement("prediction-server"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
 	Context("When predicted-latency-producer plugin is NOT in the scheduler config", func() {
 		It("should not inject sidecar containers", func(ctx SpecContext) {
 			svcName := "test-llm-no-lp"

--- a/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
@@ -570,6 +570,23 @@ func WithSchedulerConfigInline(configYAML string) LLMInferenceServiceOption {
 	}
 }
 
+// WithSchedulerConfigTemplateArgs sets the scheduler config as a --config-text
+// argument on the "main" container of the scheduler pod template, instead of
+// spec.router.scheduler.config.inline.
+func WithSchedulerConfigTemplateArgs(configYAML string) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		ensureSchedulerSpec(&llmSvc.Spec)
+		llmSvc.Spec.Router.Scheduler.Template = &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Args: []string{"--config-text", configYAML},
+				},
+			},
+		}
+	}
+}
+
 // WithSchedulerConfigRef sets a ConfigMap reference for scheduler config.
 // If key is empty, it defaults to "epp" at runtime.
 func WithSchedulerConfigRef(configMapName, key string) LLMInferenceServiceOption {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor.go
@@ -27,18 +27,21 @@ const (
 	predictedLatencyProducerPlugin = "predicted-latency-producer"
 )
 
-// hasLatencyProducerInSpec checks the LLMInferenceService spec's inline config.
-// NOTE: This only checks Config.Inline, not Config.Ref (ConfigMap-based config).
-// The ConfigMap Ref is resolved later in expectedSchedulerDeployment, after
+// hasLatencyProducerInSpec checks the LLMInferenceService spec's scheduler config,
+// supplied via either Config.Inline or a --config-text pair in
+// Template.Containers[].Args (see inlineSchedulerConfigBytes).
+// NOTE: This does not check Config.Ref (ConfigMap-based config). The ConfigMap
+// Ref is resolved later in expectedSchedulerDeployment, after
 // combineBaseRefsConfig has already run. If the plugin is specified via Ref,
 // the well-known config will not be auto-injected. This is a known limitation;
 // all llm-d guides and examples use Config.Inline.
 func hasLatencyProducerInSpec(spec v1alpha2.LLMInferenceServiceSpec) bool {
-	if spec.Router == nil || spec.Router.Scheduler == nil || spec.Router.Scheduler.Config == nil || spec.Router.Scheduler.Config.Inline == nil {
+	raw, ok := inlineSchedulerConfigBytes(spec)
+	if !ok {
 		return false
 	}
 	u := unstructured.Unstructured{}
-	if err := yaml.Unmarshal(spec.Router.Scheduler.Config.Inline.Raw, &u.Object); err != nil {
+	if err := yaml.Unmarshal(raw, &u.Object); err != nil {
 		return false
 	}
 	return hasPluginType(u.Object, predictedLatencyProducerPlugin)

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -81,6 +82,81 @@ func TestHasLatencyProducerInSpec(t *testing.T) {
 				Router: &v1alpha2.RouterSpec{
 					Scheduler: &v1alpha2.SchedulerSpec{
 						Config: &v1alpha2.SchedulerConfigSpec{},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "plugin supplied via template args, no config.inline set",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-text", latencyProducerConfig},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no plugin via template args",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-text", noLatencyConfig},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "config.inline takes priority over template args when both are present",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Config: &v1alpha2.SchedulerConfigSpec{
+							Inline: &runtime.RawExtension{Raw: []byte(noLatencyConfig)},
+						},
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-text", latencyProducerConfig},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "config-file flag in template args is not treated as inline plugin source",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-file", "/etc/epp/config.yaml"},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -640,7 +640,7 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                     "workload-llmd-simulator-kvcache",
                 ],
                 prompt="KServe is a",
-                service_name="tokenizer-migration-path-template-args-test",
+                service_name="tokenizer-template-args-test",
             ),
             marks=[
                 pytest.mark.cluster_cpu,


### PR DESCRIPTION
## Summary
- `hasLatencyProducerInSpec` only checked `spec.router.scheduler.config.inline`, so the `predicted-latency-producer` plugin supplied instead via `spec.router.scheduler.template.containers[].args` (a `--config-text` pair) was never detected — same blind spot already fixed for tokenizer detection in #5931.
- Reused the existing `inlineSchedulerConfigBytes` helper so `hasLatencyProducerInSpec` reads the scheduler config from either source, ensuring the latency predictor well-known config is attached consistently regardless of which mechanism supplies the plugin config.
- Fixed the `tokenizer-migration-path-template-args-test` e2e test: its service name combined with the `-kserve-router-scheduler` suffix exceeded Kubernetes' 63-char name limit, causing `kmeta.ChildName` to hash-truncate the actual scheduler Deployment name. The test's own lookup guessed the untruncated name and 404'd, even though the underlying fix worked correctly end-to-end (confirmed via CI logs: config was decomposed, tokenizer deployed, service reached `Ready=True` with a working inference response). Shortened the name to stay well under the limit.

## Test plan
- [x] `TestHasLatencyProducerInSpec` — new cases for plugin detection via template args, `config.inline` taking priority over template args when both are set, and confirming `--config-file` is correctly not treated as an inline plugin source.
- [x] `go build` / `go vet` pass for the `llmisvc` package.
- [x] e2e: `tokenizer-template-args-test` service name now fits within the 63-char Kubernetes name limit after appending `-kserve-router-scheduler`, so `assert_tokenizer_pipeline_wired`'s deployment lookup will match the actual (non-truncated) Deployment name.