### PR TITLE
test(llmisvc): extend e2e coverage for standalone KEDA autoscaling

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -557,7 +557,7 @@ jobs:
 
   test-llmisvc-autoscaling-direct-keda-and-wva-with-keda:
     runs-on: cncf-ubuntu-16-64-x86
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: [detect-changes, llmisvc-image-build, seed-model-cache, seed-image-cache]
     strategy:
       fail-fast: false
@@ -662,6 +662,18 @@ jobs:
           export PYTEST_MAXFAIL=2
           ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_direct_keda and cluster_cpu" 0 "envoy-gateway"
 
+      # Runs last and alone: scales the shared Prometheus instance to 0 to
+      # simulate an outage, so it must not overlap with the steps above.
+      - name: Run KEDA fallback E2E test
+        id: autoscaling-fallback-test
+        if: always() && steps.autoscaling-direct-keda-tests.conclusion != 'cancelled'
+        timeout-minutes: 10
+        env:
+          OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
+        run: |
+          export PYTEST_MAXFAIL=1
+          ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_fallback and cluster_cpu" 0 "envoy-gateway"
+
       - name: Check system status
         if: always()
         run: |
@@ -684,6 +696,15 @@ jobs:
           path: |
             /tmp/junit_e2e*autoscaling_direct_keda*.xml
             /tmp/e2e_results*autoscaling_direct_keda*.json
+
+      - name: Upload KEDA fallback test results
+        if: always()
+        uses: ./.github/actions/upload-test-results
+        with:
+          name: test-results-llmisvc-autoscaling-fallback-${{ matrix.install-method }}
+          path: |
+            /tmp/junit_e2e*autoscaling_fallback*.xml
+            /tmp/e2e_results*autoscaling_fallback*.json
 
   test-llmisvc-tracing:
     runs-on: cncf-ubuntu-16-64-x86

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -38,6 +38,68 @@ SCHEDULER_CONFIGMAP_KEY = "epp"
 OPT_125M_MODEL_URI = os.environ.get("OPT_125M_MODEL_URI", "hf://facebook/opt-125m")
 VLLM_CPU_IMAGE = os.environ.get("VLLM_CPU_IMAGE", "vllm/vllm-openai-cpu:v0.19.0")
 
