### PR TITLE
feat(transformer): allow ssl configuration on transformer

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -483,12 +483,22 @@ const (
 
 // InferenceService model server args
 const (
-	ArgumentModelName      = "--model_name"
-	ArgumentModelDir       = "--model_dir"
-	ArgumentModelClassName = "--model_class_name"
-	ArgumentPredictorHost  = "--predictor_host"
-	ArgumentHttpPort       = "--http_port"
-	ArgumentWorkers        = "--workers"
+	ArgumentModelName       = "--model_name"
+	ArgumentModelDir        = "--model_dir"
+	ArgumentModelClassName  = "--model_class_name"
+	ArgumentPredictorHost   = "--predictor_host"
+	ArgumentPredictorUseSSL = "--predictor_use_ssl"
+	ArgumentHttpPort        = "--http_port"
+	ArgumentWorkers         = "--workers"
+)
+
+// Transformer-to-predictor TLS env var keys
+const (
+	PredictorHostEnvVar     = "PREDICTOR_HOST"
+	PredictorPortEnvVar     = "PREDICTOR_PORT"
+	PredictorProtocolEnvVar = "PREDICTOR_PROTOCOL"
+	TransformerTLSCertEnvVar = "KSERVE_TLS_CERT_FILE"
+	TransformerTLSKeyEnvVar  = "KSERVE_TLS_KEY_FILE"
 )
 
 // InferenceService container names

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -494,9 +494,9 @@ const (
 
 // Transformer-to-predictor TLS env var keys
 const (
-	PredictorHostEnvVar     = "PREDICTOR_HOST"
-	PredictorPortEnvVar     = "PREDICTOR_PORT"
-	PredictorProtocolEnvVar = "PREDICTOR_PROTOCOL"
+	PredictorHostEnvVar      = "PREDICTOR_HOST"
+	PredictorPortEnvVar      = "PREDICTOR_PORT"
+	PredictorProtocolEnvVar  = "PREDICTOR_PROTOCOL"
 	TransformerTLSCertEnvVar = "KSERVE_TLS_CERT_FILE"
 	TransformerTLSKeyEnvVar  = "KSERVE_TLS_KEY_FILE"
 )

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -304,38 +304,63 @@ func setDefaultPodSpec(podSpec *corev1.PodSpec) {
 		// generate default readiness probe for model server container and for transformer container in case of collocation
 		if container.Name == constants.InferenceServiceContainerName || container.Name == constants.TransformerContainerName {
 			if container.ReadinessProbe == nil {
-				if len(container.Ports) == 0 {
-					container.ReadinessProbe = &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							TCPSocket: &corev1.TCPSocketAction{
-								Port: intstr.IntOrString{
-									IntVal: 8080,
-								},
+				probePort := int32(8080)
+				if len(container.Ports) > 0 {
+					probePort = container.Ports[0].ContainerPort
+				}
+				// If --http_port is set in args, use that port for the probe so the
+				// readiness check targets the port the server actually listens on.
+				if argPort, ok := getArgValue(container.Args, constants.ArgumentHttpPort); ok {
+					if parsed, err := strconv.ParseInt(argPort, 10, 32); err == nil {
+						probePort = int32(parsed)
+					}
+				}
+				container.ReadinessProbe = &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						TCPSocket: &corev1.TCPSocketAction{
+							Port: intstr.IntOrString{
+								IntVal: probePort,
 							},
 						},
-						TimeoutSeconds:   1,
-						PeriodSeconds:    10,
-						SuccessThreshold: 1,
-						FailureThreshold: 3,
-					}
-				} else {
-					container.ReadinessProbe = &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							TCPSocket: &corev1.TCPSocketAction{
-								Port: intstr.IntOrString{
-									IntVal: container.Ports[0].ContainerPort,
-								},
-							},
-						},
-						TimeoutSeconds:   1,
-						PeriodSeconds:    10,
-						SuccessThreshold: 1,
-						FailureThreshold: 3,
-					}
+					},
+					TimeoutSeconds:   1,
+					PeriodSeconds:    10,
+					SuccessThreshold: 1,
+					FailureThreshold: 3,
 				}
 			}
 		}
 	}
