### PR TITLE
fix: return TrainedModel delete errors during finalization

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -749,12 +750,14 @@ func (r *InferenceServiceReconciler) deleteExternalResources(ctx context.Context
 	}
 
 	// #nosec G601
+	var errs []error
 	for i, v := range trainedModels.Items {
 		if err := r.Delete(ctx, &trainedModels.Items[i], client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
 			r.Log.Error(err, "unable to delete trainedmodel", "trainedmodel", v)
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return utilerrors.NewAggregate(errs)
 }
 
 func (r *InferenceServiceReconciler) GetFailConditions(isvc *v1beta1.InferenceService) string {


### PR DESCRIPTION
`deleteExternalResources` logs each failed `Delete` and then returns `nil` unconditionally.

The caller treats that `nil` as success and removes the finalizer. Its own comment says the opposite is intended:

```go
if err := r.deleteExternalResources(ctx, isvc); err != nil {
    // if fail to delete the external dependency here, return with error
    // so that it can be retried
    return ctrl.Result{}, err
}
```

The `List` error a few lines above the loop already returns, so the two paths are inconsistent.

TrainedModels are matched only by the parent inferenceservice label and have no owner reference back to the InferenceService, so Kubernetes garbage collection will not reap them either. Once the finalizer is removed they are orphaned.

This collects the delete errors and returns them as an aggregate, so a failure requeues instead of silently completing finalization.

This only fires when a `Delete` actually fails, for example an RBAC gap, an admission webhook rejection, or an API server 5xx. I have not reproduced it end to end; that needs envtest with an injected Delete failure. `go build` and `go vet` on `./pkg/controller/v1beta1/inferenceservice/...` both pass.
