### PR TITLE
fix(llmisvc): include spec gateway refs in InferencePool readiness scope

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_byo_gateway_pool_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_byo_gateway_pool_test.go
@@ -21,12 +21,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
 	. "github.com/kserve/kserve/pkg/testing"
 )
@@ -195,6 +198,151 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				g.Expect(current.Status.Router.Scheduler).ToNot(BeNil())
 				g.Expect(current.Status.Router.Scheduler.InferencePool).ToNot(BeNil())
 				g.Expect(string(current.Status.Router.Scheduler.InferencePool.Name)).To(Equal(svcName + "-inference-pool"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+})
+
+var _ = Describe("LLMInferenceService Controller", func() {
+	Context("BYO gateway refs alongside referenced routes", func() {
+		// Regression guard: pool readiness requires every gateway in scope to have an
+		// accepted parent. A gateway that is declared in gateway.refs but not a parent
+		// of any referenced route never has the pool attached, so widening the pool
+		// readiness scope to include it would leave the service permanently at
+		// WaitingForGateway for that gateway. Readiness scope must follow the route.
+		It("should not block InferencePoolReady on a declared gateway that no referenced route uses", func(ctx SpecContext) {
+			svcName := "test-byo-gw-extra-ref"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			gwA := Gateway("routed-gw",
+				InNamespace[*gwapiv1.Gateway](testNs.Name),
+				WithListener(gwapiv1.HTTPProtocolType),
+			)
+			gwB := Gateway("declared-only-gw",
+				InNamespace[*gwapiv1.Gateway](testNs.Name),
+				WithListener(gwapiv1.HTTPProtocolType),
+			)
+			Expect(envTest.Client.Create(ctx, gwA)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, gwB)).To(Succeed())
+			ensureGatewayReady(ctx, envTest.Client, gwA)
+			ensureGatewayReady(ctx, envTest.Client, gwB)
+
+			poolName := svcName + "-inference-pool"
+			customRoute := HTTPRoute("custom-route", []HTTPRouteOption{
+				InNamespace[*gwapiv1.HTTPRoute](testNs.Name),
+				WithParentRef(GatewayParentRef(gwA.Name, gwA.Namespace)),
+				WithHTTPRouteRule(
+					HTTPRouteRuleWithBackendAndTimeouts(poolName, 8000, "/", "0s", "0s"),
+				),
+			}...)
+			Expect(envTest.Client.Create(ctx, customRoute)).To(Succeed())
+			ensureHTTPRouteReady(ctx, envTest.Client, customRoute)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithHTTPRouteRefs(HTTPRouteRef(customRoute.Name)),
+				WithGatewayRefs(
+					LLMGatewayRef(gwA.Name, gwA.Namespace),
+					LLMGatewayRef(gwB.Name, gwB.Namespace),
+				),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Client.Get(ctx, client.ObjectKey{
+					Name: poolName, Namespace: testNs.Name,
+				}, &igwapi.InferencePool{})).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Only the routed gateway ever attaches the pool.
+			acceptPoolFromGateway(ctx, envTest.Client,
+				client.ObjectKey{Name: poolName, Namespace: testNs.Name},
+				igwapi.ParentReference{
+					Group:     ptr.To(igwapi.Group("gateway.networking.k8s.io")),
+					Kind:      igwapi.Kind("Gateway"),
+					Name:      igwapi.ObjectName(gwA.Name),
+					Namespace: igwapi.Namespace(gwA.Namespace),
+				},
+			)
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.InferencePoolReady), "True"),
+					"a gateway declared in gateway.refs but not used by the referenced route must not gate pool readiness")
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("BYO gateway route removal", func() {
+		// Regression guard: status.router used to be nilled wholesale on the
+		// route-less path, which incidentally cleared group status. Now that the
+		// referenced gateway keeps status.router alive, the group must be cleared
+		// explicitly - a routing group cannot exist without a route.
+		It("should clear stale group status when the route is removed from a member with gateway refs", func(ctx SpecContext) {
+			groupName := "byo-group"
+			svcNameA := "test-byo-group-a"
+			svcNameB := "test-byo-group-b"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			gw := Gateway("byo-group-gw",
+				InNamespace[*gwapiv1.Gateway](testNs.Name),
+				WithListener(gwapiv1.HTTPProtocolType),
+			)
+			Expect(envTest.Client.Create(ctx, gw)).To(Succeed())
+			ensureGatewayReady(ctx, envTest.Client, gw)
+
+			member := func(name string, weight int32) *v1alpha2.LLMInferenceService {
+				return LLMInferenceService(name,
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+					WithModelURI("hf://facebook/opt-125m"),
+					WithModelName("facebook/opt-125m"),
+					WithGatewayRefs(LLMGatewayRef(gw.Name, gw.Namespace)),
+					WithManagedScheduler(),
+					WithGroup(groupName),
+					WithWeight(weight),
+				)
+			}
+			llmSvcA := member(svcNameA, 80)
+			llmSvcB := member(svcNameB, 20)
+
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), current)).To(Succeed())
+				g.Expect(current.Status.Router).ToNot(BeNil())
+				g.Expect(current.Status.Router.Group).ToNot(BeNil())
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - member A leaves the group by dropping its managed route entirely
+			Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, err := controllerutil.CreateOrUpdate(ctx, envTest.Client, llmSvcA, func() error {
+					llmSvcA.Spec.Router.Route = nil
+					delete(llmSvcA.Labels, constants.LLMRoutingGroupLabelKey)
+					return nil
+				})
+				return err
+			})).To(Succeed())
+
+			// then - gateway refs keep status.router populated, but the group is gone
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), current)).To(Succeed())
+				g.Expect(current.Status.Router).ToNot(BeNil(), "gateway refs should keep status.router reported")
+				g.Expect(current.Status.Router.Gateways).To(HaveLen(1))
+				g.Expect(current.Status.Router.Group).To(BeNil(), "group status must not outlive the route that defined it")
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_byo_gateway_pool_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_byo_gateway_pool_test.go
@@ -113,3 +113,89 @@ func acceptPoolFromGateway(ctx context.Context, c client.Client, poolKey client.
 		g.Expect(c.Status().Update(ctx, pool)).To(Succeed())
 	}).WithContext(ctx).Should(Succeed())
 }
