### PR TITLE
fix: inject MODEL_NAME env var for all predictors

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -340,6 +340,7 @@ const (
 	ModelInitModeEnvVarKey                            = "MODEL_INIT_MODE"
 	QueueProxyAggregatePrometheusMetricsPortEnvVarKey = "AGGREGATE_PROMETHEUS_METRICS_PORT"
 	InferenceServiceNameEnvVarKey                     = "INFERENCE_SERVICE_NAME"
+	ModelNameEnvVarKey                                = "MODEL_NAME"
 )
 
 type InferenceServiceComponent string
@@ -485,10 +486,10 @@ const (
 const (
 	ArgumentModelName      = "--model_name"
 	ArgumentModelDir       = "--model_dir"
-	ArgumentModelClassName = "--model_class_name"
-	ArgumentPredictorHost  = "--predictor_host"
-	ArgumentHttpPort       = "--http_port"
-	ArgumentWorkers        = "--workers"
+	ArgumentModelClassName  = "--model_class_name"
+	ArgumentPredictorHost   = "--predictor_host"
+	ArgumentHttpPort        = "--http_port"
+	ArgumentWorkers         = "--workers"
 )
 
 // InferenceService container names

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -156,6 +156,14 @@ func (p *Predictor) buildPredictorResources(ctx context.Context, isvc *v1beta1.I
 		}
 	}
 
+	// Inject MODEL_NAME so runtimes can discover the expected model name from the environment.
+	for i := range podSpec.Containers {
+		containerName := podSpec.Containers[i].Name
+		if err := isvcutils.AddEnvVarToPodSpec(&podSpec, containerName, constants.ModelNameEnvVarKey, isvc.Name); err != nil {
+			return nil, errors.Wrapf(err, "failed to add MODEL_NAME environment variable to container %s", containerName)
+		}
+	}
+
 	predictorName := constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name)
 
 	// Labels and annotations from predictor component
@@ -639,9 +647,8 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RequestGPUCountEnvName, constants.InferenceServiceContainerName)
 	}
 
-	// Set the environment variable for "isvc name" to the MODEL_NAME when multiNodeEnabled is true.
-	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, "MODEL_NAME", isvc.Name); err != nil {
-		return nil, errors.Wrapf(err, "failed to add MODEL_NAME environment to the container(%s)", constants.InferenceServiceContainerName)
+	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.ModelNameEnvVarKey, isvc.Name); err != nil {
+		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.ModelNameEnvVarKey, constants.InferenceServiceContainerName)
 	}
 
 	deploymentAnnotations := annotations[constants.StorageInitializerSourceUriInternalAnnotationKey]


### PR DESCRIPTION
## Summary

Inject `MODEL_NAME=<isvc.Name>` into all predictor containers so runtimes can discover the expected model name from the environment.

## Problem

Runtimes whose ServingRuntime templates do not include `--model_name` or `--served-model-name` (e.g. NIM) have no way to discover the user-specified model name. This causes `/v1/models` to return the runtime's internal default instead of the InferenceService name, so API calls using the dashboard-visible name fail with 404.

## Changes

| File | Change |
|------|--------|
| `pkg/constants/constants.go` | Add `ModelNameEnvVarKey` constant |
| `pkg/controller/v1beta1/inferenceservice/components/predictor.go` | Inject `MODEL_NAME` for all predictor containers; use constant in multi-node path |

## Test plan

- [x] Component tests — 16/16 pass
- [x] `make precommit` passes
- [ ] Deploy with a NIM runtime and verify `/v1/models` returns the ISVC name

🤖 Generated with [Claude Code](https://claude.com/claude-code)