### PR TITLE
ci: scope publisher PR path filters and drop redundant amd64 builds

### DIFF
--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -59,13 +59,26 @@ jobs:
       - name: Free-up disk space
         uses: ./.github/actions/free-up-disk-space
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
       - name: Run tests
         run: |
           if [ -f docker-compose.test.yml ]; then
             docker-compose --file docker-compose.test.yml build
             docker-compose --file docker-compose.test.yml run sut
           else
-            docker buildx build . --file agent.Dockerfile
+            # e2e-test.yml builds this image as amd64 on every PR, so the
+            # publisher only needs to cover the other published platform
+            docker buildx build --platform linux/arm64/v8 . --file agent.Dockerfile
           fi
 
   # Push image to GitHub Packages.

--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -13,7 +13,11 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "**"
+      - "cmd/**"
+      - "pkg/**"
+      - "go.mod"
+      - "go.sum"
+      - "agent.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!python/**"

--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -72,7 +72,9 @@ jobs:
         timeout-minutes: 10
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/artexplainer.Dockerfile
           push: false

--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -13,7 +13,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/artexplainer/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/artexplainer.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/autogluonserver-docker-publish.yml
+++ b/.github/workflows/autogluonserver-docker-publish.yml
@@ -13,7 +13,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/autogluonserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/autogluon.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/autogluonserver-docker-publish.yml
+++ b/.github/workflows/autogluonserver-docker-publish.yml
@@ -72,7 +72,9 @@ jobs:
         timeout-minutes: 25
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/autogluon.Dockerfile
           push: false

--- a/.github/workflows/custom-model-grpc-publish.yml
+++ b/.github/workflows/custom-model-grpc-publish.yml
@@ -9,7 +9,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/custom_model/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/custom_model_grpc.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/huggingface-cpu-docker-publish.yml
+++ b/.github/workflows/huggingface-cpu-docker-publish.yml
@@ -12,7 +12,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/huggingfaceserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/huggingface_server_cpu.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/huggingface-docker-publish.yml
+++ b/.github/workflows/huggingface-docker-publish.yml
@@ -12,7 +12,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/huggingfaceserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/huggingface_server.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -58,13 +58,26 @@ jobs:
       - name: Free-up disk space
         uses: ./.github/actions/free-up-disk-space
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
       - name: Run tests
         run: |
           if [ -f docker-compose.test.yml ]; then
             docker-compose --file docker-compose.test.yml build
             docker-compose --file docker-compose.test.yml run sut
           else
-            docker buildx build . --file Dockerfile
+            # e2e-test.yml builds this image as amd64 on every PR, so the
+            # publisher only needs to cover the other published platform
+            docker buildx build --platform linux/arm64/v8 . --file Dockerfile
           fi
 
   # Push image to GitHub Packages.

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -13,7 +13,11 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "**"
+      - "cmd/**"
+      - "pkg/**"
+      - "go.mod"
+      - "go.sum"
+      - "Dockerfile"
       - "!python/**"
       - "!.github/**"
       - "!docs/**"

--- a/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
+++ b/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
@@ -13,7 +13,11 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "**"
+      - "cmd/**"
+      - "pkg/**"
+      - "go.mod"
+      - "go.sum"
+      - "llmisvc-controller.Dockerfile"
       - "!python/**"
       - "!.github/**"
       - "!docs/**"

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -58,13 +58,26 @@ jobs:
       - name: Free-up disk space
         uses: ./.github/actions/free-up-disk-space
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
       - name: Run tests
         run: |
           if [ -f docker-compose.test.yml ]; then
             docker-compose --file docker-compose.test.yml build
             docker-compose --file docker-compose.test.yml run sut
           else
