### PR TITLE
fix(llmisvc): detect removals when reconciling inference pools and roles

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1976,8 +1976,67 @@ schedulingProfiles:
 
 			expectSettles(ctx, poolKey, &igwapi.InferencePool{})
 		})
-	})
 
+		It("should revoke role rules that are not in the desired state", func(ctx SpecContext) {
+			// given - the scheduler's rules are hardcoded in the controller, so a rule
+			// only disappears from the desired state when a release narrows it. Drift is
+			// the only way to exercise that here, and it stands in for the upgrade: a
+			// rule the controller no longer intends to grant must not survive.
+			svcName := "test-llm-role-rule-revocation"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			roleKey := types.NamespacedName{
+				Name:      kmeta.ChildName(svcName, "-epp-role"),
+				Namespace: testNs.Name,
+			}
+
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, roleKey, &rbacv1.Role{})
+			}).WithContext(ctx).Should(Succeed(), "the scheduler role should be created")
+
+			// when - a rule the controller never asked for is added
+			widerGrant := rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "list", "watch"},
+			}
+
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				current := &rbacv1.Role{}
+				if errGet := envTest.Get(ctx, roleKey, current); errGet != nil {
+					return errGet
+				}
+				current.Rules = append(current.Rules, widerGrant)
+
+				return envTest.Update(ctx, current)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - the controller takes it back
+			Eventually(func(g Gomega, ctx context.Context) error {
+				current := &rbacv1.Role{}
+				g.Expect(envTest.Get(ctx, roleKey, current)).To(Succeed())
+				g.Expect(current.Rules).ToNot(ContainElement(widerGrant))
+
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "a rule outside the desired state should be revoked")
+
+			expectSettles(ctx, roleKey, &rbacv1.Role{})
+		})
+	})
 })
 
 // schedulerContainerName is the expected name of the main container in the scheduler deployment

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1902,6 +1902,82 @@ schedulingProfiles:
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})
+
+	Context("Removals in the desired state", func() {
+		It("should drop inference pool selector keys removed from the spec", func(ctx SpecContext) {
+			// given - a pool selector the service owns, carrying an extra key
+			svcName := "test-llm-pool-selector-removal"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			const extraKey igwapi.LabelKey = "tier"
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+			llmSvc.Spec.Router.Scheduler.Pool = &v1alpha2.InferencePoolSpec{
+				Spec: &igwapi.InferencePoolSpec{
+					Selector: igwapi.LabelSelector{
+						MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+							"app.kubernetes.io/name": igwapi.LabelValue(svcName),
+							extraKey:                 "gpu",
+						},
+					},
+					TargetPorts: []igwapi.Port{{Number: 8000}},
+					EndpointPickerRef: igwapi.EndpointPickerRef{
+						Kind: "Service",
+						Name: igwapi.ObjectName(kmeta.ChildName(svcName, "-epp-service")),
+						Port: &igwapi.Port{Number: 9002},
+					},
+				},
+			}
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			poolKey := types.NamespacedName{
+				Name:      kmeta.ChildName(svcName, "-inference-pool"),
+				Namespace: testNs.Name,
+			}
+
+			Eventually(func(g Gomega, ctx context.Context) error {
+				pool := &igwapi.InferencePool{}
+				g.Expect(envTest.Get(ctx, poolKey, pool)).To(Succeed())
+				g.Expect(pool.Spec.Selector.MatchLabels).To(HaveKey(extraKey))
+
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "the pool should start with both selector keys")
+
+			// when - the key is removed from the service spec
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				current := &v1alpha2.LLMInferenceService{}
+				if errGet := envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current); errGet != nil {
+					return errGet
+				}
+				delete(current.Spec.Router.Scheduler.Pool.Spec.Selector.MatchLabels, extraKey)
+
+				return envTest.Update(ctx, current)
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - the pool stops selecting on it
+			Eventually(func(g Gomega, ctx context.Context) error {
+				pool := &igwapi.InferencePool{}
+				g.Expect(envTest.Get(ctx, poolKey, pool)).To(Succeed())
+				g.Expect(pool.Spec.Selector.MatchLabels).ToNot(HaveKey(extraKey))
+
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "the removed selector key should be dropped from the pool")
+
+			expectSettles(ctx, poolKey, &igwapi.InferencePool{})
+		})
+	})
+
 })
 
 // schedulerContainerName is the expected name of the main container in the scheduler deployment
