### PR TITLE
feat(llmisvc): allow idleReplicaCount=0 for true KEDA scale-to-zero

### DIFF
--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -605,7 +605,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -852,7 +852,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -17160,7 +17160,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -17407,7 +17407,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
@@ -621,7 +621,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -868,7 +868,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -17595,7 +17595,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -17842,7 +17842,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -297,7 +297,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -544,7 +544,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -16821,7 +16821,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -17068,7 +17068,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -25217,7 +25217,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -25464,7 +25464,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -41772,7 +41772,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -42019,7 +42019,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
@@ -306,7 +306,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -553,7 +553,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -17239,7 +17239,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -17486,7 +17486,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -25822,7 +25822,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -26069,7 +26069,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -42796,7 +42796,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -43043,7 +43043,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32

--- a/config/crd/full/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/full/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -285,7 +285,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -532,7 +532,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -16809,7 +16809,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -17056,7 +17056,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -25205,7 +25205,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -25452,7 +25452,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -41760,7 +41760,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -42007,7 +42007,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32

--- a/config/crd/full/llmisvc/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/full/llmisvc/serving.kserve.io_llminferenceservices.yaml
@@ -294,7 +294,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -541,7 +541,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -17227,7 +17227,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -17474,7 +17474,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -25810,7 +25810,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32
@@ -26057,7 +26057,7 @@ spec:
                                   type: object
                                 idleReplicaCount:
                                   format: int32
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 initialCooldownPeriod:
                                   format: int32
@@ -42784,7 +42784,7 @@ spec:
                           type: object
                         idleReplicaCount:
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         initialCooldownPeriod:
                           format: int32
@@ -43031,7 +43031,7 @@ spec:
                               type: object
                             idleReplicaCount:
                               format: int32
-                              minimum: 1
+                              minimum: 0
                               type: integer
                             initialCooldownPeriod:
                               format: int32

--- a/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -592,7 +592,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -842,7 +842,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -17170,7 +17170,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -17420,7 +17420,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32