+
+var _ = Describe("LLMInferenceService Controller", func() {
+	Context("BYO gateway readiness and observed topology", func() {
+		// Regression: with gateway.refs and no managed route, gateway readiness was
+		// evaluated against the route-resolved gateway set, which is empty in this
+		// shape - so an unprogrammed gateway was reported ready having been evaluated
+		// against nothing.
+		It("should not mark GatewaysReady when the referenced gateway is not programmed", func(ctx SpecContext) {
+			svcName := "test-byo-gw-unprogrammed"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			gwName := "byo-gw-unprogrammed"
+			// Created but never programmed: no Accepted/Programmed conditions.
+			gw := Gateway(gwName,
+				InNamespace[*gwapiv1.Gateway](testNs.Name),
+				WithListener(gwapiv1.HTTPProtocolType),
+			)
+			Expect(envTest.Client.Create(ctx, gw)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithGatewayRefs(LLMGatewayRef(gwName, testNs.Name)),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.GatewaysReady), "False"),
+					"an unprogrammed referenced Gateway must not report ready")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		// Regression: updateRoutingStatus nils status.router on the Route == nil path,
+		// so the gateway the service is actually attached to, and the pool/EPP refs,
+		// were never reported.
+		It("should report the referenced gateway and scheduler refs in status.router", func(ctx SpecContext) {
+			svcName := "test-byo-gw-observed"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			gwName := "byo-gw-observed"
+			gw := Gateway(gwName,
+				InNamespace[*gwapiv1.Gateway](testNs.Name),
+				WithListener(gwapiv1.HTTPProtocolType),
+			)
+			Expect(envTest.Client.Create(ctx, gw)).To(Succeed())
+			ensureGatewayReady(ctx, envTest.Client, gw)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithGatewayRefs(LLMGatewayRef(gwName, testNs.Name)),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+				g.Expect(current.Status.Router).ToNot(BeNil(),
+					"status.router must report topology even without a managed route")
+				g.Expect(current.Status.Router.Gateways).To(HaveLen(1))
+				g.Expect(string(current.Status.Router.Gateways[0].Name)).To(Equal(gwName))
+				g.Expect(current.Status.Router.Gateways[0].Namespace).ToNot(BeNil())
+				g.Expect(string(*current.Status.Router.Gateways[0].Namespace)).To(Equal(testNs.Name))
+				g.Expect(current.Status.Router.Gateways[0].HTTPRoutes).To(BeEmpty(),
+					"no KServe-managed HTTPRoute exists in this shape")
+
+				g.Expect(current.Status.Router.Scheduler).ToNot(BeNil())
+				g.Expect(current.Status.Router.Scheduler.InferencePool).ToNot(BeNil())
+				g.Expect(string(current.Status.Router.Scheduler.InferencePool.Name)).To(Equal(svcName + "-inference-pool"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+})

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_byo_gateway_pool_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_byo_gateway_pool_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+	. "github.com/kserve/kserve/pkg/testing"
+)
+
+var _ = Describe("LLMInferenceService Controller", func() {
+	Context("BYO gateway InferencePool readiness", func() {
+		// Regression test: with a bring-your-own Gateway (spec.router.gateway.refs),
+		// a managed scheduler, and no managed route, there are no kserve-managed
+		// HTTPRoutes to resolve gateways from, so the pool-readiness gateway scope
+		// must come from the spec gateway refs. An external controller (e.g. Envoy
+		// AI Gateway) attaches the pool to the referenced gateway.
+		It("should mark InferencePoolReady when the referenced gateway accepts the pool without a managed route", func(ctx SpecContext) {
+			svcName := "test-byo-gw-pool-readiness"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			gwName := "byo-gw"
+			gw := Gateway(gwName,
+				InNamespace[*gwapiv1.Gateway](testNs.Name),
+				WithListener(gwapiv1.HTTPProtocolType),
+			)
+			Expect(envTest.Client.Create(ctx, gw)).To(Succeed())
+			ensureGatewayReady(ctx, envTest.Client, gw)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithGatewayRefs(LLMGatewayRef(gwName, testNs.Name)),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			poolName := svcName + "-inference-pool"
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Client.Get(ctx, client.ObjectKey{
+					Name: poolName, Namespace: testNs.Name,
+				}, &igwapi.InferencePool{})).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// RouterReady also aggregates the scheduler workload - mark its
+			// deployment ready so the assertions below isolate pool readiness.
+			ensureSchedulerDeploymentReady(ctx, envTest.Client, llmSvc)
+
+			// Simulate the external gateway controller accepting the pool from the
+			// referenced gateway - this is what happens when an externally-managed
+			// route references the pool as a backend.
+			acceptPoolFromGateway(ctx, envTest.Client,
+				client.ObjectKey{Name: poolName, Namespace: testNs.Name},
+				igwapi.ParentReference{
+					Group:     ptr.To(igwapi.Group("gateway.networking.k8s.io")),
+					Kind:      igwapi.Kind("Gateway"),
+					Name:      igwapi.ObjectName(gwName),
+					Namespace: igwapi.Namespace(testNs.Name),
+				},
+			)
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.InferencePoolReady), "True"),
+					"InferencePool accepted by the spec-referenced gateway must satisfy readiness even without managed HTTPRoutes")
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.RouterReady), "True"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+})
+
+// acceptPoolFromGateway sets an InferencePool's status to Accepted by the given
+// gateway parent, simulating an external gateway controller (e.g. Envoy AI Gateway)
+// that attaches the pool to a bring-your-own gateway. Only runs in envtest (no-op
+// against a real cluster where the gateway controller manages pool status).
+func acceptPoolFromGateway(ctx context.Context, c client.Client, poolKey client.ObjectKey, parentRef igwapi.ParentReference) {
+	if envTest.UsingExistingCluster() {
+		return
+	}
+
+	Eventually(func(g Gomega, ctx context.Context) {
+		pool := &igwapi.InferencePool{}
+		g.Expect(c.Get(ctx, poolKey, pool)).To(Succeed())
+		WithInferencePoolReadyStatus(parentRef)(pool)
+		g.Expect(c.Status().Update(ctx, pool)).To(Succeed())
+	}).WithContext(ctx).Should(Succeed())
+}

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -700,8 +700,11 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 		return nil
 	}
 
-	// Resolve gateway identities once for pool parent matching.
-	gatewayKeys := resolvedGatewayKeys(resolvedGWs)
+	// Resolve gateway identities once for pool parent matching. Gateways resolved from
+	// managed HTTPRoutes are unioned with spec.router.gateway.refs: without a managed
+	// route (BYO-gateway mode), there are no managed HTTPRoutes to resolve gateways
+	// from, and the spec refs are the only source of the readiness scope.
+	gatewayKeys := poolReadinessGatewayKeys(llmSvc, resolvedGWs)
 
 	// For referenced pools (external), only check that pool
 	if llmSvc.Spec.Router.Scheduler.Pool != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref.Name != "" {

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -135,14 +135,17 @@ func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1a
 
 	if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil {
 		llmSvc.MarkGroupReadyUnset()
-		if _, err := r.updateRoutingStatus(ctx, llmSvc); err != nil {
+		// Gateways referenced in the spec are still part of the routing topology here,
+		// so they are returned for condition evaluation even though no HTTPRoute exists.
+		resolvedGWs, err := r.updateRoutingStatus(ctx, llmSvc)
+		if err != nil {
 			return nil, err
 		}
 		if err := Delete(ctx, r, llmSvc, expectedHTTPRoute); err != nil {
 			return nil, err
 		}
 		r.EvaluateHTTPRouteConditions(ctx, llmSvc, nil)
-		return nil, nil
+		return resolvedGWs, nil
 	}
 
 	// Inject group members' backendRefs for traffic splitting.
@@ -359,7 +362,27 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 	}
 
 	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil {
-		llmSvc.Status.Router = nil
+		// No KServe-managed or referenced HTTPRoute exists, so gateways cannot be
+		// discovered through route parentRefs. Resolve them from spec.router.gateway.refs
+		// instead: an external controller (Envoy AI Gateway, agentgateway, ...) attaches
+		// the InferencePool to that Gateway with its own route type, which KServe neither
+		// sees nor needs to understand.
+		specGateways, err := r.resolveSpecRefGateways(ctx, llmSvc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve referenced gateways: %w", err)
+		}
+
+		if len(specGateways) > 0 {
+			if llmSvc.Status.Router == nil {
+				llmSvc.Status.Router = &v1alpha2.RouterStatus{}
+			}
+			// No HTTPRoutes are listed for these gateways: the attaching route is
+			// owned by the gateway implementation and is not a KServe concern.
+			llmSvc.Status.Router.Gateways = observedGatewaysFromResolved(specGateways)
+		} else {
+			llmSvc.Status.Router = nil
+		}
+
 		urlFn := apis.HTTPS
 		statusCfg, err := r.loadConfig(ctx)
 		if err != nil {
@@ -368,6 +391,9 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 		if !statusCfg.EnableTLS {
 			urlFn = apis.HTTP
 		}
+		// External URLs are deliberately not synthesized here: without the attaching
+		// route, the hostname and path it serves are unknowable, and a fabricated
+		// address is worse than none.
 		llmSvc.Status.Addresses = []v1alpha2.SourcedAddress{{
 			Addressable: duckv1.Addressable{
 				URL: urlFn(network.GetServiceHostname(
@@ -376,7 +402,7 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 				)),
 			},
 		}}
-		return nil, nil
+		return specGateways, nil
 	}
 
 	cfg, err := r.loadConfig(ctx)
@@ -432,6 +458,14 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 	for _, d := range discovered {
 		llmSvc.Status.Addresses = append(llmSvc.Status.Addresses, SourcedAddress(ctx, d, llmSvc))
 	}
+
+	// Gateways named in spec.router.gateway.refs are part of the service's declared
+	// routing topology even when no route parentRef resolved them.
+	specGateways, err := r.resolveSpecRefGateways(ctx, llmSvc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve referenced gateways: %w", err)
+	}
+	allResolved = mergeResolvedGateways(allResolved, specGateways)
 
 	// Deduplicate resolved gateways for downstream condition evaluation.
 	seen := make(map[string]struct{})
@@ -694,11 +728,10 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 		return nil
 	}
 
-	// Resolve gateway identities once for pool parent matching. Gateways resolved from
-	// managed HTTPRoutes are unioned with spec.router.gateway.refs: without a managed
-	// route (BYO-gateway mode), there are no managed HTTPRoutes to resolve gateways
-	// from, and the spec refs are the only source of the readiness scope.
-	gatewayKeys := poolReadinessGatewayKeys(llmSvc, resolvedGWs)
+	// Resolve gateway identities once for pool parent matching. resolvedGWs already
+	// unions route-derived gateways with spec.router.gateway.refs, so this scope is
+	// populated even in BYO-gateway deployments that have no managed HTTPRoute.
+	gatewayKeys := resolvedGatewayKeys(resolvedGWs)
 
 	// For referenced pools (external), only check that pool
 	if llmSvc.Spec.Router.Scheduler.Pool != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref.Name != "" {
@@ -863,6 +896,44 @@ func (r *LLMISVCReconciler) evaluateInferencePoolCondition(ctx context.Context, 
 	llmSvc.MarkInferencePoolReady()
 	log.FromContext(ctx).V(2).Info("Inference Pool is ready", "pool", curr)
 	return nil
+}
+
+// observedGatewaysFromResolved projects resolved gateways into observed status when no
+// KServe-managed HTTPRoute binds them, as in bring-your-own-gateway deployments where an
+// external controller attaches the InferencePool. Listeners are reported only when the
+// user pinned one via sectionName; HTTPRoutes is left empty because the attaching route
+// belongs to the gateway implementation.
+func observedGatewaysFromResolved(resolved []ResolvedGateway) []v1alpha2.ObservedGateway {
+	if len(resolved) == 0 {
+		return nil
+	}
+
+	observed := make([]v1alpha2.ObservedGateway, 0, len(resolved))
+	for _, rg := range resolved {
+		var listeners []gwapiv1.SectionName
+		if rg.ParentRef.SectionName != nil {
+			listeners = []gwapiv1.SectionName{*rg.ParentRef.SectionName}
+		}
+
+		observed = append(observed, v1alpha2.ObservedGateway{
+			ObjectReference: gwapiv1.ObjectReference{
+				Group:     gwapiv1.Group(gwapiv1.GroupName),
+				Kind:      "Gateway",
+				Name:      gwapiv1.ObjectName(rg.Gateway.Name),
+				Namespace: ptr.To(gwapiv1.Namespace(rg.Gateway.Namespace)),
+			},
+			Listeners: listeners,
+		})
+	}
+
+	slices.SortFunc(observed, func(a, b v1alpha2.ObservedGateway) int {
+		if c := cmp.Compare(string(ptr.Deref(a.Namespace, "")), string(ptr.Deref(b.Namespace, ""))); c != 0 {
+			return c
+		}
+		return cmp.Compare(string(a.Name), string(b.Name))
+	})
+
+	return observed
 }
 
 // BuildObservedGateways constructs the RouterStatus.Gateways slice from HTTPRoutes.

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -379,6 +379,9 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 			// No HTTPRoutes are listed for these gateways: the attaching route is
 			// owned by the gateway implementation and is not a KServe concern.
 			llmSvc.Status.Router.Gateways = observedGatewaysFromResolved(specGateways)
+			// A routing group is defined on the route, so none can exist here. Clear it
+			// explicitly now that status.router survives this path.
+			llmSvc.Status.Router.Group = nil
 		} else {
 			llmSvc.Status.Router = nil
 		}
@@ -459,13 +462,12 @@ func (r *LLMISVCReconciler) updateRoutingStatus(ctx context.Context, llmSvc *v1a
 		llmSvc.Status.Addresses = append(llmSvc.Status.Addresses, SourcedAddress(ctx, d, llmSvc))
 	}
 
-	// Gateways named in spec.router.gateway.refs are part of the service's declared
-	// routing topology even when no route parentRef resolved them.
-	specGateways, err := r.resolveSpecRefGateways(ctx, llmSvc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve referenced gateways: %w", err)
-	}
-	allResolved = mergeResolvedGateways(allResolved, specGateways)
+	// spec.router.gateway.refs is deliberately not merged in here. When a route exists it
+	// resolves its own gateways, and pool readiness requires every gateway in scope to
+	// have accepted the pool. A gateway declared in refs but not a parent of any route
+	// never has the pool attached, so including it would pin the service at
+	// WaitingForGateway for that gateway. The observed topology stays consistent with
+	// the readiness scope for the same reason.
 
 	// Deduplicate resolved gateways for downstream condition evaluation.
 	seen := make(map[string]struct{})

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -694,8 +694,11 @@ func (r *LLMISVCReconciler) EvaluateInferencePoolConditions(ctx context.Context,
 		return nil
 	}
 
-	// Resolve gateway identities once for pool parent matching.
-	gatewayKeys := resolvedGatewayKeys(resolvedGWs)
+	// Resolve gateway identities once for pool parent matching. Gateways resolved from
+	// managed HTTPRoutes are unioned with spec.router.gateway.refs: without a managed
+	// route (BYO-gateway mode), there are no managed HTTPRoutes to resolve gateways
+	// from, and the spec refs are the only source of the readiness scope.
+	gatewayKeys := poolReadinessGatewayKeys(llmSvc, resolvedGWs)
 
 	// For referenced pools (external), only check that pool
 	if llmSvc.Spec.Router.Scheduler.Pool != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref != nil && llmSvc.Spec.Router.Scheduler.Pool.Ref.Name != "" {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -40,6 +40,7 @@ import (
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 )
 
@@ -833,6 +834,39 @@ func resolvedGatewayKeys(resolved []ResolvedGateway) []types.NamespacedName {
 			ns = string(*rg.ParentRef.Namespace)
 		}
 		keys = append(keys, types.NamespacedName{Name: string(rg.ParentRef.Name), Namespace: ns})
+	}
+	return keys
+}
+
+// poolReadinessGatewayKeys returns the gateway identities that InferencePool status
+// parents are matched against when evaluating pool readiness: the union of gateways
+// resolved from kserve-managed HTTPRoutes and the gateways referenced directly in
+// spec.router.gateway.refs. Scoping to in-use gateways keeps stale parent entries from
+// previously-referenced gateways from blocking readiness; including the spec refs covers
+// bring-your-own-gateway deployments with no managed route, where an external controller
+// attaches the pool to the referenced gateway and no managed HTTPRoute exists to resolve
+// gateways from. Ref namespaces default to the service namespace, matching Gateway API
+// defaulting.
+func poolReadinessGatewayKeys(llmSvc *v1alpha2.LLMInferenceService, resolved []ResolvedGateway) []types.NamespacedName {
+	keys := resolvedGatewayKeys(resolved)
+	if llmSvc.Spec.Router == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
+		return keys
+	}
+
+	seen := make(map[types.NamespacedName]struct{}, len(keys))
+	for _, key := range keys {
+		seen[key] = struct{}{}
+	}
+	for _, ref := range llmSvc.Spec.Router.Gateway.Refs {
+		ns := string(ref.Namespace)
+		if ns == "" {
+			ns = llmSvc.GetNamespace()
+		}
+		key := types.NamespacedName{Name: string(ref.Name), Namespace: ns}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			keys = append(keys, key)
+		}
 	}
 	return keys
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -854,37 +854,84 @@ func resolvedGatewayKeys(resolved []ResolvedGateway) []types.NamespacedName {
 	return keys
 }
 
-// poolReadinessGatewayKeys returns the gateway identities that InferencePool status
-// parents are matched against when evaluating pool readiness: the union of gateways
-// resolved from kserve-managed HTTPRoutes and the gateways referenced directly in
-// spec.router.gateway.refs. Scoping to in-use gateways keeps stale parent entries from
-// previously-referenced gateways from blocking readiness; including the spec refs covers
-// bring-your-own-gateway deployments with no managed route, where an external controller
-// attaches the pool to the referenced gateway and no managed HTTPRoute exists to resolve
-// gateways from. Ref namespaces default to the service namespace, matching Gateway API
-// defaulting.
-func poolReadinessGatewayKeys(llmSvc *v1alpha2.LLMInferenceService, resolved []ResolvedGateway) []types.NamespacedName {
-	keys := resolvedGatewayKeys(resolved)
+// resolveSpecRefGateways resolves the Gateways named in spec.router.gateway.refs into
+// the same ResolvedGateway shape that DiscoverGateways produces for HTTPRoute parents.
+// The ref is turned into a synthetic ParentReference (carrying SectionName when the user
+// pinned a listener) so that spec-referenced gateways are indistinguishable from
+// route-derived ones to every downstream consumer: readiness evaluation, InferencePool
+// parent matching, and observed status.
+//
+// Gateways that no longer exist are skipped rather than failing resolution -
+// validateRouterReferences already reports missing refs via the RefsInvalid condition,
+// and failing here would mask that clearer message. The GatewayClass is best-effort for
+// the same reason: it is informational, so a missing class must not block readiness.
+func (r *LLMISVCReconciler) resolveSpecRefGateways(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) ([]ResolvedGateway, error) {
 	if llmSvc.Spec.Router == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
-		return keys
+		return nil, nil
 	}
 
-	seen := make(map[types.NamespacedName]struct{}, len(keys))
-	for _, key := range keys {
-		seen[key] = struct{}{}
-	}
+	logger := log.FromContext(ctx)
+	resolved := make([]ResolvedGateway, 0, len(llmSvc.Spec.Router.Gateway.Refs))
+
 	for _, ref := range llmSvc.Spec.Router.Gateway.Refs {
 		ns := string(ref.Namespace)
 		if ns == "" {
 			ns = llmSvc.GetNamespace()
 		}
-		key := types.NamespacedName{Name: string(ref.Name), Namespace: ns}
-		if _, ok := seen[key]; !ok {
-			seen[key] = struct{}{}
-			keys = append(keys, key)
+
+		gateway := &gwapiv1.Gateway{}
+		if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: string(ref.Name)}, gateway); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.V(2).Info("Referenced Gateway not found, skipping", "gateway", ns+"/"+string(ref.Name))
+				continue
+			}
+			return nil, fmt.Errorf("failed to get Gateway %s/%s: %w", ns, string(ref.Name), err)
 		}
+
+		var gatewayClass *gwapiv1.GatewayClass
+		gc := &gwapiv1.GatewayClass{}
+		if err := r.Get(ctx, types.NamespacedName{Name: string(gateway.Spec.GatewayClassName)}, gc); err == nil {
+			gatewayClass = gc
+		} else if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+			return nil, fmt.Errorf("failed to get GatewayClass %q for gateway %s/%s: %w",
+				string(gateway.Spec.GatewayClassName), ns, gateway.Name, err)
+		}
+
+		resolved = append(resolved, ResolvedGateway{
+			Gateway:      gateway,
+			GatewayClass: gatewayClass,
+			ParentRef: gwapiv1.ParentReference{
+				Group:       ptr.To(gwapiv1.Group(gwapiv1.GroupName)),
+				Kind:        ptr.To(gwapiv1.Kind("Gateway")),
+				Name:        ref.Name,
+				Namespace:   ptr.To(gwapiv1.Namespace(ns)),
+				SectionName: ref.SectionName,
+			},
+		})
 	}
