### PR TITLE
test(llmisvc): add reverse direct KEDA/WVA actuator case to v1alpha2

### DIFF
--- a/pkg/apis/serving/v1alpha2/llm_inference_service_validation_test.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_validation_test.go
@@ -1138,6 +1138,31 @@ func TestValidateActuatorConsistency(t *testing.T) {
 		assert.Contains(t, errs[0].Detail, "decode uses direct keda but prefill uses wva")
 	})
 
+	t.Run("error: decode WVA, prefill direct KEDA", func(t *testing.T) {
+		svc := newBaseLLMInferenceServiceV1Alpha2()
+		svc.Spec.WorkloadSpec = WorkloadSpec{
+			Scaling: &ScalingSpec{
+				MaxReplicas: 5,
+				WVA:         &WVASpec{ActuatorSpec: ActuatorSpec{KEDA: &KEDAScalingSpec{}}},
+			},
+		}
+		svc.Spec.Prefill = &WorkloadSpec{
+			Scaling: &ScalingSpec{
+				MaxReplicas: 5,
+				KEDA: &DirectKEDAScalingSpec{
+					Triggers: []kedav1alpha1.ScaleTriggers{
+						{Type: "memory", Metadata: map[string]string{"value": "70"}},
+					},
+				},
+			},
+		}
+
+		errs := validator.validateScaling(svc)
+		require.Len(t, errs, 1)
+		assert.Contains(t, errs[0].Field, "spec.prefill.scaling")
+		assert.Contains(t, errs[0].Detail, "decode uses wva but prefill uses direct keda")
+	})
+
 	t.Run("error: decode HPA, prefill KEDA", func(t *testing.T) {
 		svc := newBaseLLMInferenceServiceV1Alpha2()
 		svc.Spec.WorkloadSpec = WorkloadSpec{


### PR DESCRIPTION
## Summary

- Adds the missing `error: decode WVA, prefill direct KEDA` subtest to `TestValidateActuatorConsistency` in
  `pkg/apis/serving/v1alpha2/llm_inference_service_validation_test.go`, mirroring the coverage `v1alpha1` already has.

Follow-up on [#5839](https://github.com/kserve/kserve/pull/5839#discussion_r3676514594).

## Test plan

- `go test ./pkg/apis/serving/v1alpha2/... -run TestValidateActuatorConsistency -v`