--- a/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceservices.yaml
@@ -608,7 +608,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -858,7 +858,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -17895,7 +17895,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -18145,7 +18145,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -6889,7 +6889,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -7139,7 +7139,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -23436,7 +23436,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -23686,7 +23686,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -31853,7 +31853,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -32103,7 +32103,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -48431,7 +48431,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -48681,7 +48681,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -56626,7 +56626,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -56876,7 +56876,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -73871,7 +73871,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -74121,7 +74121,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -82475,7 +82475,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -82725,7 +82725,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -99762,7 +99762,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -100012,7 +100012,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
@@ -529,9 +529,11 @@ type KEDAScalingSpec struct {
 
 	// IdleReplicaCount is the number of replicas KEDA will scale the resource down to
 	// when there are no triggers active. This must be less than minReplicas.
+	// Set to 0 for true scale-to-zero: KEDA scales the resource to zero replicas when idle
+	// and immediately back to minReplicas once a trigger becomes active.
 	// If not set, KEDA will not scale below minReplicas.
 	// +optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	IdleReplicaCount *int32 `json:"idleReplicaCount,omitempty"`
 
 	// Fallback defines the replica count to maintain when the scaler is in a fallback state

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
@@ -217,6 +217,23 @@ func TestValidateWorkloadScaling(t *testing.T) {
 			wantErrCount: 0,
 		},
 		{
+			name: "valid: WVA KEDA idleReplicaCount=0 (scale-to-zero)",
+			workload: &WorkloadSpec{
+				Scaling: &ScalingSpec{
+					MinReplicas: ptr.To(int32(1)),
+					MaxReplicas: 10,
+					WVA: &WVASpec{
+						ActuatorSpec: ActuatorSpec{
+							KEDA: &KEDAScalingSpec{
+								IdleReplicaCount: ptr.To(int32(0)),
+							},
+						},
+					},
+				},
+			},
+			wantErrCount: 0,
+		},
+		{
 			name: "valid: initialCooldownPeriod set",
 			workload: &WorkloadSpec{
 				Scaling: &ScalingSpec{
@@ -435,6 +452,24 @@ func TestValidateWorkloadScaling(t *testing.T) {
 									"value": "80",
 								},
 							},
+						},
+					},
+				},
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "valid: direct KEDA idleReplicaCount=0 (scale-to-zero)",
+			workload: &WorkloadSpec{
+				Scaling: &ScalingSpec{
+					MinReplicas: ptr.To(int32(1)),
+					MaxReplicas: 5,
+					KEDA: &DirectKEDAScalingSpec{
+						KEDAScalingSpec: KEDAScalingSpec{
+							IdleReplicaCount: ptr.To(int32(0)),
+						},
+						Triggers: []kedav1alpha1.ScaleTriggers{
+							{Type: "cpu", Metadata: map[string]string{"value": "80"}},
 						},
 					},
 				},

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
@@ -658,9 +658,11 @@ type KEDAScalingSpec struct {
 
 	// IdleReplicaCount is the number of replicas KEDA will scale the resource down to
 	// when there are no triggers active. This must be less than minReplicas.
+	// Set to 0 for true scale-to-zero: KEDA scales the resource to zero replicas when idle
+	// and immediately back to minReplicas once a trigger becomes active.
 	// If not set, KEDA will not scale below minReplicas.
 	// +optional
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	IdleReplicaCount *int32 `json:"idleReplicaCount,omitempty"`
 
 	// Fallback defines the replica count to maintain when the scaler is in a fallback state

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_validation_test.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_validation_test.go
@@ -396,6 +396,23 @@ func TestValidateWorkloadScaling(t *testing.T) {
 			wantErrCount: 0,
 		},
 		{
+			name: "valid: WVA KEDA idleReplicaCount=0 (scale-to-zero)",
+			workload: &WorkloadSpec{
+				Scaling: &ScalingSpec{
+					MinReplicas: ptr.To(int32(1)),
+					MaxReplicas: 10,
+					WVA: &WVASpec{
+						ActuatorSpec: ActuatorSpec{
+							KEDA: &KEDAScalingSpec{
+								IdleReplicaCount: ptr.To(int32(0)),
+							},
+						},
+					},
+				},
+			},
+			wantErrCount: 0,
+		},
+		{
 			name: "valid: initialCooldownPeriod set",
 			workload: &WorkloadSpec{
 				Scaling: &ScalingSpec{
@@ -614,6 +631,24 @@ func TestValidateWorkloadScaling(t *testing.T) {
 									"value": "80",
 								},
 							},
+						},
+					},
+				},
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "valid: direct KEDA idleReplicaCount=0 (scale-to-zero)",
+			workload: &WorkloadSpec{
+				Scaling: &ScalingSpec{
+					MinReplicas: ptr.To(int32(1)),
+					MaxReplicas: 5,
+					KEDA: &DirectKEDAScalingSpec{
+						KEDAScalingSpec: KEDAScalingSpec{
+							IdleReplicaCount: ptr.To(int32(0)),
+						},
+						Triggers: []kedav1alpha1.ScaleTriggers{
+							{Type: "cpu", Metadata: map[string]string{"value": "80"}},
 						},
 					},
 				},

--- a/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
@@ -289,6 +289,22 @@ func KEDAScaling(minReplicas int32, maxReplicas int32) *v1alpha2.ScalingSpec {
 	}
 }
 
+// KEDAScalingWithIdleReplicaCount builds scaling.wva.keda with an idleReplicaCount,
+// e.g. idleReplicaCount=0 for true scale-to-zero.
+func KEDAScalingWithIdleReplicaCount(minReplicas int32, maxReplicas int32, idleReplicaCount int32) *v1alpha2.ScalingSpec {
+	return &v1alpha2.ScalingSpec{
+		MinReplicas: &minReplicas,
+		MaxReplicas: maxReplicas,
+		WVA: &v1alpha2.WVASpec{
+			ActuatorSpec: v1alpha2.ActuatorSpec{
+				KEDA: &v1alpha2.KEDAScalingSpec{
+					IdleReplicaCount: &idleReplicaCount,
+				},
+			},
+		},
+	}
+}
+
 // DirectKEDAScaling builds scaling.keda with user-defined triggers (no WVA).
 func DirectKEDAScaling(minReplicas int32, maxReplicas int32, triggers ...kedav1alpha1.ScaleTriggers) *v1alpha2.ScalingSpec {
 	if len(triggers) == 0 {
@@ -300,6 +316,26 @@ func DirectKEDAScaling(minReplicas int32, maxReplicas int32, triggers ...kedav1a
 		MinReplicas: &minReplicas,
 		MaxReplicas: maxReplicas,
 		KEDA: &v1alpha2.DirectKEDAScalingSpec{
+			Triggers: triggers,
+		},
+	}
+}
+
+// DirectKEDAScalingWithIdleReplicaCount builds scaling.keda with user-defined triggers and an
+// idleReplicaCount (no WVA), e.g. idleReplicaCount=0 for true scale-to-zero.
+func DirectKEDAScalingWithIdleReplicaCount(minReplicas int32, maxReplicas int32, idleReplicaCount int32, triggers ...kedav1alpha1.ScaleTriggers) *v1alpha2.ScalingSpec {
+	if len(triggers) == 0 {
+		triggers = []kedav1alpha1.ScaleTriggers{
+			{Type: "cpu", Metadata: map[string]string{"value": "80"}},
+		}
+	}
+	return &v1alpha2.ScalingSpec{
+		MinReplicas: &minReplicas,
+		MaxReplicas: maxReplicas,
+		KEDA: &v1alpha2.DirectKEDAScalingSpec{
+			KEDAScalingSpec: v1alpha2.KEDAScalingSpec{
+				IdleReplicaCount: &idleReplicaCount,
+			},
 			Triggers: triggers,
 		},
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scaling_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling_int_test.go
@@ -211,6 +211,35 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 				g.Expect(so.Spec.MaxReplicaCount).To(Equal(ptr.To(int32(15))))
 			}).WithContext(ctx).Should(Succeed())
 		})
