### PR TITLE
fix(llmisvc): give P/D engines a NixlConnector so KV actually transfers

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -150,11 +150,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -178,6 +184,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -486,11 +496,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -522,6 +538,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -826,11 +846,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -862,6 +888,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
@@ -1072,11 +1102,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -1100,6 +1136,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -1349,11 +1389,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -1385,6 +1431,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -1628,11 +1678,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -1664,6 +1720,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -160,7 +160,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -506,7 +514,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -856,7 +872,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -1112,7 +1136,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -1399,7 +1431,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -1688,7 +1728,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -164,7 +164,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -518,7 +518,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -876,7 +876,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -1140,7 +1140,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -1435,7 +1435,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -1732,7 +1732,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -169,7 +169,7 @@ spec:
                 # raise RuntimeError("NIXL is not available") and never finish starting.
                 NIXL_PY=$(command -v python3 || command -v python || true)
                 if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                  KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                  KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
                   echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
                 else
                   echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -165,7 +165,15 @@ spec:
               # This template is only composed for a disaggregated P/D topology (spec.prefill set).
               # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
               if [ -z "${KV_TRANSFER_ARGS}" ]; then
-                KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+                # raise RuntimeError("NIXL is not available") and never finish starting.
+                NIXL_PY=$(command -v python3 || command -v python || true)
+                if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                  KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                  echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+                else
+                  echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+                fi
               fi
             fi
 

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -155,11 +155,17 @@ spec:
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
             fi
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
                 KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+              fi
+              # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+              # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+              if [ -z "${KV_TRANSFER_ARGS}" ]; then
+                KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
               fi
             fi
 
@@ -184,6 +190,12 @@ spec:
             value: INFO
           - name: HF_HUB_CACHE
             value: /models
+          # NixlConnector advertises this address to the peer engine for the KV side channel.
+          # It defaults to localhost, which cannot be reached across pods.
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         securityContext:
           allowPrivilegeEscalation: false
           # nvidia-cdi-hook requires a writable root filesystem

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -238,11 +238,17 @@ spec:
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
             fi
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
                 KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+              fi
+              # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+              # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+              if [ -z "${KV_TRANSFER_ARGS}" ]; then
+                KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
               fi
             fi
 
@@ -276,6 +282,12 @@ spec:
             value: INFO
           - name: HF_HUB_CACHE
             value: /models
+          # NixlConnector advertises this address to the peer engine for the KV side channel.
+          # It defaults to localhost, which cannot be reached across pods.
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         securityContext:
           allowPrivilegeEscalation: false
           # nvidia-cdi-hook requires a writable root filesystem
@@ -520,11 +532,17 @@ spec:
               SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
             fi
 
-            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
             KV_TRANSFER_ARGS=""
-            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
                 KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+              fi
+              # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+              # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+              if [ -z "${KV_TRANSFER_ARGS}" ]; then
+                KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
               fi
             fi
 
@@ -558,6 +576,12 @@ spec:
             value: INFO
           - name: HF_HUB_CACHE
             value: /models
+          # NixlConnector advertises this address to the peer engine for the KV side channel.
+          # It defaults to localhost, which cannot be reached across pods.
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
             value: "1"
         securityContext:

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -252,7 +252,7 @@ spec:
                 # raise RuntimeError("NIXL is not available") and never finish starting.
                 NIXL_PY=$(command -v python3 || command -v python || true)
                 if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                  KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                  KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
                   echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
                 else
                   echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -554,7 +554,7 @@ spec:
                 # raise RuntimeError("NIXL is not available") and never finish starting.
                 NIXL_PY=$(command -v python3 || command -v python || true)
                 if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                  KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                  KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
                   echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
                 else
                   echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -248,7 +248,15 @@ spec:
               # This template is only composed for a disaggregated P/D topology (spec.prefill set).
               # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
               if [ -z "${KV_TRANSFER_ARGS}" ]; then
-                KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+                # raise RuntimeError("NIXL is not available") and never finish starting.
+                NIXL_PY=$(command -v python3 || command -v python || true)
+                if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                  KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                  echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+                else
+                  echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+                fi
               fi
             fi
 
@@ -542,7 +550,15 @@ spec:
               # This template is only composed for a disaggregated P/D topology (spec.prefill set).
               # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
               if [ -z "${KV_TRANSFER_ARGS}" ]; then
-                KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+                # raise RuntimeError("NIXL is not available") and never finish starting.
+                NIXL_PY=$(command -v python3 || command -v python || true)
+                if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                  KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+                  echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+                else
+                  echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+                fi
               fi
             fi
 

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -166,7 +166,15 @@ spec:
                 # This template is only composed for a disaggregated P/D topology (spec.prefill set).
                 # Prefill is the KV producer; without a connector here decode has nothing to fetch.
                 if [ -z "${KV_TRANSFER_ARGS}" ]; then
-                  KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                  # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+                  # raise RuntimeError("NIXL is not available") and never finish starting.
+                  NIXL_PY=$(command -v python3 || command -v python || true)
+                  if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                    KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                    echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+                  else
+                    echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+                  fi
                 fi
               fi
 

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -156,11 +156,17 @@ spec:
                 SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
               fi
 
-              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
               KV_TRANSFER_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-                if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+                # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+                if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
                   KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+                fi