@@ -2000,4 +2076,23 @@ func assertPipelineOrder(g Gomega, pluginTypes []string) {
 		"token-producer must appear before precise-prefix-cache-producer")
 	g.Expect(producerIdx).To(BeNumerically("<", scorerIdx),
 		"precise-prefix-cache-producer must appear before prefix-cache-scorer")
+}
+
+// expectSettles asserts an object stops being rewritten once it has converged.
+// Generation only advances on spec writes, so a generation that keeps moving means
+// the controller and something else are overwriting each other - the failure mode
+// of comparing a field the controller does not fully own.
+func expectSettles(ctx context.Context, key types.NamespacedName, empty client.Object) {
+	settled := empty.DeepCopyObject().(client.Object)
+	Expect(envTest.Get(ctx, key, settled)).To(Succeed())
+	generation := settled.GetGeneration()
+
+	Consistently(func(g Gomega, ctx context.Context) error {
+		current := empty.DeepCopyObject().(client.Object)
+		g.Expect(envTest.Get(ctx, key, current)).To(Succeed())
+		g.Expect(current.GetGeneration()).To(Equal(generation))
+
+		return nil
+	}).WithContext(ctx).WithTimeout(2*time.Second).WithPolling(250*time.Millisecond).
+		Should(Succeed(), "object should converge instead of being rewritten on every reconcile")
 }

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -2010,6 +2010,10 @@ func withMetricsDataSourceParams(parameters map[string]interface{}) mutateSchedu
 	}
 }
 
+// Ports and the selector are fixed in the controller and derived from the service
+// name, so neither can shrink while a service exists and the subset comparison
+// costs nothing today. Move to DeepEqual if either becomes driven by the spec:
+// DeepDerivative would silently keep serving a port that had been removed.
 func semanticServiceIsEqual(expected *corev1.Service, current *corev1.Service) bool {
 	return equality.Semantic.DeepDerivative(expected.Spec, current.Spec) &&
 		equality.Semantic.DeepDerivative(expected.Labels, current.Labels) &&
@@ -2032,6 +2036,11 @@ func semanticInferencePoolV1Alpha2IsEqual(expected *igwapiv1alpha2.InferencePool
 		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations)
 }
 
+// Deliberately tolerant, and it must stay that way. OpenShift's service account
+// controller appends its own pull secret entries to the accounts we create, and
+// the desired object only ever carries what was copied off the namespace default
+// account. Comparing these exactly would have the two controllers take turns
+// removing each other's entries for as long as the service exists.
 func semanticServiceAccountIsEqual(expected *corev1.ServiceAccount, current *corev1.ServiceAccount) bool {
 	return equality.Semantic.DeepDerivative(expected.Secrets, current.Secrets) &&
 		equality.Semantic.DeepDerivative(expected.ImagePullSecrets, current.ImagePullSecrets) &&
@@ -2049,6 +2058,10 @@ func semanticRoleIsEqual(expected *rbacv1.Role, curr *rbacv1.Role) bool {
 		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations)
 }
 
+// Bindings are generated with exactly one subject, so the list cannot shrink and
+// a changed subject is caught in place. Move to DeepEqual if a binding ever grows
+// a second subject, since dropping back to one would otherwise leave the first
+// bound.
 func semanticClusterRoleBindingIsEqual(expected *rbacv1.ClusterRoleBinding, curr *rbacv1.ClusterRoleBinding) bool {
 	return equality.Semantic.DeepDerivative(expected.Subjects, curr.Subjects) &&
 		equality.Semantic.DeepDerivative(expected.RoleRef, curr.RoleRef) &&

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -2039,8 +2039,12 @@ func semanticServiceAccountIsEqual(expected *corev1.ServiceAccount, current *cor
 		equality.Semantic.DeepDerivative(expected.Annotations, current.Annotations)
 }
 
+// Rules are generated in full by the controller, so they are compared exactly.
+// DeepDerivative treats the cluster object as a superset, which means a grant the
+// controller has stopped asking for - because a release narrowed the rule set -
+// would never be revoked on services that already exist.
 func semanticRoleIsEqual(expected *rbacv1.Role, curr *rbacv1.Role) bool {
-	return equality.Semantic.DeepDerivative(expected.Rules, curr.Rules) &&
+	return equality.Semantic.DeepEqual(expected.Rules, curr.Rules) &&
 		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
 		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations)
 }

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -2016,14 +2016,18 @@ func semanticServiceIsEqual(expected *corev1.Service, current *corev1.Service) b
 		equality.Semantic.DeepDerivative(expected.Annotations, current.Annotations)
 }
 