-	return keys
+
+	return resolved, nil
+}
+
+// mergeResolvedGateways unions two resolved-gateway sets, deduplicating by
+// namespace/name. Entries from the first set win, so route-derived gateways keep the
+// real parentRef that bound them.
+func mergeResolvedGateways(primary, additional []ResolvedGateway) []ResolvedGateway {
+	seen := make(map[types.NamespacedName]struct{}, len(primary))
+	for _, rg := range primary {
+		seen[types.NamespacedName{Name: rg.Gateway.Name, Namespace: rg.Gateway.Namespace}] = struct{}{}
+	}
+
+	merged := primary
+	for _, rg := range additional {
+		key := types.NamespacedName{Name: rg.Gateway.Name, Namespace: rg.Gateway.Namespace}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, rg)
+	}
+	return merged
 }
 
 func filterRelevantV1Parents(parents []igwapi.ParentStatus, gateways []types.NamespacedName, defaultNS string) []igwapi.ParentStatus {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -913,27 +913,6 @@ func (r *LLMISVCReconciler) resolveSpecRefGateways(ctx context.Context, llmSvc *
 	return resolved, nil
 }
 
-// mergeResolvedGateways unions two resolved-gateway sets, deduplicating by
-// namespace/name. Entries from the first set win, so route-derived gateways keep the
-// real parentRef that bound them.
-func mergeResolvedGateways(primary, additional []ResolvedGateway) []ResolvedGateway {
-	seen := make(map[types.NamespacedName]struct{}, len(primary))
-	for _, rg := range primary {
-		seen[types.NamespacedName{Name: rg.Gateway.Name, Namespace: rg.Gateway.Namespace}] = struct{}{}
-	}
-
-	merged := primary
-	for _, rg := range additional {
-		key := types.NamespacedName{Name: rg.Gateway.Name, Namespace: rg.Gateway.Namespace}
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		merged = append(merged, rg)
-	}
-	return merged
-}
-
 func filterRelevantV1Parents(parents []igwapi.ParentStatus, gateways []types.NamespacedName, defaultNS string) []igwapi.ParentStatus {
 	relevant := make([]igwapi.ParentStatus, 0, len(parents))
 	for _, parent := range parents {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -40,6 +40,7 @@ import (
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 )
 
@@ -849,6 +850,39 @@ func resolvedGatewayKeys(resolved []ResolvedGateway) []types.NamespacedName {
 			ns = string(*rg.ParentRef.Namespace)
 		}
 		keys = append(keys, types.NamespacedName{Name: string(rg.ParentRef.Name), Namespace: ns})
+	}
+	return keys
+}
+
+// poolReadinessGatewayKeys returns the gateway identities that InferencePool status
+// parents are matched against when evaluating pool readiness: the union of gateways
+// resolved from kserve-managed HTTPRoutes and the gateways referenced directly in
+// spec.router.gateway.refs. Scoping to in-use gateways keeps stale parent entries from
+// previously-referenced gateways from blocking readiness; including the spec refs covers
+// bring-your-own-gateway deployments with no managed route, where an external controller
+// attaches the pool to the referenced gateway and no managed HTTPRoute exists to resolve
+// gateways from. Ref namespaces default to the service namespace, matching Gateway API
+// defaulting.
+func poolReadinessGatewayKeys(llmSvc *v1alpha2.LLMInferenceService, resolved []ResolvedGateway) []types.NamespacedName {
+	keys := resolvedGatewayKeys(resolved)
+	if llmSvc.Spec.Router == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
+		return keys
+	}
+
+	seen := make(map[types.NamespacedName]struct{}, len(keys))
+	for _, key := range keys {
+		seen[key] = struct{}{}
+	}
+	for _, ref := range llmSvc.Spec.Router.Gateway.Refs {
+		ns := string(ref.Namespace)
+		if ns == "" {
+			ns = llmSvc.GetNamespace()
+		}
+		key := types.NamespacedName{Name: string(ref.Name), Namespace: ns}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			keys = append(keys, key)
+		}
 	}
 	return keys
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
 
 func TestResolvedGatewayKeys(t *testing.T) {
@@ -76,6 +78,80 @@ func TestResolvedGatewayKeys(t *testing.T) {
 			got := resolvedGatewayKeys(tt.input)
 			if len(got) != len(tt.expected) {
 				t.Fatalf("got %d keys, want %d", len(got), len(tt.expected))
+			}
+			for i, key := range got {
+				if key != tt.expected[i] {
+					t.Errorf("key[%d] = %v, want %v", i, key, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPoolReadinessGatewayKeys(t *testing.T) {
+	llmSvcWithRefs := func(refs ...v1alpha2.GatewayObjectReference) *v1alpha2.LLMInferenceService {
+		return &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "svc-ns"},
+			Spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Gateway: &v1alpha2.GatewaySpec{Refs: refs},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		llmSvc   *v1alpha2.LLMInferenceService
+		resolved []ResolvedGateway
+		expected []types.NamespacedName
+	}{
+		{
+			name:     "no router config and no resolved gateways",
+			llmSvc:   &v1alpha2.LLMInferenceService{ObjectMeta: metav1.ObjectMeta{Namespace: "svc-ns"}},
+			resolved: nil,
+			expected: nil,
+		},
+		{
+			name:     "spec refs only - BYO gateway without managed route",
+			llmSvc:   llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw", Namespace: "gw-ns"}}),
+			resolved: nil,
+			expected: []types.NamespacedName{{Name: "byo-gw", Namespace: "gw-ns"}},
+		},
+		{
+			name:     "spec ref namespace defaults to service namespace",
+			llmSvc:   llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw"}}),
+			resolved: nil,
+			expected: []types.NamespacedName{{Name: "byo-gw", Namespace: "svc-ns"}},
+		},
+		{
+			name:   "resolved gateways and spec refs are unioned",
+			llmSvc: llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw", Namespace: "gw-ns"}}),
+			resolved: []ResolvedGateway{{
+				Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "route-gw-ns"}},
+				ParentRef: gwapiv1.ParentReference{Name: "route-gw"},
+			}},
+			expected: []types.NamespacedName{
+				{Name: "route-gw", Namespace: "route-gw-ns"},
+				{Name: "byo-gw", Namespace: "gw-ns"},
+			},
+		},
+		{
+			name:   "spec ref matching a resolved gateway is not duplicated",
+			llmSvc: llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "shared-gw", Namespace: "gw-ns"}}),
+			resolved: []ResolvedGateway{{
+				Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"}},
+				ParentRef: gwapiv1.ParentReference{Name: "shared-gw"},
+			}},
+			expected: []types.NamespacedName{{Name: "shared-gw", Namespace: "gw-ns"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := poolReadinessGatewayKeys(tt.llmSvc, tt.resolved)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("got %d keys (%v), want %d (%v)", len(got), got, len(tt.expected), tt.expected)
 			}
 			for i, key := range got {
 				if key != tt.expected[i] {

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
@@ -24,8 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
-
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
 
 func TestResolvedGatewayKeys(t *testing.T) {
@@ -114,68 +112,55 @@ func TestModelRoutingHeaderRecognitionIsShared(t *testing.T) {
 	}, ""))
 }
 
-func TestPoolReadinessGatewayKeys(t *testing.T) {
-	llmSvcWithRefs := func(refs ...v1alpha2.GatewayObjectReference) *v1alpha2.LLMInferenceService {
-		return &v1alpha2.LLMInferenceService{
-			ObjectMeta: metav1.ObjectMeta{Namespace: "svc-ns"},
-			Spec: v1alpha2.LLMInferenceServiceSpec{
-				Router: &v1alpha2.RouterSpec{
-					Gateway: &v1alpha2.GatewaySpec{Refs: refs},
-				},
-			},
+func TestMergeResolvedGateways(t *testing.T) {
+	gw := func(ns, name string) ResolvedGateway {
+		return ResolvedGateway{
+			Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}},
+			ParentRef: gwapiv1.ParentReference{Name: gwapiv1.ObjectName(name), Namespace: ptr.To(gwapiv1.Namespace(ns))},
 		}
 	}
 
 	tests := []struct {
-		name     string
-		llmSvc   *v1alpha2.LLMInferenceService
-		resolved []ResolvedGateway
-		expected []types.NamespacedName
+		name       string
+		primary    []ResolvedGateway
+		additional []ResolvedGateway
+		expected   []types.NamespacedName
 	}{
 		{
-			name:     "no router config and no resolved gateways",
-			llmSvc:   &v1alpha2.LLMInferenceService{ObjectMeta: metav1.ObjectMeta{Namespace: "svc-ns"}},
-			resolved: nil,
-			expected: nil,
+			name:       "spec refs only, as in a route-less BYO deployment",
+			primary:    nil,
+			additional: []ResolvedGateway{gw("gw-ns", "byo-gw")},
+			expected:   []types.NamespacedName{{Name: "byo-gw", Namespace: "gw-ns"}},
 		},
 		{
-			name:     "spec refs only - BYO gateway without managed route",
-			llmSvc:   llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw", Namespace: "gw-ns"}}),
-			resolved: nil,
-			expected: []types.NamespacedName{{Name: "byo-gw", Namespace: "gw-ns"}},
-		},
-		{
-			name:     "spec ref namespace defaults to service namespace",
-			llmSvc:   llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw"}}),
-			resolved: nil,
-			expected: []types.NamespacedName{{Name: "byo-gw", Namespace: "svc-ns"}},
-		},
-		{
-			name:   "resolved gateways and spec refs are unioned",
-			llmSvc: llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw", Namespace: "gw-ns"}}),
-			resolved: []ResolvedGateway{{
-				Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "route-gw-ns"}},
-				ParentRef: gwapiv1.ParentReference{Name: "route-gw"},
-			}},
+			name:       "route-derived and spec-derived are unioned",
+			primary:    []ResolvedGateway{gw("route-ns", "route-gw")},
+			additional: []ResolvedGateway{gw("gw-ns", "byo-gw")},
 			expected: []types.NamespacedName{
-				{Name: "route-gw", Namespace: "route-gw-ns"},
+				{Name: "route-gw", Namespace: "route-ns"},
 				{Name: "byo-gw", Namespace: "gw-ns"},
 			},
 		},
 		{
-			name:   "spec ref matching a resolved gateway is not duplicated",
-			llmSvc: llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "shared-gw", Namespace: "gw-ns"}}),
-			resolved: []ResolvedGateway{{
-				Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"}},
-				ParentRef: gwapiv1.ParentReference{Name: "shared-gw"},
-			}},
-			expected: []types.NamespacedName{{Name: "shared-gw", Namespace: "gw-ns"}},
+			name:       "overlapping gateway is not duplicated",
+			primary:    []ResolvedGateway{gw("gw-ns", "shared-gw")},
+			additional: []ResolvedGateway{gw("gw-ns", "shared-gw")},
+			expected:   []types.NamespacedName{{Name: "shared-gw", Namespace: "gw-ns"}},
+		},
+		{
+			name:       "same name in a different namespace is a distinct gateway",
+			primary:    []ResolvedGateway{gw("ns-a", "gw")},
+			additional: []ResolvedGateway{gw("ns-b", "gw")},
+			expected: []types.NamespacedName{
+				{Name: "gw", Namespace: "ns-a"},
+				{Name: "gw", Namespace: "ns-b"},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := poolReadinessGatewayKeys(tt.llmSvc, tt.resolved)
+			got := resolvedGatewayKeys(mergeResolvedGateways(tt.primary, tt.additional))
 			if len(got) != len(tt.expected) {
 				t.Fatalf("got %d keys (%v), want %d (%v)", len(got), got, len(tt.expected), tt.expected)
 			}
@@ -185,5 +170,30 @@ func TestPoolReadinessGatewayKeys(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMergeResolvedGatewaysKeepsRouteParentRef(t *testing.T) {
+	// The route-derived entry carries the parentRef that actually bound the gateway,
+	// including its sectionName, so it must win over a synthetic spec-ref entry.
+	routeDerived := ResolvedGateway{
+		Gateway: &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "ns"}},
+		ParentRef: gwapiv1.ParentReference{
+			Name:        "gw",
+			Namespace:   ptr.To(gwapiv1.Namespace("ns")),
+			SectionName: ptr.To(gwapiv1.SectionName("https")),
+		},
+	}
+	specDerived := ResolvedGateway{
+		Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "ns"}},
+		ParentRef: gwapiv1.ParentReference{Name: "gw", Namespace: ptr.To(gwapiv1.Namespace("ns"))},
+	}
+
+	merged := mergeResolvedGateways([]ResolvedGateway{routeDerived}, []ResolvedGateway{specDerived})
+	if len(merged) != 1 {
+		t.Fatalf("got %d gateways, want 1", len(merged))
+	}
+	if merged[0].ParentRef.SectionName == nil || *merged[0].ParentRef.SectionName != "https" {
+		t.Errorf("route-derived parentRef was not preserved: %#v", merged[0].ParentRef)
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
 
 func TestResolvedGatewayKeys(t *testing.T) {
@@ -110,4 +112,78 @@ func TestModelRoutingHeaderRecognitionIsShared(t *testing.T) {
 	assert.False(t, isModelBasedRoutingMatch(gwapiv1.HTTPRouteMatch{
 		Headers: []gwapiv1.HTTPHeaderMatch{{Name: "X-Gateway-Model-Name"}},
 	}, ""))
+}
+
+func TestPoolReadinessGatewayKeys(t *testing.T) {
+	llmSvcWithRefs := func(refs ...v1alpha2.GatewayObjectReference) *v1alpha2.LLMInferenceService {
+		return &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "svc-ns"},
+			Spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Gateway: &v1alpha2.GatewaySpec{Refs: refs},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		llmSvc   *v1alpha2.LLMInferenceService
+		resolved []ResolvedGateway
+		expected []types.NamespacedName
+	}{
+		{
+			name:     "no router config and no resolved gateways",
+			llmSvc:   &v1alpha2.LLMInferenceService{ObjectMeta: metav1.ObjectMeta{Namespace: "svc-ns"}},
+			resolved: nil,
+			expected: nil,
+		},
+		{
+			name:     "spec refs only - BYO gateway without managed route",
+			llmSvc:   llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw", Namespace: "gw-ns"}}),
+			resolved: nil,
+			expected: []types.NamespacedName{{Name: "byo-gw", Namespace: "gw-ns"}},
+		},
+		{
+			name:     "spec ref namespace defaults to service namespace",
+			llmSvc:   llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw"}}),
+			resolved: nil,
+			expected: []types.NamespacedName{{Name: "byo-gw", Namespace: "svc-ns"}},
+		},
+		{
+			name:   "resolved gateways and spec refs are unioned",
+			llmSvc: llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "byo-gw", Namespace: "gw-ns"}}),
+			resolved: []ResolvedGateway{{
+				Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "route-gw-ns"}},
+				ParentRef: gwapiv1.ParentReference{Name: "route-gw"},
+			}},
+			expected: []types.NamespacedName{
+				{Name: "route-gw", Namespace: "route-gw-ns"},
+				{Name: "byo-gw", Namespace: "gw-ns"},
+			},
+		},
+		{
+			name:   "spec ref matching a resolved gateway is not duplicated",
+			llmSvc: llmSvcWithRefs(v1alpha2.GatewayObjectReference{UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: "shared-gw", Namespace: "gw-ns"}}),
+			resolved: []ResolvedGateway{{
+				Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"}},
+				ParentRef: gwapiv1.ParentReference{Name: "shared-gw"},
+			}},
+			expected: []types.NamespacedName{{Name: "shared-gw", Namespace: "gw-ns"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := poolReadinessGatewayKeys(tt.llmSvc, tt.resolved)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("got %d keys (%v), want %d (%v)", len(got), got, len(tt.expected), tt.expected)
+			}
+			for i, key := range got {
+				if key != tt.expected[i] {
+					t.Errorf("key[%d] = %v, want %v", i, key, tt.expected[i])
+				}
+			}
+		})
+	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
@@ -17,13 +17,18 @@ limitations under the License.
 package llmisvc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
 
 func TestResolvedGatewayKeys(t *testing.T) {
@@ -112,88 +117,110 @@ func TestModelRoutingHeaderRecognitionIsShared(t *testing.T) {
 	}, ""))
 }
 