+                # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+                # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+                if [ -z "${KV_TRANSFER_ARGS}" ]; then
+                  KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
                 fi
               fi
 
@@ -185,6 +191,12 @@ spec:
               value: INFO
             - name: HF_HUB_CACHE
               value: /models
+            # NixlConnector advertises this address to the peer engine for the KV side channel.
+            # It defaults to localhost, which cannot be reached across pods.
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           securityContext:
             allowPrivilegeEscalation: false
             # nvidia-cdi-hook requires a writable root filesystem

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -170,7 +170,7 @@ spec:
                   # raise RuntimeError("NIXL is not available") and never finish starting.
                   NIXL_PY=$(command -v python3 || command -v python || true)
                   if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                    KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                    KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                     echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
                   else
                     echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -178,11 +178,17 @@ spec:
                 SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
               fi
 
-              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
               KV_TRANSFER_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-                if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+                # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+                if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
                   KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+                fi
+                # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+                # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+                if [ -z "${KV_TRANSFER_ARGS}" ]; then
+                  KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
                 fi
               fi
 
@@ -216,6 +222,12 @@ spec:
               value: INFO
             - name: HF_HUB_CACHE
               value: /models
+            # NixlConnector advertises this address to the peer engine for the KV side channel.
+            # It defaults to localhost, which cannot be reached across pods.
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           securityContext:
             allowPrivilegeEscalation: false
             # nvidia-cdi-hook requires a writable root filesystem
@@ -460,11 +472,17 @@ spec:
                 SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
               fi
 
-              # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+              # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
               KV_TRANSFER_ARGS=""
-              if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-                if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+                # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+                if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
                   KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+                fi
+                # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+                # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+                if [ -z "${KV_TRANSFER_ARGS}" ]; then
+                  KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
                 fi
               fi
 
@@ -498,6 +516,12 @@ spec:
               value: INFO
             - name: HF_HUB_CACHE
               value: /models
+            # NixlConnector advertises this address to the peer engine for the KV side channel.
+            # It defaults to localhost, which cannot be reached across pods.
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           securityContext:
             allowPrivilegeEscalation: false
             # nvidia-cdi-hook requires a writable root filesystem

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -192,7 +192,7 @@ spec:
                   # raise RuntimeError("NIXL is not available") and never finish starting.
                   NIXL_PY=$(command -v python3 || command -v python || true)
                   if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                    KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                    KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                     echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
                   else
                     echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -494,7 +494,7 @@ spec:
                   # raise RuntimeError("NIXL is not available") and never finish starting.
                   NIXL_PY=$(command -v python3 || command -v python || true)
                   if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                    KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                    KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                     echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
                   else
                     echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -188,7 +188,15 @@ spec:
                 # This template is only composed for a disaggregated P/D topology (spec.prefill set).
                 # Prefill is the KV producer; without a connector here decode has nothing to fetch.
                 if [ -z "${KV_TRANSFER_ARGS}" ]; then
-                  KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                  # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+                  # raise RuntimeError("NIXL is not available") and never finish starting.
+                  NIXL_PY=$(command -v python3 || command -v python || true)
+                  if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                    KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                    echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+                  else
+                    echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+                  fi
                 fi
               fi
 
@@ -482,7 +490,15 @@ spec:
                 # This template is only composed for a disaggregated P/D topology (spec.prefill set).
                 # Prefill is the KV producer; without a connector here decode has nothing to fetch.
                 if [ -z "${KV_TRANSFER_ARGS}" ]; then
-                  KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                  # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+                  # raise RuntimeError("NIXL is not available") and never finish starting.
+                  NIXL_PY=$(command -v python3 || command -v python || true)
+                  if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                    KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                    echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+                  else
+                    echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+                  fi
                 fi
               fi
 

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2781,7 +2781,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3127,7 +3135,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3477,7 +3493,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3733,7 +3757,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -4020,7 +4052,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -4309,7 +4349,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2771,11 +2771,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -2799,6 +2805,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -3107,11 +3117,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -3143,6 +3159,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -3447,11 +3467,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -3483,6 +3509,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
@@ -3693,11 +3723,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -3721,6 +3757,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -3970,11 +4010,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -4006,6 +4052,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -4249,11 +4299,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -4285,6 +4341,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2785,7 +2785,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3139,7 +3139,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3497,7 +3497,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3761,7 +3761,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -4056,7 +4056,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -4353,7 +4353,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2367,7 +2367,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -2721,7 +2721,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3079,7 +3079,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3343,7 +3343,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3638,7 +3638,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3935,7 +3935,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2353,11 +2353,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -2381,6 +2387,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -2689,11 +2699,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -2725,6 +2741,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -3029,11 +3049,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -3065,6 +3091,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
@@ -3275,11 +3305,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -3303,6 +3339,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -3552,11 +3592,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -3588,6 +3634,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -3831,11 +3881,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -3867,6 +3923,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2363,7 +2363,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -2709,7 +2717,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3059,7 +3075,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3315,7 +3339,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -3602,7 +3634,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -3891,7 +3931,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -2745,11 +2745,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -2773,6 +2779,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -3081,11 +3091,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -3117,6 +3133,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -3421,11 +3441,17 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
           fi
         fi
 
