### PR TITLE
fix(webhook): cap HPA memory ScaleTarget at [1-100] like CPU

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -536,13 +536,12 @@ func validateScalingHPACompExtension(compExtSpec *ComponentExtensionSpec) error 
 	}
 
 	if compExtSpec.ScaleTarget != nil {
-		target := *compExtSpec.ScaleTarget
-		if metric == MetricCPU && (target < 1 || target > 100) {
-			return errors.New("the target utilization percentage should be a [1-100] integer")
-		}
-
-		if metric == MetricMemory && target < 1 {
-			return errors.New("the target memory utilization percentage should be greater than 0")
+		// ScaleTarget always becomes an AverageUtilization percentage for both CPU and
+		// Memory (see hpa_reconciler.go), so both are bounded by the same [1-100] rule -
+		// matching the Utilization-type handling in validateTargetUtilization/validateScaleTarget
+		// used by the KEDA AutoScaling.Metrics path below.
+		if err := validateTargetUtilization(*compExtSpec.ScaleTarget); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -537,12 +537,12 @@ func validateScalingHPACompExtension(compExtSpec *ComponentExtensionSpec) error 
 
 	if compExtSpec.ScaleTarget != nil {
 		target := *compExtSpec.ScaleTarget
-		if metric == MetricCPU && target < 1 || target > 100 {
+		if metric == MetricCPU && (target < 1 || target > 100) {
 			return errors.New("the target utilization percentage should be a [1-100] integer")
 		}
 
 		if metric == MetricMemory && target < 1 {
-			return errors.New("the target memory should be greater than 1 MiB")
+			return errors.New("the target memory utilization percentage should be greater than 0")
 		}
 	}
 

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -334,7 +334,7 @@ func TestAutoscalerClassHPA(t *testing.T) {
 			},
 			errMatcher: gomega.BeNil(),
 		},
-		"Valid HPA Memory metrics with ScaleTarget above 100": {
+		"HPA Memory metrics with target utilization above 100": {
 			isvc: &InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -359,7 +359,7 @@ func TestAutoscalerClassHPA(t *testing.T) {
 					},
 				},
 			},
-			errMatcher: gomega.BeNil(),
+			errMatcher: gomega.MatchError("the target utilization percentage should be a [1-100] integer"),
 		},
 		"HPA Memory metrics with invalid target utilization": {
 			isvc: &InferenceService{
@@ -386,7 +386,7 @@ func TestAutoscalerClassHPA(t *testing.T) {
 					},
 				},
 			},
-			errMatcher: gomega.MatchError("the target memory utilization percentage should be greater than 0"),
+			errMatcher: gomega.MatchError("the target utilization percentage should be a [1-100] integer"),
 		},
 		"Invalid autoscaler class": {
 			isvc: &InferenceService{

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -334,6 +334,60 @@ func TestAutoscalerClassHPA(t *testing.T) {
 			},
 			errMatcher: gomega.BeNil(),
 		},
+		"Valid HPA Memory metrics with ScaleTarget above 100": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":  "Standard",
+						"serving.kserve.io/autoscalerClass": "hpa",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							ScaleMetric: ptr.To(MetricMemory),
+							ScaleTarget: ptr.To(int32(500)),
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.BeNil(),
+		},
+		"HPA Memory metrics with invalid target utilization": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":  "Standard",
+						"serving.kserve.io/autoscalerClass": "hpa",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							ScaleMetric: ptr.To(MetricMemory),
+							ScaleTarget: ptr.To(int32(0)),
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.MatchError("the target memory utilization percentage should be greater than 0"),
+		},
 		"Invalid autoscaler class": {
 			isvc: &InferenceService{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

`validateScalingHPACompExtension` in `pkg/apis/serving/v1beta1/inference_service_validation.go` had a boolean operator-precedence bug:

```go
if metric == MetricCPU && target < 1 || target > 100 {
    return errors.New("the target utilization percentage should be a [1-100] integer")
}
```

Because `&&` binds tighter than `||` in Go, this parses as `(metric == MetricCPU && target < 1) || (target > 100)` — the `target > 100` clause applies to every metric, not just CPU, as an accident of the broken boolean logic rather than an intentional, correctly-worded check. The adjacent memory-specific floor check also returned a misleading message (`"the target memory should be greater than 1 MiB"`) for a field that is always a percentage, never an absolute MiB value.

`ScaleTarget` for `scaleMetric: memory` becomes an `AverageUtilization` percentage of the pod's memory request — exactly like CPU — confirmed by the HPA reconciler (`hpa_reconciler.go`), which has treated it this way unchanged since the field's introduction. The codebase already has an established, exercised policy for this exact situation: `validateScalingKedaCompExtension`'s `validateScaleTarget`/`validateTargetUtilization` helpers cap *any* `Utilization`-type target at `[1-100]` regardless of resource (CPU or memory). This PR brings `validateScalingHPACompExtension` in line with that existing policy by reusing the same `validateTargetUtilization` helper, replacing the broken metric-specific conditionals with a single, explicit `[1-100]` check that applies uniformly to both metrics.

**Which issue(s) this PR fixes**:
Fixes #5981

**Feature/Issue validation/testing**:

- [x] Updated `TestAutoscalerClassHPA` in `pkg/apis/serving/v1beta1/inference_service_validation_test.go`:
  - `scaleMetric: memory`, `scaleTarget: 500` → rejected with the standard `[1-100]` message (previously rejected with the same message only by accident of the precedence bug; now explicit and consistent)
  - `scaleMetric: memory`, `scaleTarget: 0` → rejected with the same standard message (previously the misleading MiB-based message)
  - Existing CPU cases (including `scaleTarget: 120` → rejected) and the valid-memory case (`scaleTarget: 10`) are unchanged and still pass
- [x] `go test ./pkg/apis/serving/v1beta1/...`, `go vet`, and `golangci-lint run` all pass

**Special notes for your reviewer**:

No API surface change. This also slightly simplifies the function by removing metric-specific branching in favor of reusing the existing shared helper, consistent with how the KEDA validation path already handles the same case.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? — not needed, no user-facing API change

**Release note**:
```release-note
Fix a webhook validation bug where HPA memory scaleTarget validation used a CPU-worded error message due to an operator-precedence bug, and a misleading MiB-based message on invalid values; memory scaleTarget is now explicitly validated against the same [1-100] percentage range as CPU.
```
