### PR TITLE
chore(llmisvc): aligns additional url discovery

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -399,7 +399,7 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 		llmSvc.Status.Router.Gateways = BuildObservedGateways(routes)
 	}
 
-	additional, err := r.discoverAdditionalURLs(ctx, discovered)
+	additional, err := r.discoverAdditionalURLs(ctx, llmSvc, discovered)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover additional URLs: %w", err)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_default.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_default.go
@@ -20,10 +20,12 @@ package llmisvc
 
 import (
 	"context"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
 
 // discoverAdditionalURLs is a hook for distribution-specific URL discovery
 // (e.g. OpenShift Routes fronting ClusterIP-backed Gateways).
-func (r *LLMISVCReconciler) discoverAdditionalURLs(_ context.Context, _ []DiscoveredURL) ([]DiscoveredURL, error) {
+func (r *LLMISVCReconciler) discoverAdditionalURLs(_ context.Context, _ *v1alpha2.LLMInferenceService, _ []DiscoveredURL) ([]DiscoveredURL, error) {
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Passes LLMInferenceService down the chain for the distro hook.

This enables e.g. emitting events so operators can know if there are misconfigurations on top of regular routing setup.

**Release note**:
```release-note
NONE
```
