### PR TITLE
feat(storage): report Hugging Face download progress in non-TTY logs

### DIFF
--- a/python/storage/kserve_storage/huggingface_progress.py
+++ b/python/storage/kserve_storage/huggingface_progress.py
@@ -1,0 +1,215 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import threading
+import time
+
+from huggingface_hub.utils import tqdm as huggingface_tqdm
+
+from kserve_storage.logging import logger
+
+_HEARTBEAT_SECONDS = 60.0
+
+
+def get_huggingface_repo_size_bytes(
+    repo_id: str,
+    revision: str | None = None,
+    allow_patterns: list[str] | None = None,
+    ignore_patterns: list[str] | None = None,
+) -> int | None:
+    from huggingface_hub import HfApi
+    from huggingface_hub.utils import filter_repo_objects
+
+    try:
+        model_info = HfApi().model_info(
+            repo_id=repo_id,
+            revision=revision,
+            files_metadata=True,
+        )
+    except Exception as error:
+        logger.warning(
+            "Unable to determine Hugging Face download size; "
+            "continuing without percentage: %s",
+            error,
+        )
+        return None
+
+    siblings = model_info.siblings or []
+    selected_files = filter_repo_objects(
+        siblings,
+        allow_patterns=allow_patterns,
+        ignore_patterns=ignore_patterns,
+        key=lambda sibling: sibling.rfilename,
+    )
+    sizes = [sibling.size for sibling in selected_files]
+    if not sizes or any(size is None for size in sizes):
+        return None
+
+    return sum(sizes)
+
+
+def _get_local_size_bytes(local_dir: str) -> int:
+    total_bytes = 0
+    directories = [local_dir]
+
+    while directories:
+        directory = directories.pop()
+        try:
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            directories.append(entry.path)
+                        elif entry.is_file(follow_symlinks=False):
+                            stat = entry.stat(follow_symlinks=False)
+                            allocated_blocks = getattr(stat, "st_blocks", None)
+                            total_bytes += (
+                                allocated_blocks * 512
+                                if allocated_blocks is not None
+                                else stat.st_size
+                            )
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+
+    return total_bytes
+
+
+class HuggingFaceLogProgress(huggingface_tqdm):
+    """Render Hugging Face snapshot progress as line-oriented logs."""
+
+    def __init__(
+        self,
+        *args,
+        local_dir: str | None = None,
+        total_size_bytes: int | None = None,
+        **kwargs,
+    ):
+        self.local_dir = local_dir
+        self.total_size_bytes = total_size_bytes
+        self._heartbeat_stop = threading.Event()
+        self._heartbeat_thread = None
+        self._progress_lock = threading.Lock()
+        self._last_log_at = time.monotonic()
+        self._kserve_initialized = False
+        self._kserve_closed = False
+        kwargs.setdefault("mininterval", _HEARTBEAT_SECONDS)
+        kwargs.setdefault("maxinterval", _HEARTBEAT_SECONDS)
+        kwargs.setdefault("leave", False)
+        super().__init__(*args, **kwargs)
+        self._kserve_initialized = True
+
+        if not self.disable:
+            self._emit_progress("started")
+            self._start_heartbeat()
+
+    def display(self, msg=None, pos=None):
+        if self._kserve_initialized and not self._kserve_closed:
+            self._log_progress_if_due("running")
+
+    def _start_heartbeat(self):
+        self._heartbeat_thread = threading.Thread(
+            target=self._heartbeat,
+            name="huggingface-download-progress",
+            daemon=True,
+        )
+        self._heartbeat_thread.start()
+
+    def _heartbeat(self):
+        while True:
+            with self._progress_lock:
+                next_log_in = max(
+                    0.0,
+                    _HEARTBEAT_SECONDS - (time.monotonic() - self._last_log_at),
+                )
+            if self._heartbeat_stop.wait(next_log_in):
+                return
+            self._emit_progress("running")
+
+    def _log_progress_if_due(self, state: str):
+        with self._progress_lock:
+            if time.monotonic() - self._last_log_at < _HEARTBEAT_SECONDS:
+                return
+        self._emit_progress(state)
+
+    def _emit_progress(self, state: str):
+        now = time.monotonic()
+        with self._progress_lock:
+            self._last_log_at = now
+        total = self.total if self.total is not None else "unknown"
+        local_size_bytes = (
+            _get_local_size_bytes(self.local_dir) if self.local_dir is not None else 0
+        )
+        local_size_gb = local_size_bytes / 1_000_000_000
+
+        if self.total_size_bytes:
+            total_size_gb = self.total_size_bytes / 1_000_000_000
+            progress_percent = min(
+                local_size_bytes / self.total_size_bytes * 100,
+                100.0,
+            )
+            if state == "completed":
+                progress_percent = 100.0
+            message = (
+                f"HF progress: {local_size_gb:.2f}/{total_size_gb:.2f}GB "
+                f"({progress_percent:.1f}%), {self.n}/{total} files"
+            )
+        else:
+            message = f"HF progress: {local_size_gb:.2f}GB, {self.n}/{total} files"
+
+        if state == "completed":
+            message += ", complete"
+        elif state == "stopped":
+            message += ", stopped"
+
+        logger.info(message)
+
+    def close(self):
+        if not getattr(self, "_kserve_initialized", False):
+            return super().close()
+        if self._kserve_closed:
+            return
+
+        self._kserve_closed = True
+        self._heartbeat_stop.set()
+        if self._heartbeat_thread is not None:
+            self._heartbeat_thread.join(timeout=1)
+
+        progress_was_disabled = self.disable
+        super().close()
+        if not progress_was_disabled:
+            state = (
+                "completed"
+                if self.total is not None and self.n >= self.total
+                else "stopped"
+            )
+            self._emit_progress(state)
+
+
+def create_huggingface_log_progress(
+    local_dir: str,
+    total_size_bytes: int | None = None,
+) -> type[HuggingFaceLogProgress]:
+    class BoundHuggingFaceLogProgress(HuggingFaceLogProgress):
+        def __init__(self, *args, **kwargs):
+            super().__init__(
+                *args,
+                local_dir=local_dir,
+                total_size_bytes=total_size_bytes,
+                **kwargs,
+            )
+
+    return BoundHuggingFaceLogProgress