+# Prometheus server address used by direct-KEDA (no WVA) `prometheus` triggers.
+# Matches the URL setup-kserve.sh patches into autoscaling-wva-controller-config
+# for the WVA-mediated KEDA path, so both paths talk to the same instance.
+PROMETHEUS_SERVER_ADDRESS = os.environ.get(
+    "PROMETHEUS_SERVER_ADDRESS",
+    "https://prometheus-kube-prometheus-prometheus.monitoring:9090",
+)
+
+# Whole-service request-rate signal from the EPP scheduler's /metrics (port
+# 9090), namespace-filtered. Sums successes and errors because requests to a
+# scaled-to-zero deployment (no ready endpoints) only increment the error
+# counter, and `or vector(0)` keeps each side from going empty when idle.
+EPP_REQUEST_RATE_QUERY = (
+    "(sum(rate(inference_objective_request_total"
+    '{namespace="{{ .ObjectMeta.Namespace }}"}[1m])) or vector(0))'
+    " + "
+    "(sum(rate(inference_objective_request_error_total"
+    '{namespace="{{ .ObjectMeta.Namespace }}"}[1m])) or vector(0))'
+)
+
+
+def _epp_prometheus_trigger(threshold):
+    """Build a KEDA `prometheus` trigger against the EPP request-rate counter."""
+    return {
+        "type": "prometheus",
+        "name": "epp-request-rate",
+        "metadata": {
+            "serverAddress": PROMETHEUS_SERVER_ADDRESS,
+            "query": EPP_REQUEST_RATE_QUERY,
+            "threshold": threshold,
+            "unsafeSsl": "true",
+        },
+    }
+
+
+def _vllm_running_requests_trigger(pod_prefix_template, threshold):
+    """Build a KEDA `prometheus` trigger against per-pod vllm:num_requests_running.
+
+    pod_prefix_template is a Go text/template expression resolving to the
+    prefill or main/decode Deployment name, e.g.
+    "{{ ChildName .ObjectMeta.Name `-kserve-prefill` }}". The regex anchors on
+    exactly two dash-separated suffix segments (replicaset hash + pod suffix)
+    so main/decode pods don't match prefill's extra "-prefill-" segment.
+    """
+    query = (
+        "avg(vllm:num_requests_running{"
+        'namespace="{{ .ObjectMeta.Namespace }}",'
+        'pod=~"^' + pod_prefix_template + '-[a-z0-9]+-[a-z0-9]+$"'
+        "})"
+    )
+    return {
+        "type": "prometheus",
+        "name": "vllm-running-requests",
+        "metadata": {
+            "serverAddress": PROMETHEUS_SERVER_ADDRESS,
+            "query": query,
+            "threshold": threshold,
+            "unsafeSsl": "true",
+        },
+    }
+
+
 # PVC storage test constants
 PVC_STORAGE_NAME = "e2e-pvc-model-storage"
 STORAGE_INITIALIZER_IMAGE = os.environ.get(
@@ -1253,6 +1315,13 @@ LLMINFERENCESERVICE_CONFIGS = {
                         "--mode",
                         "random",
                         "--force-dummy-tokenizer",
+                        # Keeps requests in flight long enough for
+                        # vllm:num_requests_running (an instantaneous gauge)
+                        # to be observable within Prometheus's scrape interval.
+                        "--time-to-first-token",
+                        "200ms",
+                        "--inter-token-latency",
+                        "100ms",
                         "{{ if .GlobalConfig.EnableTLS }}--ssl-certfile{{- end }}",
                         "{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls/tls.crt{{- end }}",
                         "{{ if .GlobalConfig.EnableTLS }}--ssl-keyfile{{- end }}",
@@ -1281,6 +1350,11 @@ LLMINFERENCESERVICE_CONFIGS = {
                             "--mode",
                             "random",
                             "--force-dummy-tokenizer",
+                            # Prefill has no token stream to apply
+                            # inter-token-latency to, so it needs a larger
+                            # time-to-first-token to stay observable instead.
+                            "--time-to-first-token",
+                            "5s",
                             "{{ if .GlobalConfig.EnableTLS }}--ssl-certfile{{- end }}",
                             "{{ if .GlobalConfig.EnableTLS }}/var/run/kserve/tls/tls.crt{{- end }}",
                             "{{ if .GlobalConfig.EnableTLS }}--ssl-keyfile{{- end }}",
@@ -1301,6 +1375,47 @@ LLMINFERENCESERVICE_CONFIGS = {
             "prometheus.io/scrape": "true",
             "prometheus.io/port": "8000",
             "prometheus.io/path": "/metrics",
+        },
+    },
+    # Like "prometheus-scrape" but for the P/D simulator, which listens on
+    # different ports per role: main/decode on 8001, prefill on 8000. The
+    # prefill pod template is a separate WorkloadSpec, so it needs its own
+    # "annotations" under the "prefill" key.
+    "prometheus-scrape-pd": {
+        "annotations": {
+            "prometheus.io/scrape": "true",
+            "prometheus.io/port": "8001",
+            "prometheus.io/path": "/metrics",
+        },
+        "prefill": {
+            "annotations": {
+                "prometheus.io/scrape": "true",
+                "prometheus.io/port": "8000",
+                "prometheus.io/path": "/metrics",
+            },
+        },
+    },
+    # Annotates the EPP/scheduler pod so Prometheus scrapes its request-rate
+    # counters (port 9090). Disables EPP's default bearer-token auth since
+    # the annotation-based scrape job doesn't send one and would otherwise
+    # get 401s.
+    "scheduler-prometheus-scrape": {
+        "router": {
+            "scheduler": {
+                "annotations": {
+                    "prometheus.io/scrape": "true",
+                    "prometheus.io/port": "9090",
+                    "prometheus.io/path": "/metrics",
+                },
+                "template": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "args": ["--metrics-endpoint-auth=false"],
+                        }
+                    ],
+                },
+            },
         },
     },
     "scaling-hpa": {
@@ -1356,12 +1471,79 @@ LLMINFERENCESERVICE_CONFIGS = {
                 "pollingInterval": 5,
                 "cooldownPeriod": 10,
                 "initialCooldownPeriod": 0,
+                "triggers": [_epp_prometheus_trigger(threshold="2")],
+            },
+        }
+    },
+    # Direct KEDA with idleReplicaCount=0: scales to zero when the EPP
+    # request-rate trigger reports no traffic, and back up once load resumes.
+    "scaling-direct-keda-idle": {
+        "scaling": {
+            "minReplicas": 1,
+            "maxReplicas": 3,
+            "keda": {
+                "pollingInterval": 5,
+                "cooldownPeriod": 15,
+                "initialCooldownPeriod": 0,
+                "idleReplicaCount": 0,
+                "triggers": [_epp_prometheus_trigger(threshold="2")],
+            },
+        }
+    },
+    # Direct KEDA (standalone, no WVA) with a fallback replica count: when the
+    # Prometheus scaler repeatedly fails to reach the server (outage), KEDA
+    # holds the deployment at `fallback.replicas` instead of scaling to zero.
+    "scaling-direct-keda-fallback": {
+        "scaling": {
+            "minReplicas": 1,
+            "maxReplicas": 3,
+            "keda": {
+                "pollingInterval": 5,
+                "cooldownPeriod": 10,
+                "initialCooldownPeriod": 0,
+                "fallback": {
+                    "failureThreshold": 3,
+                    "replicas": 1,
+                },
+                "triggers": [_epp_prometheus_trigger(threshold="2")],
+            },
+        }
+    },
+    # Direct KEDA triggers scoped to prefill vs. decode/main pods individually
+    # via vllm:num_requests_running, so each role scales based on its own
+    # per-pod metric rather than a shared signal.
+    "scaling-prefill-direct-keda": {
+        "prefill": {
+            "scaling": {
+                "minReplicas": 1,
+                "maxReplicas": 3,
+                "keda": {
+                    "pollingInterval": 5,
+                    "cooldownPeriod": 10,
+                    "initialCooldownPeriod": 0,
+                    "triggers": [
+                        _vllm_running_requests_trigger(
+                            "{{ ChildName .ObjectMeta.Name `-kserve-prefill` }}",
+                            threshold="1",
+                        )
+                    ],
+                },
+            }
+        }
+    },
+    "scaling-decode-direct-keda": {
+        "scaling": {
+            "minReplicas": 1,
+            "maxReplicas": 3,
+            "keda": {
+                "pollingInterval": 5,
+                "cooldownPeriod": 10,
+                "initialCooldownPeriod": 0,
                 "triggers": [
-                    {
-                        "type": "cpu",
-                        "metricType": "Utilization",
-                        "metadata": {"value": "50"},
-                    }
+                    _vllm_running_requests_trigger(
+                        "{{ ChildName .ObjectMeta.Name `-kserve` }}",
+                        threshold="1",
+                    )
                 ],
             },
         }

--- a/test/e2e/llmisvc/test_llm_autoscaling_direct_keda.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling_direct_keda.py
@@ -42,20 +42,26 @@ from .test_llm_autoscaling_wva import (
     KEDA_GROUP,
     KEDA_PLURAL,
     KEDA_VERSION,
+    WORKLOAD_COMPONENT_MAIN,
     _get_custom_resource,
-    assert_scaled_object_active,
+    assert_scaled_object_condition,
+    assert_scaled_object_ready,
     assert_scaling_ready_absent,
     assert_scaling_ready_condition,
     assert_scaling_resources_deleted,
     hpa_name,
     resource_exists,
     scaled_object_name,
+    send_load,
+    wait_for_pod_count,
+    wait_for_pod_count_at_most,
     wait_for_resource,
 )
 from .test_llm_inference_service import (
     TestCase,
     create_llmisvc,
     delete_llmisvc,
+    get_llm_service_url,
     wait_for,
     wait_for_llm_isvc_ready,
 )
@@ -100,7 +106,9 @@ def patch_llmisvc(kserve_client, llm_isvc, patch_body):
     return result
 
 
-def assert_direct_keda_scaled_object(service_name, *, namespace, trigger_type="cpu"):
+def assert_direct_keda_scaled_object(
+    service_name, *, namespace, trigger_type="prometheus"
+):
     """Assert ScaledObject exists with user triggers and without WVA annotations."""
     name = scaled_object_name(service_name)
     wait_for_resource(KEDA_GROUP, KEDA_VERSION, KEDA_PLURAL, name, namespace)
@@ -134,6 +142,7 @@ def assert_direct_keda_scaled_object(service_name, *, namespace, trigger_type="c
             TestCase(
                 base_refs=[
                     "router-managed",
+                    "scheduler-prometheus-scrape",
                     "workload-llmd-simulator-no-replicas",
                     "scaling-direct-keda",
                 ],
@@ -152,7 +161,9 @@ def assert_direct_keda_scaled_object(service_name, *, namespace, trigger_type="c
 )
 @log_execution
 def test_llm_autoscaling_direct_keda_deployment(test_case: TestCase):
-    """Direct KEDA + Deployment: ScaledObject uses user triggers and skips WVA annotations."""
+    """Direct KEDA + Deployment: user-defined Prometheus trigger (EPP request
+    rate) fires under load and drives an actual scale-up, not just object
+    existence/Ready."""
     inject_k8s_proxy()
     kserve_client = _new_kserve_client()
     service_name = test_case.llm_service.metadata.name
@@ -161,7 +172,7 @@ def test_llm_autoscaling_direct_keda_deployment(test_case: TestCase):
     try:
         _create_and_wait(kserve_client, test_case)
 
-        assert_direct_keda_scaled_object(service_name, namespace=ns, trigger_type="cpu")
+        assert_direct_keda_scaled_object(service_name, namespace=ns)
         assert not resource_exists(
             HPA_GROUP,
             HPA_VERSION,
@@ -169,8 +180,24 @@ def test_llm_autoscaling_direct_keda_deployment(test_case: TestCase):
             hpa_name(service_name),
             ns,
         )
-        assert_scaled_object_active(service_name, namespace=ns)
+        assert_scaled_object_ready(service_name, namespace=ns)
         assert_scaling_ready_condition(service_name, namespace=ns)
+
+        service_url = get_llm_service_url(kserve_client, test_case.llm_service)
+        send_load(
+            service_url, test_case.model_name, concurrency=10, duration_seconds=60
+        )
+
+        wait_for_pod_count(
+            service_name,
+            min_count=2,
+            namespace=ns,
+            timeout=300,
+            component=WORKLOAD_COMPONENT_MAIN,
+        )
+        assert_scaled_object_condition(
+            service_name, namespace=ns, condition_type="Active", expected_status="True"
+        )
     finally:
         _cleanup(kserve_client, test_case)
 
@@ -227,5 +254,104 @@ def test_llm_autoscaling_direct_keda_cleanup(test_case: TestCase):
 
         assert_scaling_resources_deleted(service_name, actuator="keda", namespace=ns)
         assert_scaling_ready_absent(service_name, namespace=ns)
+    finally:
+        _cleanup(kserve_client, test_case)
+
+
+# =============================================================================
+# Idle scale-to-zero: direct KEDA + idleReplicaCount: 0
+# =============================================================================
+#
+# Scoped to the direct-KEDA path only; see test_llm_autoscaling_wva.py for
+# why WVA-mediated idle scale-down is out of scope (the simulator never
+# emits decreasing WVA saturation metrics).
+
+
+@pytest.mark.autoscaling_keda
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-prometheus-scrape",
+                    "workload-llmd-simulator-no-replicas",
+                    "scaling-direct-keda-idle",
+                ],
+                prompt="KServe is a",
+                service_name="autoscale-direct-keda-idle",
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+        ),
+    ],
+    indirect=["test_case"],
+    ids=generate_test_id,
+)
+@log_execution
+def test_llm_autoscaling_direct_keda_scale_to_zero(test_case: TestCase):
+    """Direct KEDA + idleReplicaCount=0: deployment scales to zero when idle
+    and back up once the EPP request-rate trigger becomes active again."""
+    inject_k8s_proxy()
+    kserve_client = _new_kserve_client()
+    service_name = test_case.llm_service.metadata.name
+    ns = test_case.namespace
+
+    try:
+        _create_and_wait(kserve_client, test_case)
+        assert_direct_keda_scaled_object(service_name, namespace=ns)
+
+        # Scoped to the main workload component so the always-running
+        # router/scheduler pod doesn't mask the workload reaching zero.
+        wait_for_pod_count_at_most(
+            service_name,
+            max_count=0,
+            namespace=ns,
+            timeout=120,
+            component=WORKLOAD_COMPONENT_MAIN,
+        )
+        assert_scaled_object_condition(
+            service_name, namespace=ns, condition_type="Active", expected_status="False"
+        )
+
+        # KEDA has no request-buffering activator like Knative, so requests
+        # sent while scaled to zero are expected to fail; they only need to
+        # make EPP emit request-rate signal for KEDA's next poll to scale up.
+        service_url = get_llm_service_url(kserve_client, test_case.llm_service)
+        send_load(
+            service_url,
+            test_case.model_name,
+            concurrency=10,
+            duration_seconds=60,
+            tolerate_failures=True,
+        )
+
+        wait_for_pod_count(
+            service_name,
+            min_count=1,
+            namespace=ns,
+            timeout=300,
+            component=WORKLOAD_COMPONENT_MAIN,
+        )
+        assert_scaled_object_condition(
+            service_name, namespace=ns, condition_type="Active", expected_status="True"
+        )
+
+        # Once the cooldown period elapses, KEDA scales back to
+        # idleReplicaCount=0.
+        wait_for_pod_count_at_most(
+            service_name,
+            max_count=0,
+            namespace=ns,
+            timeout=180,
+            component=WORKLOAD_COMPONENT_MAIN,
+        )
+        assert_scaled_object_condition(
+            service_name, namespace=ns, condition_type="Active", expected_status="False"
+        )
     finally:
         _cleanup(kserve_client, test_case)