-            docker buildx build . --file localmodel-agent.Dockerfile
+            # e2e-test.yml builds this image as amd64 on every PR, so the
+            # publisher only needs to cover the other published platform
+            docker buildx build --platform linux/arm64/v8 . --file localmodel-agent.Dockerfile
           fi
 
   # Push image to GitHub Packages.

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -13,7 +13,11 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "**"
+      - "cmd/**"
+      - "pkg/**"
+      - "go.mod"
+      - "go.sum"
+      - "localmodel-agent.Dockerfile"
       - "!python/**"
       - "!.github/**"
       - "!docs/**"

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -13,7 +13,11 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "**"
+      - "cmd/**"
+      - "pkg/**"
+      - "go.mod"
+      - "go.sum"
+      - "localmodel.Dockerfile"
       - "!python/**"
       - "!.github/**"
       - "!docs/**"

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -58,13 +58,26 @@ jobs:
       - name: Free-up disk space
         uses: ./.github/actions/free-up-disk-space
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
       - name: Run tests
         run: |
           if [ -f docker-compose.test.yml ]; then
             docker-compose --file docker-compose.test.yml build
             docker-compose --file docker-compose.test.yml run sut
           else
-            docker buildx build . --file localmodel.Dockerfile
+            # e2e-test.yml builds this image as amd64 on every PR, so the
+            # publisher only needs to cover the other published platform
+            docker buildx build --platform linux/arm64/v8 . --file localmodel.Dockerfile
           fi
 
   # Push image to GitHub Packages.

--- a/.github/workflows/lightgbm-docker-publish.yml
+++ b/.github/workflows/lightgbm-docker-publish.yml
@@ -13,7 +13,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/lgbserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/lgb.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/lightgbm-docker-publish.yml
+++ b/.github/workflows/lightgbm-docker-publish.yml
@@ -72,7 +72,9 @@ jobs:
         timeout-minutes: 10
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/lgb.Dockerfile
           push: false

--- a/.github/workflows/paddle-docker-publish.yml
+++ b/.github/workflows/paddle-docker-publish.yml
@@ -13,7 +13,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/paddleserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/paddle.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/paddle-docker-publish.yml
+++ b/.github/workflows/paddle-docker-publish.yml
@@ -72,7 +72,9 @@ jobs:
         timeout-minutes: 15
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/paddle.Dockerfile
           push: false

--- a/.github/workflows/pmml-docker-publish.yml
+++ b/.github/workflows/pmml-docker-publish.yml
@@ -72,7 +72,9 @@ jobs:
         timeout-minutes: 15
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/pmml.Dockerfile
           push: false

--- a/.github/workflows/pmml-docker-publish.yml
+++ b/.github/workflows/pmml-docker-publish.yml
@@ -13,7 +13,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/pmmlserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/pmml.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/predictiveserver-docker-publish.yml
+++ b/.github/workflows/predictiveserver-docker-publish.yml
@@ -75,7 +75,9 @@ jobs:
         timeout-minutes: 10
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/predictiveserver.Dockerfile
           push: false

