### PR TITLE
fix(llmisvc): allow omitted optional KEDA advanced CEL fields

### DIFF
--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -651,7 +651,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -865,7 +865,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -873,7 +873,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17206,7 +17206,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17420,7 +17420,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -17428,7 +17428,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd-minimal/templates/serving.kserve.io_llminferenceservices.yaml
@@ -667,7 +667,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -881,7 +881,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -889,7 +889,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17641,7 +17641,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17855,7 +17855,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -17863,7 +17863,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -343,7 +343,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -557,7 +557,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -565,7 +565,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -16867,7 +16867,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17081,7 +17081,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -17089,7 +17089,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend
@@ -25263,7 +25263,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -25477,7 +25477,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -25485,7 +25485,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -41818,7 +41818,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -42032,7 +42032,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -42040,7 +42040,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
+++ b/charts/kserve-llmisvc-crd/templates/serving.kserve.io_llminferenceservices.yaml
@@ -352,7 +352,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -566,7 +566,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -574,7 +574,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17285,7 +17285,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17499,7 +17499,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -17507,7 +17507,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend
@@ -25868,7 +25868,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -26082,7 +26082,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -26090,7 +26090,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -42842,7 +42842,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -43056,7 +43056,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -43064,7 +43064,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/config/crd/full/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/full/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -331,7 +331,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -545,7 +545,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -553,7 +553,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -16855,7 +16855,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17069,7 +17069,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -17077,7 +17077,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend
@@ -25251,7 +25251,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -25465,7 +25465,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -25473,7 +25473,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -41806,7 +41806,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -42020,7 +42020,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -42028,7 +42028,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/config/crd/full/llmisvc/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/full/llmisvc/serving.kserve.io_llminferenceservices.yaml
@@ -340,7 +340,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -554,7 +554,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -562,7 +562,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -17273,7 +17273,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -17487,7 +17487,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -17495,7 +17495,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend
@@ -25856,7 +25856,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         maxReplicas:
                           format: int32
                           minimum: 1
@@ -26070,7 +26070,7 @@ spec:
                               type: object
                               x-kubernetes-validations:
                                 - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                                  rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                             variantCost:
                               default: "10.0"
                               pattern: ^\d+(\.\d+)?$
@@ -26078,7 +26078,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                              rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                              rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                             - message: hpa and keda are mutually exclusive; choose one actuator backend
                               rule: '!(has(self.hpa) && has(self.keda))'
                             - message: either hpa or keda must be specified as the actuator backend
@@ -42830,7 +42830,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                          rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                     maxReplicas:
                       format: int32
                       minimum: 1
@@ -43044,7 +43044,7 @@ spec:
                           type: object
                           x-kubernetes-validations:
                             - message: horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name
-                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
+                              rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0'
                         variantCost:
                           default: "10.0"
                           pattern: ^\d+(\.\d+)?$
@@ -43052,7 +43052,7 @@ spec:
                       type: object
                       x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))'
                         - message: hpa and keda are mutually exclusive; choose one actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
                         - message: either hpa or keda must be specified as the actuator backend

--- a/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -640,6 +640,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -857,6 +858,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -867,11 +869,16 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                            == 0 && size(self.keda.advanced.scalingModifiers.target)
-                            == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                            == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                            == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                            || ((!has(self.keda.advanced.scalingModifiers.formula)
+                            || size(self.keda.advanced.scalingModifiers.formula) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.target)
+                            || size(self.keda.advanced.scalingModifiers.target) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                            || size(self.keda.advanced.scalingModifiers.activationTarget)
+                            == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                            || size(self.keda.advanced.scalingModifiers.metricType)
+                            == 0))'
                         - message: hpa and keda are mutually exclusive; choose one
                             actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
@@ -17218,6 +17225,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -17435,6 +17443,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -17445,11 +17454,15 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                        == 0 && size(self.keda.advanced.scalingModifiers.target) ==
-                        0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                        == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                        == 0)'
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                        || ((!has(self.keda.advanced.scalingModifiers.formula) ||
+                        size(self.keda.advanced.scalingModifiers.formula) == 0) &&
+                        (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                        || size(self.keda.advanced.scalingModifiers.activationTarget)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                        || size(self.keda.advanced.scalingModifiers.metricType) ==
+                        0))'
                     - message: hpa and keda are mutually exclusive; choose one actuator
                         backend
                       rule: '!(has(self.hpa) && has(self.keda))'

