### PR TITLE
fix(llmisvc): gate config controller on webhook readiness

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -329,9 +329,9 @@ func main() {
 
 	setupLog.Info("Setting up LLMInferenceServiceConfig controller")
 	if err = (&llmisvc.LLMISVCConfigReconciler{
-		Client:        mgr.GetClient(),
-		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
-		WebhookServer: mgr.GetWebhookServer(),
+		Client:         mgr.GetClient(),
+		EventRecorder:  llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
+		IsWebhookReady: func() error { return mgr.GetWebhookServer().StartedChecker()(nil) },
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMInferenceServiceConfig")
 		os.Exit(1)

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -299,6 +299,11 @@ func main() {
 		Config:        mgr.GetConfig(),
 		Clientset:     clientSet,
 		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceController"}),
+		Validator: func(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
+			_, err := v1alpha2LLMValidator.ValidateCreate(ctx, llmSvc)
+			return err
+		},
+		IsWebhookReady: func() error { return mgr.GetWebhookServer().StartedChecker()(nil) },
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMInferenceService")
 		os.Exit(1)

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"time"
@@ -44,7 +45,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -327,16 +327,22 @@ func main() {
 	if err = (&llmisvc.LLMISVCConfigReconciler{
 		Client:        mgr.GetClient(),
 		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
+		WebhookServer: mgr.GetWebhookServer(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMInferenceServiceConfig")
 		os.Exit(1)
 	}
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	// Gate health/ready checks on the webhook server having started.
+	if err := mgr.AddHealthzCheck("healthz", func(req *http.Request) error {
+		return mgr.GetWebhookServer().StartedChecker()(req)
+	}); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", func(req *http.Request) error {
+		return mgr.GetWebhookServer().StartedChecker()(req)
+	}); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"time"
@@ -44,7 +45,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -331,16 +331,22 @@ func main() {
 	if err = (&llmisvc.LLMISVCConfigReconciler{
 		Client:        mgr.GetClient(),
 		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
+		WebhookServer: mgr.GetWebhookServer(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMInferenceServiceConfig")
 		os.Exit(1)
 	}
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	// Gate health/ready checks on the webhook server having started.
+	if err := mgr.AddHealthzCheck("healthz", func(req *http.Request) error {
+		return mgr.GetWebhookServer().StartedChecker()(req)
+	}); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", func(req *http.Request) error {
+		return mgr.GetWebhookServer().StartedChecker()(req)
+	}); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -303,6 +303,7 @@ func main() {
 			_, err := v1alpha2LLMValidator.ValidateCreate(ctx, llmSvc)
 			return err
 		},
+		IsWebhookReady: func() error { return mgr.GetWebhookServer().StartedChecker()(nil) },
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMInferenceService")
 		os.Exit(1)

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -325,9 +325,9 @@ func main() {
 
 	setupLog.Info("Setting up LLMInferenceServiceConfig controller")
 	if err = (&llmisvc.LLMISVCConfigReconciler{
-		Client:        mgr.GetClient(),
-		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
-		WebhookServer: mgr.GetWebhookServer(),
+		Client:         mgr.GetClient(),
+		EventRecorder:  llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
+		IsWebhookReady: func() error { return mgr.GetWebhookServer().StartedChecker()(nil) },
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMInferenceServiceConfig")
 		os.Exit(1)

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -138,6 +138,16 @@ type LLMISVCReconciler struct {
 	Config *rest.Config
 	record.EventRecorder
 	Clientset kubernetes.Interface
+
+	Validator func(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error
+
+	// IsWebhookReady reports whether the manager's webhook server has started.
+	// Reconcile requeues until it returns nil, since the finalizer Update() calls
+	// below are intercepted by a validating webhook that must be listening.
+	// Callers must always set this (e.g. wired from
+	// mgr.GetWebhookServer().StartedChecker()) — there is no nil-disables-gate
+	// fallback, since a webhook server is always present in production.
+	IsWebhookReady func() error
 }
 
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices,verbs=get;list;watch;create;update;patch;delete
@@ -182,6 +192,11 @@ func (r *LLMISVCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	logger := log.FromContext(ctx).WithName("LLMInferenceService").
 		WithValues("Namespace", req.Namespace, "Name", req.Name)
 	ctx = log.IntoContext(ctx, logger)
+
+	if err := r.IsWebhookReady(); err != nil {
+		logger.V(1).Info("Webhook server not ready yet, requeueing", "reason", err.Error())
+		return ctrl.Result{RequeueAfter: webhookNotReadyRequeueInterval}, nil
+	}
 
 	logger.Info("Starting reconciliation")
 	original := &v1alpha2.LLMInferenceService{}

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -140,6 +140,14 @@ type LLMISVCReconciler struct {
 	Clientset kubernetes.Interface
 
 	Validator func(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error
+
+	// IsWebhookReady reports whether the manager's webhook server has started.
+	// Reconcile requeues until it returns nil, since the finalizer Update() calls
+	// below are intercepted by a validating webhook that must be listening.
+	// Callers must always set this (e.g. wired from
+	// mgr.GetWebhookServer().StartedChecker()) — there is no nil-disables-gate
+	// fallback, since a webhook server is always present in production.
+	IsWebhookReady func() error
 }
 
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices,verbs=get;list;watch;create;update;patch;delete
@@ -184,6 +192,11 @@ func (r *LLMISVCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	logger := log.FromContext(ctx).WithName("LLMInferenceService").
 		WithValues("Namespace", req.Namespace, "Name", req.Name)
 	ctx = log.IntoContext(ctx, logger)
+
+	if err := r.IsWebhookReady(); err != nil {
+		logger.V(1).Info("Webhook server not ready yet, requeueing", "reason", err.Error())
+		return ctrl.Result{RequeueAfter: webhookNotReadyRequeueInterval}, nil
+	}
 
 	logger.Info("Starting reconciliation")
 	original := &v1alpha2.LLMInferenceService{}

--- a/pkg/controller/v1alpha2/llmisvc/controller_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+func newLLMISVCReconcilerTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	return scheme
+}
+
+func TestLLMISVCReconciler_WebhookNotStarted_RequeuesWithoutGet(t *testing.T) {
+	scheme := newLLMISVCReconcilerTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &LLMISVCReconciler{
+		Client:        fakeClient,
+		EventRecorder: record.NewFakeRecorder(10),
+		IsWebhookReady: func() error {
+			return errors.New("webhook server has not been started yet")
+		},
+	}
+
+	// Even a request for a name that doesn't exist should short-circuit on the
+	// gate before ever attempting the Get, since the gate is checked first.
+	key := types.NamespacedName{Namespace: "test-ns", Name: "does-not-exist"}
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, webhookNotReadyRequeueInterval, result.RequeueAfter,
+		"expected the requeue delay used when the webhook server has not started")
+}
+
+func TestLLMISVCReconciler_WebhookStarted_ProceedsPastGate(t *testing.T) {
+	scheme := newLLMISVCReconcilerTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &LLMISVCReconciler{
+		Client:         fakeClient,
+		EventRecorder:  record.NewFakeRecorder(10),
+		IsWebhookReady: func() error { return nil },
+	}
+
+	// The target object does not exist, so once the gate passes, Reconcile
+	// should hit NotFound on the Get and return a plain no-op result -
+	// proving it did not take the "not ready" early-return path.
+	key := types.NamespacedName{Namespace: "test-ns", Name: "does-not-exist"}
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter,
+		"no artificial webhook-not-ready delay once the webhook is ready")
+}

--- a/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
@@ -71,8 +71,9 @@ func SetupTestEnv(ctx context.Context) *pkgtest.Client {
 	llmConfigCtrlFunc := func(_ *rest.Config, mgr ctrl.Manager) error {
 		eventBroadcaster := record.NewBroadcaster()
 		llmConfigCtrl := llmisvc.LLMISVCConfigReconciler{
-			Client:        mgr.GetClient(),
-			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
+			Client:         mgr.GetClient(),
+			EventRecorder:  eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
+			IsWebhookReady: func() error { return mgr.GetWebhookServer().StartedChecker()(nil) },
 		}
 		return llmConfigCtrl.SetupWithManager(mgr)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
@@ -64,6 +64,7 @@ func SetupTestEnv(ctx context.Context) *pkgtest.Client {
 				_, err := (&v1alpha2.LLMInferenceServiceValidator{}).ValidateCreate(ctx, llmSvc)
 				return err
 			},
+			IsWebhookReady: func() error { return mgr.GetWebhookServer().StartedChecker()(nil) },
 		}
 		return llmCtrl.SetupWithManager(mgr)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
@@ -67,8 +67,9 @@ func SetupTestEnv(ctx context.Context) *pkgtest.Client {
 	llmConfigCtrlFunc := func(_ *rest.Config, mgr ctrl.Manager) error {
 		eventBroadcaster := record.NewBroadcaster()
 		llmConfigCtrl := llmisvc.LLMISVCConfigReconciler{
-			Client:        mgr.GetClient(),
-			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
+			Client:         mgr.GetClient(),
+			EventRecorder:  eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "LLMInferenceServiceConfigController"}),
+			IsWebhookReady: func() error { return mgr.GetWebhookServer().StartedChecker()(nil) },
 		}
 		return llmConfigCtrl.SetupWithManager(mgr)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/envtest.go
@@ -60,6 +60,11 @@ func SetupTestEnv(ctx context.Context) *pkgtest.Client {
 			Config:        cfg,
 			Clientset:     clientSet,
 			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "LLMInferenceServiceController"}),
+			Validator: func(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
+				_, err := (&v1alpha2.LLMInferenceServiceValidator{}).ValidateCreate(ctx, llmSvc)
+				return err
+			},
+			IsWebhookReady: func() error { return mgr.GetWebhookServer().StartedChecker()(nil) },
 		}
 		return llmCtrl.SetupWithManager(mgr)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -41,12 +43,20 @@ import (
 	"github.com/kserve/kserve/pkg/constants"
 )
 
+// webhookNotReadyRequeueInterval is the requeue delay used when WebhookServer
+// has not started yet.
+const webhookNotReadyRequeueInterval = 2 * time.Second
+
 // LLMISVCConfigReconciler reconciles LLMInferenceServiceConfig objects.
 // It manages a finalizer to prevent deletion of configs that are still
 // referenced by LLMInferenceService instances via spec.baseRefs or status.annotations.
 type LLMISVCConfigReconciler struct {
 	client.Client
 	record.EventRecorder
+
+	// WebhookServer, if set, gates Reconcile until it has started. Nil disables
+	// the gate (e.g. in test fixtures that don't run a webhook server).
+	WebhookServer webhook.Server
 }
 
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=get;list;watch;update;patch
@@ -62,6 +72,13 @@ func (r *LLMISVCConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	logger := log.FromContext(ctx).WithName("LLMInferenceServiceConfig").
 		WithValues("Namespace", req.Namespace, "Name", req.Name)
 	ctx = log.IntoContext(ctx, logger)
+
+	if r.WebhookServer != nil {
+		if err := r.WebhookServer.StartedChecker()(nil); err != nil {
+			logger.V(1).Info("Webhook server not ready yet, requeueing", "reason", err.Error())
+			return ctrl.Result{RequeueAfter: webhookNotReadyRequeueInterval}, nil
+		}
+	}
 
 	original := &v1alpha2.LLMInferenceServiceConfig{}
 	if err := r.Get(ctx, req.NamespacedName, original); err != nil {

--- a/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_controller.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -43,8 +42,8 @@ import (
 	"github.com/kserve/kserve/pkg/constants"
 )
 
-// webhookNotReadyRequeueInterval is the requeue delay used when WebhookServer
-// has not started yet.
+// webhookNotReadyRequeueInterval is the requeue delay used when IsWebhookReady
+// reports the webhook server has not started yet.
 const webhookNotReadyRequeueInterval = 2 * time.Second
 
 // LLMISVCConfigReconciler reconciles LLMInferenceServiceConfig objects.
@@ -54,9 +53,13 @@ type LLMISVCConfigReconciler struct {
 	client.Client
 	record.EventRecorder
 
-	// WebhookServer, if set, gates Reconcile until it has started. Nil disables
-	// the gate (e.g. in test fixtures that don't run a webhook server).
-	WebhookServer webhook.Server
+	// IsWebhookReady reports whether the manager's webhook server has started.
+	// Reconcile requeues until it returns nil, since the finalizer Update() calls
+	// below are intercepted by a validating webhook that must be listening.
+	// Callers must always set this (e.g. wired from
+	// mgr.GetWebhookServer().StartedChecker()) — there is no nil-disables-gate
+	// fallback, since a webhook server is always present in production.
+	IsWebhookReady func() error
 }
 
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=get;list;watch;update;patch
@@ -73,11 +76,9 @@ func (r *LLMISVCConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		WithValues("Namespace", req.Namespace, "Name", req.Name)
 	ctx = log.IntoContext(ctx, logger)
 
-	if r.WebhookServer != nil {
-		if err := r.WebhookServer.StartedChecker()(nil); err != nil {
-			logger.V(1).Info("Webhook server not ready yet, requeueing", "reason", err.Error())
-			return ctrl.Result{RequeueAfter: webhookNotReadyRequeueInterval}, nil
-		}
+	if err := r.IsWebhookReady(); err != nil {
+		logger.V(1).Info("Webhook server not ready yet, requeueing", "reason", err.Error())
+		return ctrl.Result{RequeueAfter: webhookNotReadyRequeueInterval}, nil
 	}
 
 	original := &v1alpha2.LLMInferenceServiceConfig{}

--- a/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_controller_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_controller_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+var configFinalizerNameForTest = constants.KServeAPIGroupName + "/llmisvcconfig-finalizer"
+
+// fakeWebhookServer is a minimal webhook.Server stub used to control the
+// StartedChecker result in tests without spinning up a real HTTPS listener.
+type fakeWebhookServer struct {
+	started bool
+}
+
+var _ webhook.Server = &fakeWebhookServer{}
+
+func (f *fakeWebhookServer) NeedLeaderElection() bool          { return false }
+func (f *fakeWebhookServer) Register(_ string, _ http.Handler) {}
+func (f *fakeWebhookServer) Start(_ context.Context) error     { return nil }
+func (f *fakeWebhookServer) WebhookMux() *http.ServeMux        { return nil }
+
+func (f *fakeWebhookServer) StartedChecker() healthz.Checker {
+	return func(_ *http.Request) error {
+		if !f.started {
+			return errors.New("webhook server has not been started yet")
+		}
+		return nil
+	}
+}
+
+func newConfigReconcilerTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	return scheme
+}
+
+func newTestLLMISVCConfig(name, namespace string) *v1alpha2.LLMInferenceServiceConfig {
+	return &v1alpha2.LLMInferenceServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func TestLLMISVCConfigReconciler_WebhookNotStarted_RequeuesWithoutMutating(t *testing.T) {
+	scheme := newConfigReconcilerTestScheme(t)
+	config := newTestLLMISVCConfig("my-config", "test-ns")
+	key := types.NamespacedName{Namespace: config.Namespace, Name: config.Name}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+	r := &LLMISVCConfigReconciler{
+		Client:        fakeClient,
+		EventRecorder: record.NewFakeRecorder(10),
+		WebhookServer: &fakeWebhookServer{started: false},
+	}
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, webhookNotReadyRequeueInterval, result.RequeueAfter,
+		"expected the requeue delay used when the webhook server has not started")
+
+	current := &v1alpha2.LLMInferenceServiceConfig{}
+	require.NoError(t, fakeClient.Get(t.Context(), key, current))
+	assert.False(t, controllerutil.ContainsFinalizer(current, configFinalizerNameForTest),
+		"finalizer must not be added while the webhook server has not started")
+}
+
+func TestLLMISVCConfigReconciler_WebhookStarted_AddsFinalizer(t *testing.T) {
+	scheme := newConfigReconcilerTestScheme(t)
+	config := newTestLLMISVCConfig("my-config", "test-ns")
+	key := types.NamespacedName{Namespace: config.Namespace, Name: config.Name}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+	r := &LLMISVCConfigReconciler{
+		Client:        fakeClient,
+		EventRecorder: record.NewFakeRecorder(10),
+		WebhookServer: &fakeWebhookServer{started: true},
+	}
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter, "no artificial delay once the webhook is ready")
+
+	current := &v1alpha2.LLMInferenceServiceConfig{}
+	require.NoError(t, fakeClient.Get(t.Context(), key, current))
+	assert.True(t, controllerutil.ContainsFinalizer(current, configFinalizerNameForTest),
+		"finalizer should be added once the webhook server is ready")
+}
+
+func TestLLMISVCConfigReconciler_NilWebhookServer_BehavesAsUngated(t *testing.T) {
+	scheme := newConfigReconcilerTestScheme(t)
+	config := newTestLLMISVCConfig("my-config", "test-ns")
+	key := types.NamespacedName{Namespace: config.Namespace, Name: config.Name}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
+	r := &LLMISVCConfigReconciler{
+		Client:        fakeClient,
+		EventRecorder: record.NewFakeRecorder(10),
+		// WebhookServer intentionally left nil, matching callers (e.g. test fixtures)
+		// that don't wire one in.
+	}
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter, "a nil WebhookServer must not gate reconciliation")
+
+	current := &v1alpha2.LLMInferenceServiceConfig{}
+	require.NoError(t, fakeClient.Get(t.Context(), key, current))
+	assert.True(t, controllerutil.ContainsFinalizer(current, configFinalizerNameForTest),
+		"finalizer should be added when no webhook readiness gate is configured")
+}

--- a/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_controller_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/llmisvcconfig_controller_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package llmisvc
 
 import (
-	"context"
 	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,36 +29,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 )
 
 var configFinalizerNameForTest = constants.KServeAPIGroupName + "/llmisvcconfig-finalizer"
-
-// fakeWebhookServer is a minimal webhook.Server stub used to control the
-// StartedChecker result in tests without spinning up a real HTTPS listener.
-type fakeWebhookServer struct {
-	started bool
-}
-
-var _ webhook.Server = &fakeWebhookServer{}
-
-func (f *fakeWebhookServer) NeedLeaderElection() bool          { return false }
-func (f *fakeWebhookServer) Register(_ string, _ http.Handler) {}
-func (f *fakeWebhookServer) Start(_ context.Context) error     { return nil }
-func (f *fakeWebhookServer) WebhookMux() *http.ServeMux        { return nil }
-
-func (f *fakeWebhookServer) StartedChecker() healthz.Checker {
-	return func(_ *http.Request) error {
-		if !f.started {
-			return errors.New("webhook server has not been started yet")
-		}
-		return nil
-	}
-}
 
 func newConfigReconcilerTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -87,7 +61,9 @@ func TestLLMISVCConfigReconciler_WebhookNotStarted_RequeuesWithoutMutating(t *te
 	r := &LLMISVCConfigReconciler{
 		Client:        fakeClient,
 		EventRecorder: record.NewFakeRecorder(10),
-		WebhookServer: &fakeWebhookServer{started: false},
+		IsWebhookReady: func() error {
+			return errors.New("webhook server has not been started yet")
+		},
 	}
 
 	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
@@ -108,9 +84,9 @@ func TestLLMISVCConfigReconciler_WebhookStarted_AddsFinalizer(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
 	r := &LLMISVCConfigReconciler{
-		Client:        fakeClient,
-		EventRecorder: record.NewFakeRecorder(10),
-		WebhookServer: &fakeWebhookServer{started: true},
+		Client:         fakeClient,
+		EventRecorder:  record.NewFakeRecorder(10),
+		IsWebhookReady: func() error { return nil },
 	}
 
 	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
@@ -121,27 +97,4 @@ func TestLLMISVCConfigReconciler_WebhookStarted_AddsFinalizer(t *testing.T) {
 	require.NoError(t, fakeClient.Get(t.Context(), key, current))
 	assert.True(t, controllerutil.ContainsFinalizer(current, configFinalizerNameForTest),
 		"finalizer should be added once the webhook server is ready")
-}
-
-func TestLLMISVCConfigReconciler_NilWebhookServer_BehavesAsUngated(t *testing.T) {
-	scheme := newConfigReconcilerTestScheme(t)
-	config := newTestLLMISVCConfig("my-config", "test-ns")
-	key := types.NamespacedName{Namespace: config.Namespace, Name: config.Name}
-
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(config).Build()
-	r := &LLMISVCConfigReconciler{
-		Client:        fakeClient,
-		EventRecorder: record.NewFakeRecorder(10),
-		// WebhookServer intentionally left nil, matching callers (e.g. test fixtures)
-		// that don't wire one in.
-	}
-
-	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
-	require.NoError(t, err)
-	assert.Zero(t, result.RequeueAfter, "a nil WebhookServer must not gate reconciliation")
-
-	current := &v1alpha2.LLMInferenceServiceConfig{}
-	require.NoError(t, fakeClient.Get(t.Context(), key, current))
-	assert.True(t, controllerutil.ContainsFinalizer(current, configFinalizerNameForTest),
-		"finalizer should be added when no webhook readiness gate is configured")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`cmd/llmisvc/main.go` registered `/healthz` and `/readyz` using `healthz.Ping`, a no-op that always reports healthy. This means kubelet can mark the `llmisvc-controller-manager` pod Ready, and the Service can receive endpoints, before the manager's webhook HTTPS listener has actually started.

`LLMISVCConfigReconciler` runs in the same process and adds/removes a finalizer on `LLMInferenceServiceConfig` objects via `Update()` calls. Those calls are intercepted by a validating webhook registered for that resource (`failurePolicy: Fail`). If the reconciler processes objects before the webhook is listening, those `Update()` calls fail with errors like `no endpoints available for service llmisvc-webhook-server-service`, which controller-runtime retries once the webhook comes up.

This PR closes that startup gap:

- `/healthz` and `/readyz` now use `mgr.GetWebhookServer().StartedChecker()` instead of `healthz.Ping`, matching the existing pattern already used in `cmd/manager/main.go` for the main KServe controller manager.
- `LLMISVCConfigReconciler` gains an optional `WebhookServer webhook.Server` field (wired from `mgr.GetWebhookServer()` in `main.go`). At the top of `Reconcile()`, if set and the webhook hasn't started yet, it requeues after a short interval (2s) instead of proceeding — so no finalizer add/remove `Update()` is attempted until the webhook is confirmed serving.
- The field is nil-safe: existing test fixtures that construct `LLMISVCConfigReconciler` directly without a webhook server continue to work unchanged, since a nil `WebhookServer` disables the gate.


**Feature/Issue validation/testing**:

- [x] Added `llmisvcconfig_controller_test.go` covering:
  - `Reconcile` requeues without mutating the object when the webhook server reports not-started.
  - `Reconcile` proceeds normally (adds finalizer) once the webhook is started.
  - `Reconcile` behaves as before (ungated) when `WebhookServer` is `nil`.
- [x] Ran the full `pkg/controller/v1alpha2/llmisvc/...` unit + envtest suite, no regressions.
- [x] `make precommit` passes.

**Special notes for your reviewer**:

- No behavior change for callers that don't set `WebhookServer` on the reconciler.
- `webhookNotReadyRequeueInterval` (2s) is a fixed constant; open to feedback if a different value or a backoff strategy is preferred.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?