### PR TITLE
fix(llmisvc): drop vLLM flag removed upstream from gpt-oss samples

### DIFF
--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_default.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_default.yaml
@@ -16,7 +16,6 @@ spec:
             --served-model-name "{{ .Spec.Model.Name }}"
             --port 8000
             --disable-access-log-for-endpoints /health,/metrics,/ping
-            --disable-log-requests
             $VLLM_ADDITIONAL_ARGS
         # Override security context
         securityContext:

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
@@ -15,7 +15,6 @@ spec:
             --served-model-name "{{ .Spec.Model.Name }}"
             --port 8000
             --disable-access-log-for-endpoints /health,/metrics,/ping
-            --disable-log-requests
             --prefix-caching-hash-algo sha256_cbor
             --block-size 64
             --kv-events-config "$KV_EVENTS_CONFIG"


### PR DESCRIPTION
**What this PR does / why we need it**:

The e2e-gpt-oss samples pass a vLLM flag that no longer exists in the release their images ship. vLLM dropped `--disable-log-requests` in favour of an opt-in `--enable-log-requests`, and argparse rejects unknown arguments outright - so `vllm serve` exits immediately and the container never comes up.

Anyone copying these samples hits a container that will not start. It went unnoticed because the samples need a GPU and no CI job exercises them.

The replacement flag defaults to off, which is exactly the behaviour the samples were asking for, so dropping the argument restores them without changing what they do. Swapping to the new flag name would have turned request logging on instead.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] Traced the vLLM version the sample images ship, via their OCI labels
      through to the pinned upstream commit, and confirmed the flag is absent
      there while its replacement is present.
- [x] Confirmed the frozen `install/` release snapshots that still reference the
      old flag are untouched - they pin older images where it remains valid.
- [x] `make precommit`

**Special notes for your reviewer**:

Behaviour is unchanged: request logging stays off, because that is now the
default rather than something to ask for.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
NONE
```
