### PR TITLE
fix(llmisvc): allow triggerAuthName without authModes for KEDA

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_loader.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_loader.go
@@ -122,13 +122,19 @@ type PrometheusConfig struct {
 	// TLSInsecureSkipVerify disables TLS certificate verification for the Prometheus connection.
 	TLSInsecureSkipVerify bool `json:"tlsInsecureSkipVerify"`
 	// AuthModes is the KEDA authModes value for the Prometheus trigger
-	// (e.g. "bearer", "basic", "tls"). Empty means no authentication.
+	// (e.g. "bearer", "basic", "tls"). Empty means no secret-backed authentication.
+	// Requires TriggerAuthName to be set, since the referenced CR supplies the actual
+	// credential values. Must be left empty when TriggerAuthName references a
+	// pod-identity-based CR (e.g. AWS/Azure/GCP managed Prometheus) - KEDA's Prometheus
+	// scaler rejects pod identity combined with any other auth mode.
 	// See: https://keda.sh/docs/latest/scalers/prometheus/#authentication-parameters
 	// +optional
 	AuthModes string `json:"authModes,omitempty"`
 	// TriggerAuthName is the name of a pre-existing TriggerAuthentication or
 	// ClusterTriggerAuthentication CR that KEDA should use when querying Prometheus.
 	// The CR must be created by the cluster admin before enabling KEDA autoscaling.
+	// May be set without AuthModes, e.g. when the CR configures pod-identity-based auth
+	// for a managed Prometheus service instead of secret-backed credentials.
 	// +optional
 	TriggerAuthName string `json:"triggerAuthName,omitempty"`
 	// TriggerAuthKind specifies the kind of the authentication CR referenced by

--- a/pkg/controller/v1alpha2/llmisvc/scaling.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling.go
@@ -340,15 +340,19 @@ func (r *LLMISVCReconciler) propagateScaledObjectStatus(ctx context.Context, exp
 }
 
 // validateAutoscalingConfig checks that the WVAAutoscalingConfig is valid for use with KEDA.
-// It returns an error if the config is nil, if prometheus.url is missing, or if the auth
-// fields are only partially configured (both prometheus.authModes and prometheus.triggerAuthName
-// must be set together or both left empty).
+// It returns an error if the config is nil, if prometheus.url is missing, or if
+// prometheus.authModes is set without a prometheus.triggerAuthName to source credentials
+// from. The reverse (triggerAuthName set without authModes) is valid and required for
+// pod-identity-based auth against managed Prometheus (AWS, Azure, GCP): KEDA's Prometheus
+// scaler rejects authModes combined with pod identity, so those TriggerAuthentication CRs
+// carry no secret-backed auth fields and authModes must stay empty.
+// See: https://keda.sh/docs/latest/scalers/prometheus/#authentication-parameters
 func validateAutoscalingConfig(cfg *WVAAutoscalingConfig) error {
 	if cfg == nil || cfg.Prometheus.URL == "" {
 		return fmt.Errorf("%s.prometheus.url is required in inferenceservice-config when using KEDA", autoscalingConfigName)
 	}
-	if (cfg.Prometheus.TriggerAuthName == "") != (cfg.Prometheus.AuthModes == "") {
-		return fmt.Errorf("%s.prometheus.authModes and %s.prometheus.triggerAuthName must both be set or both be empty", autoscalingConfigName, autoscalingConfigName)
+	if cfg.Prometheus.AuthModes != "" && cfg.Prometheus.TriggerAuthName == "" {
+		return fmt.Errorf("%s.prometheus.triggerAuthName is required in inferenceservice-config when %s.prometheus.authModes is set", autoscalingConfigName, autoscalingConfigName)
 	}
 	return nil
 }

--- a/pkg/controller/v1alpha2/llmisvc/scaling_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling_test.go
@@ -500,6 +500,30 @@ func TestExpectedScaledObject(t *testing.T) {
 			},
 		},
 		{
+			name:   "TriggerAuthName without AuthModes is wired into trigger without authModes metadata",
+			llmSvc: newTestLLMISVC("test-svc", "test-ns"),
+			scaling: &v1alpha2.ScalingSpec{
+				MaxReplicas: 5,
+				WVA:         &v1alpha2.WVASpec{ActuatorSpec: v1alpha2.ActuatorSpec{KEDA: &v1alpha2.KEDAScalingSpec{}}},
+			},
+			config: &Config{WVAAutoscalingConfig: &WVAAutoscalingConfig{
+				Prometheus: PrometheusConfig{
+					URL:             "https://prom.monitoring:9090",
+					TriggerAuthName: "aws-managed-prometheus-auth",
+					TriggerAuthKind: "TriggerAuthentication",
+				},
+			}},
+			scaleTargetRef: deploymentScaleTargetRef("test-svc-kserve"),
+			soName:         "test-svc-kserve-keda",
+			validate: func(t *testing.T, so *kedav1alpha1.ScaledObject) {
+				trigger := so.Spec.Triggers[0]
+				assert.NotContains(t, trigger.Metadata, "authModes")
+				require.NotNil(t, trigger.AuthenticationRef)
+				assert.Equal(t, "aws-managed-prometheus-auth", trigger.AuthenticationRef.Name)
+				assert.Equal(t, "TriggerAuthentication", trigger.AuthenticationRef.Kind)
+			},
+		},
+		{
 			name:   "ClusterTriggerAuthentication auth fields are wired into trigger",
 			llmSvc: newTestLLMISVC("test-svc", "test-ns"),
 			scaling: &v1alpha2.ScalingSpec{
@@ -792,17 +816,16 @@ func TestValidateAutoscalingConfig(t *testing.T) {
 					AuthModes: "bearer",
 				},
 			},
-			wantErr: "autoscaling-wva-controller-config.prometheus.authModes and autoscaling-wva-controller-config.prometheus.triggerAuthName must both be set or both be empty",
+			wantErr: "autoscaling-wva-controller-config.prometheus.triggerAuthName is required in inferenceservice-config when autoscaling-wva-controller-config.prometheus.authModes is set",
 		},
 		{
-			name: "triggerAuthName set without authModes returns error",
+			name: "triggerAuthName set without authModes is valid (pod identity / managed Prometheus)",
 			cfg: &WVAAutoscalingConfig{
 				Prometheus: PrometheusConfig{
 					URL:             "https://prom:9090",
-					TriggerAuthName: "prom-auth",
+					TriggerAuthName: "aws-managed-prometheus-auth",
 				},
 			},
-			wantErr: "autoscaling-wva-controller-config.prometheus.authModes and autoscaling-wva-controller-config.prometheus.triggerAuthName must both be set or both be empty",
 		},
 		{
 			name: "ClusterTriggerAuthentication kind with both auth fields is valid",


### PR DESCRIPTION
**What this PR does / why we need it**:

`validateAutoscalingConfig` (`pkg/controller/v1alpha2/llmisvc/scaling.go`) required `prometheus.authModes` and `prometheus.triggerAuthName` to be set together or both empty. That makes it impossible to configure KEDA against a managed Prometheus service (AWS Managed Prometheus, Azure Monitor managed Prometheus, Google Managed Prometheus) using pod-identity-based auth, which is the documented way to authenticate against those services.

Evidence:
- KEDA's Prometheus scaler explicitly rejects combining pod identity with any other auth mode: [`checkAuthConfigWithPodIdentity`](https://github.com/kedacore/keda/blob/main/pkg/scalers/prometheus_scaler.go#L173-L181) returns `"pod identity cannot be enabled with other auth types"` when `PodIdentity.Provider` is set and `authModes` is not disabled/empty.
- KEDA's [Prometheus scaler docs](https://keda.sh/docs/latest/scalers/prometheus/) show `TriggerAuthentication` examples for AWS Managed Prometheus, Azure Monitor managed Prometheus, and Google Managed Prometheus that all use `podIdentity` on the `TriggerAuthentication` with `authModes` omitted entirely — e.g. for Azure: "No other auth (via `authModes`) can be provided with Azure Pod/Workload Identity Auth."

So `triggerAuthName` set with `authModes` empty is a valid, necessary configuration (the `TriggerAuthentication` CR carries `podIdentity` instead of secret-backed credentials), while `authModes` set without `triggerAuthName` remains invalid (KEDA has nowhere to source the credential values from). `prometheusTrigger` (`scaling.go`) already builds the KEDA `ScaleTriggers` correctly for this case — it sets `authModes` metadata and `AuthenticationRef` independently of each other — so the only bug was the validation gate blocking a config that the rest of the code already supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] `TestValidateAutoscalingConfig` updated: `triggerAuthName` set without `authModes` now asserts valid (was previously asserting an error); `authModes` set without `triggerAuthName` still asserts an error, with updated message
- [x] `go test ./pkg/controller/v1alpha2/llmisvc/...` passes, including `TestExpectedScaledObject` (exercises the KEDA trigger-building path end to end)
- [x] `go vet`, `gofmt` clean on changed files

**Special notes for your reviewer**:

No behavior change to the KEDA trigger construction itself (`prometheusTrigger`) — this only relaxes the config validation to match what that function already does. Doc comments on `PrometheusConfig.AuthModes`/`TriggerAuthName` updated to explain the asymmetry.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix KEDA/WVA autoscaling config validation to allow `prometheus.triggerAuthName` without `prometheus.authModes`, required for pod-identity-based auth against managed Prometheus services (AWS, Azure, GCP).
```