--- a/.github/workflows/predictiveserver-docker-publish.yml
+++ b/.github/workflows/predictiveserver-docker-publish.yml
@@ -13,7 +13,15 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/predictiveserver/**"
+      - "python/sklearnserver/**"
+      - "python/xgbserver/**"
+      - "python/lgbserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/predictiveserver.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -13,7 +13,11 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "**"
+      - "cmd/**"
+      - "pkg/**"
+      - "go.mod"
+      - "go.sum"
+      - "router.Dockerfile"
       - "!python/**"
       - "!.github/**"
       - "!docs/**"

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -58,13 +58,26 @@ jobs:
       - name: Free-up disk space
         uses: ./.github/actions/free-up-disk-space
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
       - name: Run tests
         run: |
           if [ -f docker-compose.test.yml ]; then
             docker-compose --file docker-compose.test.yml build
             docker-compose --file docker-compose.test.yml run sut
           else
-            docker buildx build . --file router.Dockerfile
+            # e2e-test.yml builds this image as amd64 on every PR, so the
+            # publisher only needs to cover the other published platform
+            docker buildx build --platform linux/arm64/v8 . --file router.Dockerfile
           fi
 
   # Push image to GitHub Packages.

--- a/.github/workflows/sklearnserver-docker-publish.yml
+++ b/.github/workflows/sklearnserver-docker-publish.yml
@@ -13,7 +13,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/sklearnserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/sklearn.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/sklearnserver-docker-publish.yml
+++ b/.github/workflows/sklearnserver-docker-publish.yml
@@ -72,7 +72,9 @@ jobs:
         timeout-minutes: 10
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/sklearn.Dockerfile
           push: false

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -71,7 +71,9 @@ jobs:
         timeout-minutes: 35
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/storage-initializer.Dockerfile
           push: false

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -13,7 +13,11 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/storage-initializer/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/storage-initializer.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/tf2openapi-docker-publisher.yml
+++ b/.github/workflows/tf2openapi-docker-publisher.yml
@@ -13,7 +13,7 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "tools/**"
+      - "tools/tf2openapi/**"
       - "!python/**"
       - "!.github/**"
       - "!docs/**"

--- a/.github/workflows/transformer-docker-publish.yml
+++ b/.github/workflows/transformer-docker-publish.yml
@@ -9,7 +9,13 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/custom_transformer/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/custom_transformer.Dockerfile"
+      - "python/custom_transformer_grpc.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"

--- a/.github/workflows/xgbserver-docker-publisher.yml
+++ b/.github/workflows/xgbserver-docker-publisher.yml
@@ -72,7 +72,9 @@ jobs:
         timeout-minutes: 15
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          # e2e-test.yml builds this image as amd64 on every PR, so the
+          # publisher only needs to cover the other published platform
+          platforms: linux/arm64/v8
           context: python
           file: python/xgb.Dockerfile
           push: false

--- a/.github/workflows/xgbserver-docker-publisher.yml
+++ b/.github/workflows/xgbserver-docker-publisher.yml
@@ -13,7 +13,12 @@ on:
   # Run tests for any PRs.
   pull_request:
     paths:
-      - "python/**"
+      - "python/xgbserver/**"
+      - "python/kserve/**"
+      - "python/storage/**"
+      - "python/pyproject.toml"
+      - "python/third_party/**"
+      - "python/xgb.Dockerfile"
       - "!.github/**"
       - "!docs/**"
       - "!**.md"


### PR DESCRIPTION
**What this PR does / why we need it**:

Two commits. The first scopes each publisher's `pull_request.paths` to what its Dockerfile actually consumes, so a change to one Python server stops fanning out to ~15 builds. The second drops the amd64 build from the PR job wherever e2e already builds that image as amd64, leaving `linux/arm64/v8`. Release jobs are untouched.

**Which issue(s) this PR fixes**:
Fixes #5956

**Feature/Issue validation/testing**:

- [x] Confirmed every narrowed image is built as amd64 by an e2e job that has no `needs` and no job-level `if`: `kserve-image-build`, `predictor-runtime-build`, `explainer-runtime-build`. So amd64 comes from e2e, arm64 from the publisher, and the union is unchanged. The five Go publishers gain arm64, which they never validated on a PR before.
- [x] `actionlint` on all 20 changed workflows, no new findings (same 19 pre-existing shellcheck infos as master).
- [x] Path filters checked against each Dockerfile's `COPY` lines, e.g. `storage-initializer` does not copy `kserve`, `predictiveserver` copies sklearn/xgb/lgb, `custom_model_grpc` copies `custom_model`.

**Special notes for your reviewer**:

Three departures from the grouping in the issue, happy to revert any of them:

1. `artexplainer` moved B to A. `explainer-runtime-build` has no `needs` and no job-level `if` (`e2e-test.yml:277`); the `if: github.event_name == 'pull_request'` lines nearby are step-level, on "Merge target branch". So its amd64 is built on every PR.
2. `custom-model-grpc`, `huggingface-cpu` and `transformer` moved A to B. All three publish `linux/amd64` only, so an arm64-only PR build would test a platform that never ships and drop the amd64 check they have today.
3. `tf2openapi` paths narrowed to `tools/tf2openapi/**`. `qpext` was already narrow and is untouched.

One thing to note: `e2e-test.yml` excludes `.github/**`, so a PR touching only a publisher's own workflow file (this one, for instance) gets no amd64 build anywhere. Say the word if you'd rather that entry came out of the Group A filters.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

CI-only, so no tests. The reason for each arm64-only build is commented next to the platform line.

**Release note**:

```release-note
NONE
```
