### PR TITLE
ci: cache openapi-generator JAR to avoid Maven rate limiting

### DIFF
--- a/.github/workflows/precommit-check.yml
+++ b/.github/workflows/precommit-check.yml
@@ -40,6 +40,12 @@ jobs:
           go mod download
           cd qpext && go mod download
 
+      - name: Cache openapi-generator JAR
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: hack/python-sdk/openapi-generator-cli-*.jar
+          key: openapi-generator-${{ hashFiles('hack/python-sdk/client-gen.sh') }}
+
       - name: Check
         shell: bash
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Precommit checks were intermittently failing with HTTP 429 (Too Many Requests) while fetching the openapi-generator CLI JAR from Maven Central during Python SDK generation. The JAR is a fixed, stable artifact that was needlessly re-downloaded on every run, making CI dependent on an external host's rate limits.

Observed in one of the PRs:

```
Downloading the swagger-codegen JAR package ...
--2026-07-31 11:32:44--  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
Resolving repo1.maven.org (repo1.maven.org)... 104.18.18.12, 104.18.19.12, 2606:4700::6812:120c, ...
Connecting to repo1.maven.org (repo1.maven.org)|104.18.18.12|:443... connected.
HTTP request sent, awaiting response... 429 Too Many Requests
2026-07-31 11:32:44 ERROR 429: Too Many Requests.
```

Caching the JAR removes that external dependency from the hot path. The download now happens only on a cache miss (first run or a version bump), keeping precommit checks fast and immune to Maven throttling.


**Feature/Issue validation/testing**:

- [x] Verified `client-gen.sh` already skips the download when the JAR is present, so the restored cache short-circuits the Maven fetch.
- [x] Confirmed no other CI-invoked script downloads this artifact, so a single cache step covers the affected path.

**Special notes for your reviewer**:

The cache key is derived from `client-gen.sh`, which pins the generator version - bumping the version automatically invalidates the cache with no manual key maintenance.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
NONE
```