+}
+
+// getArgValue extracts the value for a CLI flag from an args slice.
+// It handles both "--flag value" (two elements) and "--flag=value" (single element) forms.
+func getArgValue(args []string, flag string) (string, bool) {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1], true
+		}
+		if strings.HasPrefix(arg, flag+"=") {
+			return strings.TrimPrefix(arg, flag+"="), true
+		}
+	}
+	return "", false
+}
+
+// setArgValue replaces the value of an existing "--flag value" pair in an args
+// slice, or appends it if absent. It handles both two-element and "=" forms.
+func setArgValue(args []string, flag, value string) []string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			args[i+1] = value
+			return args
+		}
+		if strings.HasPrefix(arg, flag+"=") {
+			args[i] = flag + "=" + value
+			return args
+		}
+	}
+	return append(args, flag, value)
 }
 
 func setDefaultDeploymentSpec(spec *appsv1.DeploymentSpec) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -1673,11 +1673,11 @@ func TestSetControllerReferences(t *testing.T) {
 
 func TestGetArgValue(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     []string
-		flag     string
-		wantVal  string
-		wantOk   bool
+		name    string
+		args    []string
+		flag    string
+		wantVal string
+		wantOk  bool
 	}{
 		{
 			name:    "two-element form",

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -1670,3 +1670,154 @@ func TestSetControllerReferences(t *testing.T) {
 	assert.Len(t, deployment2.GetOwnerReferences(), 1)
 	assert.Equal(t, owner.Name, deployment2.GetOwnerReferences()[0].Name)
 }
+
+func TestGetArgValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flag     string
+		wantVal  string
+		wantOk   bool
+	}{
+		{
+			name:    "two-element form",
+			args:    []string{"--model_name", "foo", "--http_port", "9090"},
+			flag:    "--http_port",
+			wantVal: "9090",
+			wantOk:  true,
+		},
+		{
+			name:    "equals form",
+			args:    []string{"--model_name=foo", "--http_port=9090"},
+			flag:    "--http_port",
+			wantVal: "9090",
+			wantOk:  true,
+		},
+		{
+			name:   "flag not present",
+			args:   []string{"--model_name", "foo"},
+			flag:   "--http_port",
+			wantOk: false,
+		},
+		{
+			name:   "flag at end without value",
+			args:   []string{"--http_port"},
+			flag:   "--http_port",
+			wantOk: false,
+		},
+		{
+			name:   "empty args",
+			args:   nil,
+			flag:   "--http_port",
+			wantOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, ok := getArgValue(tt.args, tt.flag)
+			assert.Equal(t, tt.wantOk, ok)
+			if ok {
+				assert.Equal(t, tt.wantVal, val)
+			}
+		})
+	}
+}
+
+func TestSetArgValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flag     string
+		value    string
+		expected []string
+	}{
+		{
+			name:     "replace two-element form",
+			args:     []string{"--http_port", "8080"},
+			flag:     "--http_port",
+			value:    "8443",
+			expected: []string{"--http_port", "8443"},
+		},
+		{
+			name:     "replace equals form",
+			args:     []string{"--http_port=8080"},
+			flag:     "--http_port",
+			value:    "8443",
+			expected: []string{"--http_port=8443"},
+		},
+		{
+			name:     "append when absent",
+			args:     []string{"--model_name", "foo"},
+			flag:     "--http_port",
+			value:    "8443",
+			expected: []string{"--model_name", "foo", "--http_port", "8443"},
+		},
+		{
+			name:     "append to nil",
+			args:     nil,
+			flag:     "--http_port",
+			value:    "8443",
+			expected: []string{"--http_port", "8443"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := setArgValue(tt.args, tt.flag, tt.value)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSetDefaultPodSpec_ReadinessProbeRespectsHttpPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		ports        []corev1.ContainerPort
+		expectedPort int32
+	}{
+		{
+			name:         "no ports no args defaults to 8080",
+			expectedPort: 8080,
+		},
+		{
+			name:         "port defined takes precedence over default",
+			ports:        []corev1.ContainerPort{{ContainerPort: 9090}},
+			expectedPort: 9090,
+		},
+		{
+			name:         "--http_port arg overrides default",
+			args:         []string{"--http_port", "8443"},
+			expectedPort: 8443,
+		},
+		{
+			name:         "--http_port= arg overrides default",
+			args:         []string{"--http_port=7070"},
+			expectedPort: 7070,
+		},
+		{
+			name:         "--http_port overrides container port",
+			ports:        []corev1.ContainerPort{{ContainerPort: 9090}},
+			args:         []string{"--http_port", "8443"},
+			expectedPort: 8443,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podSpec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "kserve-container",
+						Image: "test:latest",
+						Args:  tt.args,
+						Ports: tt.ports,
+					},
+				},
+			}
+			setDefaultPodSpec(podSpec)
+			probe := podSpec.Containers[0].ReadinessProbe
+			require.NotNil(t, probe)
+			require.NotNil(t, probe.TCPSocket)
+			assert.Equal(t, tt.expectedPort, probe.TCPSocket.Port.IntVal)
+		})
+	}
+}

