### PR TITLE
feat(autogluonserver): inject synthetic item ID for two-column ts

### DIFF
--- a/python/autogluonserver/autogluonserver/timeseries_model.py
+++ b/python/autogluonserver/autogluonserver/timeseries_model.py
@@ -54,6 +54,7 @@ class TimeSeriesInferenceMetadata:
     timestamp_column: str
     prediction_length: int
     known_covariates_names: List[str]
+    uses_synthetic_id: bool = False
 
 
 def _nonempty_metadata_str(value: Any, *, field: str, meta_path: str) -> str:
@@ -208,6 +209,7 @@ def _ts_metadata_from_json_file(
         id_column, timestamp_column
     )
     pl = _prediction_length_from_predictor(predictor)
+    uses_synthetic_id = bool(raw.get("uses_synthetic_id", False))
     _raise_if_known_covariates_overlap_columns(
         known_list,
         target,
@@ -221,6 +223,7 @@ def _ts_metadata_from_json_file(
         timestamp_column=timestamp_column,
         prediction_length=pl,
         known_covariates_names=known_list,
+        uses_synthetic_id=uses_synthetic_id,
     )
 
 
@@ -266,6 +269,15 @@ def _check_duplicate_columns(
         raise InferenceError(msg)
 
 
+def _inject_synthetic_id_if_needed(
+    df: pd.DataFrame, meta: TimeSeriesInferenceMetadata
+) -> pd.DataFrame:
+    if meta.uses_synthetic_id and meta.id_column not in df.columns:
+        df = df.copy()
+        df[meta.id_column] = "item_0"
+    return df
+
+
 def _dataframe_to_tsdf(
     df: pd.DataFrame, meta: TimeSeriesInferenceMetadata
 ) -> TimeSeriesDataFrame:
@@ -274,6 +286,7 @@ def _dataframe_to_tsdf(
         "instances DataFrame",
         detail="Use unique keys in each row object.",
     )
+    df = _inject_synthetic_id_if_needed(df, meta)
     missing = {meta.id_column, meta.timestamp_column, meta.target} - set(df.columns)
     if missing:
         raise InferenceError(
@@ -293,6 +306,7 @@ def _known_covariates_to_tsdf(
 ) -> TimeSeriesDataFrame:
     df = pd.DataFrame(rows)
     _check_duplicate_columns(df, "known_covariates DataFrame")
+    df = _inject_synthetic_id_if_needed(df, meta)
     required = {meta.id_column, meta.timestamp_column, *meta.known_covariates_names}
     missing = required - set(df.columns)
     if missing:
@@ -348,6 +362,8 @@ def _forecast_to_records(
     work = forecasts.reset_index().copy()
     if rename:
         work = work.rename(columns=rename)
+    if meta.uses_synthetic_id and meta.id_column in work.columns:
+        work = work.drop(columns=[meta.id_column])
     for col in work.columns:
         if pd.api.types.is_datetime64_any_dtype(work[col]):
             work[col] = work[col].dt.strftime("%Y-%m-%dT%H:%M:%S")

--- a/python/autogluonserver/tests/test_timeseries_model.py
+++ b/python/autogluonserver/tests/test_timeseries_model.py
@@ -23,8 +23,10 @@ from kserve.protocol.infer_type import InferRequest, InferInput
 from autogluonserver.timeseries_model import (
     AutoGluonTimeSeriesModel,
     TimeSeriesInferenceMetadata,
+    _dataframe_to_tsdf,
     _forecast_columns_rename_map,
     _forecast_to_records,
+    _inject_synthetic_id_if_needed,
     _load_ts_metadata,
 )
 
@@ -37,12 +39,15 @@ def _write_predictor_metadata(
     target: str = "y",
     id_column: str = "item_id",
     timestamp_column: str = "ts",
+    uses_synthetic_id: bool = False,
 ) -> None:
     payload = {
         "target": target,
         "id_column": id_column,
         "timestamp_column": timestamp_column,
     }
+    if uses_synthetic_id:
+        payload["uses_synthetic_id"] = True
     (tmp_path / "predictor_metadata.json").write_text(
         json.dumps(payload),
         encoding="utf-8",
@@ -433,3 +438,142 @@ def test_timeseries_v2_request_raises(monkeypatch, tmp_path):
     )
     with pytest.raises(InferenceError, match="REST v1 JSON"):
         model.predict(req)
+
+
+# --- Synthetic item ID injection tests ---
+
+
+def _synthetic_meta(**overrides):
+    defaults = dict(
+        target="y",
+        id_column="__synthetic_item_id",
+        timestamp_column="timestamp",
+        prediction_length=1,
+        known_covariates_names=[],
+        uses_synthetic_id=True,
+    )
+    defaults.update(overrides)
+    return TimeSeriesInferenceMetadata(**defaults)
+
+
+def test_inject_synthetic_id_adds_column_when_missing():
+    df = pd.DataFrame({"timestamp": ["2024-01-01"], "y": [1.0]})
+    meta = _synthetic_meta()
+    result = _inject_synthetic_id_if_needed(df, meta)
+    assert "__synthetic_item_id" in result.columns
+    assert result["__synthetic_item_id"].iloc[0] == "item_0"
+    assert "__synthetic_item_id" not in df.columns
+
+
+def test_inject_synthetic_id_noop_when_column_present():
+    df = pd.DataFrame(
+        {"__synthetic_item_id": ["custom"], "timestamp": ["2024-01-01"], "y": [1.0]}
+    )
+    meta = _synthetic_meta()
+    result = _inject_synthetic_id_if_needed(df, meta)
+    assert result["__synthetic_item_id"].iloc[0] == "custom"
+
+
+def test_inject_synthetic_id_noop_when_flag_false():
+    df = pd.DataFrame({"timestamp": ["2024-01-01"], "y": [1.0]})
+    meta = _synthetic_meta(uses_synthetic_id=False)
+    result = _inject_synthetic_id_if_needed(df, meta)
+    assert "__synthetic_item_id" not in result.columns
+
+
+def test_dataframe_to_tsdf_injects_synthetic_id():
+    df = pd.DataFrame({"timestamp": ["2024-01-01", "2024-01-02"], "y": [1.0, 2.0]})
+    meta = _synthetic_meta()
+    tsdf = _dataframe_to_tsdf(df, meta)
+    assert len(tsdf) == 2
+
+
+def test_dataframe_to_tsdf_still_raises_for_missing_non_id_columns():
+    df = pd.DataFrame({"y": [1.0]})
+    meta = _synthetic_meta()
+    with pytest.raises(InferenceError, match="timestamp"):
+        _dataframe_to_tsdf(df, meta)
+
+
+def test_forecast_to_records_strips_synthetic_id():
+    meta = _synthetic_meta()
+    idx = pd.MultiIndex.from_tuples(
+        [("item_0", pd.Timestamp("2024-01-05"))],
+        names=["item_id", "timestamp"],
+    )
+    forecasts = pd.DataFrame({"mean": [3.14]}, index=idx)
+    records = _forecast_to_records(forecasts, meta)
+    assert len(records) == 1
+    assert "__synthetic_item_id" not in records[0]
+    assert "item_id" not in records[0]
+    assert records[0]["timestamp"] == "2024-01-05T00:00:00"
+    assert records[0]["mean"] == pytest.approx(3.14)
+
+
+def test_forecast_to_records_keeps_id_when_not_synthetic():
+    meta = _synthetic_meta(uses_synthetic_id=False, id_column="item_id")
+    idx = pd.MultiIndex.from_tuples(
+        [("i1", pd.Timestamp("2024-01-05"))],
+        names=["item_id", "timestamp"],
+    )
+    forecasts = pd.DataFrame({"mean": [3.14]}, index=idx)
+    records = _forecast_to_records(forecasts, meta)
+    assert records[0]["item_id"] == "i1"
+
+
+def test_load_ts_metadata_reads_uses_synthetic_id_flag(tmp_path):
+    _write_predictor_metadata(
+        tmp_path,
+        id_column="__synthetic_item_id",
+        timestamp_column="timestamp",
+        uses_synthetic_id=True,
+    )
+    meta = _load_ts_metadata(FakeTimeSeriesPredictor(), str(tmp_path))
+    assert meta.uses_synthetic_id is True
+
+
+def test_load_ts_metadata_defaults_synthetic_id_to_false(tmp_path):
+    _write_predictor_metadata(tmp_path)
+    meta = _load_ts_metadata(FakeTimeSeriesPredictor(), str(tmp_path))
+    assert meta.uses_synthetic_id is False
+
+
+def test_load_ts_metadata_without_file_synthetic_id_is_false(tmp_path):
+    meta = _load_ts_metadata(FakeTimeSeriesPredictor(), str(tmp_path))
+    assert meta.uses_synthetic_id is False
+
+
+def test_timeseries_synthetic_id_full_predict_flow(monkeypatch, tmp_path):
+    _write_predictor_metadata(
+        tmp_path,
+        id_column="__synthetic_item_id",
+        timestamp_column="ts",
+        uses_synthetic_id=True,
+    )
+    fake = FakeTimeSeriesPredictor()
+    monkeypatch.setattr(
+        "autogluonserver.timeseries_model.Storage.download", lambda _: str(tmp_path)
+    )
+    monkeypatch.setattr(
+        "autogluonserver.timeseries_model.TimeSeriesPredictor.load",
+        lambda path: fake,
+    )
+    model = AutoGluonTimeSeriesModel("forecast", "s3://bucket/artifact")
+    assert model.load()
+    assert model._metadata.uses_synthetic_id is True
+
+    resp = model.predict(
+        {
+            "instances": [
+                {"ts": "2024-01-01", "y": 1.0},
+                {"ts": "2024-01-02", "y": 2.0},
+            ]
+        }
+    )
+    assert fake.last_data is not None
+    assert "predictions" in resp
+    row = resp["predictions"][0]
+    assert "__synthetic_item_id" not in row
+    assert "item_id" not in row
+    assert row["ts"] == "2024-01-05T00:00:00"
+    assert row["mean"] == pytest.approx(3.14)


### PR DESCRIPTION
## Summary
  - Support two-column (timestamp + target) time series models at inference time
    by auto-injecting a synthetic `item_id` when the request payload omits it
  - Read `uses_synthetic_id` flag from `predictor_metadata.json` (written by the
    training pipeline) to gate injection — multi-item models are unaffected
  - Strip the synthetic ID column from prediction responses so the user-facing
    contract reflects only the real two columns

## Changes
  ### `timeseries_model.py`
  - Add `uses_synthetic_id: bool` to `TimeSeriesInferenceMetadata` dataclass
  - Read the flag from `predictor_metadata.json` in `_ts_metadata_from_json_file()`
  - New `_inject_synthetic_id_if_needed()` — called in `_dataframe_to_tsdf()` and
    `_known_covariates_to_tsdf()` before column validation
  - Strip synthetic ID column in `_forecast_to_records()` output

## How to test
  ```bash
  cd python/autogluonserver
  python -m pytest tests/test_timeseries_model.py -v