--- a/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/minimal/llmisvc/serving.kserve.io_llminferenceservices.yaml
@@ -656,6 +656,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -873,6 +874,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -883,11 +885,16 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                            == 0 && size(self.keda.advanced.scalingModifiers.target)
-                            == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                            == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                            == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                            || ((!has(self.keda.advanced.scalingModifiers.formula)
+                            || size(self.keda.advanced.scalingModifiers.formula) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.target)
+                            || size(self.keda.advanced.scalingModifiers.target) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                            || size(self.keda.advanced.scalingModifiers.activationTarget)
+                            == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                            || size(self.keda.advanced.scalingModifiers.metricType)
+                            == 0))'
                         - message: hpa and keda are mutually exclusive; choose one
                             actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
@@ -17943,6 +17950,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -18160,6 +18168,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -18170,11 +18179,15 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                        == 0 && size(self.keda.advanced.scalingModifiers.target) ==
-                        0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                        == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                        == 0)'
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                        || ((!has(self.keda.advanced.scalingModifiers.formula) ||
+                        size(self.keda.advanced.scalingModifiers.formula) == 0) &&
+                        (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                        || size(self.keda.advanced.scalingModifiers.activationTarget)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                        || size(self.keda.advanced.scalingModifiers.metricType) ==
+                        0))'
                     - message: hpa and keda are mutually exclusive; choose one actuator
                         backend
                       rule: '!(has(self.hpa) && has(self.keda))'

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
@@ -457,7 +457,9 @@ type ScalingSpec struct {
 
 // WVASpec configures the Workload Variant Autoscaler.
 // scalingModifiers under wva.keda.advanced are forbidden because WVA owns the metric formula.
-// +kubebuilder:validation:XValidation:rule="!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)",message="scalingModifiers must not be set; WVA controls the scaling metric formula and logic"
+// Optional-field presence is checked before dereference so omitting scalingModifiers (or its
+// children) is valid; only non-empty forbidden values are rejected.
+// +kubebuilder:validation:XValidation:rule="!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))",message="scalingModifiers must not be set; WVA controls the scaling metric formula and logic"
 type WVASpec struct {
 	// VariantCost specifies the cost per replica for this variant (used in saturation analysis).
 	// Must be a non-negative numeric string (e.g., "10", "10.0", "0.5").
@@ -505,7 +507,9 @@ type HPAScalingSpec struct {
 // The fields are directly from the upstream KEDA ScaledObject API.
 // Note: WVA-only restrictions on scalingModifiers live on WVASpec so direct KEDA
 // (DirectKEDAScalingSpec) can use scalingModifiers when users define their own triggers.
-// +kubebuilder:validation:XValidation:rule="!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0",message="horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name"
+// Optional name must be presence-checked: omitting horizontalPodAutoscalerConfig.name is valid;
+// only a non-empty name is rejected (the controller owns the HPA name).
+// +kubebuilder:validation:XValidation:rule="!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0",message="horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name"
 type KEDAScalingSpec struct {
 	// PollingInterval is the interval in seconds to check each trigger on.
 	// Must be at least 1 second.

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
@@ -574,7 +574,9 @@ type ScalingSpec struct {
 
 // WVASpec configures the Workload Variant Autoscaler.
 // scalingModifiers under wva.keda.advanced are forbidden because WVA owns the metric formula.
-// +kubebuilder:validation:XValidation:rule="!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula) == 0 && size(self.keda.advanced.scalingModifiers.target) == 0 && size(self.keda.advanced.scalingModifiers.activationTarget) == 0 && size(self.keda.advanced.scalingModifiers.metricType) == 0)",message="scalingModifiers must not be set; WVA controls the scaling metric formula and logic"
+// Optional-field presence is checked before dereference so omitting scalingModifiers (or its
+// children) is valid; only non-empty forbidden values are rejected.
+// +kubebuilder:validation:XValidation:rule="!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers) || ((!has(self.keda.advanced.scalingModifiers.formula) || size(self.keda.advanced.scalingModifiers.formula) == 0) && (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target) == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget) || size(self.keda.advanced.scalingModifiers.activationTarget) == 0) && (!has(self.keda.advanced.scalingModifiers.metricType) || size(self.keda.advanced.scalingModifiers.metricType) == 0))",message="scalingModifiers must not be set; WVA controls the scaling metric formula and logic"
 type WVASpec struct {
 	// VariantCost specifies the cost per replica for this variant (used in saturation analysis).
 	// Must be a non-negative numeric string (e.g., "10", "10.0", "0.5").
@@ -634,7 +636,9 @@ type HPAScalingSpec struct {
 // The fields are directly from the upstream KEDA ScaledObject API.
 // Note: WVA-only restrictions on scalingModifiers live on WVASpec so direct KEDA
 // (DirectKEDAScalingSpec) can use scalingModifiers when users define their own triggers.
-// +kubebuilder:validation:XValidation:rule="!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0",message="horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name"
+// Optional name must be presence-checked: omitting horizontalPodAutoscalerConfig.name is valid;
+// only a non-empty name is rejected (the controller owns the HPA name).
+// +kubebuilder:validation:XValidation:rule="!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig) || !has(self.advanced.horizontalPodAutoscalerConfig.name) || size(self.advanced.horizontalPodAutoscalerConfig.name) == 0",message="horizontalPodAutoscalerConfig.name must not be set; the controller manages the HPA name"
 type KEDAScalingSpec struct {
 	// PollingInterval is the interval in seconds to check each trigger on.
 	// Must be at least 1 second.

--- a/pkg/controller/v1alpha2/llmisvc/crdvalidation/keda_advanced_cel_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/crdvalidation/keda_advanced_cel_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdvalidation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+// These tests exercise CRD CEL (x-kubernetes-validations) for WVA+KEDA advanced
+// fields. They catch optional-field dereference bugs that webhook unit tests miss
+// (see https://github.com/kserve/kserve/issues/5936).
+var _ = Describe("LLMInferenceService KEDA advanced CEL", func() {
+	var ns string
+
+	BeforeEach(func(ctx SpecContext) {
+		ns = fixture.NewTestNamespace(ctx, envTest).Name
+	})
+
+	baseLLMSvc := func(name string, scaling *v1alpha2.ScalingSpec) *v1alpha2.LLMInferenceService {
+		return fixture.LLMInferenceService(name,
+			fixture.WithModelURI("hf://facebook/opt-125m"),
+			fixture.WithScaling(scaling),
+		)
+	}
+
+	It("should accept advanced HPA behavior when optional scalingModifiers and name are omitted", func(ctx SpecContext) {
+		// Reproduces #5936: advanced present with only behavior set.
+		llmSvc := baseLLMSvc("keda-advanced-behavior-ok", &v1alpha2.ScalingSpec{
+			MinReplicas: ptr.To(int32(1)),
+			MaxReplicas: 6,
+			WVA: &v1alpha2.WVASpec{
+				ActuatorSpec: v1alpha2.ActuatorSpec{
+					KEDA: &v1alpha2.KEDAScalingSpec{
+						PollingInterval: ptr.To(int32(10)),
+						Advanced: &kedav1alpha1.AdvancedConfig{
+							HorizontalPodAutoscalerConfig: &kedav1alpha1.HorizontalPodAutoscalerConfig{
+								Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+									ScaleDown: &autoscalingv2.HPAScalingRules{
+										StabilizationWindowSeconds: ptr.To(int32(120)),
+										Policies: []autoscalingv2.HPAScalingPolicy{{
+											Type:          autoscalingv2.PodsScalingPolicy,
+											Value:         1,
+											PeriodSeconds: 120,
+										}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		llmSvc.Namespace = ns
+
+		Expect(envTest.Client.Create(ctx, llmSvc)).To(Succeed(),
+			"CRD CEL should accept omitted optional advanced.scalingModifiers and horizontalPodAutoscalerConfig.name")
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(envTest.Client.Delete(ctx, llmSvc)).To(Succeed())
+		})
+	})
+
+	It("should accept advanced with only restoreToOriginalReplicaCount set", func(ctx SpecContext) {
+		llmSvc := baseLLMSvc("keda-advanced-restore-ok", &v1alpha2.ScalingSpec{
+			MaxReplicas: 5,
+			WVA: &v1alpha2.WVASpec{
+				ActuatorSpec: v1alpha2.ActuatorSpec{
+					KEDA: &v1alpha2.KEDAScalingSpec{
+						Advanced: &kedav1alpha1.AdvancedConfig{
+							RestoreToOriginalReplicaCount: true,
+						},
+					},
+				},
+			},
+		})
+		llmSvc.Namespace = ns
+
+		Expect(envTest.Client.Create(ctx, llmSvc)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(envTest.Client.Delete(ctx, llmSvc)).To(Succeed())
+		})
+	})
+
+	It("should reject WVA KEDA scalingModifiers when set", func(ctx SpecContext) {
+		llmSvc := baseLLMSvc("keda-advanced-modifiers-bad", &v1alpha2.ScalingSpec{
+			MaxReplicas: 5,
+			WVA: &v1alpha2.WVASpec{
+				ActuatorSpec: v1alpha2.ActuatorSpec{
+					KEDA: &v1alpha2.KEDAScalingSpec{
+						Advanced: &kedav1alpha1.AdvancedConfig{
+							ScalingModifiers: kedav1alpha1.ScalingModifiers{
+								Formula: "trig0 + trig1",
+							},
+						},
+					},
+				},
+			},
+		})
+		llmSvc.Namespace = ns
+
+		err := envTest.Client.Create(ctx, llmSvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("scalingModifiers must not be set"))
+	})
+
+	It("should reject horizontalPodAutoscalerConfig.name when set", func(ctx SpecContext) {
+		llmSvc := baseLLMSvc("keda-advanced-hpa-name-bad", &v1alpha2.ScalingSpec{
+			MaxReplicas: 5,
+			WVA: &v1alpha2.WVASpec{
+				ActuatorSpec: v1alpha2.ActuatorSpec{
+					KEDA: &v1alpha2.KEDAScalingSpec{
+						Advanced: &kedav1alpha1.AdvancedConfig{
+							HorizontalPodAutoscalerConfig: &kedav1alpha1.HorizontalPodAutoscalerConfig{
+								Name: "user-chosen-hpa",
+							},
+						},
+					},
+				},
+			},
+		})
+		llmSvc.Namespace = ns
+
+		err := envTest.Client.Create(ctx, llmSvc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("horizontalPodAutoscalerConfig.name must not be set"))
+	})
+
+	It("should accept LLMInferenceServiceConfig with the same omitted-optional advanced shape", func(ctx SpecContext) {
+		cfg := &v1alpha2.LLMInferenceServiceConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "keda-advanced-behavior-cfg-ok",
+				Namespace: ns,
+			},
+			Spec: v1alpha2.LLMInferenceServiceSpec{
+				WorkloadSpec: v1alpha2.WorkloadSpec{
+					Scaling: &v1alpha2.ScalingSpec{
+						MinReplicas: ptr.To(int32(1)),
+						MaxReplicas: 6,
+						WVA: &v1alpha2.WVASpec{
+							ActuatorSpec: v1alpha2.ActuatorSpec{
+								KEDA: &v1alpha2.KEDAScalingSpec{
+									PollingInterval: ptr.To(int32(10)),
+									Advanced: &kedav1alpha1.AdvancedConfig{
+										HorizontalPodAutoscalerConfig: &kedav1alpha1.HorizontalPodAutoscalerConfig{
+											Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+												ScaleDown: &autoscalingv2.HPAScalingRules{
+													StabilizationWindowSeconds: ptr.To(int32(120)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(envTest.Client.Create(ctx, cfg)).To(Succeed(),
+			"Config CRD shares KEDAScalingSpec/WVASpec CEL and must accept omitted optional advanced fields")
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(envTest.Client.Delete(ctx, cfg)).To(Succeed())
+		})
+	})
+})

--- a/test/crds/serving.kserve.io_all_crds.yaml
+++ b/test/crds/serving.kserve.io_all_crds.yaml
@@ -50237,6 +50237,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -50454,6 +50455,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -50464,11 +50466,16 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                            == 0 && size(self.keda.advanced.scalingModifiers.target)
-                            == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                            == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                            == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                            || ((!has(self.keda.advanced.scalingModifiers.formula)
+                            || size(self.keda.advanced.scalingModifiers.formula) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.target)
+                            || size(self.keda.advanced.scalingModifiers.target) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                            || size(self.keda.advanced.scalingModifiers.activationTarget)
+                            == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                            || size(self.keda.advanced.scalingModifiers.metricType)
+                            == 0))'
                         - message: hpa and keda are mutually exclusive; choose one
                             actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
@@ -66784,6 +66791,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -67001,6 +67009,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -67011,11 +67020,15 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                        == 0 && size(self.keda.advanced.scalingModifiers.target) ==
-                        0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                        == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                        == 0)'
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                        || ((!has(self.keda.advanced.scalingModifiers.formula) ||
+                        size(self.keda.advanced.scalingModifiers.formula) == 0) &&
+                        (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                        || size(self.keda.advanced.scalingModifiers.activationTarget)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                        || size(self.keda.advanced.scalingModifiers.metricType) ==
+                        0))'
                     - message: hpa and keda are mutually exclusive; choose one actuator
                         backend
                       rule: '!(has(self.hpa) && has(self.keda))'
@@ -75201,6 +75214,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -75418,6 +75432,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -75428,11 +75443,16 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                            == 0 && size(self.keda.advanced.scalingModifiers.target)
-                            == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                            == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                            == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                            || ((!has(self.keda.advanced.scalingModifiers.formula)
+                            || size(self.keda.advanced.scalingModifiers.formula) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.target)
+                            || size(self.keda.advanced.scalingModifiers.target) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                            || size(self.keda.advanced.scalingModifiers.activationTarget)
+                            == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                            || size(self.keda.advanced.scalingModifiers.metricType)
+                            == 0))'
                         - message: hpa and keda are mutually exclusive; choose one
                             actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
@@ -91779,6 +91799,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -91996,6 +92017,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -92006,11 +92028,15 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                        == 0 && size(self.keda.advanced.scalingModifiers.target) ==
-                        0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                        == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                        == 0)'
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                        || ((!has(self.keda.advanced.scalingModifiers.formula) ||
+                        size(self.keda.advanced.scalingModifiers.formula) == 0) &&
+                        (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                        || size(self.keda.advanced.scalingModifiers.activationTarget)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                        || size(self.keda.advanced.scalingModifiers.metricType) ==
+                        0))'
                     - message: hpa and keda are mutually exclusive; choose one actuator
                         backend
                       rule: '!(has(self.hpa) && has(self.keda))'
@@ -99974,6 +100000,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -100191,6 +100218,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -100201,11 +100229,16 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                            == 0 && size(self.keda.advanced.scalingModifiers.target)
-                            == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                            == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                            == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                            || ((!has(self.keda.advanced.scalingModifiers.formula)
+                            || size(self.keda.advanced.scalingModifiers.formula) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.target)
+                            || size(self.keda.advanced.scalingModifiers.target) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                            || size(self.keda.advanced.scalingModifiers.activationTarget)
+                            == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                            || size(self.keda.advanced.scalingModifiers.metricType)
+                            == 0))'
                         - message: hpa and keda are mutually exclusive; choose one
                             actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
@@ -117219,6 +117252,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -117436,6 +117470,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -117446,11 +117481,15 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                        == 0 && size(self.keda.advanced.scalingModifiers.target) ==
-                        0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                        == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                        == 0)'
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                        || ((!has(self.keda.advanced.scalingModifiers.formula) ||
+                        size(self.keda.advanced.scalingModifiers.formula) == 0) &&
+                        (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                        || size(self.keda.advanced.scalingModifiers.activationTarget)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                        || size(self.keda.advanced.scalingModifiers.metricType) ==
+                        0))'
                     - message: hpa and keda are mutually exclusive; choose one actuator
                         backend
                       rule: '!(has(self.hpa) && has(self.keda))'
@@ -125823,6 +125862,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       maxReplicas:
@@ -126040,6 +126080,7 @@ spec:
                             - message: horizontalPodAutoscalerConfig.name must not
                                 be set; the controller manages the HPA name
                               rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                                || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                                 || size(self.advanced.horizontalPodAutoscalerConfig.name)
                                 == 0'
                           variantCost:
@@ -126050,11 +126091,16 @@ spec:
                         x-kubernetes-validations:
                         - message: scalingModifiers must not be set; WVA controls
                             the scaling metric formula and logic
-                          rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                            == 0 && size(self.keda.advanced.scalingModifiers.target)
-                            == 0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                            == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                            == 0)'
+                          rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                            || ((!has(self.keda.advanced.scalingModifiers.formula)
+                            || size(self.keda.advanced.scalingModifiers.formula) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.target)
+                            || size(self.keda.advanced.scalingModifiers.target) ==
+                            0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                            || size(self.keda.advanced.scalingModifiers.activationTarget)
+                            == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                            || size(self.keda.advanced.scalingModifiers.metricType)
+                            == 0))'
                         - message: hpa and keda are mutually exclusive; choose one
                             actuator backend
                           rule: '!(has(self.hpa) && has(self.keda))'
@@ -143110,6 +143156,7 @@ spec:
                     - message: horizontalPodAutoscalerConfig.name must not be set;
                         the controller manages the HPA name
                       rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                        || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                         || size(self.advanced.horizontalPodAutoscalerConfig.name)
                         == 0'
                   maxReplicas:
@@ -143327,6 +143374,7 @@ spec:
                         - message: horizontalPodAutoscalerConfig.name must not be
                             set; the controller manages the HPA name
                           rule: '!has(self.advanced) || !has(self.advanced.horizontalPodAutoscalerConfig)
+                            || !has(self.advanced.horizontalPodAutoscalerConfig.name)
                             || size(self.advanced.horizontalPodAutoscalerConfig.name)
                             == 0'
                       variantCost:
@@ -143337,11 +143385,15 @@ spec:
                     x-kubernetes-validations:
                     - message: scalingModifiers must not be set; WVA controls the
                         scaling metric formula and logic
-                      rule: '!has(self.keda) || !has(self.keda.advanced) || (size(self.keda.advanced.scalingModifiers.formula)
-                        == 0 && size(self.keda.advanced.scalingModifiers.target) ==
-                        0 && size(self.keda.advanced.scalingModifiers.activationTarget)
-                        == 0 && size(self.keda.advanced.scalingModifiers.metricType)
-                        == 0)'
+                      rule: '!has(self.keda) || !has(self.keda.advanced) || !has(self.keda.advanced.scalingModifiers)
+                        || ((!has(self.keda.advanced.scalingModifiers.formula) ||
+                        size(self.keda.advanced.scalingModifiers.formula) == 0) &&
+                        (!has(self.keda.advanced.scalingModifiers.target) || size(self.keda.advanced.scalingModifiers.target)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.activationTarget)
+                        || size(self.keda.advanced.scalingModifiers.activationTarget)
+                        == 0) && (!has(self.keda.advanced.scalingModifiers.metricType)
+                        || size(self.keda.advanced.scalingModifiers.metricType) ==
+                        0))'
                     - message: hpa and keda are mutually exclusive; choose one actuator
                         backend
                       rule: '!(has(self.hpa) && has(self.keda))'


### PR DESCRIPTION
**Problem:** Configs that set KEDA `advanced` options like HPA `behavior`, but omitted optional nested fields (`scalingModifiers`, `name`), were rejected by CRD CEL with `no such key` errors.

**Fix:** Added `has(...)` checks so omitted optional fields are allowed, while still rejecting forbidden values when those fields are actually set.

**Tests:** Added CRD envtest coverage for the API admission/CEL path (same gate as `kubectl apply`), not a full live-cluster deploy.