### PR TITLE
feat(llmisvc): host aggregator in the existing controller

### DIFF
--- a/charts/_common/kserve-llmisvc-resources-specific.yaml
+++ b/charts/_common/kserve-llmisvc-resources-specific.yaml
@@ -76,6 +76,12 @@ kserve:
       extraVolumeMounts: []
       extraArgs: []
       terminationGracePeriodSeconds: 10
+      aggregator:
+        enabled: true
+        bindAddress: ':8080'
+        port: 8080
+        backendTimeout: 3s
+        namespace: ''
   controller:
     deploymentMode: Knative
     gateway:

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -59,6 +59,11 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.inferenceservice.resources.requests.cpu | string | `"1"` |  |
 | kserve.inferenceservice.resources.requests.memory | string | `"2Gi"` |  |
 | kserve.llmisvc.controller.affinity | object | `{}` |  |
+| kserve.llmisvc.controller.aggregator.backendTimeout | string | `"3s"` |  |
+| kserve.llmisvc.controller.aggregator.bindAddress | string | `":8080"` |  |
+| kserve.llmisvc.controller.aggregator.enabled | bool | `true` |  |
+| kserve.llmisvc.controller.aggregator.namespace | string | `""` |  |
+| kserve.llmisvc.controller.aggregator.port | int | `8080` |  |
 | kserve.llmisvc.controller.annotations | object | `{}` |  |
 | kserve.llmisvc.controller.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | kserve.llmisvc.controller.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |

--- a/charts/kserve-llmisvc-resources/files/llmisvc/deployment-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/deployment-patch.yaml
@@ -91,6 +91,17 @@ spec:
         args:
         - "--metrics-addr={{ .Values.kserve.llmisvc.controller.metricsBindAddress }}:{{ .Values.kserve.llmisvc.controller.metricsBindPort }}"
         - "--leader-elect"
