### PR TITLE
fix(llmisvc): detect removals when reconciling generated routing rules

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -2231,8 +2231,7 @@ func publisherModel(namespace, model string) string {
 	return fmt.Sprintf("publishers/%s/models/%s", namespace, model)
 }
 
-// modelRoutingHeaderValues collects every value the model-routing header is matched
-// against, across all rules and matches of the route.
+// modelRoutingHeaderValues returns all values matched by the named header.
 func modelRoutingHeaderValues(route *gwapiv1.HTTPRoute, headerName string) []string {
 	var values []string
 	for _, rule := range route.Spec.Rules {
@@ -2248,9 +2247,8 @@ func modelRoutingHeaderValues(route *gwapiv1.HTTPRoute, headerName string) []str
 	return values
 }
 
-// expectRouteConverged asserts the managed HTTPRoute settles instead of being
-// rewritten on every reconcile. Generation only advances on spec writes, so a
-// moving generation means the controller is fighting itself.
+// expectRouteConverged verifies that reconciliation stops updating the route spec.
+// The generation changes only when the spec changes.
 func expectRouteConverged(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) {
 	routes, err := managedRoutes(ctx, llmSvc)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -1257,6 +1257,62 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				Expect(expectedHTTPRoute).To(HaveHeaderMatch(headerName, adapterAHeaderValue))
 				Expect(expectedHTTPRoute).To(HaveHeaderMatch(headerName, adapterBHeaderValue))
 			})
