### PR TITLE
fix(llmisvc): grant configmap write RBAC for CA bundle sync

### DIFF
--- a/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
@@ -1132,10 +1132,12 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -1145,6 +1147,14 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/llmisvc/role.yaml
+++ b/config/rbac/llmisvc/role.yaml
@@ -12,10 +12,12 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -25,6 +27,14 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -107940,10 +107940,12 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -107953,6 +107955,14 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -166,7 +166,7 @@ type LLMISVCReconciler struct {
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews;subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:urls=/metrics,verbs=get
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,resourceNames=llminferenceservices.serving.kserve.io;llminferenceserviceconfigs.serving.kserve.io,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,resourceNames=llminferenceservices.serving.kserve.io;llminferenceserviceconfigs.serving.kserve.io,verbs=update;patch
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create


### PR DESCRIPTION
**What this PR does / why we need it**:

When `caBundleConfigMapName` is set (e.g. in `inferenceservice-config`), the
LLMInferenceService reconciler syncs that CA bundle into a `global-ca-bundle`
ConfigMap in the user namespace. The controller ClusterRole only had
`get/list/watch` on ConfigMaps, so reconciliation fails with:

```
fails to update cabundle configmap: configmaps "global-ca-bundle" is forbidden:
User "system:serviceaccount:kserve:llmisvc-controller-manager" cannot update
resource "configmaps"
```

This updates the kubebuilder RBAC marker and regenerates
`config/rbac/llmisvc/role.yaml` + the Helm chart resources so ConfigMaps get
`create/update/patch` (pods stay read-only).

Recreates / supersedes #5053 (which only patched a chart path that no longer
exists; this fixes the marker + generated manifests).

**Which issue(s) this PR fixes**:
Fixes #5052

**Feature/Issue validation/testing**:

- [x] Regenerated RBAC via `controller-gen` from updated kubebuilder marker
- [x] Regenerated chart manifests via `generate_chart_manifests.sh`
- [x] Verified on cluster: after applying updated ClusterRole, `global-ca-bundle`
      sync succeeds for LLMInferenceServices with `caBundleConfigMapName` set

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Grant LLMInferenceService controller create/update/patch on ConfigMaps so CA bundle sync to global-ca-bundle succeeds
```