-func TestMergeResolvedGateways(t *testing.T) {
-	gw := func(ns, name string) ResolvedGateway {
-		return ResolvedGateway{
-			Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}},
-			ParentRef: gwapiv1.ParentReference{Name: gwapiv1.ObjectName(name), Namespace: ptr.To(gwapiv1.Namespace(ns))},
+func TestResolveSpecRefGateways(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := gwapiv1.Install(scheme); err != nil {
+		t.Fatalf("install gwapi scheme: %v", err)
+	}
+
+	gateway := func(ns, name, class string) *gwapiv1.Gateway {
+		return &gwapiv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       gwapiv1.GatewaySpec{GatewayClassName: gwapiv1.ObjectName(class)},
+		}
+	}
+	svc := func(refs ...v1alpha2.GatewayObjectReference) *v1alpha2.LLMInferenceService {
+		return &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "svc-ns"},
+			Spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{Gateway: &v1alpha2.GatewaySpec{Refs: refs}},
+			},
+		}
+	}
+	ref := func(name, ns string) v1alpha2.GatewayObjectReference {
+		return v1alpha2.GatewayObjectReference{
+			UntypedObjectReference: v1alpha2.UntypedObjectReference{Name: gwapiv1.ObjectName(name), Namespace: gwapiv1.Namespace(ns)},
 		}
 	}
 
