### PR TITLE
fix(llmisvc): close v1alpha1 validation gaps for LoRA and DRA annotations

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_validation.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_validation.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/utils"
+	kservevalidation "github.com/kserve/kserve/pkg/validation"
 )
 
 // +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha1-llminferenceservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceservices,verbs=create;update,versions=v1alpha1,name=llminferenceservice.kserve-webhook-server.v1alpha1.validator,admissionReviewVersions=v1
@@ -93,6 +94,8 @@ func (l *LLMInferenceServiceValidator) validate(ctx context.Context, prev *LLMIn
 	allErrs = append(allErrs, l.validateParallelismConstraints(llmSvc)...)
 	allErrs = append(allErrs, l.validateSchedulerConfig(llmSvc)...)
 	allErrs = append(allErrs, l.validateScaling(llmSvc)...)
+	allErrs = append(allErrs, l.validateLoRAAdapters(llmSvc)...)
+	allErrs = append(allErrs, kservevalidation.ValidateManagedDRAAnnotations(llmSvc.GetAnnotations())...)
 	allErrs = append(allErrs, l.validateImmutable(prev, llmSvc)...)
 
 	if len(allErrs) == 0 {
@@ -373,6 +376,16 @@ func (l *LLMInferenceServiceValidator) validateWorkloadScaling(basePath *field.P
 	// the scaling rules live in exactly one place.
 	w := convertWorkloadSpecToV1Alpha2(workload)
 	return v1alpha2.ValidateWorkloadScaling(basePath, &w)
+}
+
+func (l *LLMInferenceServiceValidator) validateLoRAAdapters(llmSvc *LLMInferenceService) field.ErrorList {
+	if llmSvc.Spec.Model.LoRA == nil {
+		return nil
+	}
+	// Convert to the hub (v1alpha2) type and delegate to its exported validator so
+	// the LoRA rules live in exactly one place.
+	hub := convertLoRASpecToV1Alpha2(llmSvc.Spec.Model.LoRA)
+	return v1alpha2.ValidateLoRAAdapters(hub, ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.Name), field.NewPath("spec", "model", "lora"))
 }
 
 // immutable returns a *Error indicating "unsupported mutation".

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 func newBaseLLMInferenceService() *LLMInferenceService {
@@ -831,6 +833,180 @@ func TestValidateTrafficFields_V1Alpha1(t *testing.T) {
 				}
 			} else {
 				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func TestValidateLoRAAdapters_V1Alpha1(t *testing.T) {
+	validator := &LLMInferenceServiceValidator{}
+
+	makeAdapter := func(name, uri string) LLMModelSpec {
+		return LLMModelSpec{URI: apis.URL{Scheme: "hf", Host: uri}, Name: ptr.To(name)}
+	}
+
+	makeSvc := func(modelName string, loraSpec *LoRASpec) *LLMInferenceService {
+		svc := newBaseLLMInferenceService()
+		svc.Spec.Model.Name = ptr.To(modelName)
+		svc.Spec.Model.LoRA = loraSpec
+		return svc
+	}
+
+	tests := []struct {
+		name           string
+		svc            *LLMInferenceService
+		wantErrCount   int
+		wantErrStrings []string
+	}{
+		{
+			name:         "no lora",
+			svc:          makeSvc("base", nil),
+			wantErrCount: 0,
+		},
+		{
+			name: "valid single adapter",
+			svc: makeSvc("base", &LoRASpec{
+				Adapters: []LLMModelSpec{makeAdapter("adapter-1", "adapter-1")},
+			}),
+			wantErrCount: 0,
+		},
+		{
+			name: "adapter name missing",
+			svc: makeSvc("base", &LoRASpec{
+				Adapters: []LLMModelSpec{{URI: apis.URL{Scheme: "hf", Host: "adapter-1"}}},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"spec.model.lora.adapters[0].name"},
+		},
+		{
+			name: "path traversal rejected",
+			svc: makeSvc("base", &LoRASpec{
+				Adapters: []LLMModelSpec{makeAdapter("..", "adapter-dotdot")},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"path traversal"},
+		},
+		{
+			name: "duplicate adapter names",
+			svc: makeSvc("base", &LoRASpec{
+				Adapters: []LLMModelSpec{
+					makeAdapter("dup", "adapter-1"),
+					makeAdapter("dup", "adapter-2"),
+				},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"duplicate"},
+		},
+		{
+			name: "adapter name same as base model",
+			svc: makeSvc("base-model", &LoRASpec{
+				Adapters: []LLMModelSpec{makeAdapter("base-model", "adapter-1")},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"adapter name must differ from base model name"},
+		},
+		{
+			name: "maxRank zero invalid",
+			svc: makeSvc("base", &LoRASpec{
+				MaxRank:  ptr.To(int32(0)),
+				Adapters: []LLMModelSpec{makeAdapter("a", "a")},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"maxRank"},
+		},
+		{
+			name: "all lora params valid",
+			svc: makeSvc("base", &LoRASpec{
+				MaxRank:        ptr.To(int32(128)),
+				MaxAdapters:    ptr.To(int32(4)),
+				MaxCpuAdapters: ptr.To(int32(8)),
+				Adapters: []LLMModelSpec{
+					makeAdapter("adapter-1", "adapter-1"),
+					makeAdapter("adapter-2", "adapter-2"),
+				},
+			}),
+			wantErrCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.validateLoRAAdapters(tt.svc)
+			assert.Len(t, errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
+			for _, wantStr := range tt.wantErrStrings {
+				found := false
+				for _, e := range errs {
+					if strings.Contains(e.Error(), wantStr) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected error containing %q, got: %v", wantStr, errs)
+			}
+		})
+	}
+}
+
+func TestValidateManagedDRAAnnotations_V1Alpha1(t *testing.T) {
+	validator := &LLMInferenceServiceValidator{}
+
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantErrCount int
+		wantErrField string
+	}{
+		{
+			name:         "no DRA annotations",
+			annotations:  nil,
+			wantErrCount: 0,
+		},
+		{
+			name: "valid: device class only",
+			annotations: map[string]string{
+				constants.ManagedDRADeviceClassAnnotationKey: "gpu.nvidia.com",
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "invalid: device count without device class",
+			annotations: map[string]string{
+				constants.ManagedDRADeviceCountAnnotationKey: "2",
+			},
+			wantErrCount: 1,
+			wantErrField: constants.ManagedDRADeviceClassAnnotationKey,
+		},
+		{
+			name: "invalid: empty device class",
+			annotations: map[string]string{
+				constants.ManagedDRADeviceClassAnnotationKey: "   ",
+			},
+			wantErrCount: 1,
+			wantErrField: constants.ManagedDRADeviceClassAnnotationKey,
+		},
+		{
+			name: "invalid: non-numeric device count",
+			annotations: map[string]string{
+				constants.ManagedDRADeviceClassAnnotationKey: "gpu.nvidia.com",
+				constants.ManagedDRADeviceCountAnnotationKey: "abc",
+			},
+			wantErrCount: 1,
+			wantErrField: constants.ManagedDRADeviceCountAnnotationKey,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newBaseLLMInferenceService()
+			svc.Annotations = tt.annotations
+
+			// Exercise the full validate() path to ensure DRA validation is wired in.
+			err := validator.validate(t.Context(), nil, svc)
+			if tt.wantErrCount == 0 {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrField)
 			}
 		})
 	}

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types_func.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types_func.go
@@ -17,14 +17,10 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
 
-	"github.com/kserve/kserve/pkg/constants"
+	kservevalidation "github.com/kserve/kserve/pkg/validation"
 )
 
 func (s *SchedulerSpec) InferencePoolName(llmSvc *LLMInferenceService) string {
@@ -162,8 +158,7 @@ func (s *LLMInferenceService) HasManagedDRA() bool {
 	if s == nil {
 		return false
 	}
-	_, ok := s.Annotations[constants.ManagedDRADeviceClassAnnotationKey]
-	return ok
+	return kservevalidation.HasManagedDRA(s.Annotations)
 }
 
 // ManagedDRADeviceClass returns the trimmed device-class annotation value and
@@ -172,11 +167,7 @@ func (s *LLMInferenceService) ManagedDRADeviceClass() (string, bool) {
 	if s == nil {
 		return "", false
 	}
-	raw, ok := s.Annotations[constants.ManagedDRADeviceClassAnnotationKey]
-	if !ok {
-		return "", false
-	}
-	return strings.TrimSpace(raw), true
+	return kservevalidation.ManagedDRADeviceClass(s.Annotations)
 }
 
 // ManagedDRADeviceCount returns the requested device count, defaulting to 1.
@@ -184,18 +175,7 @@ func (s *LLMInferenceService) ManagedDRADeviceCount() (int, error) {
 	if s == nil {
 		return 1, nil
 	}
-	raw, ok := s.Annotations[constants.ManagedDRADeviceCountAnnotationKey]
-	if !ok || strings.TrimSpace(raw) == "" {
-		return 1, nil
-	}
-	count, err := strconv.Atoi(strings.TrimSpace(raw))
-	if err != nil {
-		return 0, fmt.Errorf("invalid %s value %q: %w", constants.ManagedDRADeviceCountAnnotationKey, raw, err)
-	}
-	if count < 1 {
-		return 0, fmt.Errorf("invalid %s value %q: must be >= 1", constants.ManagedDRADeviceCountAnnotationKey, raw)
-	}
-	return count, nil
+	return kservevalidation.ManagedDRADeviceCount(s.Annotations)
 }
 
 // ManagedDRACelSelectors returns the newline-separated CEL expressions, with
@@ -204,18 +184,7 @@ func (s *LLMInferenceService) ManagedDRACelSelectors() []string {
 	if s == nil {
 		return nil
 	}
-	raw, ok := s.Annotations[constants.ManagedDRACelSelectorAnnotationKey]
-	if !ok || strings.TrimSpace(raw) == "" {
-		return nil
-	}
-	parts := strings.Split(raw, "\n")
-	selectors := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if v := strings.TrimSpace(p); v != "" {
-			selectors = append(selectors, v)
-		}
-	}
-	return selectors
+	return kservevalidation.ManagedDRACelSelectors(s.Annotations)
 }
 
 // ManagedDRAContainerName returns the trimmed container-name annotation value
@@ -224,9 +193,5 @@ func (s *LLMInferenceService) ManagedDRAContainerName() (string, bool) {
 	if s == nil {
 		return "", false
 	}
-	raw, ok := s.Annotations[constants.ManagedDRAContainerNameAnnotationKey]
-	if !ok {
-		return "", false
-	}
-	return strings.TrimSpace(raw), true
+	return kservevalidation.ManagedDRAContainerName(s.Annotations)
 }

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_validation.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_validation.go
@@ -22,13 +22,11 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
-	"strings"
 
 	"k8s.io/utils/ptr"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/utils"
 	kservevalidation "github.com/kserve/kserve/pkg/validation"
 )
@@ -418,14 +415,18 @@ func (l *LLMInferenceServiceValidator) validateSchedulerConfig(svc *LLMInference
 }
 
 func (l *LLMInferenceServiceValidator) validateLoRAAdapters(llmSvc *LLMInferenceService) field.ErrorList {
+	return ValidateLoRAAdapters(llmSvc.Spec.Model.LoRA, ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.Name), field.NewPath("spec", "model", "lora"))
+}
+
+// ValidateLoRAAdapters validates a LoRA spec: numeric bounds, adapter name
+// uniqueness, path traversal, and base-model collision. It is exported so
+// v1alpha1 can convert its spoke type and call the same logic.
+func ValidateLoRAAdapters(loraSpec *LoRASpec, baseModelName string, loraPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if llmSvc.Spec.Model.LoRA == nil {
+	if loraSpec == nil {
 		return allErrs
 	}
-
-	loraPath := field.NewPath("spec").Child("model", "lora")
-	loraSpec := llmSvc.Spec.Model.LoRA
 
 	if loraSpec.MaxRank != nil && *loraSpec.MaxRank < 1 {
 		allErrs = append(allErrs, field.Invalid(loraPath.Child("maxRank"), *loraSpec.MaxRank, "maxRank must be at least 1"))
@@ -437,15 +438,14 @@ func (l *LLMInferenceServiceValidator) validateLoRAAdapters(llmSvc *LLMInference
 		allErrs = append(allErrs, field.Invalid(loraPath.Child("maxCpuAdapters"), *loraSpec.MaxCpuAdapters, "maxCpuAdapters must be at least 1"))
 	}
 
-	if len(llmSvc.Spec.Model.LoRA.Adapters) == 0 {
+	if len(loraSpec.Adapters) == 0 {
 		return allErrs
 	}
 
 	adaptersPath := loraPath.Child("adapters")
-	baseModelName := ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.Name)
-	seen := make(map[string]int, len(llmSvc.Spec.Model.LoRA.Adapters))
+	seen := make(map[string]int, len(loraSpec.Adapters))
 
-	for i, adapter := range llmSvc.Spec.Model.LoRA.Adapters {
+	for i, adapter := range loraSpec.Adapters {
 		namePath := adaptersPath.Index(i).Child("name")
 
 		if adapter.Name == nil || *adapter.Name == "" {
@@ -678,84 +678,7 @@ func immutableField(path *field.Path, value interface{}, detail string) *field.E
 // validateManagedDRAAnnotations performs admission-time validation of the
 // serving.kserve.io/exp-dra-* annotations to catch user mistakes early.
 func (l *LLMInferenceServiceValidator) validateManagedDRAAnnotations(llmSvc *LLMInferenceService) field.ErrorList {
-	var allErrs field.ErrorList
-	annotations := llmSvc.GetAnnotations()
-	if len(annotations) == 0 {
-		return allErrs
-	}
-
-	annotationsPath := field.NewPath("metadata").Child("annotations")
-
-	hasDeviceClass := llmSvc.HasManagedDRA()
-	_, hasDeviceCount := annotations[constants.ManagedDRADeviceCountAnnotationKey]
-	_, hasCelSelector := annotations[constants.ManagedDRACelSelectorAnnotationKey]
-	_, hasContainerName := annotations[constants.ManagedDRAContainerNameAnnotationKey]
-
-	// Require device-class if any other DRA annotation is set.
-	if !hasDeviceClass && (hasDeviceCount || hasCelSelector || hasContainerName) {
-		allErrs = append(allErrs, field.Required(
-			annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
-			fmt.Sprintf("%s is required to enable managed DRA when %s, %s, or %s is set",
-				constants.ManagedDRADeviceClassAnnotationKey,
-				constants.ManagedDRADeviceCountAnnotationKey,
-				constants.ManagedDRACelSelectorAnnotationKey,
-				constants.ManagedDRAContainerNameAnnotationKey),
-		))
-	}
-
-	if trimmed, present := llmSvc.ManagedDRADeviceClass(); present {
-		raw := annotations[constants.ManagedDRADeviceClassAnnotationKey]
-		if trimmed == "" {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
-				raw,
-				"device class must not be empty",
-			))
-		} else if errs := validation.IsDNS1123Subdomain(trimmed); len(errs) > 0 {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
-				raw,
-				"device class must be a DNS subdomain: "+strings.Join(errs, "; "),
-			))
-		}
-	}
-
-	if hasDeviceCount {
-		if _, err := llmSvc.ManagedDRADeviceCount(); err != nil {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRADeviceCountAnnotationKey),
-				annotations[constants.ManagedDRADeviceCountAnnotationKey],
-				err.Error(),
-			))
-		}
-	}
-
-	if hasCelSelector && len(llmSvc.ManagedDRACelSelectors()) == 0 {
-		allErrs = append(allErrs, field.Invalid(
-			annotationsPath.Key(constants.ManagedDRACelSelectorAnnotationKey),
-			annotations[constants.ManagedDRACelSelectorAnnotationKey],
-			"cel selector must contain at least one non-empty CEL expression",
-		))
-	}
-
-	if trimmed, present := llmSvc.ManagedDRAContainerName(); present {
-		raw := annotations[constants.ManagedDRAContainerNameAnnotationKey]
-		if trimmed == "" {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRAContainerNameAnnotationKey),
-				raw,
-				"container name must not be empty",
-			))
-		} else if errs := validation.IsDNS1123Label(trimmed); len(errs) > 0 {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRAContainerNameAnnotationKey),
-				raw,
-				"container name must be a DNS label: "+strings.Join(errs, "; "),
-			))
-		}
-	}
-
-	return allErrs
+	return kservevalidation.ValidateManagedDRAAnnotations(llmSvc.GetAnnotations())
 }
 
 // validateKVCacheOffloading validates KVCacheOffloading secondary tier specs.