+// The pool spec is taken wholesale from spec.router.scheduler.pool.spec, so it is
+// compared exactly. DeepDerivative treats the cluster object as a superset, which
+// hides a selector key or a target port dropped from the service spec - leaving
+// the pool matching a wider set of pods than the spec asks for.
 func semanticInferencePoolIsEqual(expected *igwapi.InferencePool, curr *igwapi.InferencePool) bool {
-	return equality.Semantic.DeepDerivative(expected.Spec, curr.Spec) &&
+	return equality.Semantic.DeepEqual(expected.Spec, curr.Spec) &&
 		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
 		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations)
 }
 
 func semanticInferencePoolV1Alpha2IsEqual(expected *igwapiv1alpha2.InferencePool, curr *igwapiv1alpha2.InferencePool) bool {
-	return equality.Semantic.DeepDerivative(expected.Spec, curr.Spec) &&
+	return equality.Semantic.DeepEqual(expected.Spec, curr.Spec) &&
 		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
 		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations)
 }

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_comparator_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_comparator_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
+	igwapiv1alpha2 "github.com/kserve/kserve/pkg/apis/gie/v1alpha2pool"
+)
+
+// The selector is a map, and a map with an extra key on the cluster is a subset
+// match. Dropping a key from the spec therefore leaves the pool selecting a wider
+// set of pods than the service asks for.
+func TestSemanticInferencePoolIsEqual(t *testing.T) {
+	pool := func(selector map[igwapi.LabelKey]igwapi.LabelValue, ports ...int32) *igwapi.InferencePool {
+		targetPorts := make([]igwapi.Port, 0, len(ports))
+		for _, p := range ports {
+			targetPorts = append(targetPorts, igwapi.Port{Number: igwapi.PortNumber(p)})
+		}
+		return &igwapi.InferencePool{
+			Spec: igwapi.InferencePoolSpec{
+				Selector:    igwapi.LabelSelector{MatchLabels: selector},
+				TargetPorts: targetPorts,
+			},
+		}
+	}
+
+	both := map[igwapi.LabelKey]igwapi.LabelValue{"app": "vllm", "tier": "gpu"}
+	one := map[igwapi.LabelKey]igwapi.LabelValue{"app": "vllm"}
+
+	tests := []struct {
+		name     string
+		expected *igwapi.InferencePool
+		current  *igwapi.InferencePool
+		wantEq   bool
+	}{
+		{
+			name:     "identical - no update",
+			expected: pool(both, 8000),
+			current:  pool(both, 8000),
+			wantEq:   true,
+		},
+		{
+			name:     "selector key removed from spec - update",
+			expected: pool(one, 8000),
+			current:  pool(both, 8000),
+			wantEq:   false,
+		},
+		{
+			name:     "selector key added to spec - update",
+			expected: pool(both, 8000),
+			current:  pool(one, 8000),
+			wantEq:   false,
+		},
+		{
+			name:     "selector value changed - update",
+			expected: pool(map[igwapi.LabelKey]igwapi.LabelValue{"app": "sglang"}, 8000),
+			current:  pool(one, 8000),
+			wantEq:   false,
+		},
+		{
+			name:     "target port removed from spec - update",
+			expected: pool(one, 8000),
+			current:  pool(one, 8000, 8001),
+			wantEq:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantEq, semanticInferencePoolIsEqual(tt.expected, tt.current))
+		})
+	}
+}
+
+func TestSemanticInferencePoolV1Alpha2IsEqual(t *testing.T) {
+	pool := func(selector map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue) *igwapiv1alpha2.InferencePool {
+		return &igwapiv1alpha2.InferencePool{
+			Spec: igwapiv1alpha2.InferencePoolSpec{
+				Selector:         selector,
+				TargetPortNumber: 8000,
+			},
+		}
+	}
+
+	both := map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm", "tier": "gpu"}
+	one := map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{"app": "vllm"}
+
+	tests := []struct {
+		name     string
+		expected *igwapiv1alpha2.InferencePool
+		current  *igwapiv1alpha2.InferencePool
+		wantEq   bool
+	}{
+		{
+			name:     "identical - no update",
+			expected: pool(both),
+			current:  pool(both),
+			wantEq:   true,
+		},
+		{
+			name:     "selector key removed from spec - update",
+			expected: pool(one),
+			current:  pool(both),
+			wantEq:   false,
+		},
+		{
+			name:     "selector key added to spec - update",
+			expected: pool(both),
+			current:  pool(one),
+			wantEq:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantEq, semanticInferencePoolV1Alpha2IsEqual(tt.expected, tt.current))
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_comparator_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_comparator_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	igwapiv1alpha2 "github.com/kserve/kserve/pkg/apis/gie/v1alpha2pool"
@@ -132,6 +133,69 @@ func TestSemanticInferencePoolV1Alpha2IsEqual(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.wantEq, semanticInferencePoolV1Alpha2IsEqual(tt.expected, tt.current))
+		})
+	}
+}
+
+// Role rules are hardcoded in the controller, so they shrink when a release
+// narrows them. Until the comparison is exact, that narrowing never reaches
+// services that already exist - the wider grant stays in place.
+func TestSemanticRoleIsEqual(t *testing.T) {
+	role := func(rules ...rbacv1.PolicyRule) *rbacv1.Role {
+		return &rbacv1.Role{Rules: rules}
+	}
+
+	pods := rbacv1.PolicyRule{
+		APIGroups: []string{""},
+		Resources: []string{"pods"},
+		Verbs:     []string{"get", "list", "watch"},
+	}
+	podsReadOnly := rbacv1.PolicyRule{
+		APIGroups: []string{""},
+		Resources: []string{"pods"},
+		Verbs:     []string{"get", "list"},
+	}
+	leases := rbacv1.PolicyRule{
+		APIGroups: []string{"coordination.k8s.io"},
+		Resources: []string{"leases"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+	}
+
+	tests := []struct {
+		name     string
+		expected *rbacv1.Role
+		current  *rbacv1.Role
+		wantEq   bool
+	}{
+		{
+			name:     "identical - no update",
+			expected: role(pods, leases),
+			current:  role(pods, leases),
+			wantEq:   true,
+		},
+		{
+			name:     "rule dropped from the desired state - update",
+			expected: role(pods),
+			current:  role(pods, leases),
+			wantEq:   false,
+		},
+		{
+			name:     "verb trimmed within a rule - update",
+			expected: role(podsReadOnly),
+			current:  role(pods),
+			wantEq:   false,
+		},
+		{
+			name:     "rule added - update",
+			expected: role(pods, leases),
+			current:  role(pods),
+			wantEq:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantEq, semanticRoleIsEqual(tt.expected, tt.current))
 		})
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -352,6 +352,12 @@ func (r *LLMISVCReconciler) propagateWorkloadDeploymentStatus(ctx context.Contex
 	return nil
 }
 
+// The pod template is compared exactly and the rest of the spec is not. That is a
+// deliberate split: removals matter most in the template, and this is one of only
+// two objects here whose rewrite restarts a workload, so the tolerant half stays
+// tolerant. Note the replica count is not the reason - PreserveDeploymentReplicas
+// already adopts the cluster's value before the comparison runs, so autoscalers
+// are not in contention either way.
 func semanticDeploymentIsEqual(expected *appsv1.Deployment, curr *appsv1.Deployment) bool {
 	// Use DeepEqual for the Pod Spec so that when fields are removed (like resource requirements, we push them down to the
 	// child resource)


### PR DESCRIPTION
**What this PR does / why we need it**:

Generated objects are compared against the cluster as a subset, so removals never reach it.

Removing a selector entry or target port from an inference pool had no effect - the pool kept matching a wider set of pods than the service asked for. Role rules narrowed by a release only reached new services; anything already running kept the wider grant for its lifetime.

Both are now compared exactly, after the dry run that fills in cluster-populated values.

**Which issue(s) this PR fixes**

None. Just rabbit-holing ;)

**Feature/Issue validation/testing**:

- [x] Unit coverage for both comparisons, both pool API versions
- [x] Controller test removing a selector entry from a live service
- [x] Controller test asserting a rule the controller never asked for is taken back
- [x] Both assert the object settles, not just converges
- [x] Full `llmisvc` envtest suite and `make precommit` green

Each test fails before its fix and passes after.

- Logs

```
ok  github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc               346.783s
ok  github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/crdvalidation   8.698s
```

**Special notes for your reviewer**:

The comparisons left tolerant are deliberate and now commented. Service accounts must stay tolerant, since the cluster adds pull secret entries of its own. Deployments keep the pod template exact and the rest tolerant.

Tightening a comparison risks unneeded updates.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
NONE
```