--- a/python/storage/kserve_storage/kserve_storage.py
+++ b/python/storage/kserve_storage/kserve_storage.py
@@ -26,6 +26,7 @@ import platform
 import re
 import shutil
 import ssl
+import sys
 import tarfile
 import tempfile
 import time
@@ -779,6 +780,10 @@ class Storage(object):
             GatedRepoError,
             HfHubHTTPError,
         )
+        from kserve_storage.huggingface_progress import (
+            create_huggingface_log_progress,
+            get_huggingface_repo_size_bytes,
+        )
 
         components = uri[len(_HF_PREFIX) :].split("/")
 
@@ -817,6 +822,17 @@ class Storage(object):
                 kwargs["allow_patterns"] = allow_patterns
             if ignore_patterns:
                 kwargs["ignore_patterns"] = ignore_patterns
+            if not sys.stderr.isatty():
+                total_size_bytes = get_huggingface_repo_size_bytes(
+                    repo_id,
+                    revision=revision,
+                    allow_patterns=allow_patterns,
+                    ignore_patterns=ignore_patterns,
+                )
+                kwargs["tqdm_class"] = create_huggingface_log_progress(
+                    temp_dir,
+                    total_size_bytes=total_size_bytes,
+                )
             snapshot_download(**kwargs)
         except (
             RepositoryNotFoundError,

--- a/python/storage/test/test_hf_storage.py
+++ b/python/storage/test/test_hf_storage.py
@@ -15,10 +15,17 @@
 import os
 import unittest.mock as mock
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 
 from kserve_storage import Storage
+from kserve_storage.huggingface_progress import (
+    HuggingFaceLogProgress,
+    create_huggingface_log_progress,
+    get_huggingface_repo_size_bytes,
+)
 
 # Real (self-signed, parse-valid) certificate: the combined bundle is
 # validated with ssl before being exported, so the fixture must parse.
@@ -36,6 +43,20 @@ mjrvDJwPyARHZg==
 """
 
 
+@pytest.fixture(autouse=True)
+def non_tty_stderr():
+    with (
+        mock.patch(
+            "kserve_storage.kserve_storage.sys.stderr.isatty", return_value=False
+        ),
+        mock.patch(
+            "kserve_storage.huggingface_progress.get_huggingface_repo_size_bytes",
+            return_value=None,
+        ),
+    ):
+        yield
+
+
 @mock.patch("huggingface_hub.snapshot_download")
 def test_download_model(mock_snapshot_download):
     uri = "hf://example.com/model:hash_value"
@@ -49,6 +70,7 @@ def test_download_model(mock_snapshot_download):
         repo_id=f"{repo}/{model}",
         revision=revision,
         local_dir=mock.ANY,
+        tqdm_class=mock.ANY,
     )
 
 
@@ -82,6 +104,7 @@ def test_download_model_with_allow_patterns(mock_snapshot_download):
         revision=None,
         local_dir="/tmp/out",
         allow_patterns=["*.safetensors", "*.json"],
+        tqdm_class=mock.ANY,
     )
 
 
@@ -96,6 +119,7 @@ def test_download_model_with_ignore_patterns(mock_snapshot_download):
         revision=None,
         local_dir="/tmp/out",
         ignore_patterns=["*.bin", "*.gguf"],
+        tqdm_class=mock.ANY,
     )
 
 
@@ -116,6 +140,7 @@ def test_download_model_with_both_patterns(mock_snapshot_download):
         local_dir="/tmp/out",
         allow_patterns=["*.json"],
         ignore_patterns=["config.json"],
+        tqdm_class=mock.ANY,
     )
 
 
@@ -129,7 +154,169 @@ def test_download_model_no_patterns_omits_kwargs(mock_snapshot_download):
         repo_id="example.com/model",
         revision=None,
         local_dir="/tmp/out",
+        tqdm_class=mock.ANY,
     )
+
+    progress_class = mock_snapshot_download.call_args.kwargs["tqdm_class"]
+    assert issubclass(progress_class, HuggingFaceLogProgress)
+    with mock.patch.object(progress_class, "_start_heartbeat"):
+        progress = progress_class(total=1)
+    assert progress.local_dir == "/tmp/out"
+    progress.close()
+
+
+@mock.patch("huggingface_hub.snapshot_download")
+def test_download_model_binds_total_size_to_progress(mock_snapshot_download):
+    with mock.patch(
+        "kserve_storage.huggingface_progress.get_huggingface_repo_size_bytes",
+        return_value=16_020_000_000,
+    ):
+        Storage._download_hf("hf://example.com/model", "/tmp/out")
+
+    progress_class = mock_snapshot_download.call_args.kwargs["tqdm_class"]
+    with mock.patch.object(progress_class, "_start_heartbeat"):
+        progress = progress_class(total=9)
+
+    assert progress.total_size_bytes == 16_020_000_000
+    progress.close()
+
+
+@mock.patch("huggingface_hub.snapshot_download")
+def test_download_model_in_tty_keeps_default_progress(mock_snapshot_download):
+    with mock.patch(
+        "kserve_storage.kserve_storage.sys.stderr.isatty", return_value=True
+    ):
+        Storage._download_hf("hf://example.com/model", "/tmp/out")
+
+    assert "tqdm_class" not in mock_snapshot_download.call_args.kwargs
+
+
+def test_hf_log_progress_emits_line_oriented_heartbeat(caplog):
+    progress_class = create_huggingface_log_progress(
+        "/tmp/models", total_size_bytes=59_550_000_000
+    )
+    with mock.patch.object(progress_class, "_start_heartbeat"):
+        progress = progress_class(total=2)
+
+    progress.n = 1
+    with (
+        mock.patch(
+            "kserve_storage.huggingface_progress._get_local_size_bytes",
+            return_value=42_730_000_000,
+        ),
+        mock.patch.object(
+            progress._heartbeat_stop,
+            "wait",
+            side_effect=[False, True],
+        ),
+        caplog.at_level("INFO", logger="storage.initializer"),
+    ):
+        progress._heartbeat()
+
+    progress.close()
+
+    heartbeat = next(
+        record.message
+        for record in caplog.records
+        if record.message.startswith("HF progress:")
+        and "42.73/59.55GB" in record.message
+    )
+    assert "(71.8%)" in heartbeat
+    assert "1/2 files" in heartbeat
+    assert heartbeat.endswith("1/2 files")
+    assert "\r" not in heartbeat
+
+
+def test_hf_log_progress_emits_completion(caplog):
+    progress_class = create_huggingface_log_progress(
+        "/tmp/models", total_size_bytes=59_550_000_000
+    )
+    with (
+        mock.patch.object(progress_class, "_start_heartbeat"),
+        mock.patch(
+            "kserve_storage.huggingface_progress._get_local_size_bytes",
+            return_value=59_550_000_000,
+        ),
+        caplog.at_level("INFO", logger="storage.initializer"),
+    ):
+        progress = progress_class(total=2)
+        progress.update(2)
+        progress.close()
+
+    completion_logs = [
+        record.message
+        for record in caplog.records
+        if record.message.endswith(", complete")
+    ]
+    assert len(completion_logs) == 1
+    assert "59.55/59.55GB (100.0%)" in completion_logs[0]
+    assert "2/2 files" in completion_logs[0]
+
+
+def test_hf_log_progress_falls_back_when_total_size_is_unknown(caplog):
+    progress_class = create_huggingface_log_progress("/tmp/models")
+    with (
+        mock.patch.object(progress_class, "_start_heartbeat"),
+        mock.patch(
+            "kserve_storage.huggingface_progress._get_local_size_bytes",
+            return_value=42_730_000_000,
+        ),
+        caplog.at_level("INFO", logger="storage.initializer"),
+    ):
+        progress = progress_class(total=2)
+        progress.close()
+
+    completion = next(
+        record.message
+        for record in caplog.records
+        if record.message.endswith(", stopped")
+    )
+    assert "HF progress: 42.73GB" in completion
+    assert "%" not in completion
+
+
+@mock.patch("huggingface_hub.HfApi")
+def test_get_huggingface_repo_size_bytes_applies_patterns(mock_hf_api):
+    mock_hf_api.return_value.model_info.return_value.siblings = [
+        SimpleNamespace(rfilename="config.json", size=1_000),
+        SimpleNamespace(rfilename="model-00001.safetensors", size=4_000),
+        SimpleNamespace(rfilename="model-00002.safetensors", size=5_000),
+        SimpleNamespace(rfilename="pytorch_model.bin", size=6_000),
+    ]
+
+    total_size = get_huggingface_repo_size_bytes(
+        "example/model",
+        revision="main",
+        allow_patterns=["*.json", "*.safetensors"],
+        ignore_patterns=["model-00002.safetensors"],
+    )
+
+    assert total_size == 5_000
+    mock_hf_api.return_value.model_info.assert_called_once_with(
+        repo_id="example/model",
+        revision="main",
+        files_metadata=True,
+    )
+
+
+@mock.patch("huggingface_hub.HfApi")
+def test_get_huggingface_repo_size_bytes_returns_none_on_failure(mock_hf_api):
+    mock_hf_api.return_value.model_info.side_effect = RuntimeError("metadata failed")
+
+    assert get_huggingface_repo_size_bytes("example/model") is None
+
+
+def test_hf_log_progress_respects_disabled_progress_bars():
+    disable_progress_bars()
+    try:
+        with mock.patch.object(HuggingFaceLogProgress, "_start_heartbeat") as start:
+            progress = HuggingFaceLogProgress(total=2)
+
+        assert progress.disable
+        start.assert_not_called()
+        progress.close()
+    finally:
+        enable_progress_bars()
 
 
 @mock.patch("huggingface_hub.snapshot_download")


### PR DESCRIPTION
**What this PR does / why we need it**:

Hugging Face downloads currently rely on a carriage-return-based tqdm progress bar. In non-TTY environments such as Kubernetes CRI logs, incremental updates are not visible through `kubectl logs -f`; the progress bar generally appears only after the download completes. This can leave LocalModelCache download jobs silent for several minutes when a repository contains a small number of large model shards.

This PR adds periodic, newline-delimited progress logs for non-TTY environments. The logs report downloaded and total size, percentage, and completed file count. Native Hugging Face progress rendering remains unchanged in TTY environments. If repository size metadata cannot be retrieved, downloads continue and the logs fall back to local size and completed file count.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #6016

**Feature/Issue validation/testing**:

- [x] Ran `make precommit` successfully.
- [x] Ran Ruff formatting and lint checks successfully.
- [x] Ran `python/storage/test/test_hf_storage.py`: 20 tests passed.
- [x] Built and deployed a test storage-initializer image and completed a LocalModelCache download for `google/gemma-4-E4B-it` on Kubernetes v1.35.2.

- Logs

```text
HF progress: 0.00/16.02GB (0.0%), 0/9 files
HF progress: 4.93/16.02GB (30.7%), 0/9 files
HF progress: 9.17/16.02GB (57.2%), 0/9 files
HF progress: 16.02/16.02GB (100.0%), 0/9 files
HF progress: 16.02/16.02GB (100.0%), 9/9 files, complete
Successfully copied hf://google/gemma-4-E4B-it to /mnt/models
Model downloaded in 189.66264288598904 seconds.
```

**Special notes for your reviewer**:

- TTY behavior is unchanged; line-oriented logging is enabled only when stderr is not a TTY.
- Byte progress reflects local allocated size, while the file count follows Hugging Face snapshot tasks and can lag while large files are finalized.
- Repository metadata failures do not fail the model download.
- This PR does not change any image versions or user-facing configuration.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

No documentation changes are required because this PR does not add or change user-facing configuration.

**Release note**:

```release-note
Hugging Face model downloads now emit periodic progress logs in non-TTY environments.
```