+
+		It("should accept idleReplicaCount=0 for scale-to-zero", func(ctx SpecContext) {
+			svcName := "test-keda-scale-to-zero"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(KEDAScalingWithIdleReplicaCount(1, 8, 0)),
+			)
+
+			// Regression test: the CRD schema previously rejected idleReplicaCount=0
+			// (minimum:1), which made true scale-to-zero unreachable.
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			soKey := types.NamespacedName{Name: kmeta.ChildName(svcName, "-kserve-keda"), Namespace: testNs.Name}
+
+			so := &kedav1alpha1.ScaledObject{}
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Get(ctx, soKey, so)).To(Succeed())
+				g.Expect(so.Spec.MinReplicaCount).To(Equal(ptr.To(int32(1))))
+				g.Expect(so.Spec.MaxReplicaCount).To(Equal(ptr.To(int32(8))))
+				g.Expect(so.Spec.IdleReplicaCount).To(Equal(ptr.To(int32(0))))
+			}).WithContext(ctx).Should(Succeed())
+		})
 	})
 
 	Context("Direct KEDA scaling", func() {
@@ -329,6 +358,40 @@ var _ = Describe("LLMInferenceService Controller - Scaling", func() {
 			Consistently(func(g Gomega, ctx context.Context) {
 				err := envTest.Get(ctx, hpaKey, &autoscalingv2.HorizontalPodAutoscaler{})
 				g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should accept idleReplicaCount=0 for scale-to-zero", func(ctx SpecContext) {
+			svcName := "test-direct-keda-scale-to-zero"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://meta-llama/Llama-3.1-8B"),
+				WithModelName("meta-llama/Llama-3.1-8B"),
+				WithScaling(DirectKEDAScalingWithIdleReplicaCount(1, 8, 0,
+					kedav1alpha1.ScaleTriggers{
+						Type:     "cpu",
+						Metadata: map[string]string{"value": "80"},
+					},
+				)),
+			)
+
+			// Regression test: the CRD schema previously rejected idleReplicaCount=0
+			// (minimum:1), which made true scale-to-zero unreachable.
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			soKey := types.NamespacedName{Name: kmeta.ChildName(svcName, "-kserve-keda"), Namespace: testNs.Name}
+
+			so := &kedav1alpha1.ScaledObject{}
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Get(ctx, soKey, so)).To(Succeed())
+				g.Expect(so.Spec.MinReplicaCount).To(Equal(ptr.To(int32(1))))
+				g.Expect(so.Spec.MaxReplicaCount).To(Equal(ptr.To(int32(8))))
+				g.Expect(so.Spec.IdleReplicaCount).To(Equal(ptr.To(int32(0))))
 			}).WithContext(ctx).Should(Succeed())
 		})
 