+        {{- with .Values.kserve.llmisvc.controller.aggregator }}
+        {{- if .enabled }}
+        - "--aggregator-addr={{ .bindAddress }}"
+        - "--aggregator-backend-timeout={{ .backendTimeout }}"
+        {{- if .namespace }}
+        - "--aggregator-namespace={{ .namespace }}"
+        {{- end }}
+        {{- else }}
+        - "--enable-aggregator=false"
+        {{- end }}
+        {{- end }}
         {{- with .Values.kserve.llmisvc.controller.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -135,6 +146,13 @@ spec:
         - containerPort: {{ .Values.kserve.llmisvc.controller.metricsBindPort }}
           name: metrics
           protocol: TCP
+        {{- with .Values.kserve.llmisvc.controller.aggregator }}
+        {{- if .enabled }}
+        - containerPort: {{ .port }}
+          name: aggregator
+          protocol: TCP
+        {{- end }}
+        {{- end }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/resources.yaml
@@ -1441,6 +1441,10 @@ spec:
     port: 8443
     protocol: TCP
     targetPort: metrics
+  - name: aggregator
+    port: 8080
+    protocol: TCP
+    targetPort: aggregator
   selector:
     control-plane: llmisvc-controller-manager
     controller-tools.k8s.io: "1.0"
@@ -1487,6 +1491,7 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8443
         - --leader-elect
+        - --aggregator-addr=:8080
         command:
         - /manager
         env:
@@ -1511,6 +1516,9 @@ spec:
           protocol: TCP
         - containerPort: 8443
           name: metrics
+          protocol: TCP
+        - containerPort: 8080
+          name: aggregator
           protocol: TCP
         readinessProbe:
           failureThreshold: 5

--- a/charts/kserve-llmisvc-resources/files/llmisvc/service-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/llmisvc/service-patch.yaml
@@ -29,6 +29,14 @@ spec:
     targetPort: {{ .Values.kserve.llmisvc.controller.service.targetPort }}
     protocol: TCP
     name: https
+  {{- with .Values.kserve.llmisvc.controller.aggregator }}
+  {{- if .enabled }}
+  - port: {{ .port }}
+    targetPort: aggregator
+    protocol: TCP
+    name: aggregator
+  {{- end }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -180,6 +180,12 @@ kserve:
       extraVolumeMounts: []
       extraArgs: []
       terminationGracePeriodSeconds: 10
+      aggregator:
+        enabled: true
+        bindAddress: ':8080'
+        port: 8080
+        backendTimeout: 3s
+        namespace: ''
   controller:
     deploymentMode: Knative
     gateway:

--- a/cmd/llmisvc/aggregator.go
+++ b/cmd/llmisvc/aggregator.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/kserve/kserve/pkg/aggregator"
+)
+
+// aggregatorServer serves aggregated LLMInferenceService endpoints from the
+// llmisvc controller process. It does not require leader election so every
+// replica can answer read-only aggregation requests.
+type aggregatorServer struct {
+	addr    string
+	handler http.Handler
+}
+
+func (s aggregatorServer) Start(ctx context.Context) error {
+	server := &http.Server{
+		Addr:              s.addr,
+		Handler:           s.handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		// ctx is already canceled; WithoutCancel keeps values while allowing a
+		// shutdown deadline that is not immediately expired.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	setupLog.Info("Starting LLMInferenceService aggregator", "addr", s.addr)
+	err := server.ListenAndServe()
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+func (s aggregatorServer) NeedLeaderElection() bool { return false }
+
+func newAggregatorServer(addr string, timeout time.Duration, discovery aggregator.BackendDiscovery) (aggregatorServer, error) {
+	agg, err := aggregator.New(aggregator.Options{
+		Discovery: discovery,
+		Timeout:   timeout,
+	})
+	if err != nil {
+		return aggregatorServer{}, err
+	}
+	return aggregatorServer{addr: addr, handler: agg.Handler()}, nil
+}

--- a/cmd/llmisvc/aggregator_test.go
+++ b/cmd/llmisvc/aggregator_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kserve/kserve/pkg/aggregator"
+)
+
+func TestAggregatorServerDoesNotRequireLeaderElection(t *testing.T) {
+	server, err := newAggregatorServer(":0", 0, aggregator.StaticDiscovery{})
+	require.NoError(t, err)
+	require.False(t, server.NeedLeaderElection())
+}

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -51,6 +51,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/kserve/kserve/pkg/aggregator"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
@@ -89,6 +90,10 @@ type Options struct {
 	migrationPollInterval time.Duration
 	tlsMinVersion         string
 	tlsCipherSuites       string
+	enableAggregator      bool
+	aggregatorAddr        string
+	aggregatorNamespace   string
+	aggregatorTimeout     time.Duration
 	zapOpts               zap.Options
 }
 
@@ -101,6 +106,9 @@ func DefaultOptions() Options {
 		metricsSecure:         true,
 		migrationTimeout:      1 * time.Hour,
 		migrationPollInterval: 30 * time.Second,
+		enableAggregator:      true,
+		aggregatorAddr:        ":8080",
+		aggregatorTimeout:     3 * time.Second,
 		zapOpts:               zap.Options{},
 	}
 }
@@ -120,6 +128,10 @@ func GetOptions() Options {
 	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
 	flag.DurationVar(&opts.migrationTimeout, "storage-migration-timeout", opts.migrationTimeout, "Total retry budget for storage version migration.")
 	flag.DurationVar(&opts.migrationPollInterval, "storage-migration-poll-interval", opts.migrationPollInterval, "Polling interval for storage version migration retries after initial backoff.")
+	flag.BoolVar(&opts.enableAggregator, "enable-aggregator", opts.enableAggregator, "Serve aggregated LLMInferenceService endpoints from this controller process.")
+	flag.StringVar(&opts.aggregatorAddr, "aggregator-addr", opts.aggregatorAddr, "The address the aggregator HTTP server binds to.")
+	flag.StringVar(&opts.aggregatorNamespace, "aggregator-namespace", opts.aggregatorNamespace, "Namespace to aggregate LLMInferenceServices from. Empty watches all namespaces.")
+	flag.DurationVar(&opts.aggregatorTimeout, "aggregator-backend-timeout", opts.aggregatorTimeout, "Per-backend request timeout for aggregated endpoints.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 	return opts
@@ -343,6 +355,21 @@ func main() {
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
+	}
+
+	if options.enableAggregator {
+		aggServer, err := newAggregatorServer(options.aggregatorAddr, options.aggregatorTimeout, aggregator.ClientDiscovery{
+			Client:    mgr.GetClient(),
+			Namespace: options.aggregatorNamespace,
+		})
+		if err != nil {
+			setupLog.Error(err, "unable to create aggregator")
+			os.Exit(1)
+		}
+		if err := mgr.Add(aggServer); err != nil {
+			setupLog.Error(err, "unable to register aggregator")
+			os.Exit(1)
+		}
 	}
 
 	// Storage version migration runs as a LeaderElection runnable, which starts

--- a/config/llmisvc/manager.yaml
+++ b/config/llmisvc/manager.yaml
@@ -50,6 +50,7 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8443"
         - "--leader-elect"
+        - "--aggregator-addr=:8080"
         env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -84,6 +85,9 @@ spec:
           protocol: TCP
         - containerPort: 8443
           name: metrics
+          protocol: TCP
+        - containerPort: 8080
+          name: aggregator
           protocol: TCP
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs

--- a/config/llmisvc/service.yaml
+++ b/config/llmisvc/service.yaml
@@ -16,3 +16,7 @@ spec:
     targetPort: metrics
     protocol: TCP
     name: https
+  - port: 8080
+    targetPort: aggregator
+    protocol: TCP
+    name: aggregator

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -107600,6 +107600,10 @@ spec:
     port: 8443
     protocol: TCP
     targetPort: metrics
+  - name: aggregator
+    port: 8080
+    protocol: TCP
+    targetPort: aggregator
   selector:
     control-plane: llmisvc-controller-manager
     controller-tools.k8s.io: "1.0"
@@ -107646,6 +107650,7 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8443
         - --leader-elect
+        - --aggregator-addr=:8080
         command:
         - /manager
         env:
@@ -107670,6 +107675,9 @@ spec:
           protocol: TCP
         - containerPort: 8443
           name: metrics
+          protocol: TCP
+        - containerPort: 8080
+          name: aggregator
           protocol: TCP
         readinessProbe:
           failureThreshold: 5

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Aggregator lists backends via BackendDiscovery and serves aggregated endpoints.
+type Aggregator struct {
+	discovery BackendDiscovery
+	filter    BackendFilter
+	client    *http.Client
+	timeout   time.Duration
+	mergers   map[string]Merger
+	log       logr.Logger
+}
+
+// New builds an Aggregator from Options.
+func New(opts Options) (*Aggregator, error) {
+	if opts.Discovery == nil {
+		return nil, errors.New("discovery is required")
+	}
+
+	timeout := opts.timeout()
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+
+	mergers := defaultMergers()
+	for path, merger := range opts.Mergers {
+		mergers[path] = merger
+	}
+
+	filter := opts.Filter
+	if filter == nil {
+		filter = func(_ *http.Request, backends []Backend) []Backend { return backends }
+	}
+
+	return &Aggregator{
+		discovery: opts.Discovery,
+		filter:    filter,
+		client:    client,
+		timeout:   timeout,
+		mergers:   mergers,
+		log:       logf.Log.WithName("aggregator"),
+	}, nil
+}
+
+// Handler returns an http.Handler that serves aggregated paths.
+// Unknown paths return 404.
+func (a *Aggregator) Handler() http.Handler {
+	mux := http.NewServeMux()
+	for _, path := range []string{PathModels, PathHealth, PathMetrics, PathLoad} {
+		mux.HandleFunc(path, a.handle(path))
+	}
+	return mux
+}
+
+func (a *Aggregator) handle(path string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		backends, err := a.discovery.List(r.Context())
+		if err != nil {
+			a.log.Error(err, "Failed to list backends")
+			http.Error(w, "failed to list backends", http.StatusInternalServerError)
+			return
+		}
+		backends = a.filter(r, backends)
+
+		ctx, cancel := context.WithTimeout(r.Context(), a.timeout)
+		defer cancel()
+
+		results := FanOut(ctx, a.client, backends, path, r.Header)
+		for _, res := range results {
+			if res.Err != nil {
+				a.log.Info("Backend request failed", "backend", res.Backend.ID(), "path", path, "error", res.Err.Error())
+			} else if !res.OK() {
+				a.log.Info("Backend returned non-success", "backend", res.Backend.ID(), "path", path, "status", res.StatusCode)
+			}
+		}
+
+		merger, ok := a.mergers[path]
+		if !ok {
+			http.Error(w, "no merger configured", http.StatusInternalServerError)
+			return
+		}
+		body, status, err := merger(results)
+		if err != nil {
+			a.log.Error(err, "Failed to merge backend responses", "path", path)
+			http.Error(w, "failed to merge responses", http.StatusInternalServerError)
+			return
+		}
+
+		contentType := "application/json"
+		if path == PathMetrics {
+			contentType = "text/plain; version=0.0.4; charset=utf-8"
+		}
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(status)
+		if _, err := w.Write(body); err != nil {
+			a.log.Error(err, "Failed to write response", "path", path)
+		}
+	}
+}

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregatorHandlerModels(t *testing.T) {
+	backendA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, PathModels, r.URL.Path)
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"model-a","object":"model"}]}`))
+	}))
+	defer backendA.Close()
+
+	backendB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"model-b","object":"model"}]}`))
+	}))
+	defer backendB.Close()
+
+	agg, err := New(Options{
+		Discovery: StaticDiscovery{Backends: []Backend{
+			{Name: "a", Namespace: "ns", URL: backendA.URL},
+			{Name: "b", Namespace: "ns", URL: backendB.URL},
+		}},
+		Timeout: time.Second,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, PathModels, nil)
+	rr := httptest.NewRecorder()
+	agg.Handler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var list openAIModelList
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &list))
+	require.Len(t, list.Data, 2)
+}
+
+func TestAggregatorHandlerHealthAllMustPass(t *testing.T) {
+	okServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer okServer.Close()
+	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer badServer.Close()
+
+	agg, err := New(Options{
+		Discovery: StaticDiscovery{Backends: []Backend{
+			{Name: "ok", Namespace: "ns", URL: okServer.URL},
+			{Name: "bad", Namespace: "ns", URL: badServer.URL},
+		}},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, PathHealth, nil)
+	rr := httptest.NewRecorder()
+	agg.Handler().ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+func TestFanOut(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/health", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	results := FanOut(t.Context(), http.DefaultClient, []Backend{{Name: "a", URL: srv.URL}}, PathHealth, nil)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].OK())
+	assert.Equal(t, "ok", string(results[0].Body))
+}

--- a/pkg/aggregator/client.go
+++ b/pkg/aggregator/client.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// FanOut issues a GET to path on every backend concurrently and returns one result per backend.
+// Per-backend deadlines are enforced via context; order of results matches backends.
+func FanOut(ctx context.Context, client *http.Client, backends []Backend, path string, header http.Header) []BackendResult {
+	results := make([]BackendResult, len(backends))
+	if len(backends) == 0 {
+		return results
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(backends))
+	for i := range backends {
+		go func() {
+			defer wg.Done()
+			results[i] = queryBackend(ctx, client, backends[i], path, header)
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+func queryBackend(ctx context.Context, client *http.Client, backend Backend, path string, header http.Header) BackendResult {
+	start := time.Now()
+	result := BackendResult{Backend: backend}
+
+	target, err := joinURL(backend.URL, path)
+	if err != nil {
+		result.Err = err
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		result.Err = err
+		result.Duration = time.Since(start)
+		return result
+	}
+	for k, values := range header {
+		for _, v := range values {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		result.Err = err
+		result.Duration = time.Since(start)
+		return result
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // 16 MiB cap
+	result.StatusCode = resp.StatusCode
+	result.Body = body
+	result.Err = err
+	result.Duration = time.Since(start)
+	return result
+}
+
+func joinURL(base, path string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("invalid backend URL %q: %w", base, err)
+	}
+	ref, err := url.Parse(path)
+	if err != nil {
+		return "", fmt.Errorf("invalid path %q: %w", path, err)
+	}
+	return u.ResolveReference(ref).String(), nil
+}

--- a/pkg/aggregator/discovery.go
+++ b/pkg/aggregator/discovery.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"context"
+	"errors"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	listersv1alpha2 "github.com/kserve/kserve/pkg/client/listers/serving/v1alpha2"
+)
+
+// StaticDiscovery returns a fixed backend list.
+// Useful for tests and for embedding the library without Kubernetes.
+type StaticDiscovery struct {
+	Backends []Backend
+}
+
+// List implements BackendDiscovery.
+func (d StaticDiscovery) List(context.Context) ([]Backend, error) {
+	out := make([]Backend, len(d.Backends))
+	copy(out, d.Backends)
+	return out, nil
+}
+
+// ClientDiscovery lists Ready LLMInferenceService backends from a controller-runtime client.
+// This is the discovery implementation used when embedding the aggregator in cmd/llmisvc.
+type ClientDiscovery struct {
+	Client    client.Reader
+	Namespace string // empty means all namespaces
+}
+
+// List implements BackendDiscovery.
+func (d ClientDiscovery) List(ctx context.Context) ([]Backend, error) {
+	if d.Client == nil {
+		return nil, errors.New("client is required")
+	}
+
+	list := &v1alpha2.LLMInferenceServiceList{}
+	opts := []client.ListOption{}
+	if d.Namespace != "" {
+		opts = append(opts, client.InNamespace(d.Namespace))
+	}
+	if err := d.Client.List(ctx, list, opts...); err != nil {
+		return nil, err
+	}
+
+	items := make([]*v1alpha2.LLMInferenceService, 0, len(list.Items))
+	for i := range list.Items {
+		items = append(items, &list.Items[i])
+	}
+	return backendsFromLLMInferenceServices(items), nil
+}
+
+// InformerDiscovery lists Ready LLMInferenceService backends from a generated lister.
+// Callers that already run a SharedInformerFactory can use this instead of ClientDiscovery.
+type InformerDiscovery struct {
+	Lister    listersv1alpha2.LLMInferenceServiceLister
+	Namespace string // empty means all namespaces
+}
+
+// List implements BackendDiscovery.
+func (d InformerDiscovery) List(_ context.Context) ([]Backend, error) {
+	if d.Lister == nil {
+		return nil, errors.New("lister is required")
+	}
+
+	if d.Namespace != "" {
+		items, err := d.Lister.LLMInferenceServices(d.Namespace).List(labels.Everything())
+		if err != nil {
+			return nil, err
+		}
+		return backendsFromLLMInferenceServices(items), nil
+	}
+
+	items, err := d.Lister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	return backendsFromLLMInferenceServices(items), nil
+}
+
+func backendsFromLLMInferenceServices(items []*v1alpha2.LLMInferenceService) []Backend {
+	backends := make([]Backend, 0, len(items))
+	for _, svc := range items {
+		if b, ok := BackendFromLLMInferenceService(svc); ok {
+			backends = append(backends, b)
+		}
+	}
+	return backends
+}

--- a/pkg/aggregator/discovery_test.go
+++ b/pkg/aggregator/discovery_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	listersv1alpha2 "github.com/kserve/kserve/pkg/client/listers/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func newTestLister(t *testing.T, items ...*v1alpha2.LLMInferenceService) listersv1alpha2.LLMInferenceServiceLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, item := range items {
+		require.NoError(t, indexer.Add(item))
+	}
+	return listersv1alpha2.NewLLMInferenceServiceLister(indexer)
+}
+
+func llmSvc(t *testing.T, name, namespace, url string, ready bool, stopped bool) *v1alpha2.LLMInferenceService {
+	t.Helper()
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+	svc := &v1alpha2.LLMInferenceService{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha2.SchemeGroupVersion.String(),
+			Kind:       "LLMInferenceService",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: v1alpha2.LLMInferenceServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   apis.ConditionReady,
+					Status: status,
+				}},
+			},
+		},
+	}
+	if url != "" {
+		svc.Status.Addresses = []v1alpha2.SourcedAddress{
+			{Addressable: duckv1.Addressable{URL: mustURL(t, url)}},
+		}
+	}
+	if stopped {
+		svc.Annotations = map[string]string{constants.StopAnnotationKey: "true"}
+	}
+	return svc
+}
+
+func TestInformerDiscoveryList(t *testing.T) {
+	readyA := llmSvc(t, "a", "ns1", "http://a.ns1.svc.cluster.local", true, false)
+	readyB := llmSvc(t, "b", "ns2", "http://b.ns2.svc.cluster.local", true, false)
+	notReady := llmSvc(t, "c", "ns1", "http://c.ns1.svc.cluster.local", false, false)
+	stopped := llmSvc(t, "d", "ns1", "http://d.ns1.svc.cluster.local", true, true)
+	noURL := llmSvc(t, "e", "ns1", "", true, false)
+
+	lister := newTestLister(t, readyA, readyB, notReady, stopped, noURL)
+
+	allNS, err := InformerDiscovery{Lister: lister}.List(t.Context())
+	require.NoError(t, err)
+	require.Len(t, allNS, 2)
+	ids := []string{allNS[0].ID(), allNS[1].ID()}
+	assert.ElementsMatch(t, []string{"ns1/a", "ns2/b"}, ids)
+
+	ns1Only, err := InformerDiscovery{Lister: lister, Namespace: "ns1"}.List(t.Context())
+	require.NoError(t, err)
+	require.Len(t, ns1Only, 1)
+	assert.Equal(t, "ns1/a", ns1Only[0].ID())
+	assert.Equal(t, "http://a.ns1.svc.cluster.local", ns1Only[0].URL)
+}
+
+func TestInformerDiscoveryRequiresLister(t *testing.T) {
+	_, err := InformerDiscovery{}.List(t.Context())
+	require.Error(t, err)
+}
+
+func TestClientDiscoveryList(t *testing.T) {
+	readyA := llmSvc(t, "a", "ns1", "http://a.ns1.svc.cluster.local", true, false)
+	readyB := llmSvc(t, "b", "ns2", "http://b.ns2.svc.cluster.local", true, false)
+	notReady := llmSvc(t, "c", "ns1", "http://c.ns1.svc.cluster.local", false, false)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readyA, readyB, notReady).Build()
+
+	allNS, err := ClientDiscovery{Client: c}.List(t.Context())
+	require.NoError(t, err)
+	require.Len(t, allNS, 2)
+	ids := []string{allNS[0].ID(), allNS[1].ID()}
+	assert.ElementsMatch(t, []string{"ns1/a", "ns2/b"}, ids)
+
+	ns1Only, err := ClientDiscovery{Client: c, Namespace: "ns1"}.List(t.Context())
+	require.NoError(t, err)
+	require.Len(t, ns1Only, 1)
+	assert.Equal(t, "ns1/a", ns1Only[0].ID())
+}
+
+func TestClientDiscoveryRequiresClient(t *testing.T) {
+	_, err := ClientDiscovery{}.List(t.Context())
+	require.Error(t, err)
+}
+
+// Ensure runtime.Object compliance for indexer helpers in this package's tests.
+var _ runtime.Object = &v1alpha2.LLMInferenceService{}

