### PR TITLE
feat: added power support for xgbserver component

### DIFF
--- a/.github/workflows/xgbserver-ppc64le-docker-publish.yml
+++ b/.github/workflows/xgbserver-ppc64le-docker-publish.yml
@@ -1,0 +1,138 @@
+name: XgbServer ppc64le Docker Publisher
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+    paths:
+      - "python/*xgbserver*"
+      - "python/storage/**"
+      - "python/xgb.Dockerfile"
+      - "!.github/**"
+      - "!docs/**"
+      - "!**.md"
+      - ".github/workflows/xgbserver-ppc64le-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
+
+env:
+  IMAGE_NAME: xgbserver
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Merge target branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --unshallow origin
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
+      - name: Run tests
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/ppc64le
+          context: python
+          file: python/xgb.Dockerfile
+          push: false
+          # https://github.com/docker/buildx/issues/1533
+          provenance: false
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Export version variable
+        run: |
+          IMAGE_ID=kserve/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/ppc64le
+          context: python
+          file: python/xgb.Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
+          # https://github.com/docker/buildx/issues/1533
+          provenance: false
+          sbom: true

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora.go
@@ -47,10 +47,6 @@ const (
 // Replaces anything that is not alphanumeric, dash, underscore, or dot.
 var loraPathInvalidCharsRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
 
-// loraVolumeNameInvalidCharsRe matches characters that are invalid in Kubernetes volume names
-// (which must be DNS labels: lowercase alphanumeric and hyphens only).
-var loraVolumeNameInvalidCharsRe = regexp.MustCompile(`[^a-z0-9-]`)
-
 // resolvedLoRAAdapter is one adapter after URI validation (hf/s3 downloads are handled in attachModelArtifacts).
 type resolvedLoRAAdapter struct {
 	name      string
@@ -153,7 +149,7 @@ func (r *LLMISVCReconciler) attachLoRAAdapters(
 	for _, a := range adapters {
 		switch a.scheme {
 		case constants.PvcURIPrefix:
-			volName := kmeta.ChildName("lora-pvc-", a.name)
+			volName := utils.SafeObjectName(kmeta.ChildName("lora-pvc-", a.name))
 			if err := attachLoraPVCAdapter(a.uri, podSpec, containerName, a.mountPath, volName); err != nil {
 				return fmt.Errorf("LoRA adapter %q: %w", a.name, err)
 			}

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -20,7 +20,12 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 func TestSanitizeLoRAPathSegment(t *testing.T) {
@@ -36,6 +41,55 @@ func TestSanitizeLoRAPathSegment(t *testing.T) {
 	}
 	if got, want := sanitizeLoRAPathSegment(""), "adapter"; got != want {
 		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+// TestAttachLoRAAdaptersVolumeNames covers PVC adapter volume naming. Volume
+// names are part of the Deployment pod template, so deriving a different name
+// for an unchanged adapter rolls every pod on controller upgrade - the
+// hardcoded name below is what the controller produced before the sanitizer
+// existed and must never change. The HF-style adapter name used to yield a
+// volume name the API server rejected; it only has to yield a valid one now,
+// as the exact rewrite is pkg/utils's contract, tested there.
+func TestAttachLoRAAdaptersVolumeNames(t *testing.T) {
+	t.Parallel()
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+	}
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "main"}},
+	}
+	adapters := []resolvedLoRAAdapter{
+		{name: "billing-en-v1", mountPath: "/mnt/lora/billing-en-v1", uri: "pvc://claim/adapters/billing", scheme: constants.PvcURIPrefix},
+		{name: "acme/x.r16", mountPath: "/mnt/lora/acme-x.r16", uri: "pvc://claim/adapters/x", scheme: constants.PvcURIPrefix},
+	}
+
+	r := &LLMISVCReconciler{}
+	if err := r.attachLoRAAdapters(t.Context(), llmSvc, podSpec, adapters); err != nil {
+		t.Fatal(err)
+	}
+	if len(podSpec.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %v", podSpec.Volumes)
+	}
+
+	// The exact name running Deployments already use; a change rolls pods.
+	if got, want := podSpec.Volumes[0].Name, "lora-pvc-billing-en-v1"; got != want {
+		t.Fatalf("valid adapter name renamed: got %q want %q", got, want)
+	}
+
+	hfVol := podSpec.Volumes[1].Name
+	if errs := validation.IsDNS1123Label(hfVol); len(errs) > 0 {
+		t.Fatalf("volume name %q for HF-style adapter is not a valid DNS-1123 label: %v", hfVol, errs)
+	}
+	if hfVol == podSpec.Volumes[0].Name {
+		t.Fatalf("adapters must not share volume name %q", hfVol)
+	}
+
+	for i, m := range podSpec.Containers[0].VolumeMounts {
+		if m.Name != podSpec.Volumes[i].Name {
+			t.Fatalf("mounts[%d]=%q does not match volume %q", i, m.Name, podSpec.Volumes[i].Name)
+		}
 	}
 }
 

--- a/pkg/utils/names.go
+++ b/pkg/utils/names.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// dns1123InvalidCharsRe matches characters invalid in DNS-1123 labels
+// (Kubernetes volume and object names): anything but lowercase alphanumerics
+// and hyphens.
+var dns1123InvalidCharsRe = regexp.MustCompile(`[^a-z0-9-]`)
+
+// sanitizeDNS1123Label transforms an arbitrary identifier into the DNS-1123
+// label character set: lowercased, invalid characters replaced with hyphens,
+// leading and trailing hyphens trimmed. The result may be empty and is not
+// length-bounded; use SafeObjectName for a complete object name.
+func sanitizeDNS1123Label(name string) string {
+	sanitized := dns1123InvalidCharsRe.ReplaceAllString(strings.ToLower(name), "-")
+	return strings.Trim(sanitized, "-")
+}
+
+// SafeObjectName makes a candidate string a valid Kubernetes object name:
+// DNS-1123 label character set, at most 63 characters. Valid candidates pass
+// through unchanged, so adopting this helper does not rename existing
+// resources. Sanitized candidates carry a short hash of the original, keeping
+// distinct candidates distinct ("a/b" and "a.b" both reduce to "a-b");
+// over-long results are truncated in favor of the hash. Typically composed
+// with kmeta.ChildName, e.g. SafeObjectName(kmeta.ChildName(prefix, name)).
+func SafeObjectName(candidate string) string {
+	sanitized := sanitizeDNS1123Label(candidate)
+	if sanitized == candidate && len(candidate) <= validation.DNS1123LabelMaxLength {
+		return candidate
+	}
+
+	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(candidate)))[:8]
+	budget := validation.DNS1123LabelMaxLength - len(digest) - 1
+	if len(sanitized) > budget {
+		sanitized = strings.TrimRight(sanitized[:budget], "-")
+	}
+	if sanitized == "" {
+		return digest
+	}
+	return sanitized + "-" + digest
+}

--- a/pkg/utils/names_test.go
+++ b/pkg/utils/names_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeObjectName(t *testing.T) {
+	valid := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{name: "plain name", in: "lora-pvc-billing-summarize-en-v1"},
+		{name: "hf org prefix", in: "lora-pvc-acme/billing-summarize-en-v1.r16"},
+		{name: "dots", in: "lora-pvc-adapter.v1.2"},
+		{name: "uppercase", in: "lora-pvc-Qwen/Qwen2.5-7B-Instruct"},
+		{name: "trailing invalid", in: "lora-pvc-adapter."},
+		{name: "only invalid chars", in: "///"},
+		{name: "longer than a label", in: strings.Repeat("x", 80)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SafeObjectName(tt.in)
+			assert.True(t, valid.MatchString(got), "name %q must be a DNS-1123 label", got)
+			assert.LessOrEqual(t, len(got), 63)
+		})
+	}
+
+	// Valid candidates pass through unchanged; adopting the helper must not
+	// rename existing resources.
+	assert.Equal(t, "lora-pvc-my-adapter", SafeObjectName("lora-pvc-my-adapter"))
+
+	// "p-a/b" and "p-a.b" both sanitize to "p-a-b"; the hash of the original
+	// keeps the two names distinct instead of silently sharing one volume.
+	assert.Equal(t, "p-a-b-734c5699", SafeObjectName("p-a/b"))
+	assert.Equal(t, "p-a-b-87e580e9", SafeObjectName("p-a.b"))
+
+	// Results name live volumes, so the mapping must not change between
+	// releases - a new result would rename volumes and restart pods on upgrade.
+	assert.Equal(t, "p-acme-x-y-7c26bdb9", SafeObjectName("p-acme/x.y"))
+}
+
+func TestSanitizeDNS1123Label(t *testing.T) {
+	assert.Equal(t, "qwen-qwen2-5-7b-instruct", sanitizeDNS1123Label("Qwen/Qwen2.5-7B-Instruct"))
+	assert.Equal(t, "my-adapter", sanitizeDNS1123Label("my-adapter"))
+	assert.Equal(t, "", sanitizeDNS1123Label("///"))
+}

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -232,10 +232,16 @@ func FindCommonParentPath(paths []string) string {
 	return "/" + strings.Join(commonComponents, "/")
 }
 