+
+			It("should prune HTTPRoute adapter matches when all LoRA adapters are removed", func(ctx SpecContext) {
+				// given
+				svcName := "test-llm-lora-removal"
+				testNs := NewTestNamespace(ctx, envTest)
+
+				llmSvc := LLMInferenceService(svcName,
+					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+					WithModelURI("hf://facebook/opt-125m"),
+					WithModelName("base-model"),
+					WithLoRAAdapters("lora-adapter-a", "lora-adapter-b"),
+					WithManagedRoute(),
+					WithManagedGateway(),
+					WithManagedScheduler(),
+				)
+
+				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+				defer func() {
+					testNs.DeleteAndWait(ctx, llmSvc)
+				}()
+
+				headerName := "X-Gateway-Model-Name"
+				baseHeaderValue := publisherModel(testNs.Name, "base-model")
+
+				Eventually(func(g Gomega, ctx context.Context) error {
+					routes, errList := managedRoutes(ctx, llmSvc)
+					g.Expect(errList).ToNot(HaveOccurred())
+					g.Expect(routes).To(HaveLen(1))
+					g.Expect(&routes[0]).To(HaveHeaderMatch(headerName, publisherModel(testNs.Name, "lora-adapter-a")))
+					g.Expect(&routes[0]).To(HaveHeaderMatch(headerName, publisherModel(testNs.Name, "lora-adapter-b")))
+
+					return nil
+				}).WithContext(ctx).Should(Succeed(), "adapter matches should be expanded before removal")
+
+				// when - every adapter is removed
+				errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+						llmSvc.Spec.Model.LoRA = nil
+						return nil
+					})
+					return errUpdate
+				})
+				Expect(errRetry).ToNot(HaveOccurred())
+
+				// then - the route matches on the base model and nothing else
+				Eventually(func(g Gomega, ctx context.Context) error {
+					routes, errList := managedRoutes(ctx, llmSvc)
+					g.Expect(errList).ToNot(HaveOccurred())
+					g.Expect(routes).To(HaveLen(1))
+					g.Expect(modelRoutingHeaderValues(&routes[0], headerName)).To(HaveEach(baseHeaderValue))
+
+					return nil
+				}).WithContext(ctx).Should(Succeed(), "adapter matches should be pruned once the adapters are gone")
+
+				expectRouteConverged(ctx, llmSvc)
+			})
 		})
 
 		When("transitioning from managed to unmanaged router", func() {
@@ -2169,6 +2225,47 @@ func managedRoutes(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) ([
 	}
 	err := envTest.List(ctx, httpRoutes, listOpts)
 	return httpRoutes.Items, ignoreNoMatch(err)
+}
+
+func publisherModel(namespace, model string) string {
+	return fmt.Sprintf("publishers/%s/models/%s", namespace, model)
+}
+
+// modelRoutingHeaderValues collects every value the model-routing header is matched
+// against, across all rules and matches of the route.
+func modelRoutingHeaderValues(route *gwapiv1.HTTPRoute, headerName string) []string {
+	var values []string
+	for _, rule := range route.Spec.Rules {
+		for _, match := range rule.Matches {
+			for _, h := range match.Headers {
+				if string(h.Name) == headerName {
+					values = append(values, h.Value)
+				}
+			}
+		}
+	}
+
+	return values
+}
+
+// expectRouteConverged asserts the managed HTTPRoute settles instead of being
+// rewritten on every reconcile. Generation only advances on spec writes, so a
+// moving generation means the controller is fighting itself.
+func expectRouteConverged(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) {
+	routes, err := managedRoutes(ctx, llmSvc)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(routes).To(HaveLen(1))
+	generation := routes[0].Generation
+
+	Consistently(func(g Gomega, ctx context.Context) error {
+		current, errList := managedRoutes(ctx, llmSvc)
+		g.Expect(errList).ToNot(HaveOccurred())
+		g.Expect(current).To(HaveLen(1))
+		g.Expect(current[0].Generation).To(Equal(generation))
+
+		return nil
+	}).WithContext(ctx).WithTimeout(2*time.Second).WithPolling(250*time.Millisecond).
+		Should(Succeed(), "HTTPRoute should converge instead of being rewritten on every reconcile")
 }
 
 func ignoreNoMatch(err error) error {

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -475,26 +475,17 @@ func RouterLabels(llmSvc *v1alpha2.LLMInferenceService) map[string]string {
 }
 
 func semanticHTTPRouteIsEqual(e *gwapiv1.HTTPRoute, c *gwapiv1.HTTPRoute) bool {
-	specEqual := equality.Semantic.DeepDerivative(e.Spec, c.Spec)
-	if isGroupRoute(e) {
-		// Grouped routes need exact rule comparison to detect stale backendRefs
-		// from deleted members. DeepDerivative only checks subset membership.
-		specEqual = equality.Semantic.DeepEqual(e.Spec.Rules, c.Spec.Rules) &&
-			equality.Semantic.DeepDerivative(e.Spec.ParentRefs, c.Spec.ParentRefs) &&
-			equality.Semantic.DeepDerivative(e.Spec.Hostnames, c.Spec.Hostnames)
-	}
-	return specEqual &&
+	// Rules are fully controller-generated. Compare them exactly so removed LoRA
+	// matches and group backends are removed from the stored route.
+	//
+	// ParentRefs and Hostnames require a subset comparison because the API server
+	// may default fields such as ParentRef.Namespace.
+	return equality.Semantic.DeepEqual(e.Spec.Rules, c.Spec.Rules) &&
+		equality.Semantic.DeepDerivative(e.Spec.ParentRefs, c.Spec.ParentRefs) &&
+		equality.Semantic.DeepDerivative(e.Spec.Hostnames, c.Spec.Hostnames) &&
 		equality.Semantic.DeepDerivative(e.Labels, c.Labels) &&
 		!hasStaleControllerLabels(e.Labels, c.Labels) &&
 		equality.Semantic.DeepDerivative(e.Annotations, c.Annotations)
-}
-
-func isGroupRoute(route *gwapiv1.HTTPRoute) bool {
-	if route == nil || route.Labels == nil {
-		return false
-	}
-	_, hasGroupLabel := route.Labels[constants.LLMRoutingGroupLabelKey]
-	return hasGroupLabel
 }
 
 // hasStaleControllerLabels returns true when the current object carries a

--- a/pkg/controller/v1alpha2/llmisvc/router_comparator_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_comparator_test.go
@@ -170,7 +170,7 @@ func TestSemanticHTTPRouteIsEqual_GroupedRouteRules(t *testing.T) {
 			wantEq: false,
 		},
 		{
-			name: "non-grouped route - extra rule tolerated by DeepDerivative - no update",
+			name: "non-grouped route - stale rule in current - update",
 			expected: &gwapiv1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
 				Spec:       gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{makeRule("/v1/chat", 9)}},
@@ -182,7 +182,75 @@ func TestSemanticHTTPRouteIsEqual_GroupedRouteRules(t *testing.T) {
 					makeRule("/v1/chat", 1),
 				}},
 			},
-			wantEq: true,
+			wantEq: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantEq, semanticHTTPRouteIsEqual(tt.expected, tt.current))
+		})
+	}
+}
+
+// TestSemanticHTTPRouteIsEqual_StaleAdapterMatches pins the geometry of the LoRA
+// adapter bug: adapter matches are appended to an existing model-routing rule, so
+// removing adapters leaves the rule with extra matches whose prefix is identical
+// to what the controller now wants. The comparator must see the tail, whether the
+// removal empties the rule back to the base model or only trims it.
+func TestSemanticHTTPRouteIsEqual_StaleAdapterMatches(t *testing.T) {
+	const headerName = "X-Gateway-Model-Name"
+
+	modelMatch := func(model string) gwapiv1.HTTPRouteMatch {
+		return gwapiv1.HTTPRouteMatch{
+			Headers: []gwapiv1.HTTPHeaderMatch{
+				{Name: gwapiv1.HTTPHeaderName(headerName), Value: model},
+			},
+		}
+	}
+
+	route := func(matches ...gwapiv1.HTTPRouteMatch) *gwapiv1.HTTPRoute {
+		return &gwapiv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}},
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{{Matches: matches}},
+			},
+		}
+	}
+
+	base := modelMatch("publishers/default/models/base-model")
+	adapterA := modelMatch("publishers/default/models/adapter-a")
+	adapterB := modelMatch("publishers/default/models/adapter-b")
+
+	tests := []struct {
+		name     string
+		expected *gwapiv1.HTTPRoute
+		current  *gwapiv1.HTTPRoute
+		wantEq   bool
+	}{
+		{
+			name:     "all adapters removed - stale adapter matches - update",
+			expected: route(base),
+			current:  route(base, adapterA, adapterB),
+			wantEq:   false,
+		},
+		{
+			name:     "some adapters removed, desired list is a prefix - update",
+			expected: route(base, adapterA),
+			current:  route(base, adapterA, adapterB),
+			wantEq:   false,
+		},
+		{
+			name:     "adapters unchanged - no update",
+			expected: route(base, adapterA, adapterB),
+			current:  route(base, adapterA, adapterB),
+			wantEq:   true,
+		},
+		{
+			name:     "adapter added - update",
+			expected: route(base, adapterA, adapterB),
+			current:  route(base, adapterA),
+			wantEq:   false,
 		},
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/router_comparator_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_comparator_test.go
@@ -193,11 +193,8 @@ func TestSemanticHTTPRouteIsEqual_GroupedRouteRules(t *testing.T) {
 	}
 }
 