--- a/test/e2e/llmisvc/test_llm_autoscaling_fallback.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling_fallback.py
@@ -1,0 +1,192 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+E2E test for KEDA fallback during a Prometheus outage.
+
+Scales the *shared* cluster Prometheus instance to 0 replicas to simulate an
+outage. Deliberately not tagged with autoscaling_wva/autoscaling_keda/
+autoscaling_direct_keda so it runs in its own CI step, after every other test
+depending on that instance. The finally block always restores Prometheus.
+"""
+
+import logging
+import os
+import time
+
+import pytest
+from kubernetes import client
+
+from .fixtures import generate_test_id, inject_k8s_proxy
+from .logging import log_execution
+from .test_llm_autoscaling_direct_keda import _cleanup, _new_kserve_client
+from .test_llm_autoscaling_wva import (
+    assert_scaled_object_condition,
+    get_pod_count,
+)
+from .test_llm_inference_service import (
+    TestCase,
+    create_llmisvc,
+    wait_for,
+    wait_for_llm_isvc_ready,
+)
+
+logger = logging.getLogger(__name__)
+
+PROMETHEUS_GROUP = "monitoring.coreos.com"
+PROMETHEUS_VERSION = "v1"
+PROMETHEUS_PLURAL = "prometheuses"
+
+PROMETHEUS_NAMESPACE = os.environ.get("PROMETHEUS_NAMESPACE", "monitoring")
+PROMETHEUS_RELEASE_NAME = os.environ.get("PROMETHEUS_RELEASE_NAME", "prometheus")
+PROMETHEUS_CR_NAME = f"{PROMETHEUS_RELEASE_NAME}-kube-prometheus-prometheus"
+
+
+def _create_and_wait(kserve_client, test_case):
+    create_llmisvc(kserve_client, test_case.llm_service)
+    wait_for_llm_isvc_ready(
+        kserve_client, test_case.llm_service, test_case.wait_timeout
+    )
+
+
+def _get_prometheus_replicas():
+    api = client.CustomObjectsApi()
+    prom = api.get_namespaced_custom_object(
+        PROMETHEUS_GROUP,
+        PROMETHEUS_VERSION,
+        PROMETHEUS_NAMESPACE,
+        PROMETHEUS_PLURAL,
+        PROMETHEUS_CR_NAME,
+    )
+    return prom.get("spec", {}).get("replicas", 1)
+
+
+def _patch_prometheus_replicas(replicas):
+    api = client.CustomObjectsApi()
+    api.patch_namespaced_custom_object(
+        PROMETHEUS_GROUP,
+        PROMETHEUS_VERSION,
+        PROMETHEUS_NAMESPACE,
+        PROMETHEUS_PLURAL,
+        PROMETHEUS_CR_NAME,
+        {"spec": {"replicas": replicas}},
+    )
+    logger.info(f"Patched Prometheus {PROMETHEUS_CR_NAME} spec.replicas={replicas}")
+
+
+def _wait_for_prometheus_pod_count(count, timeout=180):
+    def _check():
+        v1 = client.CoreV1Api()
+        pods = v1.list_namespaced_pod(
+            namespace=PROMETHEUS_NAMESPACE,
+            label_selector="app.kubernetes.io/name=prometheus",
+        )
+        running = [p for p in pods.items if p.status.phase == "Running"]
+        assert len(running) == count, (
+            f"Prometheus running pod count: {len(running)}, expected {count}"
+        )
+
+    wait_for(_check, timeout=timeout, interval=5.0)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-prometheus-scrape",
+                    "workload-llmd-simulator-no-replicas",
+                    "scaling-direct-keda-fallback",
+                ],
+                prompt="KServe is a",
+                service_name="autoscale-keda-fallback",
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+        ),
+    ],
+    indirect=["test_case"],
+    ids=generate_test_id,
+)
+@log_execution
+def test_llm_autoscaling_keda_fallback_holds_replicas(test_case: TestCase):
+    """Direct KEDA + fallback: during a Prometheus outage, KEDA holds the
+    deployment at fallback.replicas instead of scaling to zero or erroring."""
+    inject_k8s_proxy()
+    kserve_client = _new_kserve_client()
+    service_name = test_case.llm_service.metadata.name
+    ns = test_case.namespace
+
+    original_prometheus_replicas = _get_prometheus_replicas()
+
+    try:
+        _create_and_wait(kserve_client, test_case)
+
+        baseline_pod_count = get_pod_count(service_name, ns)
+        assert baseline_pod_count >= 1, (
+            f"Expected at least 1 pod before outage, got {baseline_pod_count}"
+        )
+
+        try:
+            logger.info(
+                "Simulating Prometheus outage: scaling Prometheus to 0 replicas"
+            )
+            _patch_prometheus_replicas(0)
+            _wait_for_prometheus_pod_count(0, timeout=120)
+
+            # failureThreshold=3, pollingInterval=5s (see
+            # fixtures.scaling-direct-keda-fallback)
+            assert_scaled_object_condition(
+                service_name,
+                namespace=ns,
+                condition_type="Fallback",
+                expected_status="True",
+                timeout=120,
+            )
+
+            # Sample repeatedly over a window: the replica count must hold
+            # steady at the fallback count, not drift while metrics are down.
+            deadline = time.time() + 40
+            while time.time() < deadline:
+                current = get_pod_count(service_name, ns)
+                assert current == baseline_pod_count, (
+                    f"Pod count drifted during Prometheus outage: "
+                    f"{current}, expected {baseline_pod_count}"
+                )
+                time.sleep(5)
+        finally:
+            # Always restore Prometheus for subsequent tests/jobs, regardless
+            # of whether the outage assertions above passed or failed.
+            logger.info(
+                f"Restoring Prometheus to spec.replicas={original_prometheus_replicas}"
+            )
+            _patch_prometheus_replicas(original_prometheus_replicas)
+            _wait_for_prometheus_pod_count(original_prometheus_replicas, timeout=180)
+
+        # Once Prometheus is back, the ScaledObject should recover to a
+        # non-fallback state.
+        assert_scaled_object_condition(
+            service_name,
+            namespace=ns,
+            condition_type="Fallback",
+            expected_status="False",
+            timeout=120,
+        )
+    finally:
+        _cleanup(kserve_client, test_case)

--- a/test/e2e/llmisvc/test_llm_autoscaling_prefill_scaling.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling_prefill_scaling.py
@@ -1,0 +1,152 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+E2E test for independent prefill/decode direct-KEDA scaling.
+
+Drives real traffic and asserts each role's ScaledObject reacts to its own
+per-pod vllm:num_requests_running signal, filtered by pod name for prefill
+vs. decode/main. Uses the per-pod gauge rather than the EPP request-rate
+counter since there's one InferencePool/EPP per LLMInferenceService even in
+disaggregated mode, so EPP metrics can't distinguish prefill from decode load.
+
+Manually tagged with autoscaling_direct_keda (in addition to the
+auto-discovered autoscaling_prefill_scaling marker) so it runs in the
+existing direct-KEDA CI step without a dedicated CI job.
+"""
+
+import logging
+import threading
+
+import pytest
+
+from .fixtures import generate_test_id, inject_k8s_proxy
+from .logging import log_execution
+from .test_llm_autoscaling_direct_keda import _cleanup, _new_kserve_client
+from .test_llm_autoscaling_wva import (
+    WORKLOAD_COMPONENT_MAIN,
+    WORKLOAD_COMPONENT_PREFILL,
+    assert_scaled_object_condition,
+    send_load,
+    wait_for_pod_count,
+)
+from .test_llm_inference_service import (
+    TestCase,
+    create_llmisvc,
+    get_llm_service_url,
+    wait_for_llm_isvc_ready,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _create_and_wait(kserve_client, test_case):
+    create_llmisvc(kserve_client, test_case.llm_service)
+    wait_for_llm_isvc_ready(
+        kserve_client, test_case.llm_service, test_case.wait_timeout
+    )
+
+
+@pytest.mark.autoscaling_direct_keda
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "prometheus-scrape-pd",
+                    "workload-llmd-simulator-pd",
+                    "scaling-decode-direct-keda",
+                    "scaling-prefill-direct-keda",
+                ],
+                prompt="KServe is a",
+                service_name="autoscale-prefill-direct-keda",
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+        ),
+    ],
+    indirect=["test_case"],
+    ids=generate_test_id,
+)
+@log_execution
+def test_llm_autoscaling_prefill_decode_independent_scaling(test_case: TestCase):
+    """P/D + direct KEDA: prefill and decode ScaledObjects react independently
+    to their own per-pod vllm:num_requests_running signal under load."""
+    inject_k8s_proxy()
+    kserve_client = _new_kserve_client()
+    service_name = test_case.llm_service.metadata.name
+    ns = test_case.namespace
+
+    try:
+        _create_and_wait(kserve_client, test_case)
+
+        service_url = get_llm_service_url(kserve_client, test_case.llm_service)
+
+        # vllm:num_requests_running is an instantaneous gauge with no
+        # smoothing, so it decays right after load stops. Drive load from a
+        # background thread so it's still in flight when we check Active/pod
+        # counts below.
+        load_thread = threading.Thread(
+            target=send_load,
+            args=(service_url, test_case.model_name),
+            kwargs=dict(concurrency=10, duration_seconds=120, tolerate_failures=True),
+            daemon=True,
+        )
+        load_thread.start()
+
+        try:
+            # Checked independently per role, before pod counts, while load
+            # is still in flight (the gauge has no smoothing window).
+            assert_scaled_object_condition(
+                service_name,
+                namespace=ns,
+                condition_type="Active",
+                expected_status="True",
+                prefill=False,
+                timeout=90,
+            )
+            assert_scaled_object_condition(
+                service_name,
+                namespace=ns,
+                condition_type="Active",
+                expected_status="True",
+                prefill=True,
+                timeout=90,
+            )
+
+            # Every request passes through both a prefill and a decode step,
+            # so both roles scale beyond their minReplicas=1 baseline.
+            wait_for_pod_count(
+                service_name,
+                min_count=2,
+                namespace=ns,
+                timeout=120,
+                component=WORKLOAD_COMPONENT_MAIN,
+            )
+            wait_for_pod_count(
+                service_name,
+                min_count=2,
+                namespace=ns,
+                timeout=120,
+                component=WORKLOAD_COMPONENT_PREFILL,
+            )
+        finally:
+            load_thread.join(timeout=150)
+    finally:
+        _cleanup(kserve_client, test_case)

