### PR TITLE
chore(charts): remove stale localmodel agent values

### DIFF
--- a/charts/_common/common-sections.yaml
+++ b/charts/_common/common-sections.yaml
@@ -73,16 +73,7 @@ kserve:
       fsGroup: 1000
     disableVolumeManagement: false
     agent:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-      hostPath: /mnt/models
-      image: kserve/kserve-localmodelnode-agent
-      tag: ''
       reconcilationFrequencyInSecs: 60
-      securityContext:
-        runAsUser: 1000
-        runAsNonRoot: true
   security:
     autoMountServiceAccountToken: true
   inferenceservice:
@@ -105,4 +96,3 @@ kserve:
   autoscaler:
     scaleUpStabilizationWindowSeconds: '0'
     scaleDownStabilizationWindowSeconds: '300'
-

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -114,15 +114,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.llmisvc.controller.tolerations | list | `[]` |  |
 | kserve.llmisvc.controller.topologySpreadConstraints | list | `[]` |  |
 | kserve.llmisvc.createGIECRDs | bool | `true` |  |
-| kserve.localmodel.agent.affinity | object | `{}` |  |
-| kserve.localmodel.agent.hostPath | string | `"/mnt/models"` |  |
-| kserve.localmodel.agent.image | string | `"kserve/kserve-localmodelnode-agent"` |  |
-| kserve.localmodel.agent.nodeSelector | object | `{}` |  |
 | kserve.localmodel.agent.reconcilationFrequencyInSecs | int | `60` |  |
-| kserve.localmodel.agent.securityContext.runAsNonRoot | bool | `true` |  |
-| kserve.localmodel.agent.securityContext.runAsUser | int | `1000` |  |
-| kserve.localmodel.agent.tag | string | `""` |  |
-| kserve.localmodel.agent.tolerations | list | `[]` |  |
 | kserve.localmodel.controller.image | string | `"kserve/kserve-localmodel-controller"` |  |
 | kserve.localmodel.controller.tag | string | `""` |  |
 | kserve.localmodel.defaultJobImage | string | `"kserve/storage-initializer"` |  |

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -73,16 +73,7 @@ kserve:
       fsGroup: 1000
     disableVolumeManagement: false
     agent:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-      hostPath: /mnt/models
-      image: kserve/kserve-localmodelnode-agent
-      tag: ''
       reconcilationFrequencyInSecs: 60
-      securityContext:
-        runAsUser: 1000
-        runAsNonRoot: true
   security:
     autoMountServiceAccountToken: true
   inferenceservice:

--- a/charts/kserve-localmodel-resources/README.md
+++ b/charts/kserve-localmodel-resources/README.md
@@ -39,15 +39,7 @@ $ helm install kserve-localmodel-resources oci://ghcr.io/kserve/charts/kserve-lo
 | kserve.inferenceservice.resources.limits.memory | string | `"2Gi"` |  |
 | kserve.inferenceservice.resources.requests.cpu | string | `"1"` |  |
 | kserve.inferenceservice.resources.requests.memory | string | `"2Gi"` |  |
-| kserve.localmodel.agent.affinity | object | `{}` |  |
-| kserve.localmodel.agent.hostPath | string | `"/mnt/models"` |  |
-| kserve.localmodel.agent.image | string | `"kserve/kserve-localmodelnode-agent"` |  |
-| kserve.localmodel.agent.nodeSelector | object | `{}` |  |
 | kserve.localmodel.agent.reconcilationFrequencyInSecs | int | `60` |  |
-| kserve.localmodel.agent.securityContext.runAsNonRoot | bool | `true` |  |
-| kserve.localmodel.agent.securityContext.runAsUser | int | `1000` |  |
-| kserve.localmodel.agent.tag | string | `""` |  |
-| kserve.localmodel.agent.tolerations | list | `[]` |  |
 | kserve.localmodel.controller.image | string | `"kserve/kserve-localmodel-controller"` |  |
 | kserve.localmodel.controller.imagePullPolicy | string | `"IfNotPresent"` |  |
 | kserve.localmodel.controller.resources.limits.cpu | string | `"100m"` |  |

--- a/charts/kserve-localmodel-resources/values.yaml
+++ b/charts/kserve-localmodel-resources/values.yaml
@@ -81,16 +81,7 @@ kserve:
       fsGroup: 1000
     disableVolumeManagement: false
     agent:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-      hostPath: /mnt/models
-      image: kserve/kserve-localmodelnode-agent
-      tag: ''
       reconcilationFrequencyInSecs: 60
-      securityContext:
-        runAsUser: 1000
-        runAsNonRoot: true
   security:
     autoMountServiceAccountToken: true
   inferenceservice:

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -82,15 +82,7 @@ $ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --v
 | kserve.inferenceservice.resources.limits.memory | string | `"2Gi"` |  |
 | kserve.inferenceservice.resources.requests.cpu | string | `"1"` |  |
 | kserve.inferenceservice.resources.requests.memory | string | `"2Gi"` |  |
-| kserve.localmodel.agent.affinity | object | `{}` |  |
-| kserve.localmodel.agent.hostPath | string | `"/mnt/models"` |  |
-| kserve.localmodel.agent.image | string | `"kserve/kserve-localmodelnode-agent"` |  |
-| kserve.localmodel.agent.nodeSelector | object | `{}` |  |
 | kserve.localmodel.agent.reconcilationFrequencyInSecs | int | `60` |  |
-| kserve.localmodel.agent.securityContext.runAsNonRoot | bool | `true` |  |
-| kserve.localmodel.agent.securityContext.runAsUser | int | `1000` |  |
-| kserve.localmodel.agent.tag | string | `""` |  |
-| kserve.localmodel.agent.tolerations | list | `[]` |  |
 | kserve.localmodel.controller.image | string | `"kserve/kserve-localmodel-controller"` |  |
 | kserve.localmodel.controller.tag | string | `""` |  |
 | kserve.localmodel.defaultJobImage | string | `"kserve/storage-initializer"` |  |

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -73,16 +73,7 @@ kserve:
       fsGroup: 1000
     disableVolumeManagement: false
     agent:
-      nodeSelector: {}
-      affinity: {}
-      tolerations: []
-      hostPath: /mnt/models
-      image: kserve/kserve-localmodelnode-agent
-      tag: ''
       reconcilationFrequencyInSecs: 60
-      securityContext:
-        runAsUser: 1000
-        runAsNonRoot: true
   security:
     autoMountServiceAccountToken: true
   inferenceservice:


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes stale Helm values under `kserve.localmodel.agent.*` that no longer drive the local model node DaemonSet after the chart restructure. The only value kept under that legacy path is `reconcilationFrequencyInSecs`, which is still consumed by the ConfigMap patch in `kserve-resources` and `kserve-llmisvc-resources`.

The generated chart `values.yaml` files and chart README value tables are updated to match `charts/_common/common-sections.yaml`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5927

**Feature/Issue validation/testing**:

- [x] `git diff --check`
- [x] `make generate`
- [x] `make generate-chart-manifests`
- [x] `ruby -ryaml -e ...` parsed `charts/_common/common-sections.yaml` and the three generated chart `values.yaml` files, and confirmed `kserve.localmodel.agent` only contains `reconcilationFrequencyInSecs`
- [x] `rg -n "kserve\.localmodel\.agent\." charts` shows only the live reconciliation key in chart READMEs and ConfigMap patches

**Special notes for your reviewer**:

This is a chart values/documentation cleanup only. I did not find website docs still referencing the removed `kserve.localmodel.agent.*` scheduling/image/security keys.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```