### PR TITLE
ci: work around missing /etc/cni/net.d on current Ubuntu runners

### DIFF
--- a/.github/actions/minikube-setup/action.yml
+++ b/.github/actions/minikube-setup/action.yml
@@ -27,6 +27,10 @@ runs:
       with:
         version: 'v1.34.4'
 
+    - name: Create /etc/cni/net.d
+      shell: bash
+      run: sudo mkdir -p /etc/cni/net.d
+
     - name: Setup Minikube
       uses: medyagh/setup-minikube@latest
       with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Current GitHub-hosted Ubuntu runner images no longer ship the `/etc/cni/net.d` directory. The `setup-minikube` action's `none` driver assumes it exists and attempts to change its permissions, causing all jobs that rely on it to fail immediately.

Ensures the directory is present before minikube starts, using an idempotent `mkdir`. Applied once in the shared action, it covers all affected jobs without changes to individual workflow files.

**Which issue(s) this PR fixes**:

Ref: https://github.com/medyagh/setup-minikube/issues/835

**Feature/Issue validation/testing**:

- [ ] CI passes on re-run

- Logs

**Special notes for your reviewer**:

The fix is a workaround until `setup-minikube` addresses the root cause upstream (https://github.com/medyagh/setup-minikube/issues/835). Safe to merge as-is — `mkdir -p` is idempotent on runners where the directory already exists.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```