--- a/test/e2e/llmisvc/test_llm_autoscaling_wva.py
+++ b/test/e2e/llmisvc/test_llm_autoscaling_wva.py
@@ -145,12 +145,24 @@ def _child_name(parent, suffix):
 # --- Pod count helpers ---
 
 
-def get_pod_count(service_name, namespace):
-    """Count Running or Pending pods for this LLMISVC workload."""
+WORKLOAD_COMPONENT_MAIN = "llminferenceservice-workload"
+WORKLOAD_COMPONENT_PREFILL = "llminferenceservice-workload-prefill"
+
+
+def get_pod_count(service_name, namespace, component=None):
+    """Count Running or Pending pods for this LLMISVC workload.
+
+    When component is set (e.g. WORKLOAD_COMPONENT_PREFILL), only counts pods
+    for that role, so prefill and decode/main pod counts can be tracked
+    independently for P/D disaggregated deployments.
+    """
     v1 = client.CoreV1Api()
+    label_selector = f"app.kubernetes.io/name={service_name}"
+    if component:
+        label_selector += f",app.kubernetes.io/component={component}"
     pods = v1.list_namespaced_pod(
         namespace=namespace,
-        label_selector=f"app.kubernetes.io/name={service_name}",
+        label_selector=label_selector,
     )
     count = 0
     for pod in pods.items:
@@ -159,11 +171,11 @@ def get_pod_count(service_name, namespace):
     return count
 
 
-def wait_for_pod_count(service_name, min_count, namespace, timeout=300):
+def wait_for_pod_count(service_name, min_count, namespace, timeout=300, component=None):
     """Poll until the pod count reaches at least min_count."""
 
     def _check():
-        current = get_pod_count(service_name, namespace)
+        current = get_pod_count(service_name, namespace, component=component)
         assert current >= min_count, (
             f"Pod count for {service_name}: {current}, expected >= {min_count}"
         )
@@ -171,13 +183,29 @@ def wait_for_pod_count(service_name, min_count, namespace, timeout=300):
     wait_for(_check, timeout=timeout, interval=5.0)
 
 
-def wait_for_pod_count_exact(service_name, count, namespace, timeout=300):
+def wait_for_pod_count_exact(
+    service_name, count, namespace, timeout=300, component=None
+):
     """Poll until the pod count is exactly count."""
 
     def _check():
-        current = get_pod_count(service_name, namespace)
+        current = get_pod_count(service_name, namespace, component=component)
         assert current == count, (
             f"Pod count for {service_name}: {current}, expected {count}"
+        )
+
+    wait_for(_check, timeout=timeout, interval=5.0)
+
+
+def wait_for_pod_count_at_most(
+    service_name, max_count, namespace, timeout=300, component=None
+):
+    """Poll until the pod count drops to at most max_count (e.g. scale-to-zero)."""
+
+    def _check():
+        current = get_pod_count(service_name, namespace, component=component)
+        assert current <= max_count, (
+            f"Pod count for {service_name}: {current}, expected <= {max_count}"
         )
 
     wait_for(_check, timeout=timeout, interval=5.0)