@@ -3457,6 +3483,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
@@ -3667,11 +3697,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -3695,6 +3731,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -3944,11 +3984,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -3980,6 +4026,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -4223,11 +4273,17 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
             fi
           fi
 
@@ -4259,6 +4315,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -2755,7 +2755,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3101,7 +3109,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3451,7 +3467,15 @@ spec:
           # This template is only composed for a disaggregated P/D topology (spec.prefill set).
           # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
           if [ -z "${KV_TRANSFER_ARGS}" ]; then
-            KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3707,7 +3731,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -3994,7 +4026,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -4283,7 +4323,15 @@ spec:
             # This template is only composed for a disaggregated P/D topology (spec.prefill set).
             # Prefill is the KV producer; without a connector here decode has nothing to fetch.
             if [ -z "${KV_TRANSFER_ARGS}" ]; then
-              KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -2759,7 +2759,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3113,7 +3113,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3471,7 +3471,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3735,7 +3735,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -4030,7 +4030,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -4327,7 +4327,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
@@ -2353,11 +2353,25 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -2381,6 +2395,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -2689,11 +2707,25 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -2725,6 +2757,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
       imagePullPolicy: IfNotPresent
       lifecycle:
@@ -3029,11 +3065,25 @@ spec:
           SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
         fi
 
-        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
         KV_TRANSFER_ARGS=""
-        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+        if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
             KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+          # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+          # Decode is the KV consumer; without a connector here it recomputes prefill's KV.
+          if [ -z "${KV_TRANSFER_ARGS}" ]; then
+            # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+            # raise RuntimeError("NIXL is not available") and never finish starting.
+            NIXL_PY=$(command -v python3 || command -v python || true)
+            if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
+            else
+              echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+            fi
           fi
         fi
 
@@ -3065,6 +3115,10 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
+      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
       image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
@@ -3275,11 +3329,25 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -3303,6 +3371,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -3552,11 +3624,25 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -3588,6 +3674,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -3831,11 +3921,25 @@ spec:
             SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
           fi
 
-          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          # A user-supplied --kv-transfer-config always wins; KServe only fills the flag when it is unset.
           KV_TRANSFER_ARGS=""
-          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+            if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
               KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+            # This template is only composed for a disaggregated P/D topology (spec.prefill set).
+            # Prefill is the KV producer; without a connector here decode has nothing to fetch.
+            if [ -z "${KV_TRANSFER_ARGS}" ]; then
+              # Only inject when NIXL is importable. CPU and other non-NIXL engine images
+              # raise RuntimeError("NIXL is not available") and never finish starting.
+              NIXL_PY=$(command -v python3 || command -v python || true)
+              if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
+                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
+              else
+                echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
+              fi
             fi
           fi
 
@@ -3867,6 +3971,10 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
@@ -2367,7 +2367,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -2721,7 +2721,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3079,7 +3079,7 @@ spec:
             # raise RuntimeError("NIXL is not available") and never finish starting.
             NIXL_PY=$(command -v python3 || command -v python || true)
             if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-              KV_TRANSFER_ARGS="{{ nixlDecodeTransferConfig }}"
+              KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'"
               echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_consumer)"
             else
               echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3343,7 +3343,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3638,7 +3638,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"
@@ -3935,7 +3935,7 @@ spec:
               # raise RuntimeError("NIXL is not available") and never finish starting.
               NIXL_PY=$(command -v python3 || command -v python || true)
               if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then
-                KV_TRANSFER_ARGS="{{ nixlPrefillTransferConfig }}"
+                KV_TRANSFER_ARGS="--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'"
                 echo "[kv-transfer] NIXL available, enabling NixlConnector (kv_producer)"
               else
                 echo "[kv-transfer] NIXL not available, P/D KV transfer stays disabled"

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -697,6 +697,19 @@ type templateGlobalConfig struct {
 	InferencePoolNamespacedName string
 }
 
+// nixlTransferConfig builds the NixlConnector --kv-transfer-config argument for
+// the given kv_role. Escaping matches kvTransferConfig (see below).
+func nixlTransferConfig(role string) string {
+	b, err := json.Marshal(map[string]any{
+		"kv_connector": "NixlConnector",
+		"kv_role":      role,
+	})
+	if err != nil {
+		return ""
+	}
+	return "--kv-transfer-config '" + strings.ReplaceAll(string(b), `"`, `\\\"`) + "'"
+}
+
 // ReplaceVariables processes the configuration as a Go template to substitute
 // variables with values from the LLM service and global configuration.
 func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.LLMInferenceServiceConfig, reconcilerConfig *Config) (*v1alpha2.LLMInferenceServiceConfig, error) {
@@ -776,6 +789,13 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 				// template. Plain " would be eaten by the shell and vLLM would get invalid JSON.
 				return "--kv-transfer-config '" + strings.ReplaceAll(string(b), `"`, `\\\"`) + "'"
 			},
