### PR TITLE
fix(httproute): restrict canary weights to predictor rules only

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -330,7 +330,7 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 		},
 	}
 	if len(isvc.Spec.Canary) > 0 {
-		applyCanaryWeights(isvc, &httpRoute)
+		applyCanaryWeights(isvc, predictorName, &httpRoute)
 	}
 	return &httpRoute, nil
 }
@@ -676,14 +676,14 @@ func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc 
 		},
 	}
 	if len(isvc.Spec.Canary) > 0 {
-		applyCanaryWeights(isvc, &httpRoute)
+		applyCanaryWeights(isvc, predictorName, &httpRoute)
 	}
 	return &httpRoute, nil
 }
 
 // applyCanaryWeights modifies the HTTPRoute's backend refs to include weighted
 // backends for canary traffic splitting.
-func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPRoute) {
+func applyCanaryWeights(isvc *v1beta1.InferenceService, predictorName string, httpRoute *gwapiv1.HTTPRoute) {
 	var totalCanaryPercent int32
 	for _, canary := range isvc.Spec.Canary {
 		totalCanaryPercent += canary.TrafficPercent
@@ -697,6 +697,9 @@ func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPR
 		}
 
 		template := rule.BackendRefs[0]
+		if string(template.Name) != predictorName {
+			continue
+		}
 		weightedBackends := make([]gwapiv1.HTTPBackendRef, 0, 1+len(isvc.Spec.Canary))
 
 		sw := stableWeight

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -330,7 +330,7 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 		},
 	}
 	if len(isvc.Spec.Canary) > 0 {
-		applyCanaryWeights(isvc, predictorName, &httpRoute)
+		applyCanaryWeights(isvc, &httpRoute)
 	}
 	return &httpRoute, nil
 }
@@ -676,7 +676,7 @@ func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc 
 		},
 	}
 	if len(isvc.Spec.Canary) > 0 {
-		applyCanaryWeights(isvc, predictorName, &httpRoute)
+		applyCanaryWeights(isvc, &httpRoute)
 	}
 	return &httpRoute, nil
 }
@@ -686,7 +686,7 @@ func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc 
 // Ready (as reported in isvc.Status.CanaryStatuses) receive traffic; not-ready
 // canaries are omitted so no traffic is routed to a backend without ready
 // endpoints.
-func applyCanaryWeights(isvc *v1beta1.InferenceService, predictorName string, httpRoute *gwapiv1.HTTPRoute) {
+func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPRoute) {
 	readyMap := make(map[string]bool, len(isvc.Status.CanaryStatuses))
 	for _, cs := range isvc.Status.CanaryStatuses {
 		readyMap[cs.Name] = cs.Ready
@@ -700,6 +700,7 @@ func applyCanaryWeights(isvc *v1beta1.InferenceService, predictorName string, ht
 	}
 	stableWeight := int32(100) - totalReadyCanaryPercent
 
+	predictorName := constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name)
 	for i := range httpRoute.Spec.Rules {
 		rule := &httpRoute.Spec.Rules[i]
 		if len(rule.BackendRefs) == 0 {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -330,7 +330,7 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 		},
 	}
 	if len(isvc.Spec.Canary) > 0 {
-		applyCanaryWeights(isvc, &httpRoute)
+		applyCanaryWeights(isvc, predictorName, &httpRoute)
 	}
 	return &httpRoute, nil
 }
@@ -676,7 +676,7 @@ func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc 
 		},
 	}
 	if len(isvc.Spec.Canary) > 0 {
-		applyCanaryWeights(isvc, &httpRoute)
+		applyCanaryWeights(isvc, predictorName, &httpRoute)
 	}
 	return &httpRoute, nil
 }
@@ -686,7 +686,7 @@ func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc 
 // Ready (as reported in isvc.Status.CanaryStatuses) receive traffic; not-ready
 // canaries are omitted so no traffic is routed to a backend without ready
 // endpoints.