-// TestSemanticHTTPRouteIsEqual_StaleAdapterMatches pins the geometry of the LoRA
-// adapter bug: adapter matches are appended to an existing model-routing rule, so
-// removing adapters leaves the rule with extra matches whose prefix is identical
-// to what the controller now wants. The comparator must see the tail, whether the
-// removal empties the rule back to the base model or only trims it.
+// TestSemanticHTTPRouteIsEqual_StaleAdapterMatches verifies that removing LoRA
+// adapters makes routes with stale header matches unequal.
 func TestSemanticHTTPRouteIsEqual_StaleAdapterMatches(t *testing.T) {
 	const headerName = "X-Gateway-Model-Name"
 

--- a/pkg/controller/v1alpha2/llmisvc/router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_test.go
@@ -186,50 +186,6 @@ func TestFilterEligibleMembers(t *testing.T) {
 	})
 }
 
-func TestIsGroupRoute(t *testing.T) {
-	tests := []struct {
-		name  string
-		route *gwapiv1.HTTPRoute
-		want  bool
-	}{
-		{
-			name:  "nil route",
-			route: nil,
-			want:  false,
-		},
-		{
-			name:  "no labels",
-			route: &gwapiv1.HTTPRoute{},
-			want:  false,
-		},
-		{
-			name: "no group label",
-			route: &gwapiv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"other": "label"},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "has group label",
-			route: &gwapiv1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						constants.LLMRoutingGroupLabelKey: "llama-70b",
-					},
-				},
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isGroupRoute(tt.route))
-		})
-	}
-}
-
 func TestUpdateGroupStatus(t *testing.T) {
 	t.Run("populates group status from resolved members", func(t *testing.T) {
 		llmSvc := &v1alpha2.LLMInferenceService{


### PR DESCRIPTION
**What this PR does / why we need it**:

The controller checked the routing rules it generates against the cluster as a subset. Entries present on the cluster but absent from the desired state compared as equal, so additions and edits were applied while removals were not.

Removing every LoRA adapter from an `LLMInferenceService` left the gateway matching on all of them indefinitely. The workload updates correctly and stops serving those adapters, so requests reached the model server and failed there as an unknown model instead of being rejected at the gateway. The leftover entries also kept consuming the per-rule match limit, which caps how many adapters a service can expose - and no amount of further reconciling reclaimed it. Deleting the route or the service was the only way out.

Routing rules are generated in full from the merged configuration, so they are now compared exactly in every case. Exact comparison was already in use for services that share a route, where the same gap left behind references to deleted members. Applying it everywhere removes the special case, and with it any dependence on the order entries happen to be written in.

**Which issue(s) this PR fixes** 

None - found while characterizing the route match budget on a local cluster, no upstream issue filed.

**Feature/Issue validation/testing**:

- [x] Unit coverage for the route comparison itself, covering a desired state emptied of adapters and one that is merely shorter
- [x] Controller test that removes every adapter and asserts the route matches on the base model alone, plus a check that the route stops being rewritten once it settles
- [x] Full `llmisvc` envtest suite green, including group routing, inference pool migration and model-based routing
- [x] `make precommit` green

Both new tests were confirmed to fail before the fix and pass after.


**Special notes for your reviewer**:
For clarity: removing *some* adapters was never affected. Adapter entries are interleaved per endpoint, so a partial removal shifts their positions and the previous comparison caught it. Only removing every adapter produced a desired state that was an exact prefix of what was on the cluster.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Fixes stale LoRA adapter entries left on a service's generated route after every adapter is removed, which kept the gateway routing to adapters the runtime no longer served and permanently consumed the per-rule match budget.
```
