### PR TITLE
test(llmisvc): cover latency predictor sidecars on a live cluster

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -187,8 +187,11 @@ jobs:
 
   seed-image-cache:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
       - name: Pull and save vLLM CPU image
         run: |
           docker pull --platform linux/amd64 ${{ env.VLLM_CPU_IMAGE }}
@@ -201,6 +204,46 @@ jobs:
           path: /tmp/vllm-cpu.tar
           compression-level: 0
           if-no-files-found: error
+
+      - name: Pull and save latency predictor images
+        run: |
+          set -uo pipefail
+          # Versions are read from the preset rather than pinned again here. A
+          # second copy would diverge on the next bump, leaving the cache holding
+          # images no test loads while every run pulls them from the registry.
+          mapfile -t images < <(grep -ohE \
+            'ghcr\.io/llm-d/llm-d-latency-predictor-[a-z-]+:[^"[:space:]]+' \
+            config/llmisvcconfig/config-llm-scheduler-latency-predictor.yaml | sort -u)
+          # An empty match means the preset changed shape rather than indicating a
+          # registry problem, and would leave the cache permanently ineffective.
+          # Every step after this point is best effort.
+          if [[ ${#images[@]} -eq 0 ]]; then
+            echo "::error::no latency predictor images found in the preset - has it been restructured?"
+            exit 1
+          fi
+          # Guarded with if rather than &&: the runner already applies -e, under
+          # which an unguarded failure would abort a step that is permitted to
+          # produce nothing.
+          for image in "${images[@]}"; do
+            tar="/tmp/$(basename "${image}" | tr ':' '-').tar"
+            if ! docker pull --platform linux/amd64 "${image}"; then
+              echo "::warning::could not pull ${image}; the test job will pull it directly"
+              continue
+            fi
+            if ! docker save "${image}" -o "${tar}"; then
+              echo "::warning::could not save ${image}; the test job will pull it directly"
+              rm -f "${tar}"
+            fi
+          done
+
+      - name: Upload latency predictor image artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: latency-predictor-images-${{ env.TAG }}
+          path: /tmp/llm-d-latency-predictor-*.tar
+          compression-level: 0
+          # Producing no archives is a slower run rather than a failed one.
+          if-no-files-found: warn
 
   test-llmisvc:
     runs-on: cncf-ubuntu-16-64-x86
@@ -280,6 +323,34 @@ jobs:
 
       - name: Load vLLM CPU image into minikube
         run: minikube image load ./tmp/vllm-cpu.tar
+
+      # Cache warming must not gate the tests. A pod pulls its own images when
+      # they are not preloaded, so a registry outage costs time rather than the
+      # entire suite. An image that does not exist still fails in the test that
+      # required it, where the pod status reports the cause.
+      - name: Download latency predictor image artifact
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: latency-predictor-images-${{ env.TAG }}
+          path: ./tmp
+
+      - name: Load latency predictor images into minikube
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          shopt -s nullglob
+          loaded=0
+          for tar in ./tmp/llm-d-latency-predictor-*.tar; do
+            if minikube image load "${tar}"; then
+              loaded=$((loaded + 1))
+            else
+              echo "::warning::could not load ${tar}; the pod will pull it directly"
+            fi
+          done
+          if [[ ${loaded} -eq 0 ]]; then
+            echo "::notice::latency predictor images not preloaded; pods will pull them"
+          fi
 
       - name: KServe dependency setup
         uses: ./.github/actions/kserve-dep-setup

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -141,6 +141,14 @@ try:
 except (json.JSONDecodeError, TypeError):
     DEFAULT_LLMISVC_ANNOTATIONS = {}
 
+# Sized from the measured idle footprint of the latency predictor sidecars,
+# 138 MB and 133 MB RSS with a single uvicorn worker. The limits leave margin
+# above that while remaining schedulable on a shared build node.
+LATENCY_PREDICTOR_CI_RESOURCES = {
+    "requests": {"cpu": "200m", "memory": "512Mi"},
+    "limits": {"cpu": "1", "memory": "2Gi"},
+}
+
 STORAGE_INITIALIZER_INIT_CONTAINER = {
     "name": "storage-initializer",
     "env": [
@@ -773,6 +781,57 @@ LLMINFERENCESERVICE_CONFIGS = {
                             },
                         ],
                     },
+                },
+            },
+        },
+    },
+    # Declaring predicted-latency-producer causes the controller to append the
+    # latency predictor preset, which injects the training and prediction
+    # sidecars. No other e2e test reaches that preset, so this is the only
+    # coverage of those images.
+    #
+    # The preset requests 2 and 8 CPU with 4Gi each, sized for a production
+    # router rather than a CI node. The 8 CPU request follows from
+    # UVICORN_WORKERS, since the prediction server forks one uvicorn worker per
+    # unit; reducing it to 1 is therefore a prerequisite for reducing the
+    # request. Containers merge by name, so these entries override the
+    # resources without restating the images.
+    "scheduler-with-latency-predictor": {
+        "router": {
+            "scheduler": {
+                "config": {
+                    "inline": {
+                        "apiVersion": "llm-d.ai/v1alpha1",
+                        "kind": "EndpointPickerConfig",
+                        "plugins": [
+                            {"type": "predicted-latency-producer"},
+                            {"type": "latency-scorer"},
+                            {"type": "weighted-random-picker"},
+                        ],
+                        "schedulingProfiles": [
+                            {
+                                "name": "default",
+                                "plugins": [
+                                    {"pluginRef": "predicted-latency-producer"},
+                                    {"pluginRef": "latency-scorer"},
+                                    {"pluginRef": "weighted-random-picker"},
+                                ],
+                            },
+                        ],
+                    },
+                },
+                "template": {
+                    "containers": [
+                        {
+                            "name": "training-server",
+                            "resources": LATENCY_PREDICTOR_CI_RESOURCES,
+                        },
+                        {
+                            "name": "prediction-server",
+                            "resources": LATENCY_PREDICTOR_CI_RESOURCES,
+                            "env": [{"name": "UVICORN_WORKERS", "value": "1"}],
+                        },
+                    ],
                 },
             },
         },

--- a/test/e2e/llmisvc/test_llm_latency_predictor.py
+++ b/test/e2e/llmisvc/test_llm_latency_predictor.py
@@ -1,0 +1,197 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end coverage for latency predictor sidecar injection.
+
+The controller injects the training and prediction sidecars when the scheduler
+configuration declares predicted-latency-producer. The existing integration
+tests cover that injection under envtest, which runs without a kubelet: they
+assert the containers appear in the Deployment but never resolve their images
+or start their processes. An unpublished image version and an argument the
+binary no longer accepts both pass there.
+
+This test schedules the pod on a real cluster, so the sidecars must pull and
+start.
+"""
+
+import os
+
+import pytest
+from kserve import KServeClient
+from kubernetes import client
+
+from .fixtures import (
+    generate_test_id,
+    inject_k8s_proxy,
+)
+from .logging import log_execution, logger
+from .test_llm_inference_service import (
+    TestCase,
+    create_llmisvc,
+    maybe_delete_llmisvc,
+    wait_for,
+    wait_for_llm_isvc_ready,
+)
+
+SIDECAR_CONTAINERS = ("training-server", "prediction-server")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-with-latency-predictor",
+                    "workload-llmd-simulator",
+                ],
+                service_name="latency-predictor-test",
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+            id="latency-predictor-sidecars",
+        ),
+    ],
+    indirect=["test_case"],
+    ids=generate_test_id,
+)
+@log_execution
+def test_latency_predictor_sidecars_run(test_case: TestCase):
+    """The injected sidecars pull, start and pass their probes."""
+    inject_k8s_proxy()
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config"),
+        client_configuration=client.Configuration(),
+    )
+
+    service_name = test_case.llm_service.metadata.name
+    namespace = test_case.llm_service.metadata.namespace
+    test_failed = False
+
+    try:
+        logger.info(f"Creating LLMInferenceService {service_name}")
+        create_llmisvc(kserve_client, test_case.llm_service)
+
+        selector = assert_sidecars_injected(service_name, namespace)
+        assert_sidecars_ready(
+            selector, namespace, timeout_seconds=test_case.wait_timeout
+        )
+        wait_for_llm_isvc_ready(
+            kserve_client, test_case.llm_service, test_case.wait_timeout
+        )
+    except Exception as e:
+        test_failed = True
+        logger.error(f"Latency predictor test failed for {service_name}: {e}")
+        raise
+    finally:
+        maybe_delete_llmisvc(kserve_client, test_case.llm_service, test_failed)
+
+
+@log_execution
+def assert_sidecars_injected(service_name: str, namespace: str) -> str:
+    """Verify the controller added both sidecars to the scheduler Deployment.
+
+    Returns the Deployment's pod selector so the readiness check matches the
+    labels the controller applied rather than a copy maintained here.
+    """
+    apps_v1 = client.AppsV1Api()
+    deployment_name = f"{service_name}-kserve-router-scheduler"
+
+    def assert_containers_present():
+        dep = apps_v1.read_namespaced_deployment(deployment_name, namespace)
+        names = [c.name for c in dep.spec.template.spec.containers]
+        missing = [c for c in SIDECAR_CONTAINERS if c not in names]
+        assert not missing, (
+            f"Deployment {deployment_name} is missing {missing}; "
+            f"has {names}. Expected the predicted-latency-producer plugin to "
+            f"make the controller append the latency predictor preset."
+        )
+        return ",".join(f"{k}={v}" for k, v in dep.spec.selector.match_labels.items())
+
+    return wait_for(assert_containers_present, timeout=120, interval=2.0)
+
+
+@log_execution
+def assert_sidecars_ready(label_selector: str, namespace: str, timeout_seconds: int):
+    """Verify every scheduler container reaches Ready, sidecars included.
+
+    This assertion requires a kubelet. It fails when an image cannot be
+    resolved and when a binary rejects the arguments the preset renders.
+    """
+    core_v1 = client.CoreV1Api()
+
+    def assert_all_containers_ready():
+        pods = core_v1.list_namespaced_pod(namespace, label_selector=label_selector)
+        assert pods.items, f"No scheduler pods for {label_selector} in {namespace}"
+
+        for pod in pods.items:
+            statuses = pod.status.container_statuses or []
+            # A pod that was never scheduled has no container statuses; the
+            # reason appears in the pod conditions instead.
+            assert statuses, (
+                f"Pod {pod.metadata.name} has no container statuses "
+                f"(phase={pod.status.phase}): {describe_pod_conditions(pod)}"
+            )
+            not_ready = [s for s in statuses if not s.ready]
+            assert not not_ready, (
+                f"Pod {pod.metadata.name} not ready: "
+                f"{describe_container_states(not_ready)}"
+            )
+        return [p.metadata.name for p in pods.items]
+
+    ready = wait_for(assert_all_containers_ready, timeout=timeout_seconds, interval=5.0)
+    logger.info(f"Scheduler pods ready with sidecars: {ready}")
+
+
+def describe_pod_conditions(pod) -> str:
+    """Report why a pod has not started.
+
+    Typically Unschedulable, when the sidecar requests do not fit on the node
+    alongside the rest of the workload.
+    """
+    unmet = [c for c in (pod.status.conditions or []) if c.status != "True"]
+    if not unmet:
+        return "no unmet pod conditions reported"
+    return "; ".join(
+        " ".join(filter(None, [f"{c.type}={c.status}", c.reason, c.message]))
+        for c in unmet
+    )
+
+
+def describe_container_states(statuses) -> str:
+    """Report container states so a failure identifies its cause.
+
+    ImagePullBackOff indicates an image that cannot be resolved.
+    CrashLoopBackOff following an image bump usually indicates the binary
+    rejected an argument the preset still passes.
+    """
+    parts = []
+    for s in statuses:
+        state = s.state
+        if state.waiting:
+            detail = f"waiting/{state.waiting.reason}: {state.waiting.message}"
+        elif state.terminated:
+            detail = (
+                f"terminated/{state.terminated.reason} "
+                f"exit={state.terminated.exit_code}"
+            )
+        else:
+            detail = "running (probes not yet passing)"
+        parts.append(f"{s.name} [{detail}] restarts={s.restart_count}")
+    return "; ".join(parts)


### PR DESCRIPTION
**What this PR does / why we need it**:

Latency-aware scheduling injects two sidecars into the router pod, and nothing in CI has ever pulled their images or started them. This PR adds end-to-end coverage that schedules the pod and requires every container to report ready, which is what turns a missing image or a rejected argument into a failure rather than a silent pass.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

New E2E test.

**Special notes for your reviewer**:


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
NONE
```