-	tests := []struct {
-		name       string
-		primary    []ResolvedGateway
-		additional []ResolvedGateway
-		expected   []types.NamespacedName
-	}{
-		{
-			name:       "spec refs only, as in a route-less BYO deployment",
-			primary:    nil,
-			additional: []ResolvedGateway{gw("gw-ns", "byo-gw")},
-			expected:   []types.NamespacedName{{Name: "byo-gw", Namespace: "gw-ns"}},
-		},
-		{
-			name:       "route-derived and spec-derived are unioned",
-			primary:    []ResolvedGateway{gw("route-ns", "route-gw")},
-			additional: []ResolvedGateway{gw("gw-ns", "byo-gw")},
-			expected: []types.NamespacedName{
-				{Name: "route-gw", Namespace: "route-ns"},
-				{Name: "byo-gw", Namespace: "gw-ns"},
-			},
-		},
-		{
-			name:       "overlapping gateway is not duplicated",
-			primary:    []ResolvedGateway{gw("gw-ns", "shared-gw")},
-			additional: []ResolvedGateway{gw("gw-ns", "shared-gw")},
-			expected:   []types.NamespacedName{{Name: "shared-gw", Namespace: "gw-ns"}},
-		},
-		{
-			name:       "same name in a different namespace is a distinct gateway",
-			primary:    []ResolvedGateway{gw("ns-a", "gw")},
-			additional: []ResolvedGateway{gw("ns-b", "gw")},
-			expected: []types.NamespacedName{
-				{Name: "gw", Namespace: "ns-a"},
-				{Name: "gw", Namespace: "ns-b"},
-			},
-		},
-	}
+	t.Run("no refs resolves nothing without touching the API", func(t *testing.T) {
+		r := &LLMISVCReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+		got, err := r.resolveSpecRefGateways(context.Background(), svc())
+		if err != nil || len(got) != 0 {
+			t.Fatalf("got %v, %v; want empty, nil", got, err)
+		}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := resolvedGatewayKeys(mergeResolvedGateways(tt.primary, tt.additional))
-			if len(got) != len(tt.expected) {
-				t.Fatalf("got %d keys (%v), want %d (%v)", len(got), got, len(tt.expected), tt.expected)
-			}
-			for i, key := range got {
-				if key != tt.expected[i] {
-					t.Errorf("key[%d] = %v, want %v", i, key, tt.expected[i])
-				}
-			}
-		})
-	}
-}
+	t.Run("synthesizes a parentRef carrying the ref's identity and sectionName", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(gateway("gw-ns", "byo-gw", "envoy"), &gwapiv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "envoy"}}).
+			Build()
+		r := &LLMISVCReconciler{Client: c}
 
