### PR TITLE
fix(autoscaler): skip KEDA ScaledObject for components without autoScaling

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -479,12 +479,32 @@ func validateInferenceServiceAutoscaler(isvc *InferenceService) error {
 	value, ok := annotations[constants.AutoscalerClass]
 	class := constants.AutoscalerClassType(value)
 	if ok {
-		for _, item := range constants.AutoscalerAllowedClassList {
-			if class == item {
-				return nil
+		if !slices.Contains(constants.AutoscalerAllowedClassList, class) {
+			return fmt.Errorf("[%s] is not a supported autoscaler class type", value)
+		}
+		// KEDA requires at least one component to declare an autoScaling spec;
+		// without one no ScaledObject can be created and the ISVC would silently
+		// deploy with no autoscaling.
+		if class == constants.AutoscalerClassKeda {
+			hasAutoScaling := false
+			for _, component := range []Component{
+				&isvc.Spec.Predictor,
+				isvc.Spec.Transformer,
+				isvc.Spec.Explainer,
+			} {
+				if !reflect.ValueOf(component).IsNil() {
+					ext := component.GetExtensions()
+					if ext != nil && ext.AutoScaling != nil {
+						hasAutoScaling = true
+						break
+					}
+				}
+			}
+			if !hasAutoScaling {
+				return fmt.Errorf("autoscalerClass %q requires at least one component "+
+					"(predictor, transformer, or explainer) to have an autoScaling spec", value)
 			}
 		}
-		return fmt.Errorf("[%s] is not a supported autoscaler class type", value)
 	}
 
 	return nil

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -571,6 +571,105 @@ func TestAutoscalerClassKEDA(t *testing.T) {
 			},
 			errMatcher: gomega.BeNil(),
 		},
+		"Reject KEDA without any autoScaling spec": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":  "RawDeployment",
+						"serving.kserve.io/autoscalerClass": "keda",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.MatchError(gomega.ContainSubstring("requires at least one component")),
+		},
+		"Reject KEDA with transformer but no autoScaling on any component": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":  "RawDeployment",
+						"serving.kserve.io/autoscalerClass": "keda",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+					Transformer: &TransformerSpec{
+						PodSpec: PodSpec{
+							Containers: []corev1.Container{
+								{Image: "some-transformer:latest"},
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.MatchError(gomega.ContainSubstring("requires at least one component")),
+		},
+		"Valid KEDA with autoScaling on transformer only": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":  "Standard",
+						"serving.kserve.io/autoscalerClass": "keda",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+					Transformer: &TransformerSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							AutoScaling: &AutoScalingSpec{
+								Metrics: []MetricsSpec{
+									{
+										Type: ResourceMetricSourceType,
+										Resource: &ResourceMetricSource{
+											Name: ResourceMetricCPU,
+											Target: MetricTarget{
+												Type:               UtilizationMetricType,
+												AverageUtilization: ptr.To(int32(80)),
+											},
+										},
+									},
+								},
+							},
+						},
+						PodSpec: PodSpec{
+							Containers: []corev1.Container{
+								{Image: "some-transformer:latest"},
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.BeNil(),
+		},
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler.go
@@ -89,6 +89,15 @@ func createAutoscaler(client client.Client,
 	configMap *corev1.ConfigMap,
 ) (Autoscaler, error) {
 	ac := getAutoscalerClass(componentMeta)
+	// When KEDA is selected at the ISVC level, only create a ScaledObject for
+	// components that explicitly declare an autoScaling spec. Unlike HPA, KEDA
+	// has no legacy fallback and would produce an invalid ScaledObject with
+	// empty triggers. Components without autoScaling get a NoOpAutoscaler,
+	// allowing predictor, transformer, and explainer to be configured
+	// independently.
+	if ac == constants.AutoscalerClassKeda && (componentExt == nil || componentExt.AutoScaling == nil) {
+		return &NoOpAutoscaler{}, nil
+	}
 	switch ac {
 	case constants.AutoscalerClassHPA, constants.AutoscalerClassExternal, constants.AutoscalerClassNone:
 		return hpa.NewHPAReconciler(client, scheme, componentMeta, componentExt)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler/autoscaler_reconciler_test.go
@@ -135,9 +135,9 @@ func TestCreateAutoscaler(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:        "Return KedaReconciler for keda annotation",
+			name:        "Return NoOpAutoscaler for keda annotation without autoScaling spec",
 			annotations: map[string]string{"serving.kserve.io/autoscalerClass": "keda"},
-			wantType:    "*keda.KedaReconciler",
+			wantType:    "*autoscaler.NoOpAutoscaler",
 			wantErr:     false,
 		},
 		{
@@ -227,9 +227,9 @@ func TestNewAutoscalerReconciler(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name:        "Return AutoscalerReconciler with KedaReconciler for keda annotation",
+			name:        "Return AutoscalerReconciler with NoOpAutoscaler for keda annotation without autoScaling spec",
 			annotations: map[string]string{"serving.kserve.io/autoscalerClass": "keda"},
-			wantType:    "*keda.KedaReconciler",
+			wantType:    "*autoscaler.NoOpAutoscaler",
 			wantErr:     false,
 		},
 		{
@@ -403,5 +403,118 @@ func TestNoneAutoscalerWithNilComponentExt(t *testing.T) {
 	expectedType := "*hpa.HPAReconciler"
 	if gotType != expectedType {
 		t.Errorf("Expected autoscaler type %s, got %s", expectedType, gotType)
+	}
+}
+
+// TestKedaIndependentComponentAutoscaling verifies that when the ISVC-level
+// autoscalerClass annotation is set to "keda", only components that explicitly
+// declare an autoScaling spec get a KedaReconciler. Components without one
+// get a NoOpAutoscaler, allowing predictor, transformer, and explainer to
+// scale independently.
+func TestKedaIndependentComponentAutoscaling(t *testing.T) {
+	namespace := "test"
+	serviceName := "my-model"
+	kedaAnnotations := map[string]string{"serving.kserve.io/autoscalerClass": "keda"}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "dummy-config", Namespace: "default"},
+		Data:       map[string]string{},
+	}
+	utilization := int32(50)
+	autoScalingSpec := &v1beta1.AutoScalingSpec{
+		Metrics: []v1beta1.MetricsSpec{
+			{
+				Type: v1beta1.ResourceMetricSourceType,
+				Resource: &v1beta1.ResourceMetricSource{
+					Name: v1beta1.ResourceMetricCPU,
+					Target: v1beta1.MetricTarget{
+						Type:               v1beta1.UtilizationMetricType,
+						AverageUtilization: &utilization,
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		componentExt *v1beta1.ComponentExtensionSpec
+		wantType     string
+	}{
+		{
+			name:         "component without autoScaling gets NoOpAutoscaler",
+			componentExt: &v1beta1.ComponentExtensionSpec{
+				// No AutoScaling field
+			},
+			wantType: "*autoscaler.NoOpAutoscaler",
+		},
+		{
+			name:         "component with nil componentExt gets NoOpAutoscaler",
+			componentExt: nil,
+			wantType:     "*autoscaler.NoOpAutoscaler",
+		},
+		{
+			name: "component with autoScaling spec gets KedaReconciler",
+			componentExt: &v1beta1.ComponentExtensionSpec{
+				AutoScaling: autoScalingSpec,
+			},
+			wantType: "*keda.KedaReconciler",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := metav1.ObjectMeta{
+				Name:        serviceName,
+				Namespace:   namespace,
+				Annotations: kedaAnnotations,
+			}
+
+			as, err := createAutoscaler(nil, nil, meta, tt.componentExt, configMap)
+			if err != nil {
+				t.Fatalf("createAutoscaler() unexpected error: %v", err)
+			}
+			gotType := fmt.Sprintf("%T", as)
+			if gotType != tt.wantType {
+				t.Errorf("Expected %s, got %s", tt.wantType, gotType)
+			}
+		})
+	}
+}
+
+// TestKedaNoOpAnnotationOverride verifies that when createAutoscaler returns a
+// NoOpAutoscaler for a KEDA component without autoScaling, callers can detect
+// it via type assertion and override the annotation to "none" so the deployment
+// reconciler lets the Deployment own its replica count.
+func TestKedaNoOpAnnotationOverride(t *testing.T) {
+	meta := metav1.ObjectMeta{
+		Name:      "my-model-predictor",
+		Namespace: "test",
+		Annotations: map[string]string{
+			constants.AutoscalerClass: string(constants.AutoscalerClassKeda),
+		},
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "dummy-config", Namespace: "default"},
+		Data:       map[string]string{},
+	}
+
+	as, err := createAutoscaler(nil, nil, meta, &v1beta1.ComponentExtensionSpec{}, configMap)
+	if err != nil {
+		t.Fatalf("createAutoscaler() unexpected error: %v", err)
+	}
+
+	// Verify NoOpAutoscaler is returned
+	_, isNoOp := as.(*NoOpAutoscaler)
+	if !isNoOp {
+		t.Fatalf("Expected NoOpAutoscaler, got %T", as)
+	}
+
+	// Simulate the annotation override that raw_kube_reconciler performs
+	if isNoOp && meta.Annotations[constants.AutoscalerClass] == string(constants.AutoscalerClassKeda) {
+		meta.Annotations[constants.AutoscalerClass] = string(constants.AutoscalerClassNone)
+	}
+
+	if got := meta.Annotations[constants.AutoscalerClass]; got != string(constants.AutoscalerClassNone) {
+		t.Errorf("Expected annotation to be overridden to %q, got %q", constants.AutoscalerClassNone, got)
 	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -104,6 +104,14 @@ func NewRawKubeReconciler(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	// When KEDA is selected but the component has no autoScaling spec, the
+	// autoscaler reconciler returns a NoOpAutoscaler (no ScaledObject). Override
+	// the annotation to "none" so the deployment reconciler lets the Deployment
+	// own its own replica count instead of deferring to a non-existent scaler.
+	if _, isNoOp := as.Autoscaler.(*autoscaler.NoOpAutoscaler); isNoOp &&
+		componentMeta.Annotations[constants.AutoscalerClass] == string(constants.AutoscalerClassKeda) {
+		componentMeta.Annotations[constants.AutoscalerClass] = string(constants.AutoscalerClassNone)
+	}
 	ingressConfig, err := v1beta1.NewIngressConfig(isvcConfigMap)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
skip KEDA ScaledObject for components without autoScaling spec

When autoscalerClass is set to "keda" at the ISVC level, only components that declare an autoScaling spec should get a ScaledObject. Components without one (e.g. a predictor alongside a KEDA-scaled transformer) now receive a NoOpAutoscaler and have their annotation overridden to "none" so the deployment reconciler correctly lets the Deployment own its replica count. Additionally, reject ISVCs at admission time when autoscalerClass is keda but no component declares an autoScaling spec, preventing silent misconfiguration where no autoscaling would be created.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:
The fix was validated by the unit tests and by m anually deploying a isvc and verify if both predictor and transformer when set to keda works independently

- [x] Unit tests


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
fix(autoscaler): skip KEDA ScaledObject for components without autoScaling spec
```
