### PR TITLE
test(llmisvc): rename test-llmisvc-autoscaling-keda e2e job

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -442,7 +442,7 @@ jobs:
         with:
           name: test-results-llmisvc-autoscaling-hpa-${{ matrix.install-method }}
 
-  test-llmisvc-wva-autoscaling-keda:
+  test-llmisvc-autoscaling-direct-keda-and-wva-with-keda:
     runs-on: cncf-ubuntu-16-64-x86
     timeout-minutes: 30
     needs: [detect-changes, llmisvc-image-build, seed-model-cache, seed-image-cache]
@@ -529,25 +529,47 @@ jobs:
         run: |
           ./test/scripts/gh-actions/verify-autoscaling-health.sh keda
 
-      - name: Run KEDA autoscaling E2E tests
-        id: autoscaling-keda-tests
-        timeout-minutes: 60
+      - name: Run WVA-mediated KEDA autoscaling E2E tests
+        id: autoscaling-wva-keda-tests
+        timeout-minutes: 30
         env:
           OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
         run: |
           export PYTEST_MAXFAIL=2
-          ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_keda and cluster_cpu" 0 "envoy-gateway"
+          ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_wva and autoscaling_keda and cluster_cpu" 0 "envoy-gateway"
+
+      - name: Run direct KEDA autoscaling E2E tests
+        id: autoscaling-direct-keda-tests
+        if: always() && steps.autoscaling-wva-keda-tests.conclusion != 'cancelled'
+        timeout-minutes: 30
+        env:
+          OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
+        run: |
+          export PYTEST_MAXFAIL=2
+          ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_direct_keda and cluster_cpu" 0 "envoy-gateway"
 
       - name: Check system status
         if: always()
         run: |
           ./test/scripts/gh-actions/status-check.sh "llmisvc"
 
-      - name: Upload test results
+      - name: Upload WVA-mediated KEDA test results
         if: always()
         uses: ./.github/actions/upload-test-results
         with:
-          name: test-results-llmisvc-autoscaling-keda-${{ matrix.install-method }}
+          name: test-results-llmisvc-autoscaling-wva-keda-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e*autoscaling_wva_and_autoscaling_keda*.xml
+            /tmp/e2e_results*autoscaling_wva_and_autoscaling_keda*.json
+
+      - name: Upload direct KEDA test results
+        if: always()
+        uses: ./.github/actions/upload-test-results
+        with:
+          name: test-results-llmisvc-autoscaling-direct-keda-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e*autoscaling_direct_keda*.xml
+            /tmp/e2e_results*autoscaling_direct_keda*.json
 
   test-llmisvc-tracing:
     runs-on: cncf-ubuntu-16-64-x86


### PR DESCRIPTION
**What this PR does / why we need it**:

The `test-llmisvc-wva-autoscaling-keda` job runs pytest with the `autoscaling_keda` marker, which matches tests from two unrelated code paths: WVA-mediated KEDA autoscaling (`test_llm_autoscaling_wva.py`) and direct KEDA autoscaling with no WVA involved (`test_llm_autoscaling_direct_keda.py`). Because both run in a single step under a job named only after the WVA path, a CI failure doesn't tell you which of the two code paths broke without digging into the log.

This PR:
1. Renames the job to `test-llmisvc-autoscaling-direct-keda-and-wva-with-keda`.
2. Splits the single pytest step into two steps, one per marker: `autoscaling_wva and autoscaling_keda` (WVA-mediated) and `autoscaling_direct_keda` (direct KEDA). Both markers are already auto-registered per-file in `test/e2e/llmisvc/conftest.py`.
3. Splits the uploaded test-result artifacts to match, so results/logs are separable per path.

Same runner, same total test coverage, same job cost — just clearer attribution when something breaks.

**Which issue(s) this PR fixes**:
Fixes #5950

**Special notes for your reviewer**:

Purely a CI workflow change — no product code touched. The two new steps use `if: always() && steps.autoscaling-wva-keda-tests.conclusion != 'cancelled'` on the second step (matching the existing pattern in the `test-llmisvc` job) so a failure/timeout in the first doesn't skip the second.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?