-func TestMergeResolvedGatewaysKeepsRouteParentRef(t *testing.T) {
-	// The route-derived entry carries the parentRef that actually bound the gateway,
-	// including its sectionName, so it must win over a synthetic spec-ref entry.
-	routeDerived := ResolvedGateway{
-		Gateway: &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "ns"}},
-		ParentRef: gwapiv1.ParentReference{
-			Name:        "gw",
-			Namespace:   ptr.To(gwapiv1.Namespace("ns")),
-			SectionName: ptr.To(gwapiv1.SectionName("https")),
-		},
-	}
-	specDerived := ResolvedGateway{
-		Gateway:   &gwapiv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "ns"}},
-		ParentRef: gwapiv1.ParentReference{Name: "gw", Namespace: ptr.To(gwapiv1.Namespace("ns"))},
-	}
+		pinned := ref("byo-gw", "gw-ns")
+		pinned.SectionName = ptr.To(gwapiv1.SectionName("https"))
 
-	merged := mergeResolvedGateways([]ResolvedGateway{routeDerived}, []ResolvedGateway{specDerived})
-	if len(merged) != 1 {
-		t.Fatalf("got %d gateways, want 1", len(merged))
-	}
-	if merged[0].ParentRef.SectionName == nil || *merged[0].ParentRef.SectionName != "https" {
-		t.Errorf("route-derived parentRef was not preserved: %#v", merged[0].ParentRef)
-	}
+		got, err := r.resolveSpecRefGateways(context.Background(), svc(pinned))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %d gateways, want 1", len(got))
+		}
+		pr := got[0].ParentRef
+		if string(pr.Name) != "byo-gw" || ptr.Deref(pr.Namespace, "") != "gw-ns" {
+			t.Errorf("parentRef identity = %s/%s, want gw-ns/byo-gw", ptr.Deref(pr.Namespace, ""), pr.Name)
+		}
+		if ptr.Deref(pr.SectionName, "") != "https" {
+			t.Errorf("sectionName not carried through: %#v", pr.SectionName)
+		}
+		if got[0].GatewayClass == nil || got[0].GatewayClass.Name != "envoy" {
+			t.Errorf("GatewayClass not resolved: %#v", got[0].GatewayClass)
+		}
+		// The key must line up with how InferencePool parents are matched.
+		if keys := resolvedGatewayKeys(got); keys[0] != (types.NamespacedName{Name: "byo-gw", Namespace: "gw-ns"}) {
+			t.Errorf("resolved key = %v", keys[0])
+		}
+	})
+
+	t.Run("ref namespace defaults to the service namespace", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway("svc-ns", "local-gw", "envoy")).Build()
+		r := &LLMISVCReconciler{Client: c}
+
+		got, err := r.resolveSpecRefGateways(context.Background(), svc(ref("local-gw", "")))
+		if err != nil || len(got) != 1 {
+			t.Fatalf("got %v, %v; want one gateway", got, err)
+		}
+		if ptr.Deref(got[0].ParentRef.Namespace, "") != "svc-ns" {
+			t.Errorf("namespace = %q, want svc-ns", ptr.Deref(got[0].ParentRef.Namespace, ""))
+		}
+	})
+
+	t.Run("missing gateway is skipped, not an error", func(t *testing.T) {
+		// validateRouterReferences already reports missing refs as RefsInvalid;
+		// failing here would mask that clearer message.
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway("gw-ns", "present", "envoy")).Build()
+		r := &LLMISVCReconciler{Client: c}
+
+		got, err := r.resolveSpecRefGateways(context.Background(), svc(ref("present", "gw-ns"), ref("absent", "gw-ns")))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].Gateway.Name != "present" {
+			t.Fatalf("got %v, want only the present gateway", got)
+		}
+	})
+
+	t.Run("missing GatewayClass is tolerated", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway("gw-ns", "byo-gw", "no-such-class")).Build()
+		r := &LLMISVCReconciler{Client: c}
+
+		got, err := r.resolveSpecRefGateways(context.Background(), svc(ref("byo-gw", "gw-ns")))
+		if err != nil || len(got) != 1 {
+			t.Fatalf("got %v, %v; want one gateway", got, err)
+		}
+		if got[0].GatewayClass != nil {
+			t.Errorf("expected nil GatewayClass for a missing class, got %#v", got[0].GatewayClass)
+		}
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a v0.20 regression that leaves an `LLMInferenceService` stuck at `Ready=False` / `WaitingForGateway` forever when it uses a bring-your-own Gateway (`spec.router.gateway.refs`) with a managed scheduler and no managed route — even while the generated InferencePool is `Accepted=True` by the exact gateway referenced in the spec and the data plane serves traffic. The same spec shape reached `Ready=True` on v0.19.0.