--- a/pkg/aggregator/merge.go
+++ b/pkg/aggregator/merge.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// openAIModelList is the OpenAI-compatible GET /v1/models response shape.
+type openAIModelList struct {
+	Object string        `json:"object"`
+	Data   []openAIModel `json:"data"`
+}
+
+type openAIModel struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created,omitempty"`
+	OwnedBy string `json:"owned_by,omitempty"`
+	// Source identifies which LLMInferenceService contributed this model entry.
+	Source string `json:"source,omitempty"`
+}
+
+// MergeModels unions OpenAI model list entries across backends.
+// Partial failures are omitted; if every backend fails, returns 502.
+func MergeModels(results []BackendResult) ([]byte, int, error) {
+	seen := map[string]struct{}{}
+	out := openAIModelList{Object: "list", Data: []openAIModel{}}
+	successes := 0
+
+	for _, r := range results {
+		if !r.OK() {
+			continue
+		}
+		var list openAIModelList
+		if err := json.Unmarshal(r.Body, &list); err != nil {
+			// HTTP 200 with a non-OpenAI body is not a usable /v1/models result.
+			continue
+		}
+		successes++
+		for _, m := range list.Data {
+			key := m.ID + "|" + r.Backend.ID()
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			if m.Object == "" {
+				m.Object = "model"
+			}
+			m.Source = r.Backend.ID()
+			out.Data = append(out.Data, m)
+		}
+	}
+
+	if successes == 0 && len(results) > 0 {
+		return []byte(`{"object":"list","data":[],"error":"all backends failed"}`), http.StatusBadGateway, nil
+	}
+	body, err := json.Marshal(out)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return body, http.StatusOK, nil
+}
+
+// MergeHealth is healthy only when every backend is healthy (and there is at least one).
+func MergeHealth(results []BackendResult) ([]byte, int, error) {
+	if len(results) == 0 {
+		body, _ := json.Marshal(map[string]any{
+			"status":  "unhealthy",
+			"reason":  "no backends",
+			"results": []any{},
+		})
+		return body, http.StatusServiceUnavailable, nil
+	}
+
+	type backendHealth struct {
+		Backend string `json:"backend"`
+		OK      bool   `json:"ok"`
+		Status  int    `json:"status,omitempty"`
+		Error   string `json:"error,omitempty"`
+	}
+
+	allOK := true
+	details := make([]backendHealth, 0, len(results))
+	for _, r := range results {
+		item := backendHealth{Backend: r.Backend.ID(), OK: r.OK(), Status: r.StatusCode}
+		if r.Err != nil {
+			item.Error = r.Err.Error()
+			allOK = false
+		} else if !r.OK() {
+			allOK = false
+			item.Error = fmt.Sprintf("status %d", r.StatusCode)
+		}
+		details = append(details, item)
+	}
+
+	status := "healthy"
+	code := http.StatusOK
+	if !allOK {
+		status = "unhealthy"
+		code = http.StatusServiceUnavailable
+	}
+	body, err := json.Marshal(map[string]any{
+		"status":  status,
+		"results": details,
+	})
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return body, code, nil
+}
+
+// MergeMetrics concatenates Prometheus text and injects a backend label on metric samples.
+// Failed backends are omitted; if all fail, returns 502.
+func MergeMetrics(results []BackendResult) ([]byte, int, error) {
+	var b strings.Builder
+	successes := 0
+	for _, r := range results {
+		if !r.OK() {
+			continue
+		}
+		successes++
+		fmt.Fprintf(&b, "# BACKEND %s\n", r.Backend.ID())
+		labeled := injectPrometheusBackendLabel(string(r.Body), r.Backend.ID())
+		b.WriteString(labeled)
+		if !strings.HasSuffix(labeled, "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	if successes == 0 && len(results) > 0 {
+		return []byte("# all backends failed\n"), http.StatusBadGateway, nil
+	}
+	return []byte(b.String()), http.StatusOK, nil
+}
+
+// injectPrometheusBackendLabel adds backend="<id>" to each metric sample line.
+func injectPrometheusBackendLabel(metrics, backendID string) string {
+	label := fmt.Sprintf(`backend=%q`, backendID)
+	lines := strings.Split(metrics, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lines[i] = injectLabel(line, label)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func injectLabel(sampleLine, label string) string {
+	// metric{labels} value [timestamp]  OR  metric value
+	brace := strings.IndexByte(sampleLine, '{')
+	if brace >= 0 {
+		closeBrace := strings.IndexByte(sampleLine[brace:], '}')
+		if closeBrace < 0 {
+			return sampleLine
+		}
+		closeBrace += brace
+		inner := sampleLine[brace+1 : closeBrace]
+		if inner == "" {
+			return sampleLine[:brace+1] + label + sampleLine[closeBrace:]
+		}
+		return sampleLine[:brace+1] + inner + "," + label + sampleLine[closeBrace:]
+	}
+	// Insert labels before the first whitespace separating value.
+	fields := strings.Fields(sampleLine)
+	if len(fields) < 2 {
+		return sampleLine
+	}
+	name := fields[0]
+	rest := strings.TrimSpace(sampleLine[len(name):])
+	return name + "{" + label + "} " + rest
+}
+
+// MergeLoad aggregates /load payloads keyed by backend ID.
+// Failed backends are omitted; if all fail, returns 502.
+func MergeLoad(results []BackendResult) ([]byte, int, error) {
+	out := map[string]any{}
+	successes := 0
+	for _, r := range results {
+		if !r.OK() {
+			continue
+		}
+		successes++
+		var payload any
+		if err := json.Unmarshal(r.Body, &payload); err != nil {
+			payload = map[string]any{"raw": string(r.Body)}
+		}
+		out[r.Backend.ID()] = payload
+	}
+	if successes == 0 && len(results) > 0 {
+		body, _ := json.Marshal(map[string]any{"error": "all backends failed"})
+		return body, http.StatusBadGateway, nil
+	}
+	body, err := json.Marshal(map[string]any{"object": "load", "backends": out})
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return body, http.StatusOK, nil
+}
+
+func defaultMergers() map[string]Merger {
+	return map[string]Merger{
+		PathModels:  MergeModels,
+		PathHealth:  MergeHealth,
+		PathMetrics: MergeMetrics,
+		PathLoad:    MergeLoad,
+	}
+}

--- a/pkg/aggregator/merge_test.go
+++ b/pkg/aggregator/merge_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeModels(t *testing.T) {
+	results := []BackendResult{
+		{
+			Backend:    Backend{Name: "a", Namespace: "ns"},
+			StatusCode: 200,
+			Body:       []byte(`{"object":"list","data":[{"id":"model-a","object":"model"}]}`),
+		},
+		{
+			Backend:    Backend{Name: "b", Namespace: "ns"},
+			StatusCode: 200,
+			Body:       []byte(`{"object":"list","data":[{"id":"model-b","object":"model"}]}`),
+		},
+		{
+			Backend:    Backend{Name: "c", Namespace: "ns"},
+			StatusCode: 500,
+			Body:       []byte(`error`),
+		},
+	}
+
+	body, status, err := MergeModels(results)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	var list openAIModelList
+	require.NoError(t, json.Unmarshal(body, &list))
+	require.Len(t, list.Data, 2)
+	assert.Equal(t, "model-a", list.Data[0].ID)
+	assert.Equal(t, "ns/a", list.Data[0].Source)
+	assert.Equal(t, "model-b", list.Data[1].ID)
+}
+
+func TestMergeModelsAllFailed(t *testing.T) {
+	results := []BackendResult{
+		{Backend: Backend{Name: "a"}, Err: assert.AnError},
+	}
+	_, status, err := MergeModels(results)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, status)
+}
+
+func TestMergeModelsInvalidJSONIsNotSuccess(t *testing.T) {
+	results := []BackendResult{
+		{
+			Backend:    Backend{Name: "a", Namespace: "ns"},
+			StatusCode: 200,
+			Body:       []byte(`not-json`),
+		},
+	}
+	_, status, err := MergeModels(results)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, status)
+}
+
+func TestMergeHealth(t *testing.T) {
+	ok := []BackendResult{
+		{Backend: Backend{Name: "a", Namespace: "ns"}, StatusCode: 200, Body: []byte("ok")},
+		{Backend: Backend{Name: "b", Namespace: "ns"}, StatusCode: 200, Body: []byte("ok")},
+	}
+	body, status, err := MergeHealth(ok)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Contains(t, string(body), `"status":"healthy"`)
+
+	bad := []BackendResult{
+		{Backend: Backend{Name: "a", Namespace: "ns"}, StatusCode: 200},
+		{Backend: Backend{Name: "b", Namespace: "ns"}, StatusCode: 503},
+	}
+	_, status, err = MergeHealth(bad)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, status)
+}
+
+func TestMergeMetricsInjectsLabel(t *testing.T) {
+	results := []BackendResult{
+		{
+			Backend:    Backend{Name: "a", Namespace: "ns"},
+			StatusCode: 200,
+			Body:       []byte("http_requests_total{code=\"200\"} 1\nup 1\n"),
+		},
+	}
+	body, status, err := MergeMetrics(results)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Contains(t, string(body), `backend="ns/a"`)
+	assert.Contains(t, string(body), `http_requests_total{code="200",backend="ns/a"} 1`)
+	assert.Contains(t, string(body), `up{backend="ns/a"} 1`)
+}
+
+func TestMergeLoad(t *testing.T) {
+	results := []BackendResult{
+		{
+			Backend:    Backend{Name: "a", Namespace: "ns"},
+			StatusCode: 200,
+			Body:       []byte(`{"running":1}`),
+		},
+		{
+			Backend: Backend{Name: "b", Namespace: "ns"},
+			Err:     assert.AnError,
+		},
+	}
+	body, status, err := MergeLoad(results)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Contains(t, string(body), `"ns/a"`)
+	assert.NotContains(t, string(body), `"ns/b"`)
+}

