### PR TITLE
fix(ci): align venv activation path with setup-uv.sh

### DIFF
--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -49,7 +49,7 @@ echo "Parallelism requested for pytest is ${PARALLELISM}"
 
 MAXFAIL="${PYTEST_MAXFAIL:-5}"
 
-source python/kserve/.venv/bin/activate
+source .venv/bin/activate
 
 REPORT_DIR="${ARTIFACT_DIR:-/tmp}"
 mkdir -p "$REPORT_DIR"

--- a/test/scripts/gh-actions/run-qpext-test.sh
+++ b/test/scripts/gh-actions/run-qpext-test.sh
@@ -21,7 +21,7 @@ set -o nounset
 set -o pipefail
 
 echo "Starting E2E queue proxy extension tests ..."
-source python/kserve/.venv/bin/activate
+source .venv/bin/activate
 pushd test/e2e >/dev/null
   pytest --log-level=INFO qpext
 popd


### PR DESCRIPTION
## Summary

- `setup-uv.sh` creates the virtualenv at `.venv/` (repo root), but `run-e2e-tests.sh` and `run-qpext-test.sh` still activate from the legacy `python/kserve/.venv/` path left over from the Poetry era (#2602)
- This mismatch causes **all** e2e test jobs to fail with `python/kserve/.venv/bin/activate: No such file or directory`
- Updates both scripts to `source .venv/bin/activate` to match `setup-uv.sh`

## Test plan

- [ ] Verify e2e test jobs pass CI (the fix is self-testing — any e2e job that runs `setup-uv.sh` → `run-e2e-tests.sh` exercises the corrected path)
- [ ] Verify qpext test job passes CI