+			// Engine-side NixlConnector --kv-transfer-config for a disaggregated P/D
+			// topology; without it vLLM logs "no KVConnector found" and decode recomputes
+			// prefill's KV. Split into two zero-arg funcs (not one taking a role) because the
+			// config is json.Marshal'd before templating, so a quoted arg in {{ }} would fail
+			// to parse. kv_both is omitted — vLLM deprecates it for NixlConnector.
+			"nixlPrefillTransferConfig": func() string { return nixlTransferConfig("kv_producer") },
+			"nixlDecodeTransferConfig":  func() string { return nixlTransferConfig("kv_consumer") },
 			// shutdownTimeout computes the vLLM --shutdown-timeout value from a *corev1.PodSpec
 			// (or nil): max(0, tgps - preStop - min(5, tgps)), defaulting tgps to 60 when unset.
 			// The 5-second buffer reserves time for signal propagation and final process cleanup

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -697,19 +697,6 @@ type templateGlobalConfig struct {
 	InferencePoolNamespacedName string
 }
 
-// nixlTransferConfig builds the NixlConnector --kv-transfer-config argument for
-// the given kv_role. Escaping matches kvTransferConfig (see below).
-func nixlTransferConfig(role string) string {
-	b, err := json.Marshal(map[string]any{
-		"kv_connector": "NixlConnector",
-		"kv_role":      role,
-	})
-	if err != nil {
-		return ""
-	}
-	return "--kv-transfer-config '" + strings.ReplaceAll(string(b), `"`, `\\\"`) + "'"
-}
-
 // ReplaceVariables processes the configuration as a Go template to substitute
 // variables with values from the LLM service and global configuration.
 func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.LLMInferenceServiceConfig, reconcilerConfig *Config) (*v1alpha2.LLMInferenceServiceConfig, error) {
@@ -789,13 +776,6 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 				// template. Plain " would be eaten by the shell and vLLM would get invalid JSON.
 				return "--kv-transfer-config '" + strings.ReplaceAll(string(b), `"`, `\\\"`) + "'"
 			},
-			// Engine-side NixlConnector --kv-transfer-config for a disaggregated P/D
-			// topology; without it vLLM logs "no KVConnector found" and decode recomputes
-			// prefill's KV. Split into two zero-arg funcs (not one taking a role) because the
-			// config is json.Marshal'd before templating, so a quoted arg in {{ }} would fail
-			// to parse. kv_both is omitted — vLLM deprecates it for NixlConnector.
-			"nixlPrefillTransferConfig": func() string { return nixlTransferConfig("kv_producer") },
-			"nixlDecodeTransferConfig":  func() string { return nixlTransferConfig("kv_consumer") },
 			// shutdownTimeout computes the vLLM --shutdown-timeout value from a *corev1.PodSpec
 			// (or nil): max(0, tgps - preStop - min(5, tgps)), defaulting tgps to 60 when unset.
 			// The 5-second buffer reserves time for signal propagation and final process cleanup

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -2427,18 +2427,22 @@ func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 
 	// Mirrors the decode/prefill templates: user-supplied config wins, then the
 	// version-gated OffloadingConnector, then the P/D NixlConnector fallback.
