### PR TITLE
fix(test): wrap migration test update in RetryOnConflict

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_migration_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_migration_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -163,13 +164,17 @@ var _ = Describe("InferencePool Migration", func() {
 			Expect(envTest.Client.Update(ctx, updatedRoute)).To(Succeed())
 
 			// Trigger reconciliation by updating the LLMInferenceService
-			llmSvcUpdated := &v1alpha2.LLMInferenceService{}
-			Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(llmSvc), llmSvcUpdated)).To(Succeed())
-			if llmSvcUpdated.Annotations == nil {
-				llmSvcUpdated.Annotations = make(map[string]string)
-			}
-			llmSvcUpdated.Annotations["trigger-reconcile"] = "true"
-			Expect(envTest.Client.Update(ctx, llmSvcUpdated)).To(Succeed())
+			Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				llmSvcUpdated := &v1alpha2.LLMInferenceService{}
+				if err := envTest.Client.Get(ctx, client.ObjectKeyFromObject(llmSvc), llmSvcUpdated); err != nil {
+					return err
+				}
+				if llmSvcUpdated.Annotations == nil {
+					llmSvcUpdated.Annotations = make(map[string]string)
+				}
+				llmSvcUpdated.Annotations["trigger-reconcile"] = "true"
+				return envTest.Client.Update(ctx, llmSvcUpdated)
+			})).To(Succeed())
 
 			// then - HTTPRoute should point to v1 pool (respecting annotation)
 			Eventually(func(g Gomega, ctx context.Context) error {


### PR DESCRIPTION
## What this PR does / why we need it

Fixes a flaky test in controller_int_migration_test.go. The
"Pre-migrated deployments" test does a bare Get + Update on the
LLMInferenceService to trigger reconciliation, but the envtest controller
can modify the object between those two calls, bumping the
resourceVersion and causing a 409 Conflict:

    Operation cannot be fulfilled on llminferenceservices.serving.kserve.io
    "test-llm-pre-migrated": the object has been modified; please apply
    your changes to the latest version and try again

Wraps the update in retry.RetryOnConflict, consistent with the pattern
already used in controller_int_multi_node_test.go.

## Test plan

- [x] go build ./pkg/controller/v1alpha2/llmisvc/... passes
- [x] Full llmisvc test suite passes (278/278)