-// Helper function to generate volume name from path
+// GetVolumeNameFromPath generates a volume name from a mount path. Path
+// segments may carry characters that are valid in paths but not in volume
+// names (dots, uppercase), and distinct paths must not collapse into the same
+// name, so the joined segments go through SafeObjectName. Joining slashes here
+// rather than delegating to SafeObjectName is deliberate: it reproduces the
+// historical name, which SafeObjectName then keeps when valid, so existing
+// pods are not restarted by a rename. An empty path yields an empty name;
+// callers keep their own fallbacks.
 func GetVolumeNameFromPath(path string) string {
-	// Convert path to valid volume name (remove slashes, etc.)
-	return strings.ReplaceAll(strings.Trim(path, "/"), "/", "-")
+	return SafeObjectName(strings.ReplaceAll(strings.Trim(path, "/"), "/", "-"))
 }
 
 // AddDefaultHuggingFaceEnvVars adds default HuggingFace optimization environment variables

--- a/pkg/utils/storage_test.go
+++ b/pkg/utils/storage_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -213,6 +214,15 @@ func TestGetVolumeNameFromPath(t *testing.T) {
 			g.Expect(result).To(gomega.Equal(scenario.expected))
 		})
 	}
+
+	// Path segments may carry characters that are valid in paths but not in
+	// volume names; the result must still be a valid name and distinct paths
+	// must not collapse into the same one.
+	validLabel := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+	for _, path := range []string{"/mnt/lora/Qwen2.5-SQL", "/mnt/lora/adapter.v1"} {
+		g.Expect(GetVolumeNameFromPath(path)).To(gomega.MatchRegexp(validLabel.String()), "path %s", path)
+	}
+	g.Expect(GetVolumeNameFromPath("/mnt/a/b")).ToNot(gomega.Equal(GetVolumeNameFromPath("/mnt/a.b")))
 }
 
 func TestAddDefaultHuggingFaceEnvVars(t *testing.T) {

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -5,7 +5,9 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install necessary dependencies for building Python packages
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
+RUN apt-get update && apt-get install -y --no-install-recommends curl python3-dev build-essential && \
+    if [ "$(uname -m)" = "ppc64le" ]; then apt-get install pkg-config libssl-dev gcc gfortran cmake pkg-config libssl-dev libopenblas-dev libjpeg-dev libhdf5-dev wget -y; fi && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv
@@ -23,18 +25,129 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Copy and install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
+
+# On ppc64le: patch pyproject.toml to add the ppc64le package index and sources,
+# then regenerate uv.lock before syncing.
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^index-strategy\s*=.*/a \\' \
+            -e '/^index-strategy\s*=.*/a [[tool.uv.index]]' \
+            -e '/^index-strategy\s*=.*/a name = "ppc64le-wheels"' \
+            -e '/^index-strategy\s*=.*/a url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            -e '/^index-strategy\s*=.*/a explicit = true' \
+            -e '/^\s*"pyasn1>=[^,]*"$/s/"$/",/' \
+            -e '/^\s*"pyasn1>=/a\    "httptools==0.6.4",' \
+            -e '/^\s*"pyasn1>=/a\    "uvloop==0.21.0",' \
+            -e '/^kserve-storage\s*=.*/a grpcio = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a grpcio-tools = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a numpy = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pandas = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a psutil = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pyyaml = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a httptools = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a uvloop = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pillow = { index = "ppc64le-wheels" }' \
+            kserve/pyproject.toml && \
+        cd kserve && uv lock && \
+        cp uv.lock /tmp/kserve_ppc64le_uv.lock && \
+        cp pyproject.toml /tmp/kserve_ppc64le_pyproject.toml; \
+    fi
+
 RUN cd kserve && uv sync --active --no-cache
+
 COPY kserve kserve
+
+# On ppc64le: restore the patched pyproject.toml + uv.lock after COPY overwrites them
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        rm -f kserve/pyproject.toml kserve/uv.lock && \
+        cp /tmp/kserve_ppc64le_pyproject.toml kserve/pyproject.toml && \
+        cp /tmp/kserve_ppc64le_uv.lock kserve/uv.lock && \
+        rm -f /tmp/kserve_ppc64le_pyproject.toml /tmp/kserve_ppc64le_uv.lock; \
+    fi
+
 RUN cd kserve && uv sync --active --no-cache
 
 # Install kserve-storage
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
 
-# Copy and install dependencies for xgbserver using uv
+# On ppc64le: append ppc64le index + sources to storage/pyproject.toml,
+# regenerate uv.lock, then sync (same pattern as kserve/lgbserver).
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^    "pyasn1>=[^,]*"$/s/"$/",/' \
+            -e '/^    "pyasn1>=/a\    "google-crc32c==1.8.0",' \
+            -e '/^    "pyasn1>=/a\    "pyyaml==6.0.2",' \
+            storage/pyproject.toml && \
+        printf '%s\n' \
+            '' \
+            '[tool.uv]' \
+            'index-strategy = "unsafe-best-match"' \
+            'package = true' \
+            '' \
+            '[build-system]' \
+            'requires = ["setuptools>=61.0"]' \
+            'build-backend = "setuptools.build_meta"' \
+            '' \
+            '[[tool.uv.index]]' \
+            'name = "ppc64le-wheels"' \
+            'url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            'explicit = true' \
+            '' \
+            '[tool.uv.sources]' \
+            'google-crc32c = { index = "ppc64le-wheels" }' \
+            'hf-xet = { index = "ppc64le-wheels" }' \
+            'pyyaml = { index = "ppc64le-wheels" }' \
+            >> storage/pyproject.toml && \
+        cd storage && uv lock && \
+        uv sync --active --no-cache; \
+    else \
+        cd storage && uv pip install . --no-cache; \
+    fi
+
+# On ppc64le: patch pyproject.toml for xgbserver, then regenerate uv.lock before syncing.
 COPY xgbserver/pyproject.toml xgbserver/uv.lock xgbserver/
+
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e 's/"xgboost~=2.1.1"/"xgboost-cpu~=2.1.1"/' \
+            -e '/^    "xgboost-cpu~=2.1.1",$/s/"$/",/' \
+            -e '/^    "xgboost-cpu~=2.1.1",$/a\    "scipy==1.15.2",' \
+            xgbserver/pyproject.toml && \
+        printf '%s\n' \
+            '' \
+            '[[tool.uv.index]]' \
+            'name = "ppc64le-wheels"' \
+            'url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            'explicit = true' \
+            '' \
+            '[tool.uv]' \
+            'override-dependencies = [' \
+            '  "nvidia-nccl-cu12; sys_platform == '\''linux'\'' and (platform_machine == '\''x86_64'\'' or platform_machine == '\''aarch64'\'')"' \
+            ']' \
+            'index-strategy = "unsafe-best-match"' \
+            '' \
+            '[tool.uv.sources]' \
+            'scipy = { index = "ppc64le-wheels" }' \
+            'pillow = { index = "ppc64le-wheels" }' \
+            'xgboost-cpu = { index = "ppc64le-wheels" }' \
+            >> xgbserver/pyproject.toml && \
+        cd xgbserver && uv lock && \
+        cp uv.lock /tmp/xgbserver_ppc64le_uv.lock && \
+        cp pyproject.toml /tmp/xgbserver_ppc64le_pyproject.toml; \
+    fi
+
 RUN cd xgbserver && uv sync --active --no-cache
+
 COPY xgbserver xgbserver
+
+# On ppc64le: restore the patched pyproject.toml + uv.lock after COPY overwrites them
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        rm -f xgbserver/pyproject.toml xgbserver/uv.lock && \
+        cp /tmp/xgbserver_ppc64le_pyproject.toml xgbserver/pyproject.toml && \
+        cp /tmp/xgbserver_ppc64le_uv.lock xgbserver/uv.lock && \
+        rm -f /tmp/xgbserver_ppc64le_pyproject.toml /tmp/xgbserver_ppc64le_uv.lock; \
+    fi
+
 RUN cd xgbserver && uv sync --active --no-cache
 
 # Generate third-party licenses


### PR DESCRIPTION
**What this PR does / why we need it**: We have updated the existing Dockerfile and added a new workflow for **xgbserver** to add Power support.

**Feature/Issue validation/testing**:

```
ubuntu@pytorch-5:~/kserve-testing/xgb$ docker run -p 8080:8080 -v /home/ubuntu/kserve-testing/xgb:/mnt/models localhost/xgb-ppc64le:latest python -m xgbserver --model_dir /mnt/models --model_name xgboost-iris
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
2026-08-12 06:08:50.633 1 kserve INFO [model_server.py:register_model():439] Registering model: xgboost-iris
2026-08-12 06:08:50.635 1 kserve INFO [model_server.py:setup_event_loop():315] Setting max asyncio worker threads as 20
2026-08-12 06:08:50.763 1 kserve INFO [server.py:_register_endpoints():124] OpenAI endpoints not registered
2026-08-12 06:08:50.763 1 kserve INFO [server.py:_register_endpoints():132] Time series endpoints not registered
2026-08-12 06:08:50.763 1 kserve INFO [server.py:start():183] Starting uvicorn with 1 workers
2026-08-12 06:08:50.848 1 uvicorn.error INFO:     Started server process [1]
2026-08-12 06:08:50.848 1 uvicorn.error INFO:     Waiting for application startup.
2026-08-12 06:08:50.860 1 kserve INFO [server.py:start():70] Starting gRPC server with 4 workers
2026-08-12 06:08:50.861 1 kserve INFO [server.py:start():71] Starting gRPC server on [::]:8081
2026-08-12 06:08:50.861 1 uvicorn.error INFO:     Application startup complete.
2026-08-12 06:08:50.862 1 uvicorn.error INFO:     Uvicorn running on http://0.0.0.0:8080/ (Press CTRL+C to quit)
```

```
ubuntu@pytorch-5:~$ curl -X POST http://localhost:8080/v1/models/xgboost-iris:predict \
  -H "Content-Type: application/json" \
  -d '{"instances": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}'
{"predictions":[1.0,1.0]}
```

**Special notes for your reviewer**:

- This PR only introduces Power (ppc64le) image build support for xgbServer.
- For the packages that do not have power support, we are fetching wheels from https://wheels.developerfirst.ibm.com/ppc64le/linux. We have added this index to pyproject.toml file of kserve , xgbserver and storage.
- The build time taken for Power is below  44 mins, which is comparable to linux/arm64/v8 when built separately.

**Release note**:
`Added ppc64le support to xgbServer`