### PR TITLE
fix: reconcile orderings with consistent keys

### DIFF
--- a/pkg/apis/serving/v1beta1/predictor_model.go
+++ b/pkg/apis/serving/v1beta1/predictor_model.go
@@ -203,7 +203,10 @@ func sortClusterServingRuntimeList(runtimes *v1alpha1.ClusterServingRuntimeList)
 }
 
 func sortSupportedRuntimeByPriority(runtimes []v1alpha1.SupportedRuntime, modelFormat ModelFormat) {
-	sort.Slice(runtimes, func(i, j int) bool {
+	// Stable: equal priorities (and the common case of no priority at all) must
+	// preserve the caller's creation-timestamp/name ordering. sort.Slice is
+	// unstable and would permute those ties, re-selecting a different runtime.
+	sort.SliceStable(runtimes, func(i, j int) bool {
 		p1 := runtimes[i].Spec.GetPriority(modelFormat.Name)
 		p2 := runtimes[j].Spec.GetPriority(modelFormat.Name)
 

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -179,6 +179,12 @@ func DiscoverURLs(ctx context.Context, c client.Client, gateways []ResolvedGatew
 						return nil, fmt.Errorf("failed to combine URLs for Gateway %s/%s: %w", g.Gateway.Namespace, g.Gateway.Name, err)
 					}
 					for _, u := range gatewayURLs {
+						// Listeners collide: two listeners sharing a port yield the same
+						// URL whenever the hostname is listener-independent, which is the
+						// case when the route pins spec.hostnames.
+						if _, exists := seen[u.String()]; exists {
+							continue
+						}
 						seen[u.String()] = struct{}{}
 						urls = append(urls, DiscoveredURL{URL: u, Origin: origin})
 					}
@@ -443,7 +449,10 @@ func selectListeners(gateway *gwapiv1.Gateway, sectionName *gwapiv1.SectionName,
 		}
 		return 2
 	}
-	slices.SortFunc(listeners, func(a, b *gwapiv1.Listener) int {
+	// Stable: precedence is only ever 0, 1 or 2, so every pair of same-scheme
+	// listeners ties. An unstable sort would permute them and silently re-pick
+	// which listener wins, so keep the gateway's declared listener order.
+	slices.SortStableFunc(listeners, func(a, b *gwapiv1.Listener) int {
 		return precedence(a) - precedence(b)
 	})
 

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_test.go
@@ -1988,6 +1988,66 @@ func TestDiscoverURLs(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("listeners sharing a port do not produce duplicate URLs", func(t *testing.T) {
+		// A route that pins spec.hostnames makes the hostname listener-independent,
+		// so every listener on the same port builds the identical URL. Those
+		// duplicates flow straight into status.addresses, which is user-visible.
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+		g.Expect(gwapiv1.Install(scheme)).To(Succeed())
+		g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		route := HTTPRoute("test-route",
+			InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+			WithHostnames("pinned.example.com"),
+			WithParentRefs(gwapiv1.ParentReference{
+				Name:      "my-gateway",
+				Namespace: ptr.To(gwapiv1.Namespace("gw-ns")),
+				Group:     ptr.To(gwapiv1.Group("gateway.networking.k8s.io")),
+				Kind:      ptr.To(gwapiv1.Kind("Gateway")),
+			}),
+		)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(
+				route,
+				Gateway("my-gateway",
+					InNamespace[*gwapiv1.Gateway]("gw-ns"),
+					WithListeners(
+						gwapiv1.Listener{
+							Name:     "https-a",
+							Port:     443,
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Hostname: ptr.To(gwapiv1.Hostname("a.example.com")),
+						},
+						gwapiv1.Listener{
+							Name:     "https-b",
+							Port:     443,
+							Protocol: gwapiv1.HTTPSProtocolType,
+							Hostname: ptr.To(gwapiv1.Hostname("b.example.com")),
+						},
+					),
+					WithAddresses("1.2.3.4"),
+				),
+				DefaultGatewayClass(),
+			).
+			Build()
+
+		gateways, gwErr := llmisvc.DiscoverGateways(ctx, fakeClient, route)
+		g.Expect(gwErr).ToNot(HaveOccurred())
+		discovered, err := llmisvc.DiscoverURLs(ctx, fakeClient, gateways, route, llmisvc.Config{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		actual := make([]string, 0, len(discovered))
+		for _, d := range discovered {
+			actual = append(actual, d.URL.String())
+		}
+		g.Expect(actual).To(ConsistOf("https://pinned.example.com/"))
+	})
 }
 
 func TestFilterURLs(t *testing.T) {

--- a/pkg/controller/v1beta1/inferenceservice/model_status_churn_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/model_status_churn_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferenceservice
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// predictorPod builds a pod that the predictor component will pick up via its
+// "app: isvc.<predictor>" label selector, with the storage-initializer init
+// container in the given state. InferenceServicePodLabelKey is required as
+// well: the manager only caches pods carrying it (see NewCacheOptions), so
+// without it the controller's List comes back empty.
+func predictorPod(name, namespace, appLabel, isvcName string, initState corev1.ContainerState) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.RawDeploymentAppLabel:       appLabel,
+				constants.InferenceServicePodLabelKey: isvcName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: constants.StorageInitializerContainerName, Image: "kserve/storage-initializer:latest"},
+			},
+			Containers: []corev1.Container{
+				{Name: constants.InferenceServiceContainerName, Image: "tensorflow/serving:1.14.0"},
+			},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: constants.StorageInitializerContainerName, State: initState},
+			},
+		},
+	}
+}
+
+var _ = Describe("InferenceService model status determinism", func() {
+	Context("When several predictor pods report different storage-initializer states", func() {
+		// PropagateModelStatus derives the whole model status from a single pod
+		// (podList.Items[0]). Pods belonging to one ReplicaSet share a
+		// CreationTimestamp - it is serialized as RFC3339, so it only has second
+		// granularity - and the controller's cached client returns List results in
+		// randomized map order. Unless the pod ordering is a total order, each
+		// reconcile can land on a different pod and rewrite status.modelStatus with
+		// a conflicting verdict, churning the resource forever without any user or
+		// cluster change behind it.
+		It("Should not flip status.modelStatus across repeated reconciles", func() {
+			ctx := context.Background()
+
+			configMap := createInferenceServiceConfigMap(getRawKubeTestConfigs())
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			servingRuntime := getServingRuntime("tf-serving-churn", "default")
+			Expect(k8sClient.Create(ctx, &servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, &servingRuntime)
+
+			serviceName := "model-status-churn"
+			serviceKey := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: serviceName, Namespace: "default"},
+			}.NamespacedName
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        serviceKey.Name,
+					Namespace:   serviceKey.Namespace,
+					Annotations: getDefaultAnnotations(constants.AutoscalerClassHPA),
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(2)),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: getCommonPredictorExtensionSpec(),
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			By("Waiting for the predictor deployment to be created")
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, &appsv1.Deployment{})
+			}, timeout, interval).Should(Succeed())
+
+			By("Creating two predictor pods that disagree about the model state")
+			appLabel := constants.GetRawServiceLabel(predictorKey.Name)
+			loading := predictorPod("churn-pod-loading", serviceKey.Namespace, appLabel, serviceName,
+				corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()},
+				})
+			failed := predictorPod("churn-pod-failed", serviceKey.Namespace, appLabel, serviceName,
+				corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Reason:   constants.StateReasonError,
+						Message:  "failed to pull model",
+						ExitCode: 1,
+					},
+				})
+
+			for _, pod := range []*corev1.Pod{loading, failed} {
+				status := pod.Status
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+				defer k8sClient.Delete(ctx, pod)
+				pod.Status = status
+				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			}
+
+			// The bug only manifests when the pods tie on CreationTimestamp, which
+			// is what happens in a real ReplicaSet rollout. Creating them back to
+			// back makes that overwhelmingly likely, but assert it rather than
+			// silently passing if the two creates straddle a second boundary.
+			Expect(loading.CreationTimestamp.Equal(&failed.CreationTimestamp)).To(BeTrue(),
+				"pods must share a creation timestamp for this test to exercise the tie")
+
+			By("Reconciling repeatedly and sampling the reported model state")
+			settled := func() string {
+				cur := &v1beta1.InferenceService{}
+				Expect(k8sClient.Get(ctx, serviceKey, cur)).To(Succeed())
+				if cur.Status.ModelStatus.ModelRevisionStates == nil {
+					return ""
+				}
+				return string(cur.Status.ModelStatus.ModelRevisionStates.TargetModelState)
+			}
+
+			// Guard against a silent pass: if the pods never reach
+			// PropagateModelStatus the state stays "Pending" and the ordering is
+			// never exercised at all.
+			var first string
+			Eventually(func() string {
+				first = settled()
+				GinkgoWriter.Printf("observed target model state: %q\n", first)
+				return first
+			}, timeout, interval).Should(BeElementOf(
+				string(v1beta1.Loading), string(v1beta1.FailedToLoad),
+			), "predictor pods must drive status.modelStatus, otherwise this test proves nothing")
+
+			// Each poll nudges the InferenceService to force a fresh reconcile and
+			// then reports what that reconcile concluded. With a random List order
+			// and two pods, every sample is an independent coin flip, so a
+			// non-total ordering shows up within a handful of iterations.
+			probe := 0
+			Consistently(func(g Gomega) string {
+				probe++
+				g.Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					cur := &v1beta1.InferenceService{}
+					if err := k8sClient.Get(ctx, serviceKey, cur); err != nil {
+						return err
+					}
+					cur.Annotations["serving.kserve.io/churn-probe"] = strconv.Itoa(probe)
+					return k8sClient.Update(ctx, cur)
+				})).To(Succeed())
+				return settled()
+			}, 10*time.Second, 250*time.Millisecond).Should(Equal(first),
+				"status.modelStatus flipped between reconciles without any pod change")
+		})
+	})
+})

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -405,6 +405,13 @@ func ListPodsByLabel(ctx context.Context, cl client.Client, namespace string, la
 
 func sortPodsByCreatedTimestampDesc(pods *corev1.PodList) {
 	sort.Slice(pods.Items, func(i, j int) bool {
+		// CreationTimestamp only has second granularity, so replicas of the same
+		// ReplicaSet routinely tie. Break ties on name: the cache returns pods in
+		// random map order, and callers read Items[0], so without a total order the
+		// reported model status flips between pods on every reconcile.
+		if pods.Items[i].CreationTimestamp.Equal(&pods.Items[j].CreationTimestamp) {
+			return pods.Items[i].Name < pods.Items[j].Name
+		}
 		return pods.Items[j].CreationTimestamp.Before(&pods.Items[i].CreationTimestamp)
 	})
 }

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -18,8 +18,10 @@ package utils
 
 import (
 	"errors"
+	"slices"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega/types"
 	"k8s.io/utils/ptr"
@@ -2716,6 +2718,45 @@ func TestMergeServingRuntimeAndInferenceServiceSpecs(t *testing.T) {
 				g.Expect(index).NotTo(gomega.Equal(-1))
 				g.Expect(err).To(scenario.expectedErr)
 			}
+		})
+	}
+}
+
+func TestSortPodsByCreatedTimestampDescIsDeterministic(t *testing.T) {
+	// CreationTimestamp is serialized as RFC3339, so replicas of the same
+	// ReplicaSet share it to the second. The cache lists pods in random map
+	// order, so an unstable sort with a timestamp-only comparator would hand
+	// callers a different Items[0] on every reconcile.
+	sameSecond := metav1.NewTime(time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC))
+	older := metav1.NewTime(sameSecond.Add(-time.Minute))
+
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "predictor-xyz-1", CreationTimestamp: sameSecond}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "predictor-xyz-2", CreationTimestamp: sameSecond}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "predictor-xyz-3", CreationTimestamp: sameSecond}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "predictor-abc-0", CreationTimestamp: older}},
+	}
+
+	// Feeding the same set in two opposite orders is enough: a comparator that
+	// leaves ties unordered carries the input order through to the output, so
+	// the two runs disagree. Fixed inputs keep a CI failure reproducible.
+	reversed := slices.Clone(pods)
+	slices.Reverse(reversed)
+
+	for name, input := range map[string][]corev1.Pod{"forward": pods, "reversed": reversed} {
+		t.Run(name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			list := &corev1.PodList{Items: slices.Clone(input)}
+
+			sortPodsByCreatedTimestampDesc(list)
+
+			names := make([]string, 0, len(list.Items))
+			for _, p := range list.Items {
+				names = append(names, p.Name)
+			}
+			g.Expect(names).To(gomega.Equal([]string{
+				"predictor-xyz-1", "predictor-xyz-2", "predictor-xyz-3", "predictor-abc-0",
+			}))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Three orderings in the reconcile path were not total, so equal keys could be resolved differently from one pass to the next.

The reported model state of an InferenceService is derived from a single predictor pod. Replicas of one rollout share a creation timestamp down to the second, and the cache returns list results in an arbitrary order, so consecutive reconciles could pick different pods and publish conflicting verdicts. A service with a healthy replica and a failing one would alternate between loading and failed indefinitely, requeueing every second without anything in the cluster having changed.

Runtime selection had the same weakness. Candidates arrive pre-ordered by age and name, but the priority sort was free to permute entries sharing a priority - which is every candidate in the common case where no priority is set at all. An unchanged spec could resolve to a different serving runtime.

Separately, gateway listeners on the same port produce an identical address whenever the hostname does not depend on the listener, which is the case once a route pins its own hostnames. External addresses were collected without checking what had already been recorded, so the same entry was published twice in the LLMInferenceService status.

**Feature/Issue validation/testing**:

- [x] New envtest reproduces the model status churn: it stands up a predictor with two pods that disagree about the model state, forces repeated reconciles, and asserts the reported state never moves. It is committed separately ahead of the fix so the failure is on record, and it fails reliably without the ordering change.
- [x] New unit test pins the pod ordering against two fixed opposite-order inputs, so a regression names which order broke rather than failing at random.
- [x] New unit test covers duplicate address suppression for two listeners sharing a port with a route that pins its hostnames.
- [x] Full suites pass: `pkg/controller/v1beta1/inferenceservice/...`, `pkg/apis/serving/v1beta1`, and `pkg/controller/v1alpha2/llmisvc`.

**Special notes for your reviewer**:

The first commit is the failing test on its own, the second is the fix. Worth keeping the pair together on merge.

The listener sort is also made stable in the same change. That one is hardening rather than a fix - it has no observable effect today, since the addresses it feeds are re-sorted before reaching status and a gateway would need more than twelve listeners before Go's sort actually permutes the ties. It is one word, and it stops the next person who makes listener order matter from inheriting the problem.

Not addressed here, noticed while auditing: observed HTTPRoutes in the router status are deduplicated by name alone, so two routes with the same name in different namespaces collapse into one entry.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```