--- a/pkg/validation/managed_dra.go
+++ b/pkg/validation/managed_dra.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// HasManagedDRA reports whether the annotations contain the managed DRA device class key.
+func HasManagedDRA(annotations map[string]string) bool {
+	_, ok := annotations[constants.ManagedDRADeviceClassAnnotationKey]
+	return ok
+}
+
+// ManagedDRADeviceClass returns the trimmed device class and whether it was present.
+func ManagedDRADeviceClass(annotations map[string]string) (string, bool) {
+	raw, ok := annotations[constants.ManagedDRADeviceClassAnnotationKey]
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(raw), true
+}
+
+// ManagedDRADeviceCount parses the device count annotation, defaulting to 1.
+func ManagedDRADeviceCount(annotations map[string]string) (int, error) {
+	raw, ok := annotations[constants.ManagedDRADeviceCountAnnotationKey]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return 1, nil
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value %q: %w", constants.ManagedDRADeviceCountAnnotationKey, raw, err)
+	}
+	if count < 1 {
+		return 0, fmt.Errorf("invalid %s value %q: must be >= 1", constants.ManagedDRADeviceCountAnnotationKey, raw)
+	}
+	return count, nil
+}
+
+// ManagedDRACelSelectors splits the CEL selector annotation by newline, returning non-empty trimmed entries.
+func ManagedDRACelSelectors(annotations map[string]string) []string {
+	raw, ok := annotations[constants.ManagedDRACelSelectorAnnotationKey]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, "\n")
+	selectors := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if v := strings.TrimSpace(p); v != "" {
+			selectors = append(selectors, v)
+		}
+	}
+	return selectors
+}
+
+// ManagedDRAContainerName returns the trimmed container name and whether it was present.
+func ManagedDRAContainerName(annotations map[string]string) (string, bool) {
+	raw, ok := annotations[constants.ManagedDRAContainerNameAnnotationKey]
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(raw), true
+}
+
+// ValidateManagedDRAAnnotations validates DRA-related annotations on any resource.
+func ValidateManagedDRAAnnotations(annotations map[string]string) field.ErrorList {
+	var allErrs field.ErrorList
+	if len(annotations) == 0 {
+		return allErrs
+	}
+
+	annotationsPath := field.NewPath("metadata").Child("annotations")
+
+	hasDeviceClass := HasManagedDRA(annotations)
+	_, hasDeviceCount := annotations[constants.ManagedDRADeviceCountAnnotationKey]
+	_, hasCelSelector := annotations[constants.ManagedDRACelSelectorAnnotationKey]
+	_, hasContainerName := annotations[constants.ManagedDRAContainerNameAnnotationKey]
+
+	// Require device-class if any other DRA annotation is set.
+	if !hasDeviceClass && (hasDeviceCount || hasCelSelector || hasContainerName) {
+		allErrs = append(allErrs, field.Required(
+			annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
+			fmt.Sprintf("%s is required to enable managed DRA when %s, %s, or %s is set",
+				constants.ManagedDRADeviceClassAnnotationKey,
+				constants.ManagedDRADeviceCountAnnotationKey,
+				constants.ManagedDRACelSelectorAnnotationKey,
+				constants.ManagedDRAContainerNameAnnotationKey),
+		))
+	}
+
+	if trimmed, present := ManagedDRADeviceClass(annotations); present {
+		raw := annotations[constants.ManagedDRADeviceClassAnnotationKey]
+		if trimmed == "" {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
+				raw,
+				"device class must not be empty",
+			))
+		} else if errs := validation.IsDNS1123Subdomain(trimmed); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
+				raw,
+				"device class must be a DNS subdomain: "+strings.Join(errs, "; "),
+			))
+		}
+	}
+
+	if hasDeviceCount {
+		if _, err := ManagedDRADeviceCount(annotations); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRADeviceCountAnnotationKey),
+				annotations[constants.ManagedDRADeviceCountAnnotationKey],
+				err.Error(),
+			))
+		}
+	}
+
+	if hasCelSelector && len(ManagedDRACelSelectors(annotations)) == 0 {
+		allErrs = append(allErrs, field.Invalid(
+			annotationsPath.Key(constants.ManagedDRACelSelectorAnnotationKey),
+			annotations[constants.ManagedDRACelSelectorAnnotationKey],
+			"cel selector must contain at least one non-empty CEL expression",
+		))
+	}
+
+	if trimmed, present := ManagedDRAContainerName(annotations); present {
+		raw := annotations[constants.ManagedDRAContainerNameAnnotationKey]
+		if trimmed == "" {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRAContainerNameAnnotationKey),
+				raw,
+				"container name must not be empty",
+			))
+		} else if errs := validation.IsDNS1123Label(trimmed); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRAContainerNameAnnotationKey),
+				raw,
+				"container name must be a DNS label: "+strings.Join(errs, "; "),
+			))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/validation/managed_dra_test.go
+++ b/pkg/validation/managed_dra_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestHasManagedDRA(t *testing.T) {
+	assert.False(t, HasManagedDRA(nil))
+	assert.False(t, HasManagedDRA(map[string]string{"foo": "bar"}))
+	assert.True(t, HasManagedDRA(map[string]string{constants.ManagedDRADeviceClassAnnotationKey: "gpu.nvidia.com"}))
+}
+
+func TestManagedDRADeviceCount(t *testing.T) {
+	t.Run("missing defaults to 1", func(t *testing.T) {
+		count, err := ManagedDRADeviceCount(nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+	t.Run("valid", func(t *testing.T) {
+		count, err := ManagedDRADeviceCount(map[string]string{constants.ManagedDRADeviceCountAnnotationKey: "4"})
+		require.NoError(t, err)
+		assert.Equal(t, 4, count)
+	})
+	t.Run("zero rejected", func(t *testing.T) {
+		_, err := ManagedDRADeviceCount(map[string]string{constants.ManagedDRADeviceCountAnnotationKey: "0"})
+		assert.Error(t, err)
+	})
+	t.Run("non-numeric rejected", func(t *testing.T) {
+		_, err := ManagedDRADeviceCount(map[string]string{constants.ManagedDRADeviceCountAnnotationKey: "abc"})
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateManagedDRAAnnotations(t *testing.T) {
+	const (
+		deviceClassKey   = "serving.kserve.io/exp-dra-device-class"
+		deviceCountKey   = "serving.kserve.io/exp-dra-device-count"
+		celSelectorKey   = "serving.kserve.io/exp-dra-cel-selector"
+		containerNameKey = "serving.kserve.io/exp-dra-container-name"
+	)
+
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantErrCount int
+		wantErrField string
+	}{
+		{
+			name:         "no annotations",
+			annotations:  nil,
+			wantErrCount: 0,
+		},
+		{
+			name:         "valid: device class only",
+			annotations:  map[string]string{deviceClassKey: "gpu.nvidia.com"},
+			wantErrCount: 0,
+		},
+		{
+			name: "valid: full valid set",
+			annotations: map[string]string{
+				deviceClassKey:   "gpu.nvidia.com",
+				deviceCountKey:   "4",
+				celSelectorKey:   "device.attributes['gpu.nvidia.com']['type'] == 'A100'",
+				containerNameKey: "vllm",
+			},
+			wantErrCount: 0,
+		},
+		{
+			name:         "invalid: empty device class",
+			annotations:  map[string]string{deviceClassKey: "   "},
+			wantErrCount: 1,
+			wantErrField: deviceClassKey,
+		},
+		{
+			name:         "invalid: device count without device class",
+			annotations:  map[string]string{deviceCountKey: "2"},
+			wantErrCount: 1,
+			wantErrField: deviceClassKey,
+		},
+		{
+			name: "invalid: device count non-numeric",
+			annotations: map[string]string{
+				deviceClassKey: "gpu.nvidia.com",
+				deviceCountKey: "abc",
+			},
+			wantErrCount: 1,
+			wantErrField: deviceCountKey,
+		},
+		{
+			name: "invalid: empty cel selector",
+			annotations: map[string]string{
+				deviceClassKey: "gpu.nvidia.com",
+				celSelectorKey: "\n  \n",
+			},
+			wantErrCount: 1,
+			wantErrField: celSelectorKey,
+		},
+		{
+			name: "invalid: empty container name",
+			annotations: map[string]string{
+				deviceClassKey:   "gpu.nvidia.com",
+				containerNameKey: "   ",
+			},
+			wantErrCount: 1,
+			wantErrField: containerNameKey,
+		},
+		{
+			name: "invalid: multiple errors surfaced",
+			annotations: map[string]string{
+				deviceClassKey: "BAD CLASS",
+				deviceCountKey: "abc",
+			},
+			wantErrCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateManagedDRAAnnotations(tt.annotations)
+			require.Len(t, errs, tt.wantErrCount, "errors: %v", errs)
+			if tt.wantErrField != "" {
+				found := false
+				for _, e := range errs {
+					if strings.Contains(e.Field, tt.wantErrField) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected error on field %q, got: %v", tt.wantErrField, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The v1alpha1 LLMInferenceService validating webhook was silently accepting invalid objects that v1alpha2 correctly rejects. 

Closes the gap by reusing the existing v1alpha2 validation logic rather than duplicating it:
- LoRA validation follows the same convert-then-delegate pattern already used for scaling validation
- DRA annotation validation moves to a shared `pkg/validation/` package - same pattern as the existing `confidential.go` shared validator.

**Feature/Issue validation/testing**:

- [x] v1alpha1 LoRA adapter validation (name uniqueness, path traversal, base-model collision, numeric bounds)
- [x] v1alpha1 DRA annotation validation (device class, device count, CEL selectors, container name)
- [x] v1alpha2 validation regression (exported functions, delegated DRA) 
- [x] Shared `pkg/validation/` DRA tests

**Special notes for your reviewer**:

The remaining uncovered checks (`KVCacheOffloading`, `Confidential`) are correctly absent because v1alpha1 types don't have those fields. I am not sure if that was deliberate decision.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Closes validation gaps in the v1alpha1 LLMInferenceService webhook - LoRA adapter and DRA annotation validation now matches v1alpha2 coverage.
```