### PR TITLE
test(e2e): skip opt-125m download for non-llmisvc suites

### DIFF
--- a/config/overlays/test/s3-local-backend/seaweedfs-init-job-from-cache.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-init-job-from-cache.yaml
@@ -13,7 +13,17 @@ spec:
         command:
         - sh
         - -c
-        - mkdir -p /shared/facebook/opt-125m && cp -r /model/. /shared/facebook/opt-125m/
+        - |
+          # opt-125m is only consumed by the llmisvc suite; skip the cache copy for
+          # pure-kserve suites. Gated by DOWNLOAD_OPT_125M (set in setup-kserve.sh).
+          if [ "${DOWNLOAD_OPT_125M}" = "true" ]; then
+            mkdir -p /shared/facebook/opt-125m && cp -r /model/. /shared/facebook/opt-125m/
+          else
+            echo "DOWNLOAD_OPT_125M != true; skipping opt-125m cache copy"
+          fi
+        env:
+        - name: DOWNLOAD_OPT_125M
+          value: "__DOWNLOAD_OPT_125M__"
         volumeMounts:
         - name: model-cache
           mountPath: /shared
@@ -28,8 +38,15 @@ spec:
           aws s3 mb s3://example-models || true
           curl -L https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib -o /tmp/sklearn-model.joblib
           aws s3 cp /tmp/sklearn-model.joblib s3://example-models/sklearn/model.joblib --no-verify-ssl
-          aws s3 sync /shared/facebook/opt-125m s3://example-models/facebook/opt-125m/ --no-verify-ssl
+          # opt-125m is only consumed by the llmisvc suite (see DOWNLOAD_OPT_125M).
+          if [ "${DOWNLOAD_OPT_125M}" = "true" ]; then
+            aws s3 sync /shared/facebook/opt-125m s3://example-models/facebook/opt-125m/ --no-verify-ssl
+          else
+            echo "DOWNLOAD_OPT_125M != true; skipping opt-125m upload"
+          fi
         env:
+        - name: DOWNLOAD_OPT_125M
+          value: "__DOWNLOAD_OPT_125M__"
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml
@@ -10,10 +10,22 @@ spec:
       - name: download-hf-model
         image: kserve/storage-initializer:latest
         imagePullPolicy: IfNotPresent
-        args:
-        - "hf://facebook/opt-125m"
-        - "/shared/facebook/opt-125m"
+        command:
+        - python3
+        - -c
+        - |
+          import os, sys
+          # opt-125m is only consumed by the llmisvc e2e tests; skip the (slow)
+          # HuggingFace download for pure-kserve suites. Gated by DOWNLOAD_OPT_125M,
+          # set from ENABLE_LLMISVC/ENABLE_KSERVE_WITH_LLMISVC in setup-kserve.sh.
+          if os.environ.get("DOWNLOAD_OPT_125M") != "true":
+              print("DOWNLOAD_OPT_125M != true; skipping opt-125m download")
+              sys.exit(0)
+          entrypoint = "/storage-initializer/scripts/initializer-entrypoint"
+          os.execv(entrypoint, [entrypoint, "hf://facebook/opt-125m", "/shared/facebook/opt-125m"])
         env:
+        - name: DOWNLOAD_OPT_125M
+          value: "__DOWNLOAD_OPT_125M__"
         - name: HF_HUB_DISABLE_PROGRESS_BARS
           value: "1"
         - name: HF_HUB_DISABLE_XET
@@ -38,8 +50,15 @@ spec:
           aws s3 mb s3://example-models || true
           curl -L https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib -o /tmp/sklearn-model.joblib
           aws s3 cp /tmp/sklearn-model.joblib s3://example-models/sklearn/model.joblib --no-verify-ssl
-          aws s3 sync /shared/facebook/opt-125m s3://example-models/facebook/opt-125m/ --no-verify-ssl
+          # opt-125m is only consumed by the llmisvc suite (see DOWNLOAD_OPT_125M).
+          if [ "${DOWNLOAD_OPT_125M}" = "true" ]; then
+            aws s3 sync /shared/facebook/opt-125m s3://example-models/facebook/opt-125m/ --no-verify-ssl
+          else
+            echo "DOWNLOAD_OPT_125M != true; skipping opt-125m upload"
+          fi
         env:
+        - name: DOWNLOAD_OPT_125M
+          value: "__DOWNLOAD_OPT_125M__"
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/test/scripts/gh-actions/setup-kserve.sh
+++ b/test/scripts/gh-actions/setup-kserve.sh
@@ -32,6 +32,16 @@ export ENABLE_LLMISVC="${ENABLE_LLMISVC:-false}"
 export ENABLE_KSERVE_WITH_LLMISVC="${ENABLE_KSERVE_WITH_LLMISVC:-false}"
 export INSTALL_METHOD="${INSTALL_METHOD:-kustomize}"
 
