### PR TITLE
fix(llmisvc): re-enqueue group peers when status model names change

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router_group_handler.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_handler.go
@@ -176,5 +176,13 @@ func trafficFieldsChanged(old, new *v1alpha2.LLMInferenceService) bool {
 		return true
 	}
 
+	// Model names resolved from status.Addresses drive divergence detection
+	// for peer members. Without this, a member whose spec.model changes gets
+	// reconciled (updating its own addresses), but peers that already
+	// reconciled against the stale addresses are never re-enqueued.
+	if !slices.Equal(resolvedModelNames(old), resolvedModelNames(new)) {
+		return true
+	}
+
 	return false
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_test.go
@@ -559,6 +559,42 @@ func TestTrafficFieldsChanged(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "status addresses model names changed",
+			old: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Status.Addresses = []v1alpha2.SourcedAddress{{
+					Models: []v1alpha2.ModelSourcedAddressStatus{{Name: "model-beta"}},
+				}}
+				return &s
+			}(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Status.Addresses = []v1alpha2.SourcedAddress{{
+					Models: []v1alpha2.ModelSourcedAddressStatus{{Name: "model-alpha"}},
+				}}
+				return &s
+			}(),
+			want: true,
+		},
+		{
+			name: "status addresses model names unchanged",
+			old: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Status.Addresses = []v1alpha2.SourcedAddress{{
+					Models: []v1alpha2.ModelSourcedAddressStatus{{Name: "model-alpha"}},
+				}}
+				return &s
+			}(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Status.Addresses = []v1alpha2.SourcedAddress{{
+					Models: []v1alpha2.ModelSourcedAddressStatus{{Name: "model-alpha"}},
+				}}
+				return &s
+			}(),
+			want: false,
+		},
+		{
 			name: "non-traffic change on grouped member",
 			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
 			new:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),


### PR DESCRIPTION
## Summary
- **Race in group divergence detection**: when a member's `spec.model.name` is patched, peers that reconcile first read stale model names from `Status.Addresses` (populated during the pre-patch reconcile). The peer sees divergence and keeps `GroupDegraded=True`.
- The patched member then reconciles and updates its own addresses, but `trafficFieldsChanged` only checked spec fields and routability -- not `Status.Addresses` model names. So the peer was never re-enqueued to clear its stale `GroupDegraded`.
- **Fix**: add `resolvedModelNames` comparison to `trafficFieldsChanged` so status model name updates trigger peer re-reconciliation.

## Test plan
- [x] Unit: `TestTrafficFieldsChanged` -- two new cases (changed/unchanged status address model names)
- [ ] E2E: `test_model_name_divergence_resolves` should stop flaking (observed on Kind/GH Actions where reconcile ordering is non-deterministic)