--- a/pkg/aggregator/types.go
+++ b/pkg/aggregator/types.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Aggregated endpoint paths exposed by the aggregation layer.
+const (
+	PathModels  = "/v1/models"
+	PathHealth  = "/health"
+	PathMetrics = "/metrics"
+	PathLoad    = "/load"
+)
+
+// Backend is one model server that can be queried by the aggregator.
+type Backend struct {
+	// Name is a short identifier for the backend (e.g. service name).
+	Name string
+	// Namespace is an optional namespace qualifier for the backend.
+	Namespace string
+	// URL is the base URL used to reach the backend (scheme + host[+port][+path prefix]).
+	URL string
+	// Models are optional model identities associated with this backend.
+	Models []string
+}
+
+// ID returns a stable backend identifier suitable for logs and merge labels.
+func (b Backend) ID() string {
+	if b.Namespace == "" {
+		return b.Name
+	}
+	return b.Namespace + "/" + b.Name
+}
+
+// BackendResult is the outcome of querying one backend for one path.
+type BackendResult struct {
+	Backend    Backend
+	StatusCode int
+	Body       []byte
+	Err        error
+	Duration   time.Duration
+}
+
+// OK reports whether the backend responded with a 2xx status and no transport error.
+func (r BackendResult) OK() bool {
+	return r.Err == nil && r.StatusCode >= 200 && r.StatusCode <= 299
+}
+
+// BackendDiscovery lists backends that should participate in aggregation.
+type BackendDiscovery interface {
+	List(ctx context.Context) ([]Backend, error)
+}
+
+// BackendFilter selects which backends participate for a given request.
+// Consumers inject header-based tenancy/auth filtering here; the default is a no-op.
+type BackendFilter func(r *http.Request, backends []Backend) []Backend
+
+// Merger combines per-backend results into a single HTTP response body and status.
+type Merger func(results []BackendResult) (body []byte, statusCode int, err error)
+
+// Options configures an Aggregator.
+type Options struct {
+	// Discovery lists backends. Required.
+	Discovery BackendDiscovery
+	// Filter optionally narrows backends per request. Nil means include all.
+	Filter BackendFilter
+	// Timeout is the per-backend request timeout. Zero defaults to 3s.
+	Timeout time.Duration
+	// HTTPClient is used for backend requests. Nil uses a client built from Timeout.
+	HTTPClient *http.Client
+	// Mergers overrides default merge strategies keyed by request path.
+	// Missing paths fall back to built-in mergers.
+	Mergers map[string]Merger
+}
+
+func (o Options) timeout() time.Duration {
+	if o.Timeout > 0 {
+		return o.Timeout
+	}
+	return 3 * time.Second
+}