@@ -186,8 +214,15 @@ def wait_for_pod_count_exact(service_name, count, namespace, timeout=300):
 # --- Load generation ---
 
 
-def send_load(service_url, model_name, concurrency=5, duration_seconds=30):
-    """Send concurrent requests to the service to trigger scale-up."""
+def send_load(
+    service_url, model_name, concurrency=5, duration_seconds=30, tolerate_failures=False
+):
+    """Send concurrent requests to the service to trigger scale-up.
+
+    When tolerate_failures is True, skip the "at least one request delivered"
+    assertion, since KEDA has no request-buffering activator and requests
+    sent at a scaled-to-zero deployment are expected to fail until it's up.
+    """
     endpoint = service_url + "/v1/completions"
     payload = {
         "model": model_name,
@@ -228,9 +263,10 @@ def send_load(service_url, model_name, concurrency=5, duration_seconds=30):
         f"{counters['server_error']} server errors to {endpoint}"
     )
     total_delivered = counters["success"] + counters["client_error"]
-    assert total_delivered > 0, (
-        f"send_load: all {counters['server_error']} requests failed to {endpoint}"
-    )
+    if not tolerate_failures:
+        assert total_delivered > 0, (
+            f"send_load: all {counters['server_error']} requests failed to {endpoint}"
+        )
 
 
 # --- Patching helpers ---
