### PR TITLE
fix: preserve TCP protocol for multiprocess REST sockets

### DIFF
--- a/python/kserve/kserve/protocol/rest/multiprocess/server.py
+++ b/python/kserve/kserve/protocol/rest/multiprocess/server.py
@@ -16,6 +16,7 @@ import asyncio
 import multiprocessing as mp
 import os
 import signal
+import socket as socket_module
 import threading
 from socket import socket
 from typing import Any, Callable, List, Optional, Union
@@ -28,6 +29,25 @@ from kserve.protocol.rest.server import RESTServer
 
 mp.allow_connection_pickling()
 spawn = mp.get_context("spawn")
+
+
+def _set_tcp_socket_protocol(sock: socket) -> socket:
+    """Ensure TCP sockets carry IPPROTO_TCP in their Python socket metadata."""
+    if (
+        sock.family in (socket_module.AF_INET, socket_module.AF_INET6)
+        and sock.type == socket_module.SOCK_STREAM
+        and sock.proto != socket_module.IPPROTO_TCP
+    ):
+        rewrapped_sock = socket_module.socket(
+            sock.family,
+            sock.type,
+            socket_module.IPPROTO_TCP,
+            fileno=sock.fileno(),
+        )
+        sock.detach()
+        sock = rewrapped_sock
+
+    return sock
 
 
 class RESTServerProcess:
@@ -169,7 +189,10 @@ class RESTServerMultiProcess:
         logger.info(
             "Starting uvicorn with %s workers", self._rest_server.config.workers
         )
-        sockets = [self._rest_server.config.bind_socket()]
+        sock = self._rest_server.config.bind_socket()
+        sock = _set_tcp_socket_protocol(sock)
+        sockets = [sock]
+
         logger.info("Started parent process [%s]", os.getpid())
         self.init_processes(sockets)
         # Blocks until the parent process is ready to exit

--- a/python/kserve/test/protocol/rest/multiprocess/test_server.py
+++ b/python/kserve/test/protocol/rest/multiprocess/test_server.py
@@ -1,0 +1,78 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import socket
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kserve.protocol.rest import server as rest_mod
+from kserve.protocol.rest.multiprocess.server import RESTServerMultiProcess
+
+
+@pytest.mark.asyncio
+async def test_multiprocess_server_uses_tcp_protocol_socket(monkeypatch):
+    monkeypatch.setattr(rest_mod.RESTServer, "create_application", lambda self: None)
+
+    server = RESTServerMultiProcess(
+        app="dummy:app",
+        data_plane=Mock(),
+        model_repository_extension=Mock(),
+        http_port=0,
+        workers=2,
+    )
+
+    captured_sockets = []
+
+    def capture_sockets(sockets):
+        captured_sockets.extend(sockets)
+
+    monkeypatch.setattr(server, "init_processes", capture_sockets)
+    monkeypatch.setattr(server, "terminate_all", AsyncMock())
+
+    server.should_exit.set()
+
+    await server.start()
+
+    assert len(captured_sockets) == 1
+
+    sock = captured_sockets[0]
+    try:
+        if hasattr(socket, "SO_PROTOCOL"):
+            assert sock.proto == socket.IPPROTO_TCP
+
+            tcp_nodelay = asyncio.get_running_loop().create_future()
+
+            class Protocol(asyncio.Protocol):
+                def connection_made(self, transport):
+                    accepted = transport.get_extra_info("socket")
+                    tcp_nodelay.set_result(
+                        accepted.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
+                    )
+                    transport.close()
+
+            asyncio_server = await asyncio.get_running_loop().create_server(
+                Protocol, sock=sock
+            )
+            _, writer = await asyncio.open_connection(*sock.getsockname())
+            try:
+                assert await asyncio.wait_for(tcp_nodelay, timeout=1) != 0
+            finally:
+                writer.close()
+                await writer.wait_closed()
+                asyncio_server.close()
+                await asyncio_server.wait_closed()
+    finally:
+        sock.close()

