### PR TITLE
fix(hpa): infer memory metric target type when it is omitted

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go
@@ -57,6 +57,22 @@ func NewHPAReconciler(client client.Client,
 	}, nil
 }
 
+// resolveMemoryTargetType picks the target type to render for a memory resource metric.
+// target.type is optional in the CRD, so infer it when exactly one target value says which
+// type was meant. Anything else stays unresolved and renders as it did before.
+func resolveMemoryTargetType(target v1beta1.MetricTarget) v1beta1.MetricTargetType {
+	if target.Type != "" {
+		return target.Type
+	}
+	switch {
+	case target.AverageValue != nil && target.AverageUtilization == nil:
+		return v1beta1.AverageValueMetricType
+	case target.AverageUtilization != nil && target.AverageValue == nil:
+		return v1beta1.UtilizationMetricType
+	}
+	return ""
+}
+
 func getHPAMetrics(componentExt *v1beta1.ComponentExtensionSpec) []autoscalingv2.MetricSpec {
 	var metrics []autoscalingv2.MetricSpec
 	if componentExt != nil && componentExt.AutoScaling != nil {
@@ -88,7 +104,7 @@ func getHPAMetrics(componentExt *v1beta1.ComponentExtensionSpec) []autoscalingv2
 						Name: corev1.ResourceName(metric.Resource.Name),
 					},
 				}
