### PR TITLE
fix(llmisvc): move pipeline parallel config presets to well-known defaults

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -89,13 +89,6 @@ var (
 	configTracingName                       = configPrefix + configTracingNameSuffix
 )
 
-// FIXME move those presets to well-known when they're finally known :)
-var _ = sets.New[string](
-	configPrefillWorkerPipelineParallelName,
-	configDecodeWorkerPipelineParallelName,
-	configWorkerPipelineParallelName,
-)
-
 // WellKnownDefaultConfigs contains the set of default configuration templates
 // that are automatically applied based on the LLM service deployment pattern
 var WellKnownDefaultConfigs = sets.New[string](
@@ -110,6 +103,9 @@ var WellKnownDefaultConfigs = sets.New[string](
 	configSchedulerLatencyPredictorName,
 	configTokenizerName,
 	configTracingName,
+	configPrefillWorkerPipelineParallelName,
+	configDecodeWorkerPipelineParallelName,
+	configWorkerPipelineParallelName,
 )
 
 const (


### PR DESCRIPTION
## Description
This PR addresses the `FIXME` in `pkg/controller/v1alpha2/llmisvc/config_merge.go` by moving the pipeline parallel configuration templates into `WellKnownDefaultConfigs`. 

These presets were originally kept separate as a placeholder (`var _ = sets.New[string](...)`) while the feature was under development. Now they are appropriately unified with the rest of the well-known LLM inference service configuration templates, ensuring the LLM ISVC controller properly applies and merges them during deployments.

### Changes Made:
- Removed the separate placeholder set for `configPrefillWorkerPipelineParallelName`, `configDecodeWorkerPipelineParallelName`, and `configWorkerPipelineParallelName`.
- Added them directly into the `WellKnownDefaultConfigs` set.

## Type of change
- [x] Bug fix / Tech Debt (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


#5975 gets fixed @greenmoon55 @Datta0 