### PR TITLE
fix: guard optional KEDA fields in CEL validation

### DIFF
--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -651,7 +651,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -865,7 +865,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -17206,7 +17206,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17420,7 +17420,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -873,7 +873,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17428,7 +17428,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
@@ -667,7 +667,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -881,7 +881,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -17641,7 +17641,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17855,7 +17855,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
@@ -889,7 +889,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17863,7 +17863,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -343,7 +343,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -557,7 +557,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -16867,7 +16867,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17081,7 +17081,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -25263,7 +25263,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -25477,7 +25477,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -41818,7 +41818,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -42032,7 +42032,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -565,7 +565,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17089,7 +17089,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend
@@ -25485,7 +25485,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -42040,7 +42040,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
@@ -352,7 +352,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -566,7 +566,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -17285,7 +17285,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17499,7 +17499,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -25868,7 +25868,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -26082,7 +26082,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -42842,7 +42842,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -43056,7 +43056,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
@@ -574,7 +574,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17507,7 +17507,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend
@@ -26090,7 +26090,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -43064,7 +43064,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/config/crd/full/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/full/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -331,7 +331,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -545,7 +545,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -16855,7 +16855,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17069,7 +17069,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -25251,7 +25251,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -25465,7 +25465,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -41806,7 +41806,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -42020,7 +42020,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$

--- a/config/crd/full/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/full/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -553,7 +553,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17077,7 +17077,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend
@@ -25473,7 +25473,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -42028,7 +42028,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/config/crd/full/llmisvc/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/full/llmisvc/serving.kserve.io_llminferenceservices.yaml
@@ -340,7 +340,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -554,7 +554,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -17273,7 +17273,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17487,7 +17487,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -25856,7 +25856,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -26070,7 +26070,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -42830,7 +42830,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -43044,7 +43044,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$

--- a/config/crd/full/llmisvc/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/full/llmisvc/serving.kserve.io_llminferenceservices.yaml
@@ -562,7 +562,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17495,7 +17495,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend
@@ -26078,7 +26078,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -43052,7 +43052,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -640,6 +640,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -857,6 +858,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -17218,6 +17220,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -17435,6 +17438,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:

--- a/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -869,7 +869,7 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                             == 0 && size(self.keda.advanced.scalingModifiers.target)
                             == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                             == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -17449,7 +17449,7 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                         == 0 && size(self.keda.advanced.scalingModifiers.target) ==
                         0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                         == 0 && size(self.keda.advanced.scalingModifiers.metricType)

--- a/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceservices.yaml
@@ -656,6 +656,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -873,6 +874,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -17943,6 +17945,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -18160,6 +18163,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:

--- a/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceservices.yaml
@@ -885,7 +885,7 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                             == 0 && size(self.keda.advanced.scalingModifiers.target)
                             == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                             == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -18174,7 +18174,7 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                         == 0 && size(self.keda.advanced.scalingModifiers.target) ==
                         0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                         == 0 && size(self.keda.advanced.scalingModifiers.metricType)

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
@@ -505,7 +505,7 @@ type HPAScalingSpec struct {
 // The fields are directly from the upstream KEDA ScaledObject API.
 // Note: WVA-only restrictions on scalingModifiers live on WVASpec so direct KEDA
 // (DirectKEDAScalingSpec) can use scalingModifiers when users define their own triggers.
-// +kubebuilder:validation:XValidation:rule="!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0",message="horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name"
+// +kubebuilder:validation:XValidation:rule="!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0",message="horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name"
 type KEDAScalingSpec struct {
 	// PollingInterval is the interval in seconds to check each trigger on.
 	// Must be at least 1 second.

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
@@ -457,7 +457,7 @@ type ScalingSpec struct {
 
 // WVASpec configures the Workload Variant Autoscaler.
 // scalingModifiers under wva.keda.advanced are forbidden because WVA owns the metric formula.
-// +kubebuilder:validation:XValidation:rule="!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)",message="scalingModifiers must not be set; WVA controls the scaling metric formula and logic"
+// +kubebuilder:validation:XValidation:rule="!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)",message="scalingModifiers must not be set; WVA controls the scaling metric formula and logic"
 type WVASpec struct {
 	// VariantCost specifies the cost per replica for this variant (used in saturation analysis).
 	// Must be a non-negative numeric string (e.g., "10", "10.0", "0.5").

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
@@ -634,7 +634,7 @@ type HPAScalingSpec struct {
 // The fields are directly from the upstream KEDA ScaledObject API.
 // Note: WVA-only restrictions on scalingModifiers live on WVASpec so direct KEDA
 // (DirectKEDAScalingSpec) can use scalingModifiers when users define their own triggers.
-// +kubebuilder:validation:XValidation:rule="!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0",message="horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name"
+// +kubebuilder:validation:XValidation:rule="!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0",message="horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name"
 type KEDAScalingSpec struct {
 	// PollingInterval is the interval in seconds to check each trigger on.
 	// Must be at least 1 second.

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
@@ -574,7 +574,7 @@ type ScalingSpec struct {
 
 // WVASpec configures the Workload Variant Autoscaler.
 // scalingModifiers under wva.keda.advanced are forbidden because WVA owns the metric formula.
-// +kubebuilder:validation:XValidation:rule="!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)",message="scalingModifiers must not be set; WVA controls the scaling metric formula and logic"
+// +kubebuilder:validation:XValidation:rule="!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)",message="scalingModifiers must not be set; WVA controls the scaling metric formula and logic"
 type WVASpec struct {
 	// VariantCost specifies the cost per replica for this variant (used in saturation analysis).
 	// Must be a non-negative numeric string (e.g., "10", "10.0", "0.5").

--- a/pkg/controller/v1alpha2/llmisvc/crdvalidation/keda_scaling_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/crdvalidation/keda_scaling_test.go
@@ -36,8 +36,8 @@ var _ = Describe("KEDA scaling CRD validation", func() {
 	})
 
 	DescribeTable("accepts HPA behavior when controller-owned optional fields are omitted",
-		func(ctx SpecContext, kind, name string) {
-			resource := kedaScalingResource(kind, name, map[string]any{
+		func(ctx SpecContext, version, kind, name string) {
+			resource := kedaScalingResource(version, kind, name, map[string]any{
 				"horizontalPodAutoscalerConfig": map[string]any{
 					"behavior": map[string]any{
 						"scaleDown": map[string]any{
@@ -49,13 +49,15 @@ var _ = Describe("KEDA scaling CRD validation", func() {
 
 			Expect(envTest.Client.Create(ctx, resource)).To(Succeed())
 		},
-		Entry("for LLMInferenceService", "LLMInferenceService", "keda-behavior-service"),
-		Entry("for LLMInferenceServiceConfig", "LLMInferenceServiceConfig", "keda-behavior-config"),
+		Entry("for v1alpha2 LLMInferenceService", "v1alpha2", "LLMInferenceService", "keda-behavior-service"),
+		Entry("for v1alpha2 LLMInferenceServiceConfig", "v1alpha2", "LLMInferenceServiceConfig", "keda-behavior-config"),
+		Entry("for v1alpha1 LLMInferenceService", "v1alpha1", "LLMInferenceService", "keda-behavior-service-v1alpha1"),
+		Entry("for v1alpha1 LLMInferenceServiceConfig", "v1alpha1", "LLMInferenceServiceConfig", "keda-behavior-config-v1alpha1"),
 	)
 
 	DescribeTable("rejects user-configured scaling modifiers",
-		func(ctx SpecContext, name, field, value string) {
-			resource := kedaScalingResource("LLMInferenceService", name, map[string]any{
+		func(ctx SpecContext, version, name, field, value string) {
+			resource := kedaScalingResource(version, "LLMInferenceService", name, map[string]any{
 				"scalingModifiers": map[string]any{field: value},
 			})
 
@@ -63,28 +65,36 @@ var _ = Describe("KEDA scaling CRD validation", func() {
 			Expect(err).To(MatchError(ContainSubstring(
 				"scalingModifiers must not be set; WVA controls the scaling metric formula and logic")))
 		},
-		Entry("formula", "keda-scaling-modifier-formula", "formula", "wva_desired_replicas"),
-		Entry("target", "keda-scaling-modifier-target", "target", "1"),
-		Entry("activation target", "keda-scaling-modifier-activation-target", "activationTarget", "1"),
-		Entry("metric type", "keda-scaling-modifier-metric-type", "metricType", "Value"),
+		Entry("formula", "v1alpha2", "keda-scaling-modifier-formula", "formula", "wva_desired_replicas"),
+		Entry("target", "v1alpha2", "keda-scaling-modifier-target", "target", "1"),
+		Entry("activation target", "v1alpha2", "keda-scaling-modifier-activation-target", "activationTarget", "1"),
+		Entry("metric type", "v1alpha2", "keda-scaling-modifier-metric-type", "metricType", "Value"),
+		Entry("formula (v1alpha1)", "v1alpha1", "keda-scaling-modifier-formula-v1alpha1", "formula", "wva_desired_replicas"),
+		Entry("target (v1alpha1)", "v1alpha1", "keda-scaling-modifier-target-v1alpha1", "target", "1"),
+		Entry("activation target (v1alpha1)", "v1alpha1", "keda-scaling-modifier-activation-target-v1alpha1", "activationTarget", "1"),
+		Entry("metric type (v1alpha1)", "v1alpha1", "keda-scaling-modifier-metric-type-v1alpha1", "metricType", "Value"),
 	)
 
-	It("rejects a user-configured HPA name", func(ctx SpecContext) {
-		resource := kedaScalingResource("LLMInferenceService", "keda-hpa-name", map[string]any{
-			"horizontalPodAutoscalerConfig": map[string]any{
-				"name": "user-managed-hpa",
-			},
-		})
+	DescribeTable("rejects a user-configured HPA name",
+		func(ctx SpecContext, version, name string) {
+			resource := kedaScalingResource(version, "LLMInferenceService", name, map[string]any{
+				"horizontalPodAutoscalerConfig": map[string]any{
+					"name": "user-managed-hpa",
+				},
+			})
 
-		err := envTest.Client.Create(ctx, resource)
-		Expect(err).To(MatchError(ContainSubstring(
-			"horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name")))
-	})
+			err := envTest.Client.Create(ctx, resource)
+			Expect(err).To(MatchError(ContainSubstring(
+				"horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name")))
+		},
+		Entry("v1alpha2", "v1alpha2", "keda-hpa-name"),
+		Entry("v1alpha1", "v1alpha1", "keda-hpa-name-v1alpha1"),
+	)
 })
 
-func kedaScalingResource(kind, name string, advanced map[string]any) *unstructured.Unstructured {
+func kedaScalingResource(version, kind, name string, advanced map[string]any) *unstructured.Unstructured {
 	resource := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "serving.kserve.io/v1alpha2",
+		"apiVersion": "serving.kserve.io/" + version,
 		"kind":       kind,
 		"metadata": map[string]any{
 			"name":      name,
@@ -105,7 +115,7 @@ func kedaScalingResource(kind, name string, advanced map[string]any) *unstructur
 		},
 	}}
 	resource.SetGroupVersionKind(schema.GroupVersionKind{
-		Group: "serving.kserve.io", Version: "v1alpha2", Kind: kind,
+		Group: "serving.kserve.io", Version: version, Kind: kind,
 	})
 	return resource
 }

--- a/pkg/controller/v1alpha2/llmisvc/crdvalidation/keda_scaling_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/crdvalidation/keda_scaling_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdvalidation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const kedaValidationNamespace = "keda-crd-validation"
+
+var _ = Describe("KEDA scaling CRD validation", func() {
+	BeforeEach(func(ctx SpecContext) {
+		Expect(envTest.Client.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: kedaValidationNamespace},
+		})).To(Or(Succeed(), MatchError(ContainSubstring("already exists"))))
+	})
+
+	DescribeTable("accepts HPA behavior when controller-owned optional fields are omitted",
+		func(ctx SpecContext, kind, name string) {
+			resource := kedaScalingResource(kind, name, map[string]any{
+				"horizontalPodAutoscalerConfig": map[string]any{
+					"behavior": map[string]any{
+						"scaleDown": map[string]any{
+							"stabilizationWindowSeconds": int64(300),
+						},
+					},
+				},
+			})
+
+			Expect(envTest.Client.Create(ctx, resource)).To(Succeed())
+		},
+		Entry("for LLMInferenceService", "LLMInferenceService", "keda-behavior-service"),
+		Entry("for LLMInferenceServiceConfig", "LLMInferenceServiceConfig", "keda-behavior-config"),
+	)
+
+	DescribeTable("rejects user-configured scaling modifiers",
+		func(ctx SpecContext, name, field, value string) {
+			resource := kedaScalingResource("LLMInferenceService", name, map[string]any{
+				"scalingModifiers": map[string]any{field: value},
+			})
+
+			err := envTest.Client.Create(ctx, resource)
+			Expect(err).To(MatchError(ContainSubstring(
+				"scalingModifiers must not be set; WVA controls the scaling metric formula and logic")))
+		},
+		Entry("formula", "keda-scaling-modifier-formula", "formula", "wva_desired_replicas"),
+		Entry("target", "keda-scaling-modifier-target", "target", "1"),
+		Entry("activation target", "keda-scaling-modifier-activation-target", "activationTarget", "1"),
+		Entry("metric type", "keda-scaling-modifier-metric-type", "metricType", "Value"),
+	)
+
+	It("rejects a user-configured HPA name", func(ctx SpecContext) {
+		resource := kedaScalingResource("LLMInferenceService", "keda-hpa-name", map[string]any{
+			"horizontalPodAutoscalerConfig": map[string]any{
+				"name": "user-managed-hpa",
+			},
+		})
+
+		err := envTest.Client.Create(ctx, resource)
+		Expect(err).To(MatchError(ContainSubstring(
+			"horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name")))
+	})
+})
+
+func kedaScalingResource(kind, name string, advanced map[string]any) *unstructured.Unstructured {
+	resource := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "serving.kserve.io/v1alpha2",
+		"kind":       kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": kedaValidationNamespace,
+		},
+		"spec": map[string]any{
+			"model": map[string]any{
+				"uri": "gs://dummy",
+			},
+			"scaling": map[string]any{
+				"maxReplicas": int64(5),
+				"wva": map[string]any{
+					"keda": map[string]any{
+						"advanced": advanced,
+					},
+				},
+			},
+		},
+	}}
+	resource.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "serving.kserve.io", Version: "v1alpha2", Kind: kind,
+	})
+	return resource
+}

--- a/pkg/controller/v1alpha2/llmisvc/crdvalidation/suite_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/crdvalidation/suite_test.go
@@ -23,6 +23,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
 	pkgtest "github.com/kserve/kserve/pkg/testing"
@@ -44,5 +47,17 @@ var _ = BeforeSuite(func() {
 	envTest = pkgtest.Configure(
 		pkgtest.WithCRDs(filepath.Join(crdRoot, "llmisvc")),
 		pkgtest.WithScheme(kservescheme.AddAll),
-	).Start(context.Background())
+	).
+		// v1alpha1 is not the storage version, so the API server converts
+		// after schema and CEL validation pass. Rejection cases never reach
+		// that step, but an accepted v1alpha1 object does, and envtest has
+		// already rewritten the CRD's conversion endpoint to this suite's
+		// webhook server. Serve /convert so those creates complete instead
+		// of failing on a refused dial.
+		WithWebhooks(func(_ *rest.Config, mgr ctrl.Manager) error {
+			mgr.GetWebhookServer().Register("/convert", conversion.NewWebhookHandler(mgr.GetScheme()))
+
+			return nil
+		}).
+		Start(context.Background())
 })

--- a/test/crds/serving.kserve.io_all_crds.yaml
+++ b/test/crds/serving.kserve.io_all_crds.yaml
@@ -50237,6 +50237,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -50454,6 +50455,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -66784,6 +66786,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -67001,6 +67004,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -75201,6 +75205,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -75418,6 +75423,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -91779,6 +91785,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -91996,6 +92003,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -99974,6 +99982,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -100191,6 +100200,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -117219,6 +117229,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -117436,6 +117447,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -125823,6 +125835,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -126040,6 +126053,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -143110,6 +143124,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -143327,6 +143342,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:

--- a/test/crds/serving.kserve.io_all_crds.yaml
+++ b/test/crds/serving.kserve.io_all_crds.yaml
@@ -50466,7 +50466,7 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                             == 0 && size(self.keda.advanced.scalingModifiers.target)
                             == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                             == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -67015,7 +67015,7 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                         == 0 && size(self.keda.advanced.scalingModifiers.target) ==
                         0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                         == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -75434,7 +75434,7 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                             == 0 && size(self.keda.advanced.scalingModifiers.target)
                             == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                             == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -92014,7 +92014,7 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                         == 0 && size(self.keda.advanced.scalingModifiers.target) ==
                         0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                         == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -100211,7 +100211,7 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                             == 0 && size(self.keda.advanced.scalingModifiers.target)
                             == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                             == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -117458,7 +117458,7 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                         == 0 && size(self.keda.advanced.scalingModifiers.target) ==
                         0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                         == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -126064,7 +126064,7 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                             == 0 && size(self.keda.advanced.scalingModifiers.target)
                             == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                             == 0 && size(self.keda.advanced.scalingModifiers.metricType)
@@ -143353,7 +143353,7 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || (size(self.keda.advanced.scalingModifiers.formula)
                         == 0 && size(self.keda.advanced.scalingModifiers.target) ==
                         0 && size(self.keda.advanced.scalingModifiers.activationTarget)
                         == 0 && size(self.keda.advanced.scalingModifiers.metricType)


### PR DESCRIPTION
## Summary

KEDA-backed WVA scaling rejects an otherwise valid `LLMInferenceService` when `advanced.horizontalPodAutoscalerConfig.behavior` is present but the unrelated optional `scalingModifiers` object and HPA `name` field are omitted.

Update the two `KEDAScalingSpec` XValidation markers to guard every optional parent or leaf before reading it, while preserving rejection of any non-empty scaling modifier field and any non-empty HPA name. Add a focused envtest regression under the existing `crdvalidation` suite that creates both an `LLMInferenceService` and an `LLMInferenceServiceConfig` with HPA behavior configured and the optional controller-owned fields omitted, proving the generated schemas accept the reported shape. Include negative cases for populated `scalingModifiers` and HPA `name` so the presence guards do not weaken the intended ownership restrictions. Regenerate the full/minimal CRDs, Helm CRD templates, aggregate test CRD bundle, and quick-install manifest through `make precommit`; do not edit generated artifacts directly.

## Why this matters

KEDA-backed WVA scaling rejects an otherwise valid `LLMInferenceService` when `advanced.horizontalPodAutoscalerConfig.behavior` is present but the unrelated optional `scalingModifiers` object and HPA `name` field are omitted. The two `KEDAScalingSpec` CEL rules dereference those absent fields, so API-server validation fails with `no such key` instead of treating omission as valid. The same schema is embedded in both `LLMInferenceService` and `LLMInferenceServiceConfig`, so both resource kinds are affected. Existing Go validation already accepts omitted values and still rejects controller-owned values, leaving the generated CRD rules as the inconsistent layer.

## Testing

- Create an `LLMInferenceService` with KEDA advanced HPA scale-down behavior while omitting `scalingModifiers` and HPA `name`; CRD admission succeeds without a CEL evaluation error.
- Create an `LLMInferenceServiceConfig` with the same optional-field omissions; CRD admission succeeds, covering the second schema generated from `KEDAScalingSpec`.
- Set any supported `scalingModifiers` value while the object is present; CRD admission still rejects it with the existing WVA-ownership validation message.
- Set `horizontalPodAutoscalerConfig.name` while the HPA config is present; CRD admission still rejects it with the existing controller-ownership validation message.
- Regenerate manifests and confirm the guarded CEL expressions propagate consistently to full and minimal CRDs, both Helm CRD variants, the test CRD bundle, and the quick-install manifest.

Fixes #5936