--- a/python/kserve/test/protocol/rest/multiprocess/test_server.py
+++ b/python/kserve/test/protocol/rest/multiprocess/test_server.py
@@ -50,29 +50,34 @@ async def test_multiprocess_server_uses_tcp_protocol_socket(monkeypatch):
 
     sock = captured_sockets[0]
     try:
-        if hasattr(socket, "SO_PROTOCOL"):
-            assert sock.proto == socket.IPPROTO_TCP
+        if not hasattr(socket, "SO_PROTOCOL"):
+            pytest.skip("proto metadata not preserved without SO_PROTOCOL")
 
-            tcp_nodelay = asyncio.get_running_loop().create_future()
+        assert sock.proto == socket.IPPROTO_TCP
 
-            class Protocol(asyncio.Protocol):
-                def connection_made(self, transport):
-                    accepted = transport.get_extra_info("socket")
-                    tcp_nodelay.set_result(
-                        accepted.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
-                    )
-                    transport.close()
+        tcp_nodelay = asyncio.get_running_loop().create_future()
 
-            asyncio_server = await asyncio.get_running_loop().create_server(
-                Protocol, sock=sock
-            )
-            _, writer = await asyncio.open_connection(*sock.getsockname())
-            try:
-                assert await asyncio.wait_for(tcp_nodelay, timeout=1) != 0
-            finally:
-                writer.close()
-                await writer.wait_closed()
-                asyncio_server.close()
-                await asyncio_server.wait_closed()
+        class Protocol(asyncio.Protocol):
+            def connection_made(self, transport):
+                accepted = transport.get_extra_info("socket")
+                tcp_nodelay.set_result(
+                    accepted.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
+                )
+                transport.close()
+
+        asyncio_server = await asyncio.get_running_loop().create_server(
+            Protocol, sock=sock
+        )
+        sockname = sock.getsockname()
+        port = sockname[1]
+        host = "::1" if sock.family == socket.AF_INET6 else "127.0.0.1"
+        _, writer = await asyncio.open_connection(host, port)
+        try:
+            assert await asyncio.wait_for(tcp_nodelay, timeout=1) != 0
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            asyncio_server.close()
+            await asyncio_server.wait_closed()
     finally:
         sock.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

KServe's multiprocess REST server creates the listening socket through Uvicorn's
`Config.bind_socket()` and passes that socket to spawned workers.

For TCP sockets created by `bind_socket()`, the Python socket metadata has
`proto == 0`. When asyncio later receives that socket, its TCP_NODELAY setup only
runs when `sock.proto == socket.IPPROTO_TCP`, so accepted connections can miss
TCP_NODELAY in the multiprocess path.

This PR preserves the existing Uvicorn-bound socket while re-wrapping its file
descriptor with `IPPROTO_TCP` before it is passed to worker processes.

The socket keeps the same bound address, file descriptor, and inheritable state;
only the Python protocol metadata is corrected so asyncio recognizes it as TCP.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #6050

**Feature/Issue validation/testing**:

- [x] Added a regression test covering the actual `RESTServerMultiProcess.start()` path and verifying that the socket passed to worker initialization has `proto == socket.IPPROTO_TCP`.
- [x] Ran the existing REST server tests together with the new multiprocess regression test.
- [x] Verified that re-wrapping the socket preserves its bound address, file descriptor, and inheritable state while changing the protocol metadata from `0` to `IPPROTO_TCP`.

Test command:

```bash
cd python/kserve

python -m pytest \
  test/test_rest_server.py \
  test/protocol/rest/multiprocess/test_server.py \
  -v
```

Result:

```text
9 passed in 0.06s
```

**Special notes for your reviewer**:

The fix intentionally keeps Uvicorn responsible for creating and binding the listening
socket. KServe re-wraps the same file descriptor with explicit TCP protocol metadata
before handing the socket to worker processes.

This keeps the existing bind behavior while allowing asyncio to recognize the socket
as TCP and apply its normal TCP_NODELAY handling.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

Documentation changes are not required because this fixes internal multiprocess socket
behavior without changing the public API or configuration.

**Release note**:

```release-note
Fix TCP_NODELAY on multiprocess REST connections when using the asyncio event loop by preserving TCP protocol metadata on shared listening sockets.
```