### PR TITLE
ci: bump publisher PR test job timeout to 60 min for arm64 QEMU builds

### DIFF
--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/autogluonserver-docker-publish.yml
+++ b/.github/workflows/autogluonserver-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
+++ b/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/lightgbm-docker-publish.yml
+++ b/.github/workflows/lightgbm-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/paddle-docker-publish.yml
+++ b/.github/workflows/paddle-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/pmml-docker-publish.yml
+++ b/.github/workflows/pmml-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/predictiveserver-docker-publish.yml
+++ b/.github/workflows/predictiveserver-docker-publish.yml
@@ -43,7 +43,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/qpext-docker-publish.yml
+++ b/.github/workflows/qpext-docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/sklearnserver-docker-publish.yml
+++ b/.github/workflows/sklearnserver-docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -39,7 +39,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source

--- a/.github/workflows/xgbserver-docker-publisher.yml
+++ b/.github/workflows/xgbserver-docker-publisher.yml
@@ -40,7 +40,7 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #5963 changed the `test` jobs in 16 Docker publisher workflows from `linux/amd64` to `linux/arm64/v8`, but left `timeout-minutes` unchanged (10–30 min). QEMU-emulated arm64 builds can take up to ~41 min on a cold cache, which exceeds the current timeouts and causes `enforce-all-checks` to fail on affected PRs.

This PR bumps the `test` job timeout to 60 minutes across all 16 affected workflows.

**Verification**:

Validated on PR #6053's own CI run — all 5 Go publisher workflows that were previously timing out completed successfully within the new 60-minute limit:

| Workflow | Duration |
|---|---|
| Agent Docker Publisher | 43 min |
| Kserve controller Docker Publisher | 43 min |
| Kserve localmodel agent Docker Publisher | 43 min |
| Router Docker Publisher | 32 min |
| Kserve localmodel controller Docker Publisher | 30 min |

`enforce-all-checks` passed.

**Which issue(s) this PR fixes**:
Regression introduced by #5963.

**Checklist**:
- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

```release-note
NONE
```