--- a/test/crds/serving.kserve.io_all_crds.yaml
+++ b/test/crds/serving.kserve.io_all_crds.yaml
@@ -50189,7 +50189,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -50439,7 +50439,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -66736,7 +66736,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -66986,7 +66986,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -75153,7 +75153,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -75403,7 +75403,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -91731,7 +91731,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -91981,7 +91981,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -99926,7 +99926,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -100176,7 +100176,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -117171,7 +117171,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -117421,7 +117421,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -125775,7 +125775,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32
@@ -126025,7 +126025,7 @@ spec:
                                 type: object
                               idleReplicaCount:
                                 format: int32
-                                minimum: 1
+                                minimum: 0
                                 type: integer
                               initialCooldownPeriod:
                                 format: int32
@@ -143062,7 +143062,7 @@ spec:
                         type: object
                       idleReplicaCount:
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       initialCooldownPeriod:
                         format: int32
@@ -143312,7 +143312,7 @@ spec:
                             type: object
                           idleReplicaCount:
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           initialCooldownPeriod:
                             format: int32


### PR DESCRIPTION
**What this PR does / why we need it**:

`LLMInferenceService.spec.scaling.keda.idleReplicaCount` (used by both the WVA-mediated and standalone-KEDA autoscaling paths) was schema-validated with `minimum: 1`, which rejected `idleReplicaCount: 0`. KEDA uses `0` as the sentinel for true scale-to-zero, so this validation rule silently made scale-to-zero unreachable via the documented API, even though it's an advertised capability of both autoscaling paths.

This PR relaxes the CRD schema to `minimum: 0` for `idleReplicaCount` in both the `v1alpha1` (spoke) and `v1alpha2` (hub) `LLMInferenceService` API types, regenerates the affected CRD manifests/Helm charts, and adds test coverage
proving `idleReplicaCount: 0` is accepted and correctly propagated through to the generated `ScaledObject` for both the WVA-KEDA and direct-KEDA paths.


**Feature/Issue validation/testing**:

- [x] Unit tests: `pkg/apis/serving/v1alpha1` and `v1alpha2` validation tests cover `idleReplicaCount: 0` for both `scaling.wva.keda` and `scaling.keda` (direct) paths.
- [x] Envtest integration tests: `pkg/controller/v1alpha2/llmisvc/scaling_int_test.go` creates `LLMInferenceService`s with `idleReplicaCount: 0` and asserts the reconciled `ScaledObject.Spec.IdleReplicaCount` is `0`, for both actuator paths.
- [ ] Live-cluster e2e scale-to-zero test — **follow-up**. KEDA's `cpu`/`memory`-only triggers never scale to zero regardless of `idleReplicaCount` (KEDA requires an additional non-resource trigger for that), and the `llm-d-inference-sim` used in e2e doesn't emit decreasing saturation metrics, so WVA's `wva_desired_replicas` never drops in the current e2e environment. A real end-to-end scale-to-zero assertion needs either a non-CPU trigger fixture (e.g. Prometheus/cron) for the direct-KEDA path and/or simulator changes to emit decreasing metrics for the WVA path. Will be implemented as a follow-up.


**Special notes for your reviewer**:

The only functional change is `Minimum=1` → `Minimum=0` on `IdleReplicaCount` in the Go API types; all other diffs are generated (CRD YAML, Helm chart templates, quick-install script) via `make manifests` / `make precommit`.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? (unit + envtest; e2e tracked as follow-up, see above)
- [x] Has code been commented, particularly in hard-to-understand areas?

**Release note**:
```release-note
Enable KEDA scale-to-zero for both WVA-mediated and standalone-KEDA autoscaling.