-func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPRoute) {
+func applyCanaryWeights(isvc *v1beta1.InferenceService, predictorName string, httpRoute *gwapiv1.HTTPRoute) {
 	readyMap := make(map[string]bool, len(isvc.Status.CanaryStatuses))
 	for _, cs := range isvc.Status.CanaryStatuses {
 		readyMap[cs.Name] = cs.Ready
@@ -707,6 +707,9 @@ func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPR
 		}
 
 		template := rule.BackendRefs[0]
+		if string(template.Name) != predictorName {
+			continue
+		}
 		weightedBackends := make([]gwapiv1.HTTPBackendRef, 0, 1+len(isvc.Spec.Canary))
 
 		sw := stableWeight

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -3498,7 +3498,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(2))
@@ -3536,7 +3536,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(3))
@@ -3573,7 +3573,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		// Both rules should get canary backends
 		for _, rule := range httpRoute.Spec.Rules {
@@ -3600,8 +3600,87 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(BeNil())
+	})
+
+	t.Run("skips explainer and transformer rules", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Predictor: v1beta1.PredictorSpec{},
+				Canary: []v1beta1.CanarySpec{
+					{
+						Predictor:      v1beta1.PredictorSpec{Name: "v2"},
+						TrafficPercent: 20,
+					},
+				},
+			},
+		}
+
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Name: "my-model-explainer",
+										Port: ptr.To(gwapiv1.PortNumber(80)),
+									},
+								},
+							},
+						},
+					},
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Name: "my-model-transformer",
+										Port: ptr.To(gwapiv1.PortNumber(80)),
+									},
+								},
+							},
+						},
+					},
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Name: "my-model-predictor",
+										Port: ptr.To(gwapiv1.PortNumber(80)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+
+		// Explainer rule: unchanged
+		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(HaveLen(1))
+		g.Expect(string(httpRoute.Spec.Rules[0].BackendRefs[0].Name)).To(Equal("my-model-explainer"))
+		g.Expect(httpRoute.Spec.Rules[0].BackendRefs[0].Weight).To(BeNil())
+
+		// Transformer rule: unchanged
+		g.Expect(httpRoute.Spec.Rules[1].BackendRefs).To(HaveLen(1))
+		g.Expect(string(httpRoute.Spec.Rules[1].BackendRefs[0].Name)).To(Equal("my-model-transformer"))
+		g.Expect(httpRoute.Spec.Rules[1].BackendRefs[0].Weight).To(BeNil())
+
+		// Predictor rule: canary weights applied
+		g.Expect(httpRoute.Spec.Rules[2].BackendRefs).To(HaveLen(2))
+		g.Expect(*httpRoute.Spec.Rules[2].BackendRefs[0].Weight).To(Equal(int32(80)))
+		g.Expect(string(httpRoute.Spec.Rules[2].BackendRefs[0].Name)).To(Equal("my-model-predictor"))
+		g.Expect(*httpRoute.Spec.Rules[2].BackendRefs[1].Weight).To(Equal(int32(20)))
+		g.Expect(string(httpRoute.Spec.Rules[2].BackendRefs[1].Name)).To(Equal("my-model-v2-predictor"))
 	})
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -3502,7 +3502,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(2))
@@ -3547,7 +3547,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(3))
@@ -3590,7 +3590,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		// Both rules should get canary backends
 		for _, rule := range httpRoute.Spec.Rules {
@@ -3623,7 +3623,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(BeNil())
 	})
 
@@ -3656,7 +3656,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(1))
@@ -3695,7 +3695,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(2))
@@ -3729,12 +3729,91 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, httpRoute)
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(1))
 		g.Expect(*backends[0].Weight).To(Equal(int32(100)))
 		g.Expect(string(backends[0].Name)).To(Equal("my-model-predictor"))
+	})
+
+	t.Run("skips explainer and transformer rules", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Predictor: v1beta1.PredictorSpec{},
+				Canary: []v1beta1.CanarySpec{
+					{
+						Predictor:      v1beta1.PredictorSpec{Name: "v2"},
+						TrafficPercent: 20,
+					},
+				},
+			},
+		}
+
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Name: "my-model-explainer",
+										Port: ptr.To(gwapiv1.PortNumber(80)),
+									},
+								},
+							},
+						},
+					},
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Name: "my-model-transformer",
+										Port: ptr.To(gwapiv1.PortNumber(80)),
+									},
+								},
+							},
+						},
+					},
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Name: "my-model-predictor",
+										Port: ptr.To(gwapiv1.PortNumber(80)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+
+		// Explainer rule: unchanged
+		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(HaveLen(1))
+		g.Expect(string(httpRoute.Spec.Rules[0].BackendRefs[0].Name)).To(Equal("my-model-explainer"))
+		g.Expect(httpRoute.Spec.Rules[0].BackendRefs[0].Weight).To(BeNil())
+
+		// Transformer rule: unchanged
+		g.Expect(httpRoute.Spec.Rules[1].BackendRefs).To(HaveLen(1))
+		g.Expect(string(httpRoute.Spec.Rules[1].BackendRefs[0].Name)).To(Equal("my-model-transformer"))
+		g.Expect(httpRoute.Spec.Rules[1].BackendRefs[0].Weight).To(BeNil())
+
+		// Predictor rule: canary weights applied
+		g.Expect(httpRoute.Spec.Rules[2].BackendRefs).To(HaveLen(2))
+		g.Expect(*httpRoute.Spec.Rules[2].BackendRefs[0].Weight).To(Equal(int32(80)))
+		g.Expect(string(httpRoute.Spec.Rules[2].BackendRefs[0].Name)).To(Equal("my-model-predictor"))
+		g.Expect(*httpRoute.Spec.Rules[2].BackendRefs[1].Weight).To(Equal(int32(20)))
+		g.Expect(string(httpRoute.Spec.Rules[2].BackendRefs[1].Name)).To(Equal("my-model-v2-predictor"))
 	})
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -3751,6 +3751,11 @@ func TestApplyCanaryWeights(t *testing.T) {
 					},
 				},
 			},