--- a/python/kserve/kserve/constants/constants.py
+++ b/python/kserve/kserve/constants/constants.py
@@ -102,7 +102,12 @@ V2_ROUTE_PREFIX = "/v2"
 V1_ROUTE_PREFIX = "/v1"
 
 DEFAULT_HTTP_PORT = 8080
+DEFAULT_HTTPS_PORT = 8443
 DEFAULT_GRPC_PORT = 8081
+
+# Server-side TLS environment variables
+KSERVE_TLS_CERT_FILE_ENV = "KSERVE_TLS_CERT_FILE"
+KSERVE_TLS_KEY_FILE_ENV = "KSERVE_TLS_KEY_FILE"
 
 # Header containing the json length in case of REST raw response.
 INFERENCE_CONTENT_LENGTH_HEADER = "inference-header-content-length"

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -15,6 +15,7 @@
 import argparse
 import asyncio
 import concurrent.futures
+import os
 import signal
 import sys
 from importlib import metadata
@@ -27,7 +28,10 @@ from . import logging
 from . import context as kserve_context
 from .constants.constants import (
     DEFAULT_HTTP_PORT,
+    DEFAULT_HTTPS_PORT,
     DEFAULT_GRPC_PORT,
+    KSERVE_TLS_CERT_FILE_ENV,
+    KSERVE_TLS_KEY_FILE_ENV,
     MAX_GRPC_MESSAGE_LENGTH,
     FASTAPI_APP_IMPORT_STRING,
 )
@@ -205,6 +209,20 @@ parser.add_argument(
     help="The Transformer will perform readiness check for the predictor in addition to "
     "its health check. By default it is disabled.",
 )
+parser.add_argument(
+    "--ssl_certfile",
+    default=os.environ.get(KSERVE_TLS_CERT_FILE_ENV),
+    type=str,
+    help="The path to the SSL certificate file for serving HTTPS. "
+    f"Falls back to {KSERVE_TLS_CERT_FILE_ENV} env var if not set.",
+)
+parser.add_argument(
+    "--ssl_keyfile",
+    default=os.environ.get(KSERVE_TLS_KEY_FILE_ENV),
+    type=str,
+    help="The path to the SSL private key file for serving HTTPS. "
+    f"Falls back to {KSERVE_TLS_KEY_FILE_ENV} env var if not set.",
+)
 args, _ = parser.parse_known_args()
 
 app = FastAPI(
@@ -233,6 +251,8 @@ class ModelServer:
         timeout_keep_alive: int = args.timeout_keep_alive,
         grace_period: int = 30,
         predictor_config: Optional[PredictorConfig] = None,
+        ssl_certfile: Optional[str] = args.ssl_certfile,
+        ssl_keyfile: Optional[str] = args.ssl_keyfile,
     ):
         """KServe ModelServer Constructor
 
@@ -256,10 +276,20 @@ class ModelServer:
             timeout_keep_alive: Timeout for keep-alive connections in seconds. Default: ``65``.
             grace_period: The grace period in seconds to wait for the server to stop. Default: ``30``.
             predictor_config: Optional configuration for the predictor. Default: ``None``.
+            ssl_certfile: Path to the SSL certificate file for serving HTTPS. Default: ``None``.
+                          Falls back to KSERVE_TLS_CERT_FILE env var.
+            ssl_keyfile: Path to the SSL private key file for serving HTTPS. Default: ``None``.
+                         Falls back to KSERVE_TLS_KEY_FILE env var.
         """
         self.registered_models = (
             ModelRepository() if registered_models is None else registered_models
         )