--- a/pkg/aggregator/url.go
+++ b/pkg/aggregator/url.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/network"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/utils"
+)
+
+// ResolveBackendURL picks a base URL for an LLMInferenceService.
+// Preference order:
+//  1. First cluster-local address in status.addresses
+//  2. First internal (non-public-looking) address in status.addresses
+//  3. First address in status.addresses
+//  4. status.url
+func ResolveBackendURL(svc *v1alpha2.LLMInferenceService) string {
+	if svc == nil {
+		return ""
+	}
+
+	var clusterLocal, internal, anyURL *apis.URL
+	for i := range svc.Status.Addresses {
+		u := svc.Status.Addresses[i].URL
+		if u == nil {
+			continue
+		}
+		if anyURL == nil {
+			anyURL = u
+		}
+		if isClusterLocalURL(u) {
+			if clusterLocal == nil {
+				clusterLocal = u
+			}
+			continue
+		}
+		if isInternalHostnameURL(u) && internal == nil {
+			internal = u
+		}
+	}
+
+	switch {
+	case clusterLocal != nil:
+		return strings.TrimRight(clusterLocal.String(), "/")
+	case internal != nil:
+		return strings.TrimRight(internal.String(), "/")
+	case anyURL != nil:
+		return strings.TrimRight(anyURL.String(), "/")
+	case svc.Status.URL != nil:
+		return strings.TrimRight(svc.Status.URL.String(), "/")
+	default:
+		return ""
+	}
+}
+
+// BackendFromLLMInferenceService converts a CR into a Backend when it is usable.
+// Returns ok=false when the service is stopped, not Ready, or has no resolvable URL.
+func BackendFromLLMInferenceService(svc *v1alpha2.LLMInferenceService) (Backend, bool) {
+	if svc == nil || utils.GetForceStopRuntime(svc) || !isLLMInferenceServiceReady(svc) {
+		return Backend{}, false
+	}
+	base := ResolveBackendURL(svc)
+	if base == "" {
+		return Backend{}, false
+	}
+
+	return Backend{
+		Name:      svc.Name,
+		Namespace: svc.Namespace,
+		URL:       base,
+		Models:    collectModelNames(svc),
+	}, true
+}
+
+func isLLMInferenceServiceReady(svc *v1alpha2.LLMInferenceService) bool {
+	cond := svc.Status.GetCondition(apis.ConditionReady)
+	return cond != nil && cond.Status == corev1.ConditionTrue
+}
+
+func collectModelNames(svc *v1alpha2.LLMInferenceService) []string {
+	seen := map[string]struct{}{}
+	var models []string
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		models = append(models, name)
+	}
+	for _, addr := range svc.Status.Addresses {
+		for _, m := range addr.Models {
+			add(m.Name)
+		}
+	}
+	if svc.Spec.Model.Name != nil {
+		add(*svc.Spec.Model.Name)
+	}
+	return models
+}
+
+func isClusterLocalURL(u *apis.URL) bool {
+	if u == nil {
+		return false
+	}
+	host := strings.ToLower(u.URL().Hostname())
+	return strings.HasSuffix(host, network.GetClusterDomainName())
+}
+
+func isInternalHostnameURL(u *apis.URL) bool {
+	if u == nil {
+		return false
+	}
+	if isClusterLocalURL(u) {
+		return true
+	}
+	host := strings.ToLower(u.URL().Hostname())
+	for _, suffix := range []string{".local", ".localhost", ".internal"} {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/aggregator/url_test.go
+++ b/pkg/aggregator/url_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func mustURL(t *testing.T, raw string) *apis.URL {
+	t.Helper()
+	u, err := apis.ParseURL(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func ptr(s string) *string { return &s }
+
+func TestResolveBackendURLPrefersClusterLocal(t *testing.T) {
+	svc := &v1alpha2.LLMInferenceService{
+		Status: v1alpha2.LLMInferenceServiceStatus{
+			URL: mustURL(t, "https://public.example.com"),
+			Addresses: []v1alpha2.SourcedAddress{
+				{Addressable: duckv1.Addressable{URL: mustURL(t, "https://public.example.com")}},
+				{Addressable: duckv1.Addressable{URL: mustURL(t, "http://llama.default.svc.cluster.local")}},
+			},
+		},
+	}
+	assert.Equal(t, "http://llama.default.svc.cluster.local", ResolveBackendURL(svc))
+}
+
+func TestResolveBackendURLFallsBackToStatusURL(t *testing.T) {
+	svc := &v1alpha2.LLMInferenceService{
+		Status: v1alpha2.LLMInferenceServiceStatus{
+			URL: mustURL(t, "http://only-status-url.example"),
+		},
+	}
+	assert.Equal(t, "http://only-status-url.example", ResolveBackendURL(svc))
+}
+
+func TestBackendFromLLMInferenceService(t *testing.T) {
+	ready := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama", Namespace: "ns"},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Model: v1alpha2.LLMModelSpec{Name: ptr("llama")},
+		},
+		Status: v1alpha2.LLMInferenceServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   apis.ConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+			Addresses: []v1alpha2.SourcedAddress{
+				{
+					Addressable: duckv1.Addressable{URL: mustURL(t, "http://llama.ns.svc.cluster.local")},
+					Models:      []v1alpha2.ModelSourcedAddressStatus{{Name: "llama"}},
+				},
+			},
+		},
+	}
+	b, ok := BackendFromLLMInferenceService(ready)
+	require.True(t, ok)
+	assert.Equal(t, "llama", b.Name)
+	assert.Equal(t, "ns", b.Namespace)
+	assert.Equal(t, "http://llama.ns.svc.cluster.local", b.URL)
+	assert.Equal(t, []string{"llama"}, b.Models)
+
+	stopped := ready.DeepCopy()
+	stopped.Annotations = map[string]string{constants.StopAnnotationKey: "true"}
+	_, ok = BackendFromLLMInferenceService(stopped)
+	assert.False(t, ok)
+
+	notReady := ready.DeepCopy()
+	notReady.Status.Conditions = duckv1.Conditions{{
+		Type:   apis.ConditionReady,
+		Status: corev1.ConditionFalse,
+	}}
+	_, ok = BackendFromLLMInferenceService(notReady)
+	assert.False(t, ok)
+
+	noURL := ready.DeepCopy()
+	noURL.Status.Addresses = nil
+	noURL.Status.URL = nil
+	_, ok = BackendFromLLMInferenceService(noURL)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary

Hosts the aggregator library from #6031 in the existing llmisvc controller on port 8080, and exposes that port on the controller Service and Helm chart. Clients get one merged view of Ready services without a second pod.

Depends on #6031.

Addresses #5532

## Motivation

Clients currently have to discover each `LLMInferenceService` and call it separately. There is no supported in-cluster way to list models or check health across services.

#6031 adds the embeddable aggregator library. This PR hosts it in the llmisvc controller we already run, so we reuse the existing cache, Service, and RBAC instead of deploying another process.

## Controller (`cmd/llmisvc`)

- Serves the aggregator on `--aggregator-addr` (default `:8080`)
- `--enable-aggregator=false` disables it
- `--aggregator-backend-timeout` and `--aggregator-namespace` are optional
- Read-only, so every replica serves it (`NeedLeaderElection() == false`)
- Existing llmisvc Service exposes port 8080 (`aggregator`)

## Added

- Unit tests for the controller aggregator server
- Kind smoke test: two Ready LLMInferenceServices; `GET /v1/models` returned both models with `source` set

Until #6031 merges, the Files tab also shows `pkg/aggregator/`. After that, this PR is controller/Helm only.

Follow-up if needed: when no router is set, `status.addresses` is cluster-local without `:8000`, so HTTP defaults to port 80.

## Release note

```release-note
Add cluster-wide LLMInferenceService aggregation endpoints on the llmisvc controller