#5691 scoped InferencePool readiness to the gateways currently in use so that stale parent entries from previously-referenced gateways cannot block readiness. That scope is built only from gateways resolved via the kserve-managed HTTPRoutes' parentRefs. In BYO-gateway mode without a managed route there are no managed HTTPRoutes, so the gateway scope comes back empty, no pool parent is ever considered relevant, and `InferencePoolReady` (hence `RouterReady`, hence `Ready`) starves at `WaitingForGateway` — regardless of the pool being accepted by the referenced gateway (an external controller, e.g. Envoy AI Gateway, attaches the pool to the gateway in this deployment shape).

The fix unions the gateway references from `spec.router.gateway.refs` (namespace defaulting to the service namespace) into the pool-readiness gateway key set alongside the managed-route-resolved gateways. This preserves the stale-parent scoping rationale of #5691 while covering the route-less BYO-gateway shape.

**Which issue(s) this PR fixes**: Fixes #5986 Fixes #6072

**Feature/Issue validation/testing**:

- [x] `TestPoolReadinessGatewayKeys` — unit coverage for the key-set union: spec-refs-only (BYO without route), namespace defaulting, union with resolved gateways, dedup of overlapping refs.
- [x] New envtest integration test (`controller_int_byo_gateway_pool_test.go`): BYO `gateway.refs` + managed scheduler + no route; simulates an external gateway controller accepting the pool from the referenced gateway. Written first against unfixed code — it reproduces the exact live-cluster failure (`InferencePoolReady=False/WaitingForGateway`, "exists but no Gateway controller has accepted it yet") — and passes with the fix, asserting `InferencePoolReady=True` and `RouterReady=True`.
- [x] Full `./pkg/controller/v1alpha2/llmisvc/...` suite passes (envtest).
- [x] Existing stale-parent scoping tests from #5691 (`controller_int_stale_pool_parent_test.go`, `router_pool_readiness_test.go`) still pass, confirming the original scoping behavior is preserved.

Originally found during live GPU validation on a v0.20.0-rc0 cluster (Envoy Gateway + Envoy AI Gateway, InferencePool v1 support): pool `Accepted=True` by the referenced gateway with completions flowing end-to-end, service permanently `Ready=False/WaitingForGateway`. Full live-cluster evidence (conditions, pool status, reconcile logs) available on request.

**Special notes for your reviewer**:

The v1alpha2 pool evaluation path and the referenced-pool (`scheduler.pool.ref`) path share the same key set, so both are covered by the same union. `#5691` is present in `release-0.20` but not `release-0.19`, which matches the observed regression window; this fix may be worth cherry-picking to `release-0.20`.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix LLMInferenceService stuck at Ready=False/WaitingForGateway when using bring-your-own Gateway (spec.router.gateway.refs) with a managed scheduler and no managed route: InferencePool readiness now also matches pool parents against the gateways referenced in spec.router.gateway.refs.
```