-	const scriptTmpl = `VLLM_VERSION="0.1.dev1+g51f799c1a"
-KV_TRANSFER_ARGS=""
-if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
-  if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
-    KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
-  fi
-  if [ -z "${KV_TRANSFER_ARGS}" ]; then
-    KV_TRANSFER_ARGS="{{ KV_HELPER }}"
-  fi
-fi
-eval "set -- ${KV_TRANSFER_ARGS}"
-printf '%s' "$2"`
+	// Kept as joined lines rather than one raw literal: golangci-lint's --fix rewrites a
+	// multi-line raw string here and drops a line in the process, leaving unbalanced if/fi.
+	scriptTmpl := strings.Join([]string{
+		`VLLM_VERSION="0.1.dev1+g51f799c1a"`,
+		`KV_TRANSFER_ARGS=""`,
+		`if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then`,
+		`  if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then`,
+		`    KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"`,
+		`  fi`,
+		`  if [ -z "${KV_TRANSFER_ARGS}" ]; then`,
+		`    KV_TRANSFER_ARGS="{{ KV_HELPER }}"`,
+		`  fi`,
+		`fi`,
+		`eval "set -- ${KV_TRANSFER_ARGS}"`,
+		`printf '%s' "$2"`,
+	}, "\n")
 
 	for _, tc := range []struct {
 		name   string

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -2123,60 +2123,6 @@ func TestReplaceVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "nixlTransferConfig renders the decode-side NixlConnector consumer role",
-			cfg: &v1alpha2.LLMInferenceServiceConfig{
-				Spec: v1alpha2.LLMInferenceServiceSpec{
-					WorkloadSpec: v1alpha2.WorkloadSpec{
-						Template: &corev1.PodSpec{
-							Containers: []corev1.Container{
-								{Args: []string{`{{ nixlDecodeTransferConfig }}`}},
-							},
-						},
-					},
-				},
-			},
-			llmSvc: &v1alpha2.LLMInferenceService{},
-			want: &v1alpha2.LLMInferenceServiceConfig{
-				Spec: v1alpha2.LLMInferenceServiceSpec{
-					WorkloadSpec: v1alpha2.WorkloadSpec{
-						Template: &corev1.PodSpec{
-							Containers: []corev1.Container{
-								// Same escaping contract as kvTransferConfig: quotes stay as \" so the
-								// value survives the KV_TRANSFER_ARGS="..." bash assignment.
-								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'`}},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "nixlTransferConfig renders the prefill-side NixlConnector producer role",
-			cfg: &v1alpha2.LLMInferenceServiceConfig{
-				Spec: v1alpha2.LLMInferenceServiceSpec{
-					WorkloadSpec: v1alpha2.WorkloadSpec{
-						Template: &corev1.PodSpec{
-							Containers: []corev1.Container{
-								{Args: []string{`{{ nixlPrefillTransferConfig }}`}},
-							},
-						},
-					},
-				},
-			},
-			llmSvc: &v1alpha2.LLMInferenceService{},
-			want: &v1alpha2.LLMInferenceServiceConfig{
-				Spec: v1alpha2.LLMInferenceServiceSpec{
-					WorkloadSpec: v1alpha2.WorkloadSpec{
-						Template: &corev1.PodSpec{
-							Containers: []corev1.Container{
-								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'`}},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "kvTransferConfig includes eviction policy when set",
 			cfg: &v1alpha2.LLMInferenceServiceConfig{
 				Spec: v1alpha2.LLMInferenceServiceSpec{
@@ -2416,11 +2362,12 @@ printf '%s' "$2"`
 }
 
 // TestReplaceVariables_NixlTransferConfigBashSafe runs the P/D templates' actual
-// KV_TRANSFER_ARGS shape through bash, with VLLM_VERSION pinned to the dev string llm-d
-// images report so the NixlConnector branch (not the 0.22.0 OffloadingConnector gate) is
-// under test. It covers both sides of the NIXL probe: unconditional injection kills
-// non-NIXL images ("RuntimeError: NIXL is not available"), so "no NIXL, no injection" is
-// asserted here rather than left to e2e.
+// KV_TRANSFER_ARGS shape through bash, with the same inlined connector constant the presets
+// carry and VLLM_VERSION pinned to the dev string llm-d images report so the NixlConnector
+// branch (not the 0.22.0 OffloadingConnector gate) is under test. It covers both sides of
+// the NIXL probe: unconditional injection kills non-NIXL images ("RuntimeError: NIXL is not
+// available"), so "no NIXL, no injection" is asserted here rather than left to e2e.
+// TestPresetsInlineNixlConnector proves the constant used here is the one the presets render.
 func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 	bashPath, err := exec.LookPath("bash")
 	if err != nil {
@@ -2441,7 +2388,7 @@ func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 		`  if [ -z "${KV_TRANSFER_ARGS}" ]; then`,
 		`    NIXL_PY=$(command -v python3 || command -v python || true)`,
 		`    if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then`,
-		`      KV_TRANSFER_ARGS="{{ KV_HELPER }}"`,
+		`      KV_TRANSFER_ARGS="KV_CONNECTOR_ARG"`,
 		`    fi`,
 		`  fi`,
 		`fi`,
@@ -2464,12 +2411,12 @@ func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name   string
-		helper string
-		role   string
+		name string
+		arg  string // the literal --kv-transfer-config the preset inlines for this side
+		role string
 	}{
-		{name: "decode consumes KV", helper: "nixlDecodeTransferConfig", role: "kv_consumer"},
-		{name: "prefill produces KV", helper: "nixlPrefillTransferConfig", role: "kv_producer"},
+		{name: "decode consumes KV", arg: `--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'`, role: "kv_consumer"},
+		{name: "prefill produces KV", arg: `--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'`, role: "kv_producer"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
@@ -2479,7 +2426,7 @@ func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 					WorkloadSpec: v1alpha2.WorkloadSpec{
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{
-								{Command: []string{"/bin/bash", "-c", strings.ReplaceAll(scriptTmpl, "KV_HELPER", tc.helper)}},
+								{Command: []string{"/bin/bash", "-c", strings.ReplaceAll(scriptTmpl, "KV_CONNECTOR_ARG", tc.arg)}},
 							},
 						},
 					},
@@ -2517,6 +2464,70 @@ func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 			// A user-supplied connector must still win over the injected default.
 			g.Expect(run(stubPython(t, true), `VLLM_ADDITIONAL_ARGS=--kv-transfer-config '{"kv_connector":"MyConnector"}'`)).To(BeEmpty(),
 				"KServe overrode a user-supplied --kv-transfer-config")
+		})
+	}
+}
+
+// TestPresetsInlineNixlConnector renders the real decode/prefill presets and asserts the
+// engine-side NixlConnector --kv-transfer-config is inlined in the container command with the
+// role each side owns. The connector is a preset constant (not a controller template func), so
+// changing it can only come from editing the preset — a pinned preset never re-renders behind
+// the user. Follows the preset-rendering pattern of TestSingleNodeTensorParallelRendered.
+func TestPresetsInlineNixlConnector(t *testing.T) {
+	presetsDir := filepath.Join(ktesting.ProjectRoot(), "config", "llmisvcconfig")
+
+	tests := []struct {
+		name    string
+		file    string
+		llmSvc  *v1alpha2.LLMInferenceService
+		wantArg string
+	}{
+		{
+			name: "decode template inlines the consumer connector",
+			file: "config-llm-decode-template.yaml",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model: v1alpha2.LLMModelSpec{Name: ptr.To("model")},
+				},
+			},
+			wantArg: `--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'`,
+		},
+		{
+			name: "prefill template inlines the producer connector",
+			file: "config-llm-prefill-template.yaml",
+			llmSvc: &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					Model:   v1alpha2.LLMModelSpec{Name: ptr.To("model")},
+					Prefill: &v1alpha2.WorkloadSpec{},
+				},
+			},
+			wantArg: `--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			data, err := os.ReadFile(filepath.Clean(filepath.Join(presetsDir, tt.file)))
+			g.Expect(err).ToNot(HaveOccurred())
+			config := loadConfig(t, data, tt.file)
+
+			got, err := llmisvc.ReplaceVariables(tt.llmSvc, config, &llmisvc.Config{})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var containers []corev1.Container
+			switch {
+			case got.Spec.Prefill != nil && got.Spec.Prefill.Template != nil:
+				containers = got.Spec.Prefill.Template.Containers
+			case got.Spec.Template != nil:
+				containers = got.Spec.Template.Containers
+			}
+			g.Expect(containers).ToNot(BeEmpty())
+
+			g.Expect(strings.Join(containers[0].Command, " ")).To(ContainSubstring(tt.wantArg))
 		})
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -18,7 +18,9 @@ package llmisvc_test
 
 import (
 	"encoding/json"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -2414,11 +2416,11 @@ printf '%s' "$2"`
 }
 
 // TestReplaceVariables_NixlTransferConfigBashSafe runs the P/D templates' actual
-// KV_TRANSFER_ARGS shape through bash. VLLM_VERSION is pinned to the string the llm-d
-// engine images really report ("0.1.dev1+g51f799c1a"), which can never satisfy the
-// 0.22.0 OffloadingConnector gate — so this also pins the behaviour that matters for
-// #5987: on those images the NixlConnector fallback is what reaches vLLM, and the JSON
-// survives the bash assignment intact.
+// KV_TRANSFER_ARGS shape through bash, with VLLM_VERSION pinned to the dev string llm-d
+// images report so the NixlConnector branch (not the 0.22.0 OffloadingConnector gate) is
+// under test. It covers both sides of the NIXL probe: unconditional injection kills
+// non-NIXL images ("RuntimeError: NIXL is not available"), so "no NIXL, no injection" is
+// asserted here rather than left to e2e.
 func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 	bashPath, err := exec.LookPath("bash")
 	if err != nil {
@@ -2426,7 +2428,7 @@ func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 	}
 
 	// Mirrors the decode/prefill templates: user-supplied config wins, then the
-	// version-gated OffloadingConnector, then the P/D NixlConnector fallback.
+	// version-gated OffloadingConnector, then the NIXL-gated P/D fallback.
 	// Kept as joined lines rather than one raw literal: golangci-lint's --fix rewrites a
 	// multi-line raw string here and drops a line in the process, leaving unbalanced if/fi.
 	scriptTmpl := strings.Join([]string{
@@ -2437,12 +2439,29 @@ func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 		`    KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"`,
 		`  fi`,
 		`  if [ -z "${KV_TRANSFER_ARGS}" ]; then`,
-		`    KV_TRANSFER_ARGS="{{ KV_HELPER }}"`,
+		`    NIXL_PY=$(command -v python3 || command -v python || true)`,
+		`    if [ -n "${NIXL_PY}" ] && "${NIXL_PY}" -c "import nixl" >/dev/null 2>&1; then`,
+		`      KV_TRANSFER_ARGS="{{ KV_HELPER }}"`,
+		`    fi`,
 		`  fi`,
 		`fi`,
 		`eval "set -- ${KV_TRANSFER_ARGS}"`,
 		`printf '%s' "$2"`,
 	}, "\n")
+
+	// Shim python3 on PATH so the probe can be driven both ways without NIXL installed.
+	stubPython := func(t *testing.T, importSucceeds bool) string {
+		t.Helper()
+		dir := t.TempDir()
+		body := "#!/bin/sh\nexit 1\n"
+		if importSucceeds {
+			body = "#!/bin/sh\nexit 0\n"
+		}
+		if err := os.WriteFile(filepath.Join(dir, "python3"), []byte(body), 0o755); err != nil { //nolint:gosec // G306: probe stub must be executable
+			t.Fatalf("writing python3 stub: %v", err)
+		}
+		return dir
+	}
 
 	for _, tc := range []struct {
 		name   string
@@ -2470,22 +2489,34 @@ func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
 			// No kvCacheOffloading: this is a plain P/D topology, the #5987 reproducer.
 			got, err := llmisvc.ReplaceVariables(&v1alpha2.LLMInferenceService{}, cfg, nil)
 			g.Expect(err).ToNot(HaveOccurred())
-
 			renderedScript := got.Spec.Template.Containers[0].Command[2]
-			out, err := exec.CommandContext(t.Context(), bashPath, "-c", renderedScript).CombinedOutput() // #nosec G204 -- test input, not user data
-			g.Expect(err).ToNot(HaveOccurred(), "bash execution failed: %s", string(out))
 
+			run := func(pathDir string, extraEnv ...string) string {
+				t.Helper()
+				cmd := exec.CommandContext(t.Context(), bashPath, "-c", renderedScript) // #nosec G204 -- test input, not user data
+				cmd.Env = append(cmd.Environ(), "PATH="+pathDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+				cmd.Env = append(cmd.Env, extraEnv...)
+				out, runErr := cmd.CombinedOutput()
+				g.Expect(runErr).ToNot(HaveOccurred(), "bash execution failed: %s", string(out))
+				// The template echoes its decision; the connector JSON is the final line.
+				lines := strings.Split(string(out), "\n")
+				return lines[len(lines)-1]
+			}
+
+			// NIXL present: the connector is injected and the JSON survives bash intact.
 			var parsed map[string]any
-			g.Expect(json.Unmarshal(out, &parsed)).To(Succeed(), "vllm would reject: %q", string(out))
+			jsonArg := run(stubPython(t, true))
+			g.Expect(json.Unmarshal([]byte(jsonArg), &parsed)).To(Succeed(), "vllm would reject: %q", jsonArg)
 			g.Expect(parsed).To(HaveKeyWithValue("kv_connector", "NixlConnector"))
 			g.Expect(parsed).To(HaveKeyWithValue("kv_role", tc.role))
 
+			// NIXL absent: inject nothing. Injecting here is what breaks CPU engines.
+			g.Expect(run(stubPython(t, false))).To(BeEmpty(),
+				"a connector was injected on an image without NIXL")
+
 			// A user-supplied connector must still win over the injected default.
-			userOwned := exec.CommandContext(t.Context(), bashPath, "-c", renderedScript) // #nosec G204 -- test input, not user data
-			userOwned.Env = append(userOwned.Environ(), `VLLM_ADDITIONAL_ARGS=--kv-transfer-config '{"kv_connector":"MyConnector"}'`)
-			out, err = userOwned.CombinedOutput()
-			g.Expect(err).ToNot(HaveOccurred(), "bash execution failed: %s", string(out))
-			g.Expect(string(out)).To(BeEmpty(), "KServe overrode a user-supplied --kv-transfer-config")
+			g.Expect(run(stubPython(t, true), `VLLM_ADDITIONAL_ARGS=--kv-transfer-config '{"kv_connector":"MyConnector"}'`)).To(BeEmpty(),
+				"KServe overrode a user-supplied --kv-transfer-config")
 		})
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -2121,6 +2121,60 @@ func TestReplaceVariables(t *testing.T) {
 			},
 		},
 		{
+			name: "nixlTransferConfig renders the decode-side NixlConnector consumer role",
+			cfg: &v1alpha2.LLMInferenceServiceConfig{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Args: []string{`{{ nixlDecodeTransferConfig }}`}},
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha2.LLMInferenceService{},
+			want: &v1alpha2.LLMInferenceServiceConfig{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								// Same escaping contract as kvTransferConfig: quotes stay as \" so the
+								// value survives the KV_TRANSFER_ARGS="..." bash assignment.
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_consumer\"}'`}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nixlTransferConfig renders the prefill-side NixlConnector producer role",
+			cfg: &v1alpha2.LLMInferenceServiceConfig{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Args: []string{`{{ nixlPrefillTransferConfig }}`}},
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha2.LLMInferenceService{},
+			want: &v1alpha2.LLMInferenceServiceConfig{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_producer\"}'`}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "kvTransferConfig includes eviction policy when set",
 			cfg: &v1alpha2.LLMInferenceServiceConfig{
 				Spec: v1alpha2.LLMInferenceServiceSpec{
@@ -2357,6 +2411,79 @@ printf '%s' "$2"`
 		HaveKeyWithValue("spec_name", "TieringOffloadingSpec"),
 		HaveKeyWithValue("eviction_policy", "lru"),
 	))
+}
+
+// TestReplaceVariables_NixlTransferConfigBashSafe runs the P/D templates' actual
+// KV_TRANSFER_ARGS shape through bash. VLLM_VERSION is pinned to the string the llm-d
+// engine images really report ("0.1.dev1+g51f799c1a"), which can never satisfy the
+// 0.22.0 OffloadingConnector gate — so this also pins the behaviour that matters for
+// #5987: on those images the NixlConnector fallback is what reaches vLLM, and the JSON
+// survives the bash assignment intact.
+func TestReplaceVariables_NixlTransferConfigBashSafe(t *testing.T) {
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+
+	// Mirrors the decode/prefill templates: user-supplied config wins, then the
+	// version-gated OffloadingConnector, then the P/D NixlConnector fallback.
+	const scriptTmpl = `VLLM_VERSION="0.1.dev1+g51f799c1a"
+KV_TRANSFER_ARGS=""
+if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+  if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+    KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+  fi
+  if [ -z "${KV_TRANSFER_ARGS}" ]; then
+    KV_TRANSFER_ARGS="{{ KV_HELPER }}"
+  fi
+fi
+eval "set -- ${KV_TRANSFER_ARGS}"
+printf '%s' "$2"`
+
+	for _, tc := range []struct {
+		name   string
+		helper string
+		role   string
+	}{
+		{name: "decode consumes KV", helper: "nixlDecodeTransferConfig", role: "kv_consumer"},
+		{name: "prefill produces KV", helper: "nixlPrefillTransferConfig", role: "kv_producer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cfg := &v1alpha2.LLMInferenceServiceConfig{
+				Spec: v1alpha2.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha2.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Command: []string{"/bin/bash", "-c", strings.ReplaceAll(scriptTmpl, "KV_HELPER", tc.helper)}},
+							},
+						},
+					},
+				},
+			}
+
+			// No kvCacheOffloading: this is a plain P/D topology, the #5987 reproducer.
+			got, err := llmisvc.ReplaceVariables(&v1alpha2.LLMInferenceService{}, cfg, nil)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			renderedScript := got.Spec.Template.Containers[0].Command[2]
+			out, err := exec.CommandContext(t.Context(), bashPath, "-c", renderedScript).CombinedOutput() // #nosec G204 -- test input, not user data
+			g.Expect(err).ToNot(HaveOccurred(), "bash execution failed: %s", string(out))
+
+			var parsed map[string]any
+			g.Expect(json.Unmarshal(out, &parsed)).To(Succeed(), "vllm would reject: %q", string(out))
+			g.Expect(parsed).To(HaveKeyWithValue("kv_connector", "NixlConnector"))
+			g.Expect(parsed).To(HaveKeyWithValue("kv_role", tc.role))
+
+			// A user-supplied connector must still win over the injected default.
+			userOwned := exec.CommandContext(t.Context(), bashPath, "-c", renderedScript) // #nosec G204 -- test input, not user data
+			userOwned.Env = append(userOwned.Environ(), `VLLM_ADDITIONAL_ARGS=--kv-transfer-config '{"kv_connector":"MyConnector"}'`)
+			out, err = userOwned.CombinedOutput()
+			g.Expect(err).ToNot(HaveOccurred(), "bash execution failed: %s", string(out))
+			g.Expect(string(out)).To(BeEmpty(), "KServe overrode a user-supplied --kv-transfer-config")
+		})
+	}
 }
 
 func mustParseURL(s string) apis.URL {

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -396,6 +396,14 @@ func TestPresetFiles(t *testing.T) {
 											Value: "/models",
 										},
 										{
+											Name: "VLLM_NIXL_SIDE_CHANNEL_HOST",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "status.podIP",
+												},
+											},
+										},
+										{
 											Name:  "VLLM_RANDOMIZE_DP_DUMMY_INPUTS",
 											Value: "1",
 										},


### PR DESCRIPTION
**Draft — opening this to settle the direction question in #5987 before polishing.**

## The question first

option 1: the decode/prefill templates inject the connector themselves. That's what [#6027](https://github.com/kserve/kserve/pull/6027) implements.

option 2: document the requirement on spec.prefill and surface it loudly — a status condition or event when a P/D topology runs with no KV connector — instead of injecting anything.

This PR implements **option 1**, as a concrete proposal rather than a decision. If the position is that engine connector config is deliberately user-owned ,  roles and transports do vary across topologies (heterogeneous TP, RDMA vs TCP, custom connectors), then I'll rework it as option 2.

## What this PR does / why we need it

An `LLMInferenceService` with `spec.prefill` composes the full disaggregated topology — decode with the `llm-d-routing-sidecar`, a separate prefill Deployment, the EPP scheduler — but **neither engine is ever given a KV connector**. The sidecar's `--kv-connector=nixlv2` only orchestrates the handoff; the engines do the actual transfer. Without a connector they log

```
WARNING [core.py:367] Got kv_transfer_params, but no KVConnector found. Disabling KVTransfer for this request.
```

and decode recomputes the prompt KV that prefill just produced. Every request pays for prefill twice while the resource reports healthy and returns `200 OK`. A P/D deployment that quietly isn't P/D.

The only `--kv-transfer-config` the templates rendered was the **OffloadingConnector** for CPU/fs tiering, which is empty unless `kvCacheOffloading` is set — and is gated on vLLM `>= 0.22.0`, a gate that can never pass on llm-d images because they report a dev version string (`0.1.dev1+g51f799c1a`). So in practice the flag was always empty on the images these templates ship with.

### The change

Inject a per-side NixlConnector when nothing else claims the flag:

- `kv_producer` on prefill, `kv_consumer` on decode (`kv_both` is deprecated for NixlConnector)
- `VLLM_NIXL_SIDE_CHANNEL_HOST` from `status.podIP` — it otherwise defaults to `localhost`, which the peer engine cannot reach

Precedence is **user-supplied config > OffloadingConnector > NIXL**, so this only fills a flag that was previously left empty. Existing behaviour is unchanged and a user-supplied `--kv-transfer-config` (via `VLLM_ADDITIONAL_ARGS` or `$*`) still wins.

Scope is contained: these templates are composed exclusively when `spec.prefill` is set (`config_merge.go`), so non-P/D topologies cannot be affected.

I deliberately did **not** inject the RDMA pieces from the P/D sample (`UCX_TLS`, `KSERVE_INFER_ROCE`, `UCX_PROTO_INFO`). Those are cluster-specific; NIXL falls back to TCP without them. Injecting them would force a transport most clusters can't satisfy.

## Testing

- `TestReplaceVariables_NixlTransferConfigBashSafe` runs the templates' real `KV_TRANSFER_ARGS` shape through **actual bash**, with `VLLM_VERSION` pinned to the string llm-d images report, then parses what reaches `vllm serve` as JSON. It asserts both roles render correctly *and* that a user-supplied connector is not overridden. This mirrors the existing `TestReplaceVariables_KVTransferConfigBashSafe` and is what caught the template-parse issue above.
- Table cases for both new funcs in `TestReplaceVariables`.
- `TestPresetFiles` golden updated for the new env var.
- Full `./pkg/controller/v1alpha2/llmisvc/...` suite green locally (~370s, envtest 1.34.1). `gofmt`/`go vet` clean.
- Generated mirrors regenerated via `generate-chart-manifests` and `generate-quick-install-scripts`; diffs verified as scoped to this change.

addresses #5987.