-				switch metric.Resource.Target.Type {
+				switch resolveMemoryTargetType(metric.Resource.Target) {
 				case v1beta1.UtilizationMetricType:
 					ms.Resource.Target.Type = autoscalingv2.UtilizationMetricType
 					ms.Resource.Target.AverageUtilization = metric.Resource.Target.AverageUtilization

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler_test.go
@@ -916,6 +916,94 @@ func TestGetHPAMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "autoscaling with memory average value metric and no target type",
+			componentExt: &v1beta1.ComponentExtensionSpec{
+				AutoScaling: &v1beta1.AutoScalingSpec{
+					Metrics: []v1beta1.MetricsSpec{
+						{
+							Type: v1beta1.ResourceMetricSourceType,
+							Resource: &v1beta1.ResourceMetricSource{
+								Name: v1beta1.ResourceMetricMemory,
+								Target: v1beta1.MetricTarget{
+									AverageValue: v1beta1.NewMetricQuantity("500Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSpecs: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceMemory,
+						Target: autoscalingv2.MetricTarget{
+							Type:         autoscalingv2.AverageValueMetricType,
+							AverageValue: ptr.To(resource.MustParse("500Mi")),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "autoscaling with memory utilization metric and no target type",
+			componentExt: &v1beta1.ComponentExtensionSpec{
+				AutoScaling: &v1beta1.AutoScalingSpec{
+					Metrics: []v1beta1.MetricsSpec{
+						{
+							Type: v1beta1.ResourceMetricSourceType,
+							Resource: &v1beta1.ResourceMetricSource{
+								Name: v1beta1.ResourceMetricMemory,
+								Target: v1beta1.MetricTarget{
+									AverageUtilization: ptr.To(int32(65)),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSpecs: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceMemory,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To(int32(65)),
+						},
+					},
+				},
+			},
+		},
+		{
+			// Both values set gives no hint about which type was meant, so nothing is inferred.
+			name: "autoscaling with ambiguous memory target is not inferred",
+			componentExt: &v1beta1.ComponentExtensionSpec{
+				AutoScaling: &v1beta1.AutoScalingSpec{
+					Metrics: []v1beta1.MetricsSpec{
+						{
+							Type: v1beta1.ResourceMetricSourceType,
+							Resource: &v1beta1.ResourceMetricSource{
+								Name: v1beta1.ResourceMetricMemory,
+								Target: v1beta1.MetricTarget{
+									AverageValue:       v1beta1.NewMetricQuantity("500Mi"),
+									AverageUtilization: ptr.To(int32(65)),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSpecs: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceMemory,
+					},
+				},
+			},
+		},
+		{
 			name:         "nil componentExt should return default CPU metric",
 			componentExt: nil,
 			expectedSpecs: []autoscalingv2.MetricSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

`MetricTarget.Type` is `+optional` in the CRD ([component.go:245-248](https://github.com/kserve/kserve/blob/master/pkg/apis/serving/v1beta1/component.go#L245-L248)), but the memory branch of `getHPAMetrics` dispatched on it alone ([hpa_reconciler.go:91](https://github.com/kserve/kserve/blob/a59fe2b/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa/hpa_reconciler.go#L91)). An omitted `type` matched neither case, so the `MetricSpec` was appended with a resource target left at its zero value and no autoscaler was created at all.

This spec passes the validating webhook today, and `TestAutoscalerClassHPA` asserts that it should ([inference_service_validation_test.go:152](https://github.com/kserve/kserve/blob/a59fe2b/pkg/apis/serving/v1beta1/inference_service_validation_test.go#L152), case `Valid HPA Memory metrics with Autoscaling spec`):

```yaml
autoScaling:
  metrics:
    - type: Resource
      resource:
        name: memory
        target:
          averageValue: 1Gi
```

Rendered against a real 1.35 API server on `a59fe2b`, creating that HPA fails:

```
HorizontalPodAutoscaler.autoscaling "probe" is invalid:
  spec.metrics[0].resource.target.type: Required value: must specify a metric target type,
  spec.metrics[0].resource.target.type: Invalid value: "": must be either Utilization, Value, or AverageValue,
  spec.metrics[0].resource.target.averageUtilization: Required value: must set either a target raw value or a target utilization
```

The CPU branch never hits this because it ignores `target.type` and always renders `Utilization`. Only memory reads the field.

The fix infers the type when exactly one of `averageValue` or `averageUtilization` is set. With both set there is nothing to infer from, so that target stays unresolved and renders exactly as it does today.

**Which issue(s) this PR fixes**:

None, found while comparing the HPA and KEDA metric renderers.

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/controller/v1beta1/inferenceservice/...` and `./pkg/apis/serving/v1beta1/...` pass, envtest assets 1.35. Three cases added to `TestGetHPAMetrics`; the first two fail on `a59fe2b` and pass with the fix, the third passes on both and pins the ambiguous case.
- [x] `go vet ./pkg/... ./cmd/...` clean. `gofmt -l` clean on the changed package.
- [x] End to end on envtest: with the fix, the YAML above creates an HPA whose server-side target is `{Type:AverageValue AverageValue:1Gi}`.

- Logs

Before, on `a59fe2b`:

```
--- FAIL: TestGetHPAMetrics/autoscaling_with_memory_average_value_metric_and_no_target_type
    unexpected metrics (-want +got):
    - 	Type:         "AverageValue",
    + 	Type:         "",
    - 	AverageValue: s"500Mi",
    + 	AverageValue: nil,
```

After:

```
ok  	github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/hpa	1.809s
```

**Special notes for your reviewer**:

Scope is the renderer only. Two related gaps are deliberately left alone:

- `target.type: Value` on a memory metric still renders an empty target and is still rejected by the API server. Dropping the metric instead would be worse: I measured that an HPA submitted with no metrics comes back defaulted to 80% average CPU utilization, which would silently swap memory autoscaling for CPU autoscaling. Rejecting `Value` in `validateScalingHPACompExtension`, the way `validateScalingKedaCompExtension` already does, is the better place for it and changes admission behaviour, so it belongs in its own PR.
- A CPU metric carrying only `averageValue` is still silently rendered as the default 80% utilization target.

This touches `validateScalingHPACompExtension`'s neighbourhood conceptually but not textually, so it should not conflict with #5982.

This work was AI-assisted. The repro, the envtest run, and the before/after test output above are all from commands I ran.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Fix HorizontalPodAutoscaler creation for memory autoscaling metrics that omit `target.type`. The rendered HPA previously carried a metric target with no type and was rejected by the API server, so no autoscaler was created.
```