+# facebook/opt-125m is only consumed by the llmisvc e2e suite. Skip its (slow)
+# HuggingFace download / cache copy / S3 upload for pure-kserve runs; the s3-init
+# job still creates buckets and uploads the sklearn model, which all suites need.
+if [[ $ENABLE_LLMISVC == "true" || $ENABLE_KSERVE_WITH_LLMISVC == "true" ]]; then
+  export DOWNLOAD_OPT_125M=true
+else
+  export DOWNLOAD_OPT_125M=false
+fi
+echo "DOWNLOAD_OPT_125M=${DOWNLOAD_OPT_125M}"
+
 # Extract gateway class name from NETWORK_LAYER (e.g., "envoy-gatewayapi" -> "envoy")
 # If NETWORK_LAYER contains "-", extract the first part; otherwise, use "false"
 if [[ $NETWORK_LAYER == *"-gatewayapi"* ]]; then
@@ -104,10 +114,12 @@ if [[ $ENABLE_LLMISVC == "false" || $ENABLE_KSERVE_WITH_LLMISVC == "true" ]]; th
   echo "Add testing models to s3 storage ..."
   if [[ -n "${OPT_125M_CACHE_IMAGE:-}" ]]; then
     OPT_125M_CACHE_IMAGE="${OPT_125M_CACHE_IMAGE}" envsubst '${OPT_125M_CACHE_IMAGE}' \
-      < config/overlays/test/s3-local-backend/seaweedfs-init-job-from-cache.yaml | kubectl apply -n kserve -f -
+      < config/overlays/test/s3-local-backend/seaweedfs-init-job-from-cache.yaml \
+      | sed "s/__DOWNLOAD_OPT_125M__/${DOWNLOAD_OPT_125M}/" | kubectl apply -n kserve -f -
   else
     sed "s|kserve/storage-initializer:latest|${KO_DOCKER_REPO:-kserve}/${STORAGE_INIT_IMG:-storage-initializer}:${TAG:-latest}|g" \
-      config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml | kubectl apply -n kserve -f -
+      config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml \
+      | sed "s/__DOWNLOAD_OPT_125M__/${DOWNLOAD_OPT_125M}/" | kubectl apply -n kserve -f -
   fi
   if ! kubectl wait --for=condition=complete --timeout=900s job/s3-init -n kserve; then
     echo "S3 init job failed. Pod status and logs:"
@@ -163,10 +175,12 @@ else
   echo "Pre-caching opt-125m model in SeaweedFS ..."
   if [[ -n "${OPT_125M_CACHE_IMAGE:-}" ]]; then
     OPT_125M_CACHE_IMAGE="${OPT_125M_CACHE_IMAGE}" envsubst '${OPT_125M_CACHE_IMAGE}' \
-      < "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-init-job-from-cache.yaml" | kubectl apply -n kserve -f -
+      < "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-init-job-from-cache.yaml" \
+      | sed "s/__DOWNLOAD_OPT_125M__/${DOWNLOAD_OPT_125M}/" | kubectl apply -n kserve -f -
   else
     sed "s|kserve/storage-initializer:latest|${KO_DOCKER_REPO:-kserve}/${STORAGE_INIT_IMG:-storage-initializer}:${TAG:-latest}|g" \
-      "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml" | kubectl apply -n kserve -f -
+      "${REPO_ROOT}/config/overlays/test/s3-local-backend/seaweedfs-init-job.yaml" \
+      | sed "s/__DOWNLOAD_OPT_125M__/${DOWNLOAD_OPT_125M}/" | kubectl apply -n kserve -f -
   fi
   if ! kubectl wait --for=condition=complete --timeout=900s job/s3-init -n kserve; then
     echo "S3 init job failed. Pod status and logs:"


### PR DESCRIPTION
**What this PR does / why we need it**:

The `facebook/opt-125m` model is only consumed by the llmisvc e2e suite, but the
`s3-init` job downloaded it from HuggingFace (or copied it from the cache image)
and uploaded it to the local S3 backend on every e2e run. That download is the
slowest part of e2e setup and is pure overhead for the pure-kserve suites, which
only need the created buckets and the sklearn model.

This gates the opt-125m download, cache copy, and S3 upload behind a new
`DOWNLOAD_OPT_125M` flag, derived in `setup-kserve.sh` from `ENABLE_LLMISVC` /
`ENABLE_KSERVE_WITH_LLMISVC`. Bucket creation and the sklearn upload still run
unconditionally for all S3-using suites, so predictor/raw/graph behavior is
unchanged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] Rendered both `seaweedfs-init-job.yaml` and `seaweedfs-init-job-from-cache.yaml` with `DOWNLOAD_OPT_125M` = true and false; both parse as valid YAML with no leftover placeholder.
- [x] `bash -n` clean on `setup-kserve.sh`.
- [ ] Full e2e run in CI.

**Special notes for your reviewer**:

The non-cache init container previously passed `args` to the storage-initializer entrypoint; it now runs a small `python3 -c` wrapper that `os.execv`s the same entrypoint only when the flag is set (the entrypoint is python3-based, so no new dependency). The flag is injected via `sed` at apply time, matching the existing image-substitution pattern.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
