### PR TITLE
fix(helm): honour release namespace for `LLMInferenceServiceConfig` 

### DIFF
--- a/charts/kserve-runtime-configs/templates/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/templates/llmisvcconfigs/resources.yaml
@@ -1,3 +1,9 @@
 {{- if .Values.kserve.llmisvcConfigs.enabled }}
-{{ .Files.Get "files/llmisvcconfigs/resources.yaml" }}
+{{- /* The generated manifests hardcode "namespace: kserve", so rewrite it to the
+       release namespace, as the other charts do. Without this the presets are
+       always created in "kserve": the install fails outright when that namespace
+       does not exist, and when it does they are invisible to a controller running
+       elsewhere. */ -}}
+{{- $baseContent := .Files.Get "files/llmisvcconfigs/resources.yaml" }}
+{{ include "kserve-common.replaceNamespace" (list $baseContent .Release.Namespace) }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kserve-runtime-configs` chart ignores `--namespace` for the `LLMInferenceServiceConfig` presets. They are always created in `kserve`, so installing the chart anywhere else fails:

```
Helm install failed for release ai/kserve-runtime-configs with chart
kserve-runtime-configs@0.19.0: namespaces "kserve" not found
  ... (x11, one per preset)
```

`charts/kserve-runtime-configs/templates/llmisvcconfigs/resources.yaml` emits the generated manifests verbatim:

```gotemplate
{{- if .Values.kserve.llmisvcConfigs.enabled }}
{{ .Files.Get "files/llmisvcconfigs/resources.yaml" }}
{{- end }}
```

That file is built by `hack/setup/scripts/generate_chart_manifests.sh` from `config/llmisvcconfig`, where `namespace: kserve` is correct for the kustomize install path. It carries 11 hardcoded `metadata.namespace: kserve` entries, one per preset, which reach the cluster unmodified.

Every other chart that embeds generated manifests routes it through `kserve-common.replaceNamespace` first — `kserve-resources`, `kserve-llmisvc-resources` and `kserve-localmodel-resources` all do, via `_resources.tpl` / `_common.tpl`. This chart is the only one that does not, even though the helper is already vendored in its own `templates/_utils.tpl`. The sibling `templates/runtimes/resources.yaml` is unaffected because `ClusterServingRuntime` is cluster-scoped.

There is no value to override the namespace, so the only workarounds available today are a post-renderer or pre-creating a `kserve` namespace.

**Creating a `kserve` namespace is not a real workaround.** It gets the install to succeed but the presets are then unusable, because `LLMISVCReconciler.getConfig` resolves them from exactly two namespaces:

https://github.com/kserve/kserve/blob/v0.19.0/pkg/controller/v1alpha2/llmisvc/config_merge.go#L649

- `llmSvc.Namespace`
- `constants.KServeNamespace`, which is `POD_NAMESPACE` and comes from a `fieldRef` on the controller Deployment

With the controllers installed in `ai`, both lookups resolve to `ai`, so presets sitting in `kserve` are never found and every `LLMInferenceService` fails with `configNotFoundError` for `kserve-config-llm-template`.

The fix pipes the file through `kserve-common.replaceNamespace`, matching the other charts.

**Which issue(s) this PR fixes**:

None filed — happy to open one first if you'd prefer that for tracking.

**Feature/Issue validation/testing**:

The repo has no Helm chart test harness (no `helm-unittest`, `chart-testing`, or `charts/*/tests/`), so verification is via `helm template`. Glad to add a harness in a follow-up if you want regression coverage here.

- [x] **Reproduced on `master` without the fix** — presets ignore `--namespace`:

```console
$ helm template rc charts/kserve-runtime-configs -n ai \
    --set kserve.llmisvcConfigs.enabled=true | grep -c "^  namespace: ai$"
0
$ helm template rc charts/kserve-runtime-configs -n ai \
    --set kserve.llmisvcConfigs.enabled=true | grep -c "^  namespace: kserve$"
11
```

- [x] **With the fix** — presets follow the release namespace:

```console
$ helm template rc charts/kserve-runtime-configs -n ai \
    --set kserve.llmisvcConfigs.enabled=true | grep -c "^  namespace: ai$"
11
$ helm template rc charts/kserve-runtime-configs -n ai \
    --set kserve.llmisvcConfigs.enabled=true | grep -c "^  namespace: kserve$"
0
```

- [x] **No regression for the default namespace** — rendering into `kserve` with both
  `llmisvcConfigs.enabled=true` and `servingruntime.enabled=true` is byte-identical
  before and after (25 objects, `diff` reports no changes).

- [x] **Confirmed the edit is not clobbered by codegen** — `make generate-chart-manifests
  sync-helm-common-helpers` leaves the change in place. Only `_utils.tpl`, `_common.tpl`
  and `_resources.tpl` are synced into `charts/*/templates/`.

- [x] **Verified end to end on a live cluster** — KServe v0.19.0 installed into `ai` via
  Flux. Before: the `kserve-runtime-configs` HelmRelease is `InstallFailed` with the 11
  namespace errors above and zero `LLMInferenceServiceConfig` objects exist. Applying the
  equivalent namespace rewrite as a HelmRelease post-renderer installs all presets into
  `ai`, where the controller resolves them.

**Special notes for your reviewer**:

Three lines of template change; no Go code, no generated files, no image versions touched.

Worth noting the blast radius: any Helm install of `kserve-runtime-configs` outside the `kserve` namespace is broken today, and `llmisvcConfigs.enabled=true` is required for `LLMInferenceService` to work at all, since `kserve-config-llm-template` is the preset the reconciler prepends for every single-node service. The quick-install path is unaffected because it uses `kserve`.

I opted to fix it in the chart template rather than in `config/llmisvcconfig`, so the kustomize install path keeps its explicit namespace and only the Helm path becomes namespace-aware. Happy to take a different approach if you'd rather see it solved elsewhere.

**Release note**:

```release-note
Fixed the kserve-runtime-configs Helm chart creating LLMInferenceServiceConfig presets in the hardcoded `kserve` namespace instead of the release namespace, which made installing the chart into any other namespace fail with `namespaces "kserve" not found`.
```

**Temporary workaround**

Added the following postrender to be able to install in a different namespace:
https://github.com/mmontes11/k8s-ai/blob/6d337a63d0202601a10c530750700d1cce110be2/infrastructure/kserve/resources/kserve-runtime-configs-helmrelease.yaml#L43