+        self.ssl_certfile = ssl_certfile
+        self.ssl_keyfile = ssl_keyfile
+        # When SSL is enabled and the port was not explicitly overridden, switch to the HTTPS port.
+        if self.ssl_certfile and self.ssl_keyfile and http_port == DEFAULT_HTTP_PORT:
+            http_port = DEFAULT_HTTPS_PORT
+            logger.info("SSL enabled, switching listen port to %d", http_port)
         self.http_port = http_port
         self.grpc_port = grpc_port
         self.workers = workers
@@ -361,6 +391,8 @@ class ModelServer:
                 grace_period=self.grace_period,
                 event_loop=self.event_loop,
                 timeout_keep_alive=self.timeout_keep_alive,
+                ssl_certfile=self.ssl_certfile,
+                ssl_keyfile=self.ssl_keyfile,
             )
             self.servers.append(self._rest_server.start())
         if self.enable_grpc:

--- a/python/kserve/kserve/protocol/rest/server.py
+++ b/python/kserve/kserve/protocol/rest/server.py
@@ -78,6 +78,8 @@ class RESTServer:
         grace_period: int = 30,
         event_loop: str = "auto",
         timeout_keep_alive: int = 65,
+        ssl_certfile: Optional[str] = None,
+        ssl_keyfile: Optional[str] = None,
     ):
         self.dataplane = data_plane
         self.model_repository_extension = model_repository_extension
@@ -100,6 +102,8 @@ class RESTServer:
             timeout_graceful_shutdown=grace_period,
             timeout_keep_alive=timeout_keep_alive,
             loop=event_loop,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile,
         )
         self._server = uvicorn.Server(self.config)
 

--- a/python/kserve/test/test_model_server.py
+++ b/python/kserve/test/test_model_server.py
@@ -25,3 +25,32 @@ def test_model_server_start_no_models():
         server.start(models=None)
 
     assert exc.value.args[0] == UNKNOWN_MODEL_TYPE_ERR_MESSAGE
+
+
+def test_model_server_ssl_switches_to_https_port():
+    server = ModelServer(
+        ssl_certfile="/etc/tls/private/tls.crt",
+        ssl_keyfile="/etc/tls/private/tls.key",
+    )
+    assert server.http_port == 8443
+
+
+def test_model_server_ssl_keeps_explicit_port():
+    server = ModelServer(
+        http_port=9000,
+        ssl_certfile="/etc/tls/private/tls.crt",
+        ssl_keyfile="/etc/tls/private/tls.key",
+    )
+    assert server.http_port == 9000
+
+
+def test_model_server_no_ssl_keeps_default_port():
+    server = ModelServer()
+    assert server.http_port == 8080
+
+
+def test_model_server_partial_ssl_keeps_default_port():
+    server = ModelServer(
+        ssl_certfile="/etc/tls/private/tls.crt",
+    )
+    assert server.http_port == 8080


### PR DESCRIPTION
chore:  Allow setting ssl keyfile and certfile to serve the transformer pod
        with SSL enabled, when the envs are present, the port is automatically
        switched to 8443. The envs KSERVE_TLS_CERT_FILE and KSERVE_TLS_KEY_FILE
        will be read to configure ssl.

**What this PR does / why we need it**:
By allowing user to configure the certs in the transformers, it will enable end-to-end ssl 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:
- [x] Unit tests to verify port configuration in different scenarios.


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
feat(transformer): allow ssl configuration on transformer
```
