### PR TITLE
fix(llmisvc): grant configmaps write verbs for CA bundle reconciliation

### DIFF
--- a/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
@@ -1132,10 +1132,11 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""
@@ -1145,6 +1146,14 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/llmisvc/role.yaml
+++ b/config/rbac/llmisvc/role.yaml
@@ -12,10 +12,11 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""
@@ -25,6 +26,14 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -108044,10 +108044,11 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""
@@ -108057,6 +108058,14 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -166,7 +166,9 @@ type LLMISVCReconciler struct {
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews;subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:urls=/metrics,verbs=get
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// The CA bundle ConfigMap is created and kept in sync in the workload namespace by the shared
+// CaBundleConfigMapReconciler, so create/update are required on top of the cached read verbs.
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,resourceNames=llminferenceservices.serving.kserve.io;llminferenceserviceconfigs.serving.kserve.io,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,resourceNames=llminferenceservices.serving.kserve.io;llminferenceserviceconfigs.serving.kserve.io,verbs=update;patch
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create


### PR DESCRIPTION
**What this PR does / why we need it**:

The llmisvc controller cannot reconcile any LLMInferenceService in an application
namespace when the cluster is configured with a custom CA bundle. It fails in a
loop with:

    fails to reconcile cabundle configmap: configmaps is forbidden:
    User "system:serviceaccount:kserve:llmisvc-controller-manager"
    cannot create resource "configmaps" in API group "" in the namespace "<ns>"

During normal reconciliation the controller calls the shared
`CaBundleConfigMapReconciler`, which creates and keeps in sync the
`global-ca-bundle` ConfigMap in the workload namespace. Its ClusterRole only
granted read access to configmaps, so every reconcile failed.

This is an RBAC omission specific to llmisvc. The kubebuilder marker granted
`get;list;watch`, whereas the InferenceService controller — which drives the same
CA bundle reconciler — correctly grants write access. This PR aligns llmisvc by
adding `create` and `update`.

The verbs are deliberately limited to what the code actually calls: the reconciler
performs Get, Create and Update only. No llmisvc code path deletes or patches a
ConfigMap, so `delete` and `patch` are intentionally not granted.

**Why CI never caught this**: the reconciler short-circuits when
`storageInitializer.caBundleConfigMapName` is empty, and that field defaults to
`""` in `inferenceservice-config`. The write path is therefore unreachable in
default installs and in e2e, and only fires on clusters that configure a custom
CA bundle (private/corporate PKI). Unit and envtest suites cannot catch it either,
since envtest runs with an admin client and does not enforce RBAC — the failure is
only observable against a real API server using the controller's own ServiceAccount.

**Affected versions**: reproduced on v0.19.0 and v0.20.0
(`helm template oci://ghcr.io/kserve/charts/kserve-llmisvc-resources`).

**Which issue(s) this PR fixes**:
Fixes #5988

**Feature/Issue validation/testing**:

- [x] Regenerated RBAC with the repo-pinned toolchain (controller-gen v0.19.0,
      kustomize v5.8.1) and the quick-install generator. Regeneration is
      idempotent: re-running all generators from the patched tree reproduces
      byte-identical output with no drift outside the three generated manifests.
- [x] Verified the resulting ClusterRole grants configmaps `create/get/list/update/watch`
      while `pods` remains read-only (`get/list/watch`) — the two resources simply
      split into separate rules now that their verb sets differ.
- [x] `go build ./...`, `go vet`, `golangci-lint` — all clean.
- [x] `go test ./pkg/controller/v1alpha2/llmisvc/...` with envtest (k8s 1.34.1):

    ok   github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc                427.633s
    ok   github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/crdvalidation    8.903s

- Repro: set `caBundleConfigMapName` in the `inferenceservice-config` ConfigMap,
  create the source CA bundle ConfigMap in the `kserve` namespace, then deploy an
  LLMInferenceService in any application namespace. Before this change the
  controller loops on the forbidden error above; after it, the `global-ca-bundle`
  ConfigMap is created in the workload namespace and reconciliation completes.

**Special notes for your reviewer**:

No behavioural change beyond the permission grant — the controller already
attempted these writes; it simply lacked the rights. Kept to the minimum verb set
rather than the full CRUD used by neighbouring markers, to stay within least
privilege.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
      RBAC grants are generated config and are not observable from envtest, which
      bypasses authorization. Validation is the regenerated manifest plus a live-cluster repro.
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
Fix llmisvc controller failing to reconcile LLMInferenceService resources with "configmaps is forbidden" when a custom CA bundle is configured, by granting the controller create/update permissions on configmaps for CA bundle reconciliation.
```