@@ -391,7 +427,7 @@ def assert_hpa_active(service_name, namespace):
     wait_for(_check, timeout=60, interval=5.0)
 
 
-def assert_scaled_object_active(service_name, namespace):
+def assert_scaled_object_ready(service_name, namespace):
     """Verify KEDA ScaledObject has Ready=True condition (polls for up to 60s)."""
 
     def _check():
@@ -412,6 +448,39 @@ def assert_scaled_object_active(service_name, namespace):
         )
 
     wait_for(_check, timeout=60, interval=5.0)
+
+
+def assert_scaled_object_condition(
+    service_name,
+    namespace,
+    condition_type,
+    expected_status="True",
+    prefill=False,
+    timeout=120,
+):
+    """Verify a KEDA ScaledObject status condition matches the expected status.
+
+    Generalizes assert_scaled_object_ready to any condition type (e.g.
+    "Active", "Fallback") so callers can prove a trigger actually fired
+    (Active=True) or that a Prometheus outage tripped fallback
+    (Fallback=True), not just that the object exists and is Ready.
+    """
+    name = scaled_object_name(service_name, prefill)
+
+    def _check():
+        so = _get_custom_resource(
+            KEDA_GROUP, KEDA_VERSION, KEDA_PLURAL, name, namespace
+        )
+        assert so is not None, f"ScaledObject {name} not found"
+        conditions = so.get("status", {}).get("conditions", [])
+        cond = next((c for c in conditions if c["type"] == condition_type), None)
+        assert cond and cond["status"] == expected_status, (
+            f"ScaledObject {name} condition {condition_type} is "
+            f"{cond['status'] if cond else 'missing'}, expected {expected_status}: "
+            f"{conditions}"
+        )
+
+    wait_for(_check, timeout=timeout, interval=5.0)
 
 
 def assert_lws_replicas(service_name, min_replicas, namespace):
