### PR TITLE
fix: correct operator precedence in HPA scaleTarget validation

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -535,14 +535,12 @@ func validateScalingHPACompExtension(compExtSpec *ComponentExtensionSpec) error 
 		return err
 	}
 
+	// ScaleTarget is an AverageUtilization percentage for both cpu and memory:
+	// getHPAMetrics builds a UtilizationMetricType target from it either way. The
+	// same [1-100] bound therefore applies to both, as it does on the KEDA path.
 	if compExtSpec.ScaleTarget != nil {
-		target := *compExtSpec.ScaleTarget
-		if metric == MetricCPU && target < 1 || target > 100 {
-			return errors.New("the target utilization percentage should be a [1-100] integer")
-		}
-
-		if metric == MetricMemory && target < 1 {
-			return errors.New("the target memory should be greater than 1 MiB")
+		if err := validateTargetUtilization(*compExtSpec.ScaleTarget); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -334,6 +334,60 @@ func TestAutoscalerClassHPA(t *testing.T) {
 			},
 			errMatcher: gomega.BeNil(),
 		},
+		"HPA Memory metrics with target above the utilization range": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":  "Standard",
+						"serving.kserve.io/autoscalerClass": "hpa",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							ScaleMetric: ptr.To(MetricMemory),
+							ScaleTarget: ptr.To(int32(500)),
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.MatchError("the target utilization percentage should be a [1-100] integer"),
+		},
+		"HPA Memory metrics with target below the utilization range": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":  "Standard",
+						"serving.kserve.io/autoscalerClass": "hpa",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							ScaleMetric: ptr.To(MetricMemory),
+							ScaleTarget: ptr.To(int32(0)),
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.MatchError("the target utilization percentage should be a [1-100] integer"),
+		},
 		"Invalid autoscaler class": {
 			isvc: &InferenceService{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

`validateScalingHPACompExtension` guarded the `[1-100]` utilization range with

```go
if metric == MetricCPU && target < 1 || target > 100 {
```

Go parses this as `(metric == MetricCPU && target < 1) || (target > 100)`, so the upper bound applied to every metric while the lower bound applied only to cpu. A memory target above 100 was rejected as a side effect of that precedence rather than by an intended check, and it returned the cpu-worded message. A memory target below 1 fell through to a separate branch reporting `the target memory should be greater than 1 MiB`.

That message names the wrong unit. `ScaleTarget` is an `AverageUtilization` percentage for memory exactly as it is for cpu — `getHPAMetrics` builds a `UtilizationMetricType` target from it in the memory branch too:

```go
} else if resourceName == corev1.ResourceMemory && componentExt != nil && componentExt.ScaleTarget != nil {
	metricTarget := autoscalingv2.MetricTarget{
		Type:               autoscalingv2.UtilizationMetricType,
		AverageUtilization: componentExt.ScaleTarget,
	}
```

so the value is never a MiB quantity on this path. The KEDA path already applies a single `[1-100]` bound to any `Utilization` target through `validateTargetUtilization`. This change uses that same helper for both metrics.

Accept/reject decisions are unchanged for every input. The only observable difference is the error message for a memory target below 1, which now names the unit the field actually has.

**Which issue(s) this PR fixes**:

Fixes #5981

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/apis/serving/v1beta1/` — passes.
- [x] Added two `TestAutoscalerClassHPA` cases for memory `scaleTarget` above and below the range.
- [x] Verified the below-range case fails against the current code and passes with this change:

```
=== ORIGINAL code ===
    --- FAIL: TestAutoscalerClassHPA/HPA_Memory_metrics_with_target_below_the_utilization_range
        s: "the target memory should be greater than 1 MiB"
=== WITH THIS CHANGE ===
--- PASS: TestAutoscalerClassHPA (0.00s)
ok  	github.com/kserve/kserve/pkg/apis/serving/v1beta1
```

- [x] `go vet` and `gofmt` clean.

**Special notes for your reviewer**:

The above-range case (`scaleTarget: 500`, memory) passes both before and after — the old code happened to reject it through the stray `|| target > 100`. I included it to pin the behaviour explicitly rather than leave it resting on operator precedence, but only the below-range case is a true regression guard.

If maintainers would rather keep a distinct message for memory, I'm happy to add a metric-specific wording on top of the shared bound instead.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation? — no user-facing docs describe this message.

**Release note**:
```release-note
Fix an operator precedence bug in InferenceService HPA validation so that `scaleTarget` is validated as a [1-100] utilization percentage for both cpu and memory, and a memory target below 1 no longer reports a misleading MiB-based error.
```