+			Status: v1beta1.InferenceServiceStatus{
+				CanaryStatuses: []v1beta1.CanaryStatus{
+					{Name: "v2", Ready: true, TrafficPercent: 20},
+				},
+			},
 		}
 
 		httpRoute := &gwapiv1.HTTPRoute{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -3502,7 +3502,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+		applyCanaryWeights(isvc, httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(2))
@@ -3547,7 +3547,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+		applyCanaryWeights(isvc, httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(3))
@@ -3590,7 +3590,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+		applyCanaryWeights(isvc, httpRoute)
 
 		// Both rules should get canary backends
 		for _, rule := range httpRoute.Spec.Rules {
@@ -3623,7 +3623,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+		applyCanaryWeights(isvc, httpRoute)
 		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(BeNil())
 	})
 
@@ -3656,7 +3656,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+		applyCanaryWeights(isvc, httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(1))
@@ -3695,7 +3695,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+		applyCanaryWeights(isvc, httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(2))
@@ -3729,7 +3729,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+		applyCanaryWeights(isvc, httpRoute)
 
 		backends := httpRoute.Spec.Rules[0].BackendRefs
 		g.Expect(backends).To(HaveLen(1))
@@ -3801,7 +3801,7 @@ func TestApplyCanaryWeights(t *testing.T) {
 			},
 		}
 
-		applyCanaryWeights(isvc, "my-model-predictor", httpRoute)
+		applyCanaryWeights(isvc, httpRoute)
 
 		// Explainer rule: unchanged
 		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(HaveLen(1))


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `applyCanaryWeights` to only apply canary predictor backends to predictor HTTPRoute rules, not to Explainer or Transformer rules.

When an InferenceService has a Canary and an Explainer or Transformer, `applyCanaryWeights` was applying canary predictor backends to ALL rules in the HTTPRoute, including explainer and transformer rules. This caused `:explain` and transformer-routed `:predict` traffic to be partially routed directly to the canary predictor, bypassing the Explainer/Transformer entirely.

`CanarySpec` only defines a canary Predictor -- not a canary Transformer or Explainer. Traffic splitting must only apply to predictor rules.

## Changes

- Add `predictorName` parameter to `applyCanaryWeights`
- Skip rules whose first BackendRef doesn't match the predictor service name
- Update both call sites (`createRawPredictorHTTPRoute`, `createRawTopLevelHTTPRoute`) to pass `predictorName`
- Add test coverage for explainer + transformer + canary scenario

## Testing

- Added test case "skips explainer and transformer rules" with 3 rules (explainer, transformer, predictor)
- Verifies only the predictor rule gets canary weights applied
- All existing `TestApplyCanaryWeights` subtests still pass

**Which issue(s) this PR fixes**:

Fixes https://github.com/opendatahub-io/kserve/issues/1836

**Feature/Issue validation/testing**:

- [x] Unit tests added (`TestApplyCanaryWeights/skips_explainer_and_transformer_rules`)
- [x] All existing tests pass
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

**Special notes for your reviewer**:

This is the upstream fix for the issue identified in [odh PR #1831 review comment](https://github.com/opendatahub-io/kserve/pull/1831#discussion_r3692151924).

The fix is minimal and surgical:
- `applyCanaryWeights` gains one parameter and one guard clause
- Both call sites already have `predictorName` in scope
- For `createRawPredictorHTTPRoute`, the guard is a no-op (all rules are already predictor rules)
- For `createRawTopLevelHTTPRoute`, the guard skips explainer/transformer rules

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fix Gateway API HTTPRoute canary weights being incorrectly applied to Explainer and Transformer rules instead of only Predictor rules
```