@@ -622,7 +691,7 @@ def test_llm_autoscaling_keda_deployment(test_case: TestCase):
 
         assert_wva_annotations_on_actuator(service_name, actuator="keda", namespace=ns)
         wait_for_pod_count(service_name, min_count=2, namespace=ns, timeout=300)
-        assert_scaled_object_active(service_name, namespace=ns)
+        assert_scaled_object_ready(service_name, namespace=ns)
         assert_scaling_ready_condition(service_name, namespace=ns)
     finally:
         _cleanup(kserve_client, test_case)
@@ -737,7 +806,7 @@ def test_llm_autoscaling_keda_lws(test_case: TestCase):
 
         assert_wva_annotations_on_actuator(service_name, actuator="keda", namespace=ns)
         wait_for_pod_count(service_name, min_count=2, namespace=ns, timeout=300)
-        assert_scaled_object_active(service_name, namespace=ns)
+        assert_scaled_object_ready(service_name, namespace=ns)
         assert_lws_replicas(service_name, min_replicas=1, namespace=ns)
         assert_scaling_ready_condition(service_name, namespace=ns)
     finally:


### PR DESCRIPTION
**What this PR does**:

Adds load-driven e2e tests for the direct-KEDA path (`spec.scaling.keda`, no WVA): scale-up under real traffic, idle scale-to-zero and wake-up, independent prefill/decode scaling, and holding replicas steady during a Prometheus outage. Also adds the Prometheus scrape fixtures and trigger queries needed to drive these scenarios.