### PR TITLE
fix: update kserve install script for old version/add a new install script

### DIFF
--- a/.github/workflows/e2e-test-quick-install.yaml
+++ b/.github/workflows/e2e-test-quick-install.yaml
@@ -167,9 +167,9 @@ jobs:
       - name: Install all components via kserve-install.sh (KServe + LocalModel + LLMISvc)
         run: |
           if [ "${{ matrix.install-method }}" == "helm" ]; then
-            ./hack/kserve-install.sh --type kserve,localmodel,llmisvc --raw --helm --local-chart --kserve-version ${TAG}
+            ./hack/kserve-install.sh --ci --type kserve,localmodel,llmisvc --raw --helm --local-chart --kserve-version ${TAG}
           else
-            ./hack/kserve-install.sh --type kserve,localmodel,llmisvc --raw --kustomize --kserve-version ${TAG}
+            ./hack/kserve-install.sh --ci --type kserve,localmodel,llmisvc --raw --kustomize --kserve-version ${TAG}
           fi
       - name: Verify all controllers are running
         run: |

--- a/hack/kserve-install.sh
+++ b/hack/kserve-install.sh
@@ -16,6 +16,7 @@ INSTALL_METHOD="helm"
 ENABLE_KEDA=false
 DEPS_ONLY=false
 UNINSTALL=false
+KSERVE_INSTALL_CI=false
 USE_LOCAL_CHARTS=false
 ENABLE_KSERVE=false
 ENABLE_LOCALMODEL=false
@@ -41,6 +42,7 @@ Help() {
    echo "  --scaling MODE                 Autoscaling for LLMISvc: keda or hpa (requires --type llmisvc)"
    echo "  --deps-only, -d                Install dependencies only"
    echo "  --uninstall, -u                Uninstall all"
+   echo "  --ci                           CI mode (skip frozen install and LocalModel version checks)"
    echo ""
 }
 
@@ -102,6 +104,10 @@ while [[ $# -gt 0 ]]; do
       UNINSTALL=true
       shift
       ;;
+    --ci)
+      KSERVE_INSTALL_CI=true
+      shift
+      ;;
     *)
       log_error "Unknown option: $1"
       Help
@@ -140,6 +146,7 @@ export INSTALL_LLMISVC_CONFIGS
 export SET_KSERVE_VERSION
 export SET_KSERVE_REGISTRY
 export USE_LOCAL_CHARTS
+export KSERVE_INSTALL_CI
 
 # Normalize mode: serverless/knative → Knative, raw/standard → Standard
 case "$MODE" in
@@ -165,6 +172,27 @@ fi
 # Validate dependencies
 is_positive "$USE_LOCAL_CHARTS" && [[ $INSTALL_METHOD != "helm" ]] && { log_error "Local chart requires helm mode"; exit 1; }
 [[ -n "${SET_KSERVE_REGISTRY}" && $INSTALL_METHOD != "kustomize" ]] && { log_error "--kserve-registry requires kustomize mode"; exit 1; }
+
+INSTALL_SCRIPT_DIR="${REPO_ROOT}/hack/setup/quick-install"
+USE_FROZEN_INSTALL=false
+# Use install/${VERSION}/ frozen scripts when installing a different release without a custom registry.
+# Requires --kserve-version, version != kserve-deps.env, no --kserve-registry, and install/${VERSION}/ on disk.
+# Skipped in --ci mode (e.g. image tag is a git SHA, not a release bundle).
+if ! is_positive "$KSERVE_INSTALL_CI" \
+  && [[ -n "${SET_KSERVE_VERSION}" && "${SET_KSERVE_VERSION}" != "${KSERVE_VERSION}" && -z "${SET_KSERVE_REGISTRY}" ]]; then
+  if [[ ! -d "${REPO_ROOT}/install/${SET_KSERVE_VERSION}" ]]; then
+    if [[ $INSTALL_METHOD == "helm" ]]; then
+      log_error "KServe Helm chart for ${SET_KSERVE_VERSION} is not found. Checkout a release version"
+    else
+      log_error "KServe Manifests for ${SET_KSERVE_VERSION} is not found. Checkout a release version"
+    fi
+    exit 1
+  fi
+  is_positive "$USE_LOCAL_CHARTS" && { log_error "Local charts are not supported with install/${SET_KSERVE_VERSION}/ scripts"; exit 1; }
+  INSTALL_SCRIPT_DIR="${REPO_ROOT}/install/${SET_KSERVE_VERSION}"
+  USE_FROZEN_INSTALL=true
+  log_info "Using frozen install scripts from install/${SET_KSERVE_VERSION}/"
+fi
 
 show_installation_plan() {
   echo ""
@@ -239,6 +267,15 @@ uninstall_all() {
   log_success "All components uninstalled"
 }
 
+LOCALMODEL_MIN_VERSION="v0.21.0"
+if is_positive "$ENABLE_LOCALMODEL" && [[ -n "${SET_KSERVE_VERSION}" ]] && ! is_positive "$KSERVE_INSTALL_CI"; then
+  requested_version="${SET_KSERVE_VERSION:-${KSERVE_VERSION}}"
+  if ! version_gte "${requested_version}" "${LOCALMODEL_MIN_VERSION}"; then
+    log_error "LocalModel install requires KServe version >= ${LOCALMODEL_MIN_VERSION} (requested: ${requested_version})"
+    exit 1
+  fi
+fi
+
 if is_positive "$UNINSTALL"; then
   uninstall_all
   exit 0
@@ -254,29 +291,29 @@ install_dependencies() {
     case $type in
       kserve)
         if [[ $USER_MODE == "serverless" ]]; then
-          ${REPO_ROOT}/hack/setup/quick-install/kserve-knative-mode-dependency-install.sh
+          ${INSTALL_SCRIPT_DIR}/kserve-knative-mode-dependency-install.sh
         else
-          ${REPO_ROOT}/hack/setup/quick-install/kserve-standard-mode-dependency-install.sh
+          ${INSTALL_SCRIPT_DIR}/kserve-standard-mode-dependency-install.sh
         fi
 
         ;;
       llmisvc)
-        ${REPO_ROOT}/hack/setup/quick-install/llmisvc-dependency-install.sh
+        ${INSTALL_SCRIPT_DIR}/llmisvc-dependency-install.sh
         ;;
     esac
   done
 
   # Install KEDA dependencies if enabled
   if is_positive "${ENABLE_KEDA}"; then
-    ${REPO_ROOT}/hack/setup/quick-install/keda-dependency-install.sh
+    ${INSTALL_SCRIPT_DIR}/keda-dependency-install.sh
   fi
 
   # Install LLMISvc autoscaling dependencies if enabled
   if [[ -n "${LLMISVC_SCALING}" ]]; then
     if [[ "${LLMISVC_SCALING}" == "keda" ]]; then
-      ${REPO_ROOT}/hack/setup/quick-install/llmisvc-autoscaling-keda-dependency-install.sh
+      ${INSTALL_SCRIPT_DIR}/llmisvc-autoscaling-keda-dependency-install.sh
     else
-      ${REPO_ROOT}/hack/setup/quick-install/llmisvc-autoscaling-hpa-dependency-install.sh
+      ${INSTALL_SCRIPT_DIR}/llmisvc-autoscaling-hpa-dependency-install.sh
     fi
   fi
 
@@ -294,7 +331,23 @@ fi
 # Install all enabled types together (single execution)
 if [[ ${#TYPES[@]} -gt 0 ]]; then
   log_info "Installing: ${TYPES[*]}..."
-  if [[ $INSTALL_METHOD == "helm" ]]; then
+  if is_positive "$USE_FROZEN_INSTALL"; then
+    # Frozen scripts embed kserve (or llmisvc) manifests only — localmodel needs kustomize.
+    if is_positive "$ENABLE_KSERVE"; then
+      if [[ $USER_MODE == "serverless" ]]; then
+        ENABLE_LOCALMODEL=false ${INSTALL_SCRIPT_DIR}/kserve-knative-mode-full-install-with-manifests.sh
+      else
+        ENABLE_LOCALMODEL=false ${INSTALL_SCRIPT_DIR}/kserve-standard-mode-full-install-with-manifests.sh
+      fi
+    fi
+    if is_positive "$ENABLE_LOCALMODEL"; then
+      log_info "Installing LocalModel via frozen manifests..."
+      ${INSTALL_SCRIPT_DIR}/localmodel-full-install-with-manifests.sh
+    fi
+    if is_positive "$ENABLE_LLMISVC"; then
+      ${INSTALL_SCRIPT_DIR}/llmisvc-full-install-with-manifests.sh
+    fi
+  elif [[ $INSTALL_METHOD == "helm" ]]; then
     ${REPO_ROOT}/hack/setup/infra/manage.kserve-helm.sh
   else
     ${REPO_ROOT}/hack/setup/infra/manage.kserve-kustomize.sh

--- a/hack/setup/infra/manage.kserve-kustomize.sh
+++ b/hack/setup/infra/manage.kserve-kustomize.sh
@@ -166,8 +166,6 @@ if ! is_positive "$EMBED_MANIFESTS" && [ -z "${KSERVE_OVERLAY_DIR}" ] && ([ -n "
     
     # Customized images are loaded onto the node, not pushed to a registry, so
     # force IfNotPresent to avoid registry pulls for locally-built image tags.
-    # TODO: remove this after the following PR is merged:
-    KSERVE_INSTALL_CI=true
     if is_positive ${KSERVE_INSTALL_CI}; then
         find "${TARGET_CONFIG_ROOT_DIR}/config" -type f -name "*.yaml" \
             "${FIND_PRUNE[@]}" \

--- a/hack/setup/quick-install/definitions/localmodel/localmodel-dependency-install.definition
+++ b/hack/setup/quick-install/definitions/localmodel/localmodel-dependency-install.definition
@@ -1,0 +1,8 @@
+DESCRIPTION: Install LocalModel dependencies
+
+TOOLS:
+  - helm
+  - yq
+  
+COMPONENTS:
+  - name: cert-manager

--- a/hack/setup/quick-install/definitions/localmodel/localmodel-full-install-with-manifests.definition
+++ b/hack/setup/quick-install/definitions/localmodel/localmodel-full-install-with-manifests.definition
@@ -1,0 +1,20 @@
+DESCRIPTION: Install LocalModel and all related dependencies with manifests included in the script.
+EMBED_MANIFESTS: true
+
+TOOLS:
+  - helm
+  - kustomize
+  - yq
+  
+INCLUDE_DEFINITIONS:
+  - ./localmodel-dependency-install.definition
+    
+COMPONENTS:
+  - name: kserve-kustomize
+    env:
+      ENABLE_LLMISVC: false
+      ENABLE_KSERVE: false
+      ENABLE_LOCALMODEL: true
+      INSTALL_RUNTIMES: false
+      INSTALL_LLMISVC_CONFIGS: false
+      

--- a/hack/setup/quick-install/definitions/localmodel/localmodel-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/definitions/localmodel/localmodel-full-install-with-manifests.sh
@@ -1,0 +1,6855 @@
+#!/bin/bash
+
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install LocalModel and all related dependencies with manifests included in the script.
+#
+# AUTO-GENERATED from: localmodel-full-install-with-manifests.definition
+# DO NOT EDIT MANUALLY
+#
+# To regenerate:
+#   ./scripts/generate-install-script.py localmodel-full-install-with-manifests.definition
+#
+# Usage: localmodel-full-install-with-manifests.sh [--reinstall|--uninstall]
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+#================================================
+# Helper Functions (from common.sh)
+#================================================
+
+# Utility Functions
+# ============================================================================
+
+find_repo_root() {
+    local current_dir="${1:-$(pwd)}"
+    local skip="${2:-false}"
+
+    while [[ "$current_dir" != "/" ]]; do
+        if [[ -e "${current_dir}/.git" ]]; then
+            echo "$current_dir"
+            return 0
+        fi
+        current_dir="$(dirname "$current_dir")"
+    done
+
+    # Git repository not found
+    if [[ "$skip" == "true" ]]; then
+        log_warning "Could not find git repository root, using current directory: $PWD"
+        echo "$PWD"
+        return 0
+    else
+        log_error "Could not find git repository root"
+        exit 1
+    fi
+}
+
+ensure_dir() {
+    local dir_path="${1}"
+
+    if [[ -d "${dir_path}" ]]; then
+        return 0
+    fi
+
+    mkdir -p "${dir_path}"
+}
+
+detect_os() {
+    local os=""
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="darwin" ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
+    esac
+    echo "$os"
+}
+
+detect_arch() {
+    local arch=""
+    case "$(uname -m)" in
+        x86_64)  arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
+    esac
+    echo "$arch"
+}
+
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
+# Color codes (disable if NO_COLOR is set or not a terminal)
+if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
+    BLUE='\033[94m'
+    GREEN='\033[92m'
+    RED='\033[91m'
+    YELLOW='\033[93m'
+    RESET='\033[0m'
+else
+    BLUE=''
+    GREEN=''
+    RED=''
+    YELLOW=''
+    RESET=''
+fi
+
+log_info() {
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${RESET} $*" >&2
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
+}
+
+is_positive() {
+  local input_val="${1:-no}"
+
+  case "${input_val}" in
+    0|true|True|yes|Yes|y|Y)
+      return 0  # Success - truthy
+      ;;
+    1|false|False|no|No|n|N)
+      return 1  # Failure - falsy
+      ;;
+    *)
+      return 2  # Invalid input
+      ;;
+  esac
+}
+
+
+# ============================================================================
+# Infrastructure Installation Helper Functions
+# ============================================================================
+
+# Detect the platform (kind/minikube/openshift/kubernetes)
+# Returns: kind, minikube, openshift, or kubernetes
+detect_platform() {
+    # Check for OpenShift
+    if kubectl get clusterversion &>/dev/null; then
+        echo "openshift"
+        return 0
+    fi
+
+    # Check for Kind
+    local node_hostname
+    node_hostname=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.kubernetes\.io/hostname}' 2>/dev/null || echo "")
+    if [[ "$node_hostname" == *"kind"* ]]; then
+        echo "kind"
+        return 0
+    fi
+
+    # Check for Minikube
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null || echo "")
+    if [[ "$current_context" == *"minikube"* ]]; then
+        echo "minikube"
+        return 0
+    fi
+
+    # Default to standard Kubernetes
+    echo "kubernetes"
+    return 0
+}
+
+# Wait for pods to be created (exist)
+# Usage: wait_for_pods_created <namespace> <label-selector> [timeout_seconds]
+wait_for_pods_created() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-60}"
+    local elapsed=0
+
+    log_info "Waiting for pods with label '$label_selector' in namespace '$namespace' to be created..."
+
+    while true; do
+        # Exclude terminating pods by filtering out Terminating status
+        local pod_count=$(kubectl get pods -n "$namespace" -l "$label_selector" \
+            --no-headers 2>/dev/null | grep -v "Terminating" | wc -l)
+
+        if [ "$pod_count" -gt 0 ]; then
+            log_info "Found $pod_count pod(s) with label '$label_selector'"
+            return 0
+        fi
+
+        if [ $elapsed -ge $timeout ]; then
+            log_error "Timeout waiting for pods with label '$label_selector' to be created"
+            return 1
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+# Wait for pods to be ready
+# Usage: wait_for_pods_ready <namespace> <label-selector> [timeout]
+wait_for_pods_ready() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-180s}"
+
+    log_info "Waiting for pods with label '$label_selector' in namespace '$namespace' to be ready..."
+
+    # Get list of non-terminating pods and wait for them
+    local pods=$(kubectl get pods -n "$namespace" -l "$label_selector" \
+        --no-headers 2>/dev/null | grep -v "Terminating" | awk '{print $1}')
+
+    if [ -z "$pods" ]; then
+        log_error "No pods found with label '$label_selector' in namespace '$namespace'"
+        return 1
+    fi
+
+    for pod in $pods; do
+        kubectl wait --for=condition=Ready pod/"$pod" -n "$namespace" --timeout="$timeout" || return 1
+    done
+}
+
+# Wait for pods to be ready (combines both creation and ready checks)
+# Usage: wait_for_pods <namespace> <label-selector> [timeout]
+wait_for_pods() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-180s}"
+
+    # Convert timeout to seconds for pod creation check
+    local timeout_seconds="${timeout%s}"
+    local timeout_created=60
+
+    # If timeout is longer than 60s, use 60s for creation, rest for ready
+    # If timeout is shorter, split it
+    if [ "$timeout_seconds" -gt 60 ]; then
+        timeout_created=60
+    else
+        timeout_created=$((timeout_seconds / 3))
+    fi
+
+    # First, wait for pods to be created
+    wait_for_pods_created "$namespace" "$label_selector" "$timeout_created" || return 1
+
+    # Then, wait for pods to be ready
+    wait_for_pods_ready "$namespace" "$label_selector" "$timeout" || return 1
+
+    log_success "Pods with label '$label_selector' in namespace '$namespace' are ready!"
+}
+
+# Wait for deployment to be available using kubectl wait
+# Usage: wait_for_deployment <namespace> <deployment-name> [timeout]
+# Note: This uses kubectl wait --for=condition=Available, which checks deployment status directly
+wait_for_deployment() {
+    local namespace="$1"
+    local deployment_name="$2"
+    local timeout="${3:-180s}"
+
+    log_info "Waiting for deployment '$deployment_name' in namespace '$namespace' to be available..."
+    if kubectl wait --timeout="$timeout" -n "$namespace" deployment/"$deployment_name" --for=condition=Available; then
+        log_success "Deployment '$deployment_name' in namespace '$namespace' is available!"
+    else
+        log_error "Deployment '$deployment_name' in namespace '$namespace' failed to become available within $timeout"
+        log_error "--- Deployment status ---"
+        kubectl get deployment "$deployment_name" -n "$namespace" -o wide 2>/dev/null || true
+        log_error "--- Pod status ---"
+        kubectl get pods -n "$namespace" -l "control-plane=$deployment_name" -o wide 2>/dev/null || true
+        log_error "--- Pod describe (last 50 lines) ---"
+        kubectl describe pods -n "$namespace" -l "control-plane=$deployment_name" 2>/dev/null | tail -50 || true
+        log_error "--- Recent events in namespace '$namespace' ---"
+        kubectl get events -n "$namespace" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+        return 1
+    fi
+}
+
+# Wait for CRD to be established
+# Usage: wait_for_crd <crd-name> [timeout]
+wait_for_crd() {
+    local crd_name="$1"
+    local timeout="${2:-60s}"
+
+    log_info "Waiting for CRD '$crd_name' to be established..."
+
+    # Add small delay to allow CRD status to be initialized
+    sleep 2
+
+    # Retry logic to handle race condition where .status.conditions may not be initialized yet
+    local max_retries=10
+    local retry=0
+    while [ $retry -lt $max_retries ]; do
+        if kubectl wait --for=condition=Established --timeout="$timeout" crd/"$crd_name" 2>/dev/null; then
+            return 0
+        fi
+        retry=$((retry + 1))
+        if [ $retry -lt $max_retries ]; then
+            log_info "Retry $retry/$max_retries: Waiting for CRD status to be initialized..."
+            sleep 3
+        fi
+    done
+
+    # Final attempt with error output
+    kubectl wait --for=condition=Established --timeout="$timeout" crd/"$crd_name"
+}
+
+# Wait for multiple CRDs to be established
+# Usage: wait_for_crds <timeout> <crd1> <crd2> ...
+wait_for_crds() {
+    local timeout="$1"
+    shift
+
+    for crd in "$@"; do
+        wait_for_crd "$crd" "$timeout" || return 1
+    done
+
+    log_success "All CRDs are established!"
+}
+
+# Update multiple fields in KServe inferenceservice-config ConfigMap
+# Usage: update_isvc_config "ingress.enableGatewayApi=true" "deploy.defaultDeploymentMode=Standard"
+# Example:
+#   update_isvc_config "ingress.enableGatewayApi=true"
+#   update_isvc_config "ingress.enableGatewayApi=true" "ingress.className=\"envoy\""
+update_isvc_config() {
+    if [ $# -eq 0 ]; then
+        log_error "No update parameters provided"
+        return 1
+    fi
+
+    log_info "Updating inferenceservice-config..."
+
+    # Prepare updates as JSON array
+    local updates_file
+    updates_file=$(mktemp)
+
+    for arg in "$@"; do
+        local key="${arg%%=*}"
+        local raw_value="${arg#*=}"
+        local data_key="${key%%.*}"
+        local json_path="${key#*.}"
+        local value_json="$raw_value"
+
+        # Smart type detection: auto-quote strings, keep numbers/booleans/JSON as-is
+        if [[ ! $raw_value =~ ^\" ]] \
+           && [[ ! $raw_value =~ ^-?[0-9]+(\.[0-9]+)?$ ]] \
+           && [[ ! $raw_value =~ ^(true|false|null)$ ]] \
+           && [[ ! $raw_value =~ ^[{\[] ]]; then
+            value_json=$(jq -Rn --arg v "$raw_value" '$v')
+        fi
+
+        jq -n \
+            --arg data_key "$data_key" \
+            --arg path "$json_path" \
+            --argjson value "$value_json" \
+            '{data_key:$data_key, path:$path, value:$value}' >> "$updates_file"
+
+        log_info "  ✓ $data_key.$json_path = $value_json"
+    done
+
+    local updates_json
+    updates_json=$(jq -s '.' "$updates_file")
+    rm -f "$updates_file"
+
+    # Apply all updates with a single jq invocation
+    kubectl get configmap inferenceservice-config -n "${KSERVE_NAMESPACE}" -o json |
+        jq --argjson updates "$updates_json" '
+            # Helper function to safely set nested paths, creating intermediate objects as needed
+            def setpath_safe($parts; $value):
+                reduce range(0; ($parts|length)-1) as $i (.;
+                    $parts[:$i+1] as $prefix
+                    | if getpath($prefix) == null then setpath($prefix; {}) else . end
+                )
+                | setpath($parts; $value);
+
+            # Apply each update
+            reduce $updates[] as $item (.;
+                if .data[$item.data_key] == null or .data[$item.data_key] == "" then
+                    .data[$item.data_key] = (
+                        {}
+                        | setpath_safe($item.path | split("."); $item.value)
+                        | tojson
+                    )
+                else
+                    .data[$item.data_key] |= (
+                        fromjson
+                        | setpath_safe($item.path | split("."); $item.value)
+                        | tojson
+                    )
+                end
+            )
+        ' |
+        kubectl apply -f -
+
+    log_success "ConfigMap updated successfully"
+}
+
+# Create namespace if it does not exist (skip if already exists)
+# Usage: create_or_skip_namespace <namespace>
+create_or_skip_namespace() {
+    local namespace="$1"
+
+    if kubectl get namespace "$namespace" &>/dev/null; then
+        log_info "Namespace '$namespace' already exists"
+    else
+        log_info "Creating namespace '$namespace'..."
+        kubectl create namespace "$namespace"
+        log_success "Namespace '$namespace' created"
+    fi
+}
+
+# Check if required CLI tools exist
+# Usage: check_cli_exist <tool1> [tool2] [tool3] ...
+check_cli_exist() {
+    local missing=()
+    for cmd in "$@"; do
+        if ! command_exists "$cmd"; then
+            missing+=("$cmd")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_error "Required CLI tool(s) not found: ${missing[*]}"
+        log_error "Please install missing tool(s) first."
+        exit 1
+    fi
+}
+
+command_exists() {
+    command -v "$1" &>/dev/null
+}
+
+# Retry a command with delay between attempts
+# Usage: retry_command <max_attempts> <delay_seconds> <command...>
+# Example: retry_command 3 5 kubectl apply -k "${RUNTIMES_DIR}"
+# Returns: 0 on success, 1 on failure after all attempts
+retry_command() {
+    local max_attempts="$1"
+    local delay="$2"
+    shift 2
+    local attempt=1
+
+    while [ $attempt -le $max_attempts ]; do
+        if "$@" 2>&1; then
+            return 0
+        fi
+
+        if [ $attempt -lt $max_attempts ]; then
+            log_warning "Command failed, retrying in ${delay} seconds... (attempt $attempt/$max_attempts)"
+            sleep "$delay"
+        else
+            log_error "Command failed after $max_attempts attempts"
+            return 1
+        fi
+        attempt=$((attempt + 1))
+    done
+}
+
+# Compare semantic versions (returns 0 if v1 >= v2, 1 otherwise)
+# Usage: version_gte "v3.17.3" "v3.16.0"
+# Example: version_gte "$current_version" "$required_version" && echo "OK"
+version_gte() {
+    [ "$1" = "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" ]
+}
+
+# ============================================================================
+# Shared Resources Configuration (for dual KServe + LLMISVC installation)
+# ============================================================================
+
+determine_shared_resources_config() {
+    local install_mode="${1}"
+    local enable_kserve="${2}"
+    local enable_llmisvc="${3}"
+
+    if ! is_positive "${enable_kserve}" && ! is_positive "${enable_llmisvc}"; then
+        return
+    fi
+
+    log_info "Determining shared resources configuration (KSERVE=${enable_kserve}, LLMISVC=${enable_llmisvc})..."
+
+    if [ "${install_mode}" = "helm" ]; then
+        determine_shared_resources_helm "${enable_kserve}" "${enable_llmisvc}"
+    elif [ "${install_mode}" = "kustomize" ]; then
+        determine_shared_resources_kustomize
+    else
+        log_error "INSTALL_MODE not set. Must be 'helm' or 'kustomize'"
+        exit 1
+    fi
+}
+
+determine_shared_resources_helm() {
+    local enable_kserve="${1}"
+    local enable_llmisvc="${2}"
+
+    local kserve_installed=$(helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -c "^kserve-resources$" || true)
+    local llmisvc_installed=$(helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -c "^kserve-llmisvc-resources$" || true)
+
+    if [ "${kserve_installed}" = "0" ] && [ "${llmisvc_installed}" = "0" ]; then
+        # First installation - check which components are being enabled
+        if is_positive "${enable_kserve}" && is_positive "${enable_llmisvc}"; then
+            # Both enabled: kserve-resources installs first and creates shared resources
+            log_info "[Helm] First install (both) - kserve-resources creates shared resources, llmisvc-resources does not"
+            LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        elif is_positive "${enable_kserve}" && ! is_positive "${enable_llmisvc}"; then
+            # Only kserve enabled: kserve-resources creates shared resources
+            log_info "[Helm] First install (kserve only) - kserve-resources will create shared resources"
+            # Use default value (true) - no extra args needed
+        elif ! is_positive "${enable_kserve}" && is_positive "${enable_llmisvc}"; then
+            # Only llmisvc enabled: llmisvc-resources creates shared resources
+            log_info "[Helm] First install (llmisvc only) - llmisvc-resources will create shared resources"
+            # Use default value (true) - no extra args needed
+        else
+            # Neither enabled - shouldn't reach here
+            log_error "[Helm] No components enabled"
+            return 1
+        fi
+    elif [ "${kserve_installed}" = "1" ] && [ "${llmisvc_installed}" = "0" ]; then
+        log_info "[Helm] Only kserve-resources installed - setting createSharedResources=false for LLMISVC"
+        LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+    elif [ "${kserve_installed}" = "0" ] && [ "${llmisvc_installed}" = "1" ]; then
+        log_info "[Helm] Only kserve-llmisvc-resources installed - setting createSharedResources=false for KSERVE"
+        KSERVE_EXTRA_ARGS="${KSERVE_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+    else
+        local kserve_has_false=$(helm get values kserve-resources -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "createSharedResources: false" || true)
+
+        if [ "${kserve_has_false}" = "1" ]; then
+            log_info "[Helm] Maintaining createSharedResources=false for KSERVE"
+            KSERVE_EXTRA_ARGS="${KSERVE_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        else
+            log_info "[Helm] Setting createSharedResources=false for LLMISVC"
+            LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        fi
+    fi
+}
+
+determine_shared_resources_kustomize() {
+    KSERVE_INSTALLED=$(kubectl get deployment kserve-controller-manager -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "kserve-controller-manager" || true)
+    LLMISVC_INSTALLED=$(kubectl get deployment llmisvc-controller-manager -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "llmisvc-controller-manager" || true)
+    
+    export KSERVE_INSTALLED
+    export LLMISVC_INSTALLED
+
+    log_info "[Kustomize] Installation status(0: not installed, 1: installed): KSERVE=${KSERVE_INSTALLED}, LLMISVC=${LLMISVC_INSTALLED}"
+}
+
+# ============================================================================
+
+# Set environment variable based on priority order:
+# Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default
+# Usage: set_env_with_priority VAR_NAME COMPONENT_ENV_VALUE GLOBAL_ENV_VALUE DEFAULT_VALUE
+set_env_with_priority() {
+    local var_name="$1"
+    local component_value="$2"
+    local global_value="$3"
+    local default_value="$4"
+
+    # Get current value
+    local current_value
+    eval "current_value=\${${var_name}}"
+
+    # If current value exists and differs from default, it's a runtime value - keep it
+    if [ -n "$current_value" ] && [ -n "$default_value" ] && [ "$current_value" != "$default_value" ]; then
+        # This is a runtime value, keep it
+        return
+    fi
+
+    # Apply priority: component env > global env > default
+    if [ -n "$component_value" ]; then
+        eval "export $var_name=\"$component_value\""
+    elif [ -n "$global_value" ]; then
+        eval "export $var_name=\"$global_value\""
+    fi
+    # If both are empty, variable keeps its default value
+}
+
+#================================================
+# Determine repository root using find_repo_root
+#================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
+REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
+export REPO_ROOT
+
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
+fi
+
+export PATH="${BIN_DIR}:${PATH}"
+
+REINSTALL="${REINSTALL:-false}"
+UNINSTALL="${UNINSTALL:-false}"
+FORCE_UPGRADE="${FORCE_UPGRADE:-false}"
+
+if [[ "$*" == *"--uninstall"* ]]; then
+    UNINSTALL=true
+elif [[ "$*" == *"--reinstall"* ]]; then
+    REINSTALL=true
+elif [[ "$*" == *"--force-upgrade"* ]]; then
+    FORCE_UPGRADE=true
+fi
+
+export REINSTALL
+export UNINSTALL
+export FORCE_UPGRADE
+
+# RELEASE mode (from definition file)
+RELEASE="false"
+export RELEASE
+
+#================================================
+# Version Dependencies (from kserve-deps.env)
+#================================================
+
+GOLANGCI_LINT_VERSION=v2.9.0
+CONTROLLER_TOOLS_VERSION=v0.19.0
+ENVTEST_VERSION=release-0.19
+YQ_VERSION=v4.52.1
+HELM_VERSION=v3.16.3
+KUSTOMIZE_VERSION=v5.8.1
+HELM_DOCS_VERSION=v1.12.0
+POETRY_VERSION=1.8.3
+UV_VERSION=0.7.8
+RUFF_VERSION=0.14.13
+PINACT_VERSION=v3.9.0
+KIND_VERSION=v0.30.0
+CERT_MANAGER_VERSION=v1.17.0
+ENVOY_GATEWAY_VERSION=v1.8.1
+ENVOY_AI_GATEWAY_VERSION=v1.0.0
+KNATIVE_OPERATOR_VERSION=v1.21.1
+KNATIVE_SERVING_VERSION=1.21.1
+KEDA_OTEL_ADDON_VERSION=v0.0.6
+PROMETHEUS_VERSION=83.4.0
+PROMETHEUS_ADAPTER_VERSION=5.3.0
+JAEGER_VERSION=4.7.0
+KSERVE_VERSION=v0.20.0
+ISTIO_VERSION=1.27.1
+KEDA_VERSION=2.18.0
+OPENTELEMETRY_OPERATOR_VERSION=0.74.3
+LWS_VERSION=v0.8.0
+GATEWAY_API_VERSION=v1.5.1
+GIE_VERSION=v1.5.0
+LLMD_ROUTER_VERSION=v0.10.0
+WVA_VERSION=v0.9.0
+
+#================================================
+# Global Variables (from global-vars.env)
+#================================================
+# These provide default namespace values that can be overridden
+# by environment variables or GLOBAL_ENV settings below
+
+KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
+KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-kserve}"
+PROMETHEUS_NAMESPACE="${PROMETHEUS_NAMESPACE:-monitoring}"
+PROMETHEUS_ADAPTER_NAMESPACE="${PROMETHEUS_ADAPTER_NAMESPACE:-monitoring}"
+WVA_NAMESPACE="${WVA_NAMESPACE:-wva-system}"
+OTEL_NAMESPACE="${OTEL_NAMESPACE:-opentelemetry-operator}"
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-knative-operator}"
+SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
+ISTIO_NAMESPACE="${ISTIO_NAMESPACE:-istio-system}"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-kserve}"
+DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-Knative}"
+GATEWAY_NETWORK_LAYER="${GATEWAY_NETWORK_LAYER:-false}"
+ENABLE_KSERVE="${ENABLE_KSERVE:-true}"
+ENABLE_LLMISVC="${ENABLE_LLMISVC:-false}"
+ENABLE_LOCALMODEL="${ENABLE_LOCALMODEL:-false}"
+EMBED_MANIFESTS="${EMBED_MANIFESTS:-false}"
+EMBED_TEMPLATES="${EMBED_TEMPLATES:-false}"
+KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
+
+#================================================
+# Component-Specific Variables
+#================================================
+
+SET_KSERVE_VERSION="${SET_KSERVE_VERSION:-}"
+SET_KSERVE_REGISTRY="${SET_KSERVE_REGISTRY:-}"
+ENABLE_KSERVE="${ENABLE_KSERVE:-${KSERVE:-true}}"
+ENABLE_LLMISVC="${ENABLE_LLMISVC:-${LLMISVC:-false}}"
+ENABLE_LOCALMODEL="${ENABLE_LOCALMODEL:-${LOCALMODEL:-false}}"
+KSERVE_OVERLAY_DIR="${KSERVE_OVERLAY_DIR:-}"
+USE_LOCAL_CONFIGMAP="${USE_LOCAL_CONFIGMAP:-false}"
+KSERVE_INSTALLED="${KSERVE_INSTALLED:-0}"
+LLMISVC_INSTALLED="${LLMISVC_INSTALLED:-0}"
+INSTALL_RUNTIMES="${INSTALL_RUNTIMES:-${ENABLE_KSERVE:-false}}"
+INSTALL_LLMISVC_CONFIGS="${INSTALL_LLMISVC_CONFIGS:-${ENABLE_LLMISVC:-false}}"
+FORCE_UPGRADE="${FORCE_UPGRADE:-false}"
+TARGET_CRD_DIRS=()
+TARGET_DEPLOYMENT_NAMES=()
+TARGET_OVERLAY_DIRS=()
+TARGET_CRDS_TO_VERIFY=()
+
+#================================================
+# Template Functions (EMBED_TEMPLATES MODE)
+#================================================
+
+
+
+#================================================
+# Component Functions
+#================================================
+
+# ----------------------------------------
+# CLI/Component: helm
+# ----------------------------------------
+
+
+
+install_helm() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local archive_name="helm-${HELM_VERSION}-${os}-${arch}.tar.gz"
+    local download_url="https://get.helm.sh/${archive_name}"
+
+    log_info "Installing Helm ${HELM_VERSION} for ${os}/${arch}..."
+
+    # Check if helm is already installed in BIN_DIR with the exact required version
+    if [[ -f "${BIN_DIR}/helm" ]]; then
+        local current_version=$("${BIN_DIR}/helm" version --template='{{.Version}}' 2>/dev/null)
+        if [[ "$current_version" == "$HELM_VERSION" ]]; then
+            log_info "Helm ${current_version} is already installed in ${BIN_DIR}"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Replacing Helm ${current_version} with ${HELM_VERSION} in ${BIN_DIR}..."
+    fi
+
+    local temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${archive_name}"
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_error "Neither wget nor curl is available" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    tar -xzf "${temp_file}" -C "${temp_dir}"
+
+    local binary_path="${temp_dir}/${os}-${arch}/helm"
+
+    if [[ ! -f "${binary_path}" ]]; then
+        log_error "helm binary not found in archive" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    chmod +x "${binary_path}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${binary_path}" "${BIN_DIR}/helm"
+    else
+        sudo mv "${binary_path}" "${BIN_DIR}/helm"
+    fi
+
+    rm -rf "${temp_dir}"
+
+    log_success "Successfully installed Helm ${HELM_VERSION} to ${BIN_DIR}/helm"
+    "${BIN_DIR}/helm" version
+}
+
+# ----------------------------------------
+# CLI/Component: kustomize
+# ----------------------------------------
+
+
+
+install_kustomize() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local archive_name="kustomize_${KUSTOMIZE_VERSION}_${os}_${arch}.tar.gz"
+    local download_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${archive_name}"
+
+    log_info "Installing Kustomize ${KUSTOMIZE_VERSION} for ${os}/${arch}..."
+
+    if [[ -x "${BIN_DIR}/kustomize" ]]; then
+        local current_version=$("${BIN_DIR}/kustomize" version 2>/dev/null | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        if [[ -n "$current_version" ]] && version_gte "$current_version" "$KUSTOMIZE_VERSION"; then
+            log_info "Kustomize ${current_version} is already installed in ${BIN_DIR} (>= ${KUSTOMIZE_VERSION})"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Upgrading Kustomize from ${current_version} to ${KUSTOMIZE_VERSION}..."
+    fi
+
+    local temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${archive_name}"
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_error "Neither wget nor curl is available" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    tar -xzf "${temp_file}" -C "${temp_dir}"
+
+    local binary_path="${temp_dir}/kustomize"
+
+    if [[ ! -f "${binary_path}" ]]; then
+        log_error "kustomize binary not found in archive" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    chmod +x "${binary_path}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${binary_path}" "${BIN_DIR}/kustomize"
+    else
+        sudo mv "${binary_path}" "${BIN_DIR}/kustomize"
+    fi
+
+    rm -rf "${temp_dir}"
+
+    log_success "Successfully installed Kustomize ${KUSTOMIZE_VERSION} to ${BIN_DIR}/kustomize"
+    "${BIN_DIR}/kustomize" version
+}
+
+# ----------------------------------------
+# CLI/Component: yq
+# ----------------------------------------
+
+
+
+install_yq() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local binary_name="yq_${os}_${arch}"
+    local download_url="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${binary_name}"
+
+    log_info "Installing yq ${YQ_VERSION} for ${os}/${arch}..."
+
+    if [[ -x "${BIN_DIR}/yq" ]]; then
+        local current_version=$("${BIN_DIR}/yq" --version 2>&1 | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        # Normalize version format (add 'v' prefix if missing)
+        [[ -n "$current_version" && "$current_version" != v* ]] && current_version="v${current_version}"
+        if [[ -n "$current_version" ]] && version_gte "$current_version" "$YQ_VERSION"; then
+            log_info "yq ${current_version} is already installed in ${BIN_DIR} (>= ${YQ_VERSION})"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Upgrading yq from ${current_version} to ${YQ_VERSION}..."
+    fi
+
+    local temp_file=$(mktemp)
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_info "Neither wget nor curl is available" >&2
+        rm -f "${temp_file}"
+        exit 1
+    fi
+
+    chmod +x "${temp_file}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${temp_file}" "${BIN_DIR}/yq"
+    else
+        sudo mv "${temp_file}" "${BIN_DIR}/yq"
+    fi
+
+    log_success "Successfully installed yq ${YQ_VERSION} to ${BIN_DIR}/yq"
+    "${BIN_DIR}/yq" --version
+}
+
+# ----------------------------------------
+# CLI/Component: cert-manager
+# ----------------------------------------
+
+uninstall_cert_manager() {
+    log_info "Uninstalling cert-manager..."
+    helm uninstall cert-manager -n cert-manager 2>/dev/null || true
+    kubectl delete all --all -n cert-manager --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace cert-manager --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    log_success "cert-manager uninstalled"
+}
+
+install_cert_manager() {
+    if helm list -n cert-manager 2>/dev/null | grep -q "cert-manager"; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "cert-manager is already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling cert-manager..."
+            uninstall_cert_manager
+        fi
+    fi
+
+    log_info "Adding cert-manager Helm repository..."
+    helm repo add jetstack https://charts.jetstack.io --force-update
+
+    log_info "Installing cert-manager ${CERT_MANAGER_VERSION}..."
+    helm install \
+        cert-manager jetstack/cert-manager \
+        --namespace cert-manager \
+        --create-namespace \
+        --version "${CERT_MANAGER_VERSION}" \
+        --set crds.enabled=true \
+        --wait
+
+    log_success "Successfully installed cert-manager ${CERT_MANAGER_VERSION} via Helm"
+
+    wait_for_pods "cert-manager" "app in (cert-manager,webhook,cainjector)" "180s"
+
+    log_success "cert-manager is ready!"
+}
+
+# ----------------------------------------
+# CLI/Component: kserve-kustomize
+# ----------------------------------------
+
+uninstall_kserve_kustomize() {
+    log_info "Uninstalling KServe..."
+
+    # EMBED_MANIFESTS: use embedded manifests
+    if is_positive "$EMBED_MANIFESTS"; then
+        if type uninstall_kserve_manifest &>/dev/null; then
+            uninstall_kserve_manifest
+        else
+            log_error "EMBED_MANIFESTS enabled but uninstall_kserve_manifest function not found"
+            log_error "This script should be called from a generated installation script"
+            exit 1
+        fi
+    else
+        # Uninstall Runtimes and LLMISVC configs first
+        if is_positive "${INSTALL_RUNTIMES}"; then
+            log_info "Uninstalling ClusterServingRuntimes..."
+            kubectl delete -k config/runtimes --force --grace-period=0 2>/dev/null || true
+        fi
+        if is_positive "${INSTALL_LLMISVC_CONFIGS}"; then
+            log_info "Uninstalling LLMISVC configs..."
+            kubectl delete -k config/llmisvcconfig --force --grace-period=0 2>/dev/null || true
+        fi
+
+        # Uninstall overlay resources in reverse order
+        for ((i=${#TARGET_OVERLAY_DIRS[@]}-1; i>=0; i--)); do
+            log_info "Uninstalling resources from ${TARGET_OVERLAY_DIRS[$i]}..."
+            kustomize build "${TARGET_OVERLAY_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
+        done
+
+        # Uninstall CRDs in reverse order
+        for ((i=${#TARGET_CRD_DIRS[@]}-1; i>=0; i--)); do
+            log_info "Uninstalling CRDs from ${TARGET_CRD_DIRS[$i]}..."
+            kustomize build "${TARGET_CRD_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
+        done
+    fi
+
+    kubectl delete all --all -n "${KSERVE_NAMESPACE}" --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace "${KSERVE_NAMESPACE}" --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    log_success "KServe uninstalled"
+}
+
+install_kserve_kustomize() {
+    # Determine installation status
+    determine_shared_resources_config "${INSTALL_MODE}" "${ENABLE_KSERVE}" "${ENABLE_LLMISVC}"
+
+    # Check if already installed
+    local already_installed=false
+    if [ "${KSERVE_INSTALLED}" = "1" ] || [ "${LLMISVC_INSTALLED}" = "1" ]; then
+        already_installed=true
+    fi
+
+    if [ "${already_installed}" = "true" ]; then
+        if ! is_positive "$REINSTALL"; then
+            if is_positive "$FORCE_UPGRADE"; then
+                log_info "Force upgrading KServe..."
+            else
+                log_info "KServe is already installed. Use --reinstall to reinstall or --force-upgrade to upgrade."
+                return 0
+            fi
+        else
+            log_info "Reinstalling KServe..."
+            uninstall_kserve_kustomize
+        fi
+    fi
+
+    # EMBED_MANIFESTS: use embedded manifests from generated script
+    if is_positive "$EMBED_MANIFESTS"; then
+        log_info "Installing KServe using embedded manifests..."
+
+        # Call manifest functions (these should be available in generated script)
+        if type install_kserve_manifest &>/dev/null; then
+            install_kserve_manifest
+        else
+            log_error "EMBED_MANIFESTS enabled but install_kserve_manifest function not found"
+            log_error "This script should be called from a generated installation script"
+            exit 1
+        fi
+    else
+        log_info "Installing KServe via Kustomize..."
+
+        # Install CRDs and wait for them
+        log_info "Installing KServe CRDs..."
+        for i in "${!TARGET_CRD_DIRS[@]}"; do
+            crd_dir="${TARGET_CRD_DIRS[$i]}"
+            log_info "  - Installing CRDs from ${crd_dir}..."
+            kustomize build "${crd_dir}" | kubectl apply --server-side --force-conflicts -f -
+
+            # Collect CRDs to verify
+            crds="${TARGET_CRDS_TO_VERIFY[$i]}"
+            if [ -n "${crds}" ]; then
+                log_info "Waiting for required CRDs..."
+                wait_for_crds "60s" ${crds}
+            fi
+        done
+
+        # Install resources from overlays
+        log_info "Installing KServe resources..."
+        for i in "${!TARGET_OVERLAY_DIRS[@]}"; do
+            overlay_dir="${TARGET_OVERLAY_DIRS[$i]}"
+
+            # Install overlay
+            log_info "  - Installing resources from ${overlay_dir}..."
+            kustomize build "${overlay_dir}" | kubectl apply --server-side -f -
+
+            # Wait for corresponding deployment
+            if [ ${#TARGET_DEPLOYMENT_NAMES[@]} -gt $i ] && [ -n "${TARGET_DEPLOYMENT_NAMES[$i]}" ]; then
+                for d in ${TARGET_DEPLOYMENT_NAMES[$i]}; do
+                    wait_for_deployment "${KSERVE_NAMESPACE}" "${d}" "300s"
+                done
+            fi
+        done
+    fi
+
+    if ! is_positive "${USE_LOCAL_CONFIGMAP}"; then
+        # Build list of config updates
+        local config_updates=()
+
+        # Update deployment mode if needed
+        if [ "${DEPLOYMENT_MODE}" = "Standard" ] || [ "${DEPLOYMENT_MODE}" = "RawDeployment" ]; then
+            log_info "Adding deployment mode update: ${DEPLOYMENT_MODE}"
+            config_updates+=("deploy.defaultDeploymentMode=${DEPLOYMENT_MODE}")
+        fi
+
+        # Enable Gateway API for KServe(ISVC) if needed
+        if [ "${GATEWAY_NETWORK_LAYER}" != "false" ] && ! is_positive "${ENABLE_LLMISVC}"; then
+            log_info "Adding Gateway API updates: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
+            config_updates+=("ingress.enableGatewayApi=true")
+            config_updates+=("ingress.ingressClassName=${GATEWAY_NETWORK_LAYER}")
+        fi
+        if is_positive "${ENABLE_LOCALMODEL}"; then
+            log_info "Adding LocalModel updates: enabled=true, defaultJobImage=kserve/storage-initializer:${KSERVE_VERSION}"
+            config_updates+=("localModel.enabled=true")
+            config_updates+=("localModel.defaultJobImage=kserve/storage-initializer:${KSERVE_VERSION}")
+        fi
+        # Add custom configurations if provided
+        if [ -n "${KSERVE_CUSTOM_ISVC_CONFIGS}" ]; then
+            log_info "Adding custom configurations: ${KSERVE_CUSTOM_ISVC_CONFIGS}"
+            IFS='|' read -ra custom_configs <<< "${KSERVE_CUSTOM_ISVC_CONFIGS}"
+            config_updates+=("${custom_configs[@]}")
+        fi
+
+        # Apply all config updates at once if there are any
+        if [ ${#config_updates[@]} -gt 0 ]; then
+            log_info "Applying ${#config_updates[@]} configuration update(s):"
+            for update in "${config_updates[@]}"; do
+                log_info "  - ${update}"
+            done
+            update_isvc_config "${config_updates[@]}"
+            for i in "${!TARGET_OVERLAY_DIRS[@]}"; do
+                if [ ${#TARGET_DEPLOYMENT_NAMES[@]} -gt $i ] && [ -n "${TARGET_DEPLOYMENT_NAMES[$i]}" ]; then
+                    for d in ${TARGET_DEPLOYMENT_NAMES[$i]}; do
+                        wait_for_deployment "${KSERVE_NAMESPACE}" "${d}" "300s"
+                    done
+                fi
+            done
+            log_success "KServe configuration updated"
+        else
+            if is_positive "${ENABLE_LLMISVC}" && ! is_positive "${ENABLE_KSERVE}"; then
+                log_info "No configuration updates needed for LLMISVC (GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+            else
+                log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+            fi
+        fi
+    fi
+    # Final Check:Wait for controller manager to be ready
+    for deployment in $(kubectl get deployments -n "${KSERVE_NAMESPACE}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+        if echo "$deployment" | grep -q controller-manager; then
+            log_info "Waiting for deployment: $deployment"
+            wait_for_deployment "${KSERVE_NAMESPACE}" "$deployment" "300s"
+        fi
+    done
+    log_success "KServe is ready!"
+
+    # Wait for kserve webhook endpoint to be ready
+    sleep 2
+
+    if is_positive "${INSTALL_RUNTIMES}"; then
+        log_info "Installing ClusterServingRuntimes..."
+        if [ $EMBED_MANIFESTS = "true" ]; then
+            create_kserve_runtime_manifests
+        else
+            retry_command 3 5 kubectl apply --server-side=true -k "${RUNTIMES_DIR}"
+        fi
+    fi
+
+    if is_positive "${INSTALL_LLMISVC_CONFIGS}"; then
+        log_info "Installing LLMISVC configs..."
+         if [ $EMBED_MANIFESTS = "true" ]; then
+            create_kserve_llmisvcconfig_manifests
+        else
+            retry_command 3 5 kubectl apply --server-side=true -k "${REPO_ROOT}/config/llmisvcconfig"
+        fi
+    fi
+
+    # Cleanup temporary overlay after all resources are installed
+    if [ "${KSERVE_OVERLAY_DIR}" = "temp" ]; then
+        rm -rf "${REPO_ROOT}/config/overlays/temp"
+        log_info "Temporary overlay directory cleaned up"
+    fi
+
+}
+
+
+
+#================================================
+# Main Installation Logic
+#================================================
+
+main() {
+    if [ "$UNINSTALL" = true ]; then
+        echo "=========================================="
+        echo "Uninstalling components..."
+        echo "=========================================="
+        uninstall_kserve_manifest
+        uninstall_cert_manager
+        
+        
+        
+        echo "=========================================="
+        echo "✅ Uninstallation completed!"
+        echo "=========================================="
+        exit 0
+    fi
+
+    echo "=========================================="
+    echo "Install LocalModel and all related dependencies with manifests included in the script."
+    echo "=========================================="
+
+    export EMBED_TEMPLATES="true"
+    export EMBED_MANIFESTS="true"
+    export INSTALL_MODE="kustomize"
+
+    install_helm
+    install_kustomize
+    install_yq
+    install_cert_manager
+    (
+        set_env_with_priority "ENABLE_LLMISVC" "False" "" ""
+        set_env_with_priority "ENABLE_KSERVE" "False" "" ""
+        set_env_with_priority "ENABLE_LOCALMODEL" "True" "" ""
+        set_env_with_priority "INSTALL_RUNTIMES" "False" "" ""
+        set_env_with_priority "INSTALL_LLMISVC_CONFIGS" "False" "" ""
+        KSERVE_CRDS="inferenceservices.serving.kserve.io servingruntimes.serving.kserve.io clusterservingruntimes.serving.kserve.io inferencegraphs.serving.kserve.io trainedmodels.serving.kserve.io"
+        LLMISVC_CRDS="llminferenceservices.serving.kserve.io llminferenceserviceconfigs.serving.kserve.io"
+        LOCALMODEL_CRDS="localmodelcaches.serving.kserve.io localmodelnodegroups.serving.kserve.io localmodelnodes.serving.kserve.io"
+        KSERVE_CONFIG_DIR="${REPO_ROOT}/config/overlays/standalone/kserve"
+        LLMISVC_CONFIG_DIR="${REPO_ROOT}/config/overlays/standalone/llmisvc"
+        LOCALMODEL_CONFIG_DIR="${REPO_ROOT}/config/overlays/addons/localmodel"
+        RUNTIMES_DIR="${REPO_ROOT}/config/runtimes"
+        
+        # Override KSERVE_VERSION if SET_KSERVE_VERSION is provided
+        if [ -n "${SET_KSERVE_VERSION}" ]; then
+            KSERVE_VERSION="${SET_KSERVE_VERSION}"
+        fi
+        
+        # Create temporary overlay if version/registry override is needed
+        if ! is_positive "$EMBED_MANIFESTS" && [ -z "${KSERVE_OVERLAY_DIR}" ] && ([ -n "${SET_KSERVE_VERSION}" ] || [ -n "${SET_KSERVE_REGISTRY}" ]); then
+            TEMP_OVERLAY_DIR="${REPO_ROOT}/config/overlays/temp"
+            TEMPLATE_DIR="${REPO_ROOT}/config/overlays/version-template"
+        
+            log_info "Creating temporary overlay from template: ${TEMP_OVERLAY_DIR}"
+        
+            # Copy template
+            rm -rf "${TEMP_OVERLAY_DIR}"
+            cp -r "${TEMPLATE_DIR}" "${TEMP_OVERLAY_DIR}"
+        
+            # Replace version/registry placeholders
+            VERSION="${SET_KSERVE_VERSION:-latest}"
+            REGISTRY="${SET_KSERVE_REGISTRY:-kserve}"
+        
+            find "${TEMP_OVERLAY_DIR}" -type f -name "*.yaml" -exec sed -i \
+                -e "s/latest/${VERSION}/g" \
+                -e "s|kserve/|${REGISTRY}/|g" {} \;
+        
+            # Uncomment components/patches based on ENABLE_* flags
+            if is_positive "${ENABLE_KSERVE}"; then
+                sed -i 's/#ENABLE_KSERVE //' "${TEMP_OVERLAY_DIR}/kustomization.yaml"
+            fi
+        
+            if is_positive "${ENABLE_LLMISVC}"; then
+                sed -i 's/#ENABLE_LLMISVC //' "${TEMP_OVERLAY_DIR}/kustomization.yaml"
+            fi
+        
+            if is_positive "${ENABLE_LOCALMODEL}"; then
+                sed -i 's/#ENABLE_LOCALMODEL //' "${TEMP_OVERLAY_DIR}/kustomization.yaml"
+            fi
+        
+            # Use temporary overlay
+            KSERVE_OVERLAY_DIR="temp"
+            log_success "Temporary overlay created successfully"
+        fi
+        
+        if [ -n "${KSERVE_OVERLAY_DIR}" ]; then
+            TARGET_OVERLAY_DIRS+=("${REPO_ROOT}/config/overlays/${KSERVE_OVERLAY_DIR}")
+            if [ "${KSERVE_OVERLAY_DIR}" == "test" ]; then
+                # Auto-enable localmodel for test overlay
+                ENABLE_LOCALMODEL="true"
+        
+                # Update test overlay image tags if version is set
+                if [ -n "${SET_KSERVE_VERSION}" ]; then
+                    log_info "Updating test overlay image tags to ${SET_KSERVE_VERSION}..."
+                    sed -i -e "s/latest/${SET_KSERVE_VERSION}/g" config/overlays/test/configmap/inferenceservice.yaml
+                    sed -i -e "s/latest/${SET_KSERVE_VERSION}/g" config/overlays/test/clusterresources/kustomization.yaml
+                fi
+        
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full")
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/localmodel")
+                TARGET_CRDS_TO_VERIFY+=("${KSERVE_CRDS}")
+                TARGET_CRDS_TO_VERIFY+=("${LOCALMODEL_CRDS}")
+                test_overlay_deployments="kserve-controller-manager kserve-localmodel-controller-manager"
+                if is_positive "${ENABLE_LLMISVC}"; then
+                    TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                    TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                    test_overlay_deployments+=" llmisvc-controller-manager"
+                fi
+                TARGET_DEPLOYMENT_NAMES+=("${test_overlay_deployments}")
+            elif [ "${KSERVE_OVERLAY_DIR}" == "test-modelcache" ]; then
+                ENABLE_LOCALMODEL="true"
+                ENABLE_LLMISVC="true"
+                INSTALL_LLMISVC_CONFIGS="true"
+        
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full")
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/localmodel")
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                TARGET_CRDS_TO_VERIFY+=("${KSERVE_CRDS}")
+                TARGET_CRDS_TO_VERIFY+=("${LOCALMODEL_CRDS}")
+                TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager kserve-localmodel-controller-manager llmisvc-controller-manager")
+            elif [ "${KSERVE_OVERLAY_DIR}" == "test-llmisvc" ]; then
+                # Update test-llmisvc overlay image tags if version is set
+                if [ -n "${SET_KSERVE_VERSION}" ]; then
+                    log_info "Updating test-llmisvc overlay image tags to ${SET_KSERVE_VERSION}..."
+                    sed -i -e "s/latest/${SET_KSERVE_VERSION}/g" config/overlays/test-llmisvc/llmisvc_image_patch.yaml
+                    sed -i -e "s/latest/${SET_KSERVE_VERSION}/g" config/configmap/inferenceservice.yaml
+                fi
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
+            elif [ "${KSERVE_OVERLAY_DIR}" == "temp" ]; then
+                RUNTIMES_DIR="${REPO_ROOT}/config/overlays/temp/cluster-resources"
+                if is_positive "${ENABLE_KSERVE}"; then
+                    TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full")
+                    TARGET_CRDS_TO_VERIFY+=("${KSERVE_CRDS}")
+                    TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
+                fi
+                if is_positive "${ENABLE_LLMISVC}"; then
+                    TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                    TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                    TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
+                fi
+                if is_positive "${ENABLE_LOCALMODEL}"; then
+                    TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/localmodel")
+                    TARGET_CRDS_TO_VERIFY+=("${LOCALMODEL_CRDS}")
+                    TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
+                fi
+            fi
+        else
+            if is_positive "${ENABLE_KSERVE}"; then
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full")
+                TARGET_CRDS_TO_VERIFY+=("${KSERVE_CRDS}")
+                TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
+                if [ "${LLMISVC_INSTALLED}" = "1" ]; then
+                    KSERVE_CONFIG_DIR="${REPO_ROOT}/config/overlays/addons/kserve"
+                fi
+                TARGET_OVERLAY_DIRS+=("${KSERVE_CONFIG_DIR}")
+            fi
+        
+            if is_positive "${ENABLE_LLMISVC}"; then
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
+                if [ "${KSERVE_INSTALLED}" = "1" ]; then
+                    LLMISVC_CONFIG_DIR="${REPO_ROOT}/config/overlays/addons/llmisvc"
+                fi
+                TARGET_OVERLAY_DIRS+=("${LLMISVC_CONFIG_DIR}")
+            fi
+        
+            if is_positive "${ENABLE_LOCALMODEL}"; then
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/localmodel")
+                TARGET_CRDS_TO_VERIFY+=("${LOCALMODEL_CRDS}")
+                TARGET_OVERLAY_DIRS+=("${LOCALMODEL_CONFIG_DIR}")
+                TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
+            fi
+        fi
+        
+        # Add ClusterStorageContainer CRD if either KServe or LLMISVC is enabled
+        if is_positive "${ENABLE_KSERVE}" || is_positive "${ENABLE_LLMISVC}"; then
+            TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/clusterstoragecontainer")
+            TARGET_CRDS_TO_VERIFY+=("clusterstoragecontainers.serving.kserve.io")
+        fi
+
+        install_kserve_kustomize
+    )
+
+    echo "=========================================="
+    echo "✅ Installation completed successfully!"
+    echo "=========================================="
+}
+
+# ============================================================================
+# KServe Manifest Functions (EMBED_MANIFESTS MODE)
+# ============================================================================
+
+install_kserve_manifest() {
+    log_info "Installing KServe CRDs..."
+    get_kserve_crd_manifest | kubectl apply --server-side -f -
+
+    log_info "Installing KServe core components..."
+    get_kserve_core_manifest | kubectl apply --server-side -f -
+
+    log_success "KServe CRD and core components installed successfully!"
+}
+
+uninstall_kserve_manifest() {
+    # Uninstall in reverse order of dependencies
+    log_info "Uninstalling KServe LLMISvcConfig manifests..."
+    if [ "${LLMISVC:-false}" = "true" ] && type get_kserve_llmisvcconfig_manifests &>/dev/null; then
+        get_kserve_llmisvcconfig_manifests | kubectl delete -f - || true
+    fi
+
+    log_info "Uninstalling KServe runtime manifests..."
+    if [ "${INSTALL_RUNTIMES:-false}" = "true" ] && type get_kserve_runtime_manifests &>/dev/null; then
+        get_kserve_runtime_manifests | kubectl delete -f - || true
+    fi
+
+    log_info "Uninstalling KServe core components..."
+    get_kserve_core_manifest | kubectl delete -f - || true
+
+    log_info "Uninstalling KServe CRDs..."
+    get_kserve_crd_manifest | kubectl delete -f - || true
+
+    log_success "KServe manifests uninstalled successfully!"
+}
+
+get_kserve_runtime_manifests() {
+    cat <<'KSERVE_RUNTIME_MANIFEST_EOF'
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: autogluonserver
+  name: kserve-autogluonserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    image: kserve/autogluonserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: autogluon
+    priority: 1
+    version: "1"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: huggingfaceserver
+  name: kserve-huggingfaceserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    env:
+    - name: LMCACHE_USE_EXPERIMENTAL
+      value: "True"
+    image: kserve/huggingfaceserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: devshm
+  hostIPC: false
+  protocolVersions:
+  - v2
+  - v1
+  supportedModelFormats:
+  - autoSelect: true
+    name: huggingface
+    priority: 1
+    version: "1"
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: devshm
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: huggingfaceserver
+  name: kserve-huggingfaceserver-multinode
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    command:
+    - bash
+    - -c
+    - "export MODEL_DIR_ARG=\"\"\nif [[ ! -z ${MODEL_ID} ]]\nthen\n  export MODEL_DIR_ARG=\"--model_dir=${MODEL_ID}\"\nfi\n\nif
+      [[ ! -z ${MODEL_DIR} ]]\nthen\n  export MODEL_DIR_ARG=\"--model_dir=${MODEL_DIR}\"\nfi\n\nexport
+      RAY_ADDRESS=${POD_IP}:${RAY_PORT}\nray start --head --disable-usage-stats --include-dashboard
+      false \npython ./huggingfaceserver/health_check.py registered_nodes --retries
+      200  --probe_name runtime_start\n\npython -m huggingfaceserver ${MODEL_DIR_ARG}
+      --tensor-parallel-size=${TENSOR_PARALLEL_SIZE} --pipeline-parallel-size=${PIPELINE_PARALLEL_SIZE}
+      $0 $@\n"
+    env:
+    - name: RAY_PORT
+      value: "6379"
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: VLLM_CONFIG_ROOT
+      value: /tmp
+    - name: HF_HUB_CACHE
+      value: /tmp
+    image: kserve/huggingfaceserver:latest-gpu
+    livenessProbe:
+      exec:
+        command:
+        - bash
+        - -c
+        - |
+          python ./huggingfaceserver/health_check.py registered_node_and_runtime_health --health_check_url http://localhost:8080 --probe_name head_liveness
+      failureThreshold: 2
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 15
+    name: kserve-container
+    readinessProbe:
+      exec:
+        command:
+        - bash
+        - -c
+        - |
+          python ./huggingfaceserver/health_check.py runtime_health --health_check_url http://localhost:8080 --probe_name head_readiness
+      failureThreshold: 2
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 15
+    resources:
+      limits:
+        cpu: "4"
+        memory: 12Gi
+      requests:
+        cpu: "2"
+        memory: 6Gi
+    startupProbe:
+      exec:
+        command:
+        - bash
+        - -c
+        - |
+          python ./huggingfaceserver/health_check.py registered_node_and_runtime_health --health_check_url http://localhost:8080 --probe_name head_startup
+      failureThreshold: 40
+      initialDelaySeconds: 60
+      periodSeconds: 30
+      successThreshold: 1
+      timeoutSeconds: 30
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: shm
+  protocolVersions:
+  - v2
+  - v1
+  supportedModelFormats:
+  - autoSelect: true
+    name: huggingface
+    priority: 2
+    version: "1"
+  volumes:
+  - emptyDir:
+      medium: Memory
+      sizeLimit: 3Gi
+    name: shm
+  workerSpec:
+    containers:
+    - command:
+      - bash
+      - -c
+      - "export RAY_HEAD_ADDRESS=${HEAD_SVC}.${POD_NAMESPACE}.svc.cluster.local:6379\nSECONDS=0\n\nwhile
+        true; do              \n  if (( SECONDS <= 240 )); then\n    if ray health-check
+        --address \"${RAY_HEAD_ADDRESS}\" > /dev/null 2>&1; then\n      echo \"Ray
+        Global Control Service(GCS) is ready.\"\n      break\n    fi\n    echo \"$SECONDS
+        seconds elapsed: Waiting for Ray Global Control Service(GCS) to be ready.\"\n
+        \ else\n    if ray health-check --address \"${RAY_HEAD_ADDRESS}\"; then\n
+        \     echo \"Ray Global Control Service(GCS) is ready. Any error messages
+        above can be safely ignored.\"\n      break\n    fi\n    echo \"$SECONDS seconds
+        elapsed: Still waiting for Ray Global Control Service(GCS) to be ready.\"\n
+        \ fi\n\n  sleep 5\ndone\n\necho \"Attempting to connect to Ray cluster at
+        $RAY_HEAD_ADDRESS ...\"\nray start --address=\"${RAY_HEAD_ADDRESS}\" --block\n"
+      env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      image: kserve/huggingfaceserver:latest-gpu
+      livenessProbe:
+        exec:
+          command:
+          - bash
+          - -c
+          - |
+            export RAY_ADDRESS=${HEAD_SVC}.${POD_NAMESPACE}.svc.cluster.local:6379
+            python ./huggingfaceserver/health_check.py registered_nodes --probe_name worker_liveness
+        failureThreshold: 2
+        periodSeconds: 5
+        successThreshold: 1
+        timeoutSeconds: 15
+      name: worker-container
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      startupProbe:
+        exec:
+          command:
+          - bash
+          - -c
+          - |
+            export RAY_HEAD_NODE=${HEAD_SVC}.${POD_NAMESPACE}.svc.cluster.local
+            export RAY_ADDRESS=${RAY_HEAD_NODE}:6379
+            python ./huggingfaceserver/health_check.py registered_node_and_runtime_models --runtime_url http://${RAY_HEAD_NODE}:8080/v1/models --probe_name worker_startup
+        failureThreshold: 40
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        successThreshold: 1
+        timeoutSeconds: 30
+      volumeMounts:
+      - mountPath: /dev/shm
+        name: shm
+    pipelineParallelSize: 1
+    tensorParallelSize: 1
+    volumes:
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 3Gi
+      name: shm
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: lgbserver
+  name: kserve-lgbserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    - --nthread=1
+    image: kserve/lgbserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: lightgbm
+    priority: 1
+    version: "4"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: mlserver
+  name: kserve-mlserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - env:
+    - name: MLSERVER_MODEL_IMPLEMENTATION
+      value: '{{.Labels.modelClass}}'
+    - name: MLSERVER_HTTP_PORT
+      value: "8080"
+    - name: MLSERVER_GRPC_PORT
+      value: "9000"
+    image: docker.io/seldonio/mlserver:1.7.1
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: sklearn
+    priority: 2
+    version: "0"
+  - autoSelect: true
+    name: sklearn
+    priority: 2
+    version: "1"
+  - autoSelect: true
+    name: xgboost
+    priority: 2
+    version: "1"
+  - autoSelect: true
+    name: xgboost
+    priority: 2
+    version: "2"
+  - autoSelect: true
+    name: lightgbm
+    priority: 2
+    version: "3"
+  - autoSelect: true
+    name: lightgbm
+    priority: 2
+    version: "4"
+  - autoSelect: true
+    name: mlflow
+    priority: 1
+    version: "1"
+  - autoSelect: true
+    name: mlflow
+    priority: 1
+    version: "2"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: paddleserver
+  name: kserve-paddleserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    image: kserve/paddleserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: paddle
+    priority: 1
+    version: "2"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: pmmlserver
+  name: kserve-pmmlserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    image: kserve/pmmlserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: pmml
+    priority: 1
+    version: "3"
+  - autoSelect: true
+    name: pmml
+    priority: 1
+    version: "4"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: predictiveserver
+  name: kserve-predictiveserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    - --framework={{.Annotations.modelFormat}}
+    - --nthread=1
+    image: kserve/predictiveserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  multiModel: false
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: false
+    name: sklearn
+    priority: 3
+    version: "1"
+  - autoSelect: false
+    name: xgboost
+    priority: 3
+    version: "2"
+  - autoSelect: false
+    name: lightgbm
+    priority: 3
+    version: "4"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: sklearnserver
+  name: kserve-sklearnserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    image: kserve/sklearnserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: sklearn
+    priority: 1
+    version: "1"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: tensorflow-serving
+  name: kserve-tensorflow-serving
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --port=9000
+    - --rest_api_port=8080
+    - --model_base_path=/mnt/models
+    - --rest_api_timeout_in_ms=60000
+    command:
+    - /usr/bin/tensorflow_model_server
+    image: tensorflow/serving:2.6.2
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 1000
+  protocolVersions:
+  - v1
+  - grpc-v1
+  supportedModelFormats:
+  - autoSelect: true
+    name: tensorflow
+    priority: 2
+    version: "1"
+  - autoSelect: true
+    name: tensorflow
+    priority: 2
+    version: "2"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: torchserve
+  name: kserve-torchserve
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8082"
+  containers:
+  - args:
+    - torchserve
+    - --start
+    - --model-store=/mnt/models/model-store
+    - --ts-config=/mnt/models/config/config.properties
+    env:
+    - name: TS_SERVICE_ENVELOPE
+      value: '{{.Labels.serviceEnvelope}}'
+    image: pytorch/torchserve-kfs:0.9.0
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 1000
+  protocolVersions:
+  - v1
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: pytorch
+    priority: 2
+    version: "1"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: tritonserver
+  name: kserve-tritonserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8002"
+  containers:
+  - args:
+    - tritonserver
+    - --model-store=/mnt/models
+    - --grpc-port=9000
+    - --http-port=8080
+    - --allow-grpc=true
+    - --allow-http=true
+    image: nvcr.io/nvidia/tritonserver:23.05-py3
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 1000
+  protocolVersions:
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: tensorrt
+    priority: 1
+    version: "8"
+  - autoSelect: true
+    name: tensorflow
+    priority: 1
+    version: "1"
+  - autoSelect: true
+    name: tensorflow
+    priority: 1
+    version: "2"
+  - autoSelect: true
+    name: onnx
+    priority: 1
+    version: "1"
+  - name: pytorch
+    version: "1"
+  - autoSelect: true
+    name: triton
+    priority: 1
+    version: "2"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: vllmserver
+  name: kserve-vllmserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --port=8080
+    - --served-model-name={{.Name}}
+    - --model=/mnt/models
+    command:
+    - python
+    - -m
+    - vllm.entrypoints.openai.api_server
+    env:
+    - name: LMCACHE_USE_EXPERIMENTAL
+      value: "True"
+    - name: HF_HOME
+      value: /tmp
+    - name: VLLM_CONFIG_ROOT
+      value: /tmp
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    image: vllm/vllm-openai:latest
+    name: kserve-container
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /v1/models
+        port: 8080
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+    startupProbe:
+      failureThreshold: 60
+      httpGet:
+        path: /v1/models
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      successThreshold: 1
+      timeoutSeconds: 10
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: devshm
+  hostIPC: false
+  supportedModelFormats:
+  - autoSelect: true
+    name: vLLM
+    priority: 1
+    version: "1"
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: devshm
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: xgbserver
+  name: kserve-xgbserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    - --nthread=1
+    image: kserve/xgbserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: xgboost
+    priority: 1
+    version: "2"
+KSERVE_RUNTIME_MANIFEST_EOF
+}
+
+get_kserve_llmisvcconfig_manifests() {
+    cat <<'KSERVE_LLMISVCCONFIG_MANIFEST_EOF'
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-decode-template
+  namespace: kserve
+spec:
+  annotations:
+    serving.kserve.io/model-based-routing-enabled: "true"
+  template:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8001 \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+        timeoutSeconds: 1
+      name: main
+      ports:
+      - containerPort: 8001
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 1
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    initContainers:
+    - command:
+      - /app/pd-sidecar
+      - --port=8000
+      - --vllm-port=8001
+      - --kv-connector=nixlv2
+      - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
+      - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
+        end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--enable-tls=decoder{{- end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--enable-tls=prefiller{{- end }}'
+      env:
+      - name: INFERENCE_POOL_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: SSL_CERT_DIR
+        value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.10.0
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 10
+      name: llm-d-routing-sidecar
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 5
+      resources: {}
+      restartPolicy: Always
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 1Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-decode-worker-data-parallel
+  namespace: kserve
+spec:
+  annotations:
+    serving.kserve.io/model-based-routing-enabled: "true"
+  template:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        # In some versions, ZMQ bind doesn't resolve the address through DNS
+        # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+        RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+        for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+          DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+          if [ -n "$DP_ADDRESS" ]; then
+            echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+            break
+          else
+            echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+            sleep 1
+          fi
+        done
+
+        if [ -z "$DP_ADDRESS" ]; then
+          echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+          DP_ADDRESS=${LWS_LEADER_ADDRESS}
+          echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+        fi
+
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        START_RANK=0
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve \
+          /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8001 \
+          --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
+          {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+          {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+          --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
+          --data-parallel-address ${DP_ADDRESS} \
+          --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+          --data-parallel-start-rank $START_RANK \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+        timeoutSeconds: 1
+      name: main
+      ports:
+      - containerPort: 8001
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 1
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - IPC_LOCK
+          - SYS_RAWIO
+          - NET_RAW
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    initContainers:
+    - command:
+      - /app/pd-sidecar
+      - --port=8000
+      - --vllm-port=8001
+      - --kv-connector=nixlv2
+      - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
+      - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
+        end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--enable-tls=decoder{{- end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--enable-tls=prefiller{{- end }}'
+      env:
+      - name: INFERENCE_POOL_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: SSL_CERT_DIR
+        value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.10.0
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 10
+      name: llm-d-routing-sidecar
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 5
+      restartPolicy: Always
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+  worker:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        # In some versions, ZMQ bind doesn't resolve the address through DNS
+        # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+        RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+        for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+          DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+          if [ -n "$DP_ADDRESS" ]; then
+            echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+            break
+          else
+            echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+            sleep 1
+          fi
+        done
+
+        if [ -z "$DP_ADDRESS" ]; then
+          echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+          DP_ADDRESS=${LWS_LEADER_ADDRESS}
+          echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+        fi
+
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve \
+          /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8001 \
+          {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+          {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+          --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
+          --data-parallel-address ${DP_ADDRESS} \
+          --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+          --data-parallel-start-rank $START_RANK \
+          --headless \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
+        value: "1"
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      name: main
+      ports:
+      - containerPort: 8001
+        protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - IPC_LOCK
+          - SYS_RAWIO
+          - NET_RAW
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-prefill-template
+  namespace: kserve
+spec:
+  prefill:
+    annotations:
+      serving.kserve.io/model-based-routing-enabled: "true"
+    template:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |-
+          if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+            echo "Trying to infer RoCE configs ... "
+            grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+            grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+            cat /proc/driver/nvidia/params
+
+            KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+            echo "[Infer RoCE] Discovering active HCAs ..."
+            active_hcas=()
+            # Loop through all mlx5 devices found in sysfs
+            for hca_dir in /sys/class/infiniband/mlx5_*; do
+                # Ensure it's a directory before proceeding
+                if [ -d "$hca_dir" ]; then
+                    hca_name=$(basename "$hca_dir")
+                    port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                    type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                    echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                    if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                        echo "[Infer RoCE] Found active HCA: $hca_name"
+                        active_hcas+=("$hca_name")
+                    else
+                        echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                    fi
+                fi
+            done
+
+            # Check if we found any active HCAs
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                # Join the array elements with a comma
+                hca_port_pairs=()
+                for hca in "${active_hcas[@]}"; do
+                  hca_port_pairs+=("${hca}:1")
+                done
+
+                active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+                hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+                echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+                export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+                export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+                export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+                echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+                echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+                echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+            else
+                echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+            fi
+
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+                # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+                declare -A gid_index_count
+                declare -A hca_gid_index
+
+                for hca_name in "${active_hcas[@]}"; do
+                    echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                    # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                    for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                        if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                            idx=$(basename "$tpath")
+                            gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                            # Check for IPv4 GID (contains ffff:)
+                            if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                                gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                                echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                                hca_gid_index["${hca_name}"]="${idx}"
+                                gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                                break  # Use first found IPv4 GID per HCA
+                            fi
+                        fi
+                    done
+                done
+
+                # Find the most common GID index (most likely to be consistent across nodes)
+                best_gid_index=""
+                max_count=0
+                for idx in "${!gid_index_count[@]}"; do
+                    count=${gid_index_count["${idx}"]}
+                    echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                    if [ $count -gt $max_count ]; then
+                        max_count=$count
+                        best_gid_index="$idx"
+                    fi
+                done
+
+                # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+                if [ ${#gid_index_count[@]} -gt 1 ]; then
+                    echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                    # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                    if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                        best_gid_index="3"
+                        echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                    fi
+                fi
+
+                # Check if GID_INDEX is already set via environment variables
+                if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                    echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+                elif [ -n "$best_gid_index" ]; then
+                    echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                    export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                    echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+                else
+                    echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+                fi
+            else
+                echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+            fi
+          fi
+
+          # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+          # Older versions still need the blanket --disable-uvicorn-access-log.
+          ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+          fi
+          echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+          # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+          SHUTDOWN_TIMEOUT_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
+          fi
+
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          KV_TRANSFER_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+          fi
+
+          eval "exec vllm serve /mnt/models \
+            --served-model-name "{{ .Spec.Model.Name }}" \
+            --port 8000 \
+            ${ACCESS_LOG_ARGS} \
+            ${SHUTDOWN_TIMEOUT_ARGS} \
+            ${KV_TRANSFER_ARGS} \
+            {{- if and .Spec.Prefill .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${VLLM_ADDITIONAL_ARGS} \
+            $@"
+        - --
+        env:
+        - name: HOME
+          value: /home
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: HF_HUB_CACHE
+          value: /models
+        image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "15"
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 10
+          timeoutSeconds: 1
+        name: main
+        ports:
+        - containerPort: 8000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 10
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /home
+          name: home
+        - mountPath: /tmp
+          name: tmp-dir
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /models
+          name: model-cache
+        - mountPath: /var/run/kserve/tls
+          name: tls-certs
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - emptyDir: {}
+        name: home
+      - emptyDir: {}
+        name: tmp-dir
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1Gi
+        name: dshm
+      - emptyDir: {}
+        name: model-cache
+      - name: tls-certs
+        secret:
+          secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-prefill-worker-data-parallel
+  namespace: kserve
+spec:
+  prefill:
+    annotations:
+      serving.kserve.io/model-based-routing-enabled: "true"
+    template:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |-
+          # In some versions, ZMQ bind doesn't resolve the address through DNS
+          # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+          RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+          for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+            DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+            if [ -n "$DP_ADDRESS" ]; then
+              echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+              break
+            else
+              echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+              sleep 1
+            fi
+          done
+
+          if [ -z "$DP_ADDRESS" ]; then
+            echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+            DP_ADDRESS=${LWS_LEADER_ADDRESS}
+            echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+          fi
+
+          if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+            echo "Trying to infer RoCE configs ... "
+            grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+            grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+            cat /proc/driver/nvidia/params
+
+            KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+            echo "[Infer RoCE] Discovering active HCAs ..."
+            active_hcas=()
+            # Loop through all mlx5 devices found in sysfs
+            for hca_dir in /sys/class/infiniband/mlx5_*; do
+                # Ensure it's a directory before proceeding
+                if [ -d "$hca_dir" ]; then
+                    hca_name=$(basename "$hca_dir")
+                    port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                    type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                    echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                    if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                        echo "[Infer RoCE] Found active HCA: $hca_name"
+                        active_hcas+=("$hca_name")
+                    else
+                        echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                    fi
+                fi
+            done
+
+            # Check if we found any active HCAs
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                # Join the array elements with a comma
+                hca_port_pairs=()
+                for hca in "${active_hcas[@]}"; do
+                  hca_port_pairs+=("${hca}:1")
+                done
+
+                active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+                hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+                echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+                export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+                export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+                export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+                echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+                echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+                echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+            else
+                echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+            fi
+
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+                # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+                declare -A gid_index_count
+                declare -A hca_gid_index
+
+                for hca_name in "${active_hcas[@]}"; do
+                    echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                    # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                    for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                        if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                            idx=$(basename "$tpath")
+                            gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                            # Check for IPv4 GID (contains ffff:)
+                            if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                                gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                                echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                                hca_gid_index["${hca_name}"]="${idx}"
+                                gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                                break  # Use first found IPv4 GID per HCA
+                            fi
+                        fi
+                    done
+                done
+
+                # Find the most common GID index (most likely to be consistent across nodes)
+                best_gid_index=""
+                max_count=0
+                for idx in "${!gid_index_count[@]}"; do
+                    count=${gid_index_count["${idx}"]}
+                    echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                    if [ $count -gt $max_count ]; then
+                        max_count=$count
+                        best_gid_index="$idx"
+                    fi
+                done
+
+                # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+                if [ ${#gid_index_count[@]} -gt 1 ]; then
+                    echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                    # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                    if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                        best_gid_index="3"
+                        echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                    fi
+                fi
+
+                # Check if GID_INDEX is already set via environment variables
+                if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                    echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+                elif [ -n "$best_gid_index" ]; then
+                    echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                    export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                    echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+                else
+                    echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+                fi
+            else
+                echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+            fi
+          fi
+
+          START_RANK=0
+
+          # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+          # Older versions still need the blanket --disable-uvicorn-access-log.
+          ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+          fi
+          echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+          # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+          SHUTDOWN_TIMEOUT_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
+          fi
+
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          KV_TRANSFER_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+          fi
+
+          eval "exec vllm serve \
+            /mnt/models \
+            --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+            --port 8000 \
+            --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
+            {{- if .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+            {{- if .Spec.Prefill.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
+            --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
+            --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
+            --data-parallel-address ${DP_ADDRESS} \
+            --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+            --data-parallel-start-rank $START_RANK \
+            ${ACCESS_LOG_ARGS} \
+            ${SHUTDOWN_TIMEOUT_ARGS} \
+            ${KV_TRANSFER_ARGS} \
+            {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${VLLM_ADDITIONAL_ARGS} \
+            $@"
+        - --
+        env:
+        - name: HOME
+          value: /home
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: HF_HUB_CACHE
+          value: /models
+        image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "15"
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 10
+          timeoutSeconds: 1
+        name: main
+        ports:
+        - containerPort: 8000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - IPC_LOCK
+            - SYS_RAWIO
+            - NET_RAW
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 10
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /home
+          name: home
+        - mountPath: /tmp
+          name: tmp-dir
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /models
+          name: model-cache
+        - mountPath: /var/run/kserve/tls
+          name: tls-certs
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - emptyDir: {}
+        name: home
+      - emptyDir: {}
+        name: tmp-dir
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 8Gi
+        name: dshm
+      - emptyDir: {}
+        name: model-cache
+      - name: tls-certs
+        secret:
+          secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+    worker:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |-
+          # In some versions, ZMQ bind doesn't resolve the address through DNS
+          # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+          RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+          for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+            DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+            if [ -n "$DP_ADDRESS" ]; then
+              echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+              break
+            else
+              echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+              sleep 1
+            fi
+          done
+
+          if [ -z "$DP_ADDRESS" ]; then
+            echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+            DP_ADDRESS=${LWS_LEADER_ADDRESS}
+            echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+          fi
+
+          if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+            echo "Trying to infer RoCE configs ... "
+            grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+            grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+            cat /proc/driver/nvidia/params
+
+            KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+            echo "[Infer RoCE] Discovering active HCAs ..."
+            active_hcas=()
+            # Loop through all mlx5 devices found in sysfs
+            for hca_dir in /sys/class/infiniband/mlx5_*; do
+                # Ensure it's a directory before proceeding
+                if [ -d "$hca_dir" ]; then
+                    hca_name=$(basename "$hca_dir")
+                    port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                    type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                    echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                    if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                        echo "[Infer RoCE] Found active HCA: $hca_name"
+                        active_hcas+=("$hca_name")
+                    else
+                        echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                    fi
+                fi
+            done
+
+            # Check if we found any active HCAs
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                # Join the array elements with a comma
+                hca_port_pairs=()
+                for hca in "${active_hcas[@]}"; do
+                  hca_port_pairs+=("${hca}:1")
+                done
+
+                active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+                hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+                echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+                export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+                export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+                export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+                echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+                echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+                echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+            else
+                echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+            fi
+
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+                # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+                declare -A gid_index_count
+                declare -A hca_gid_index
+
+                for hca_name in "${active_hcas[@]}"; do
+                    echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                    # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                    for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                        if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                            idx=$(basename "$tpath")
+                            gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                            # Check for IPv4 GID (contains ffff:)
+                            if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                                gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                                echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                                hca_gid_index["${hca_name}"]="${idx}"
+                                gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                                break  # Use first found IPv4 GID per HCA
+                            fi
+                        fi
+                    done
+                done
+
+                # Find the most common GID index (most likely to be consistent across nodes)
+                best_gid_index=""
+                max_count=0
+                for idx in "${!gid_index_count[@]}"; do
+                    count=${gid_index_count["${idx}"]}
+                    echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                    if [ $count -gt $max_count ]; then
+                        max_count=$count
+                        best_gid_index="$idx"
+                    fi
+                done
+
+                # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+                if [ ${#gid_index_count[@]} -gt 1 ]; then
+                    echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                    # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                    if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                        best_gid_index="3"
+                        echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                    fi
+                fi
+
+                # Check if GID_INDEX is already set via environment variables
+                if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                    echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+                elif [ -n "$best_gid_index" ]; then
+                    echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                    export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                    echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+                else
+                    echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+                fi
+            else
+                echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+            fi
+          fi
+
+          START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} ))
+
+          # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+          # Older versions still need the blanket --disable-uvicorn-access-log.
+          ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+          fi
+          echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+          # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+          SHUTDOWN_TIMEOUT_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
+          fi
+
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          KV_TRANSFER_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+          fi
+
+          eval "exec vllm serve \
+            /mnt/models \
+            --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+            --port 8000 \
+            {{- if .Spec.Prefill.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+            {{- if .Spec.Prefill.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
+            --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
+            --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
+            --data-parallel-address ${DP_ADDRESS} \
+            --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+            --data-parallel-start-rank $START_RANK \
+            --headless \
+            ${ACCESS_LOG_ARGS} \
+            ${SHUTDOWN_TIMEOUT_ARGS} \
+            ${KV_TRANSFER_ARGS} \
+            {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${VLLM_ADDITIONAL_ARGS} \
+            $@"
+        - --
+        env:
+        - name: HOME
+          value: /home
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: HF_HUB_CACHE
+          value: /models
+        image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "15"
+        name: main
+        ports:
+        - containerPort: 8000
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - IPC_LOCK
+            - SYS_RAWIO
+            - NET_RAW
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /home
+          name: home
+        - mountPath: /tmp
+          name: tmp-dir
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /models
+          name: model-cache
+        - mountPath: /var/run/kserve/tls
+          name: tls-certs
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - emptyDir: {}
+        name: home
+      - emptyDir: {}
+        name: tmp-dir
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 8Gi
+        name: dshm
+      - emptyDir: {}
+        name: model-cache
+      - name: tls-certs
+        secret:
+          secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-router-route
+  namespace: kserve
+spec:
+  router:
+    route:
+      http:
+        spec:
+          parentRefs:
+          - group: gateway.networking.k8s.io
+            kind: Gateway
+            name: '{{ .GlobalConfig.IngressGatewayName }}'
+            namespace: '{{ .GlobalConfig.IngressGatewayNamespace }}'
+          rules:
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/completions
+            name: v1-completions-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/chat/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/chat/completions
+            name: v1-chat-completions-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
+            name: v1-responses-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/messages
+            name: v1-messages-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            matches:
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages/
+            name: v1-model-routing
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/completions
+            name: v1-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/chat/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/chat/completions
+            name: v1-chat-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/responses
+            name: v1-responses-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/messages
+            name: v1-messages-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+            name: v1-publisher-path-catch-all
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}
+            name: v1-catch-all-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            matches:
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+            name: v1-catch-all-model-routing
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-scheduler
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      annotations:
+        app.kubernetes.io/version: 0.10.0
+      pool:
+        spec:
+          endpointPickerRef:
+            failureMode: FailOpen
+            kind: Service
+            name: '{{ ChildName .ObjectMeta.Name `-epp-service` }}'
+            port:
+              number: 9002
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .ObjectMeta.Name }}'
+              app.kubernetes.io/part-of: llminferenceservice
+              kserve.io/component: workload
+          targetPorts:
+          - number: 8000
+      template:
+        containers:
+        - command:
+          - /app/epp
+          - --pool-name
+          - '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+          - --pool-namespace
+          - '{{ .ObjectMeta.Namespace }}'
+          - --zap-encoder
+          - json
+          - --grpc-port
+          - "9002"
+          - --grpc-health-port
+          - "9003"
+          - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
+            end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end
+            }}'
+          env:
+          - name: SSL_CERT_DIR
+            value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.10.0
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sleep
+                - "15"
+          livenessProbe:
+            failureThreshold: 3
+            grpc:
+              port: 9003
+              service: liveness
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: main
+          ports:
+          - containerPort: 9002
+            name: grpc
+            protocol: TCP
+          - containerPort: 9003
+            name: grpc-health
+            protocol: TCP
+          - containerPort: 9090
+            name: metrics
+            protocol: TCP
+          - containerPort: 5557
+            name: zmq
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            grpc:
+              port: 9003
+              service: readiness
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 6
+              memory: 16Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /var/run/kserve/tls
+            name: tls-certs
+            readOnly: true
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - name: tls-certs
+          secret:
+            secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs`
+              }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-scheduler-latency-predictor
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      template:
+        containers:
+        - env:
+          - name: PREDICTION_SERVER_URL
+            value: http://localhost:8001
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MAX_SAMPLE_SIZE
+            value: "10000"
+          - name: LATENCY_MAX_CONCURRENT_DISPATCHES
+            value: "36"
+          - name: LATENCY_COALESCE_WINDOW_MS
+            value: "1"
+          name: main
+        - env:
+          - name: LATENCY_RETRAINING_INTERVAL_SEC
+            value: "10"
+          - name: LATENCY_MIN_SAMPLES_FOR_RETRAIN
+            value: "100"
+          - name: LATENCY_TTFT_MODEL_PATH
+            value: /models/ttft.joblib
+          - name: LATENCY_TPOT_MODEL_PATH
+            value: /models/tpot.joblib
+          - name: LATENCY_TTFT_SCALER_PATH
+            value: /models/ttft_scaler.joblib
+          - name: LATENCY_TPOT_SCALER_PATH
+            value: /models/tpot_scaler.joblib
+          - name: LATENCY_TTFT_GATED_MODEL_PATH
+            value: /models/ttft_gated.joblib
+          - name: LATENCY_TPOT_GATED_MODEL_PATH
+            value: /models/tpot_gated.joblib
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET
+            value: "500"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: ghcr.io/llm-d/llm-d-latency-predictor-training-server:0.9.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          name: training-server
+          ports:
+          - containerPort: 8000
+            name: training-port
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 4000m
+              memory: 8Gi
+            requests:
+              cpu: 2000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz
+              port: 8000
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /models
+            name: training-server-storage
+          - mountPath: /tmp
+            name: training-server-tmp
+        - env:
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: PREDICT_HOST
+            value: 0.0.0.0
+          - name: PREDICT_PORT
+            value: "8001"
+          - name: LOCAL_TTFT_MODEL_PATH
+            value: /server_models/ttft.joblib
+          - name: LOCAL_TPOT_MODEL_PATH
+            value: /server_models/tpot.joblib
+          - name: LOCAL_TTFT_SCALER_PATH
+            value: /server_models/ttft_scaler.joblib
+          - name: LOCAL_TPOT_SCALER_PATH
+            value: /server_models/tpot_scaler.joblib
+          - name: LOCAL_TTFT_GATED_MODEL_PATH
+            value: /server_models/ttft_gated.joblib
+          - name: LOCAL_TPOT_GATED_MODEL_PATH
+            value: /server_models/tpot_gated.joblib
+          - name: UVICORN_WORKERS
+            value: "28"
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MODEL_SYNC_INTERVAL_SEC
+            value: "30"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: ghcr.io/llm-d/llm-d-latency-predictor-prediction-server:0.9.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          name: prediction-server
+          ports:
+          - containerPort: 8001
+            name: predict-port
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 28000m
+              memory: 8Gi
+            requests:
+              cpu: 8000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /readyz
+              port: 8001
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /server_models
+            name: prediction-server-storage
+          - mountPath: /tmp
+            name: prediction-server-tmp
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - emptyDir:
+            sizeLimit: 20Gi
+          name: training-server-storage
+        - emptyDir:
+            sizeLimit: 10Gi
+          name: prediction-server-storage
+        - emptyDir: {}
+          name: training-server-tmp
+        - emptyDir: {}
+          name: prediction-server-tmp
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-template
+  namespace: kserve
+spec:
+  annotations:
+    serving.kserve.io/model-based-routing-enabled: "true"
+  template:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8000 \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+        timeoutSeconds: 1
+      name: main
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 1
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 1Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - emptyDir: {}
+      name: tmp-dir
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-tokenizer
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      tokenizer:
+        template:
+          automountServiceAccountToken: false
+          containers:
+          - args: []
+            command:
+            - /bin/bash
+            - -c
+            - |-
+              exec vllm launch render /mnt/models/base \
+                --port=8000 \
+                {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh \
+                --ssl-certfile /var/run/kserve/tls/tls.crt \
+                --ssl-keyfile /var/run/kserve/tls/tls.key{{ end }}
+            env:
+            - name: HF_HOME
+              value: /tmp/hf
+            - name: DO_NOT_TRACK
+              value: "1"
+            image: docker.io/vllm/vllm-openai-cpu:v0.23.0@sha256:89e1fbe829038b1a560601990c8ec89625c622a969fcbc8f10ce48b6139795be
+            imagePullPolicy: IfNotPresent
+            name: main
+            ports:
+            - containerPort: 8000
+              name: render-http
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 60
+              httpGet:
+                path: /health
+                port: render-http
+                scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end
+                  }}'
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              timeoutSeconds: 5
+            resources:
+              limits:
+                cpu: "4"
+                memory: 12Gi
+              requests:
+                cpu: "1"
+                memory: 4Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              seccompProfile:
+                type: RuntimeDefault
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+            - mountPath: /var/run/kserve/tls
+              name: tls-certs
+              readOnly: true
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          volumes:
+          - emptyDir: {}
+            name: tmp-dir
+          - name: tls-certs
+            secret:
+              secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs`
+                }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-tracing
+  namespace: kserve
+spec:
+  tracing:
+    exporter: otlp
+    exporterEndpoint: http://otel-collector:4317
+    sampler: parentbased_traceidratio
+    samplerArg: "0.05"
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-worker-data-parallel
+  namespace: kserve
+spec:
+  annotations:
+    serving.kserve.io/model-based-routing-enabled: "true"
+  template:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        # In some versions, ZMQ bind doesn't resolve the address through DNS
+        # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+        RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+        for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+          DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+          if [ -n "$DP_ADDRESS" ]; then
+            echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+            break
+          else
+            echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+            sleep 1
+          fi
+        done
+
+        if [ -z "$DP_ADDRESS" ]; then
+          echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+          DP_ADDRESS=${LWS_LEADER_ADDRESS}
+          echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+        fi
+
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        START_RANK=0
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve \
+          /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8000 \
+          --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
+          {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+          {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+          --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
+          --data-parallel-address ${DP_ADDRESS} \
+          --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+          --data-parallel-start-rank $START_RANK \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+        timeoutSeconds: 1
+      name: main
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 1
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - IPC_LOCK
+          - SYS_RAWIO
+          - NET_RAW
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+  worker:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        # In some versions, ZMQ bind doesn't resolve the address through DNS
+        # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+        RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+        for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+          DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+          if [ -n "$DP_ADDRESS" ]; then
+            echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+            break
+          else
+            echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+            sleep 1
+          fi
+        done
+
+        if [ -z "$DP_ADDRESS" ]; then
+          echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+          DP_ADDRESS=${LWS_LEADER_ADDRESS}
+          echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+        fi
+
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve \
+          /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8000 \
+          {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+          {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+          --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
+          --data-parallel-address ${DP_ADDRESS} \
+          --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+          --data-parallel-start-rank $START_RANK \
+          --headless \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      name: main
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - IPC_LOCK
+          - SYS_RAWIO
+          - NET_RAW
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+KSERVE_LLMISVCCONFIG_MANIFEST_EOF
+}
+
+create_kserve_runtime_manifests() {
+    get_kserve_runtime_manifests | kubectl apply --server-side -f -
+}
+
+create_kserve_llmisvcconfig_manifests() {
+    get_kserve_llmisvcconfig_manifests | kubectl apply --server-side -f -
+}
+
+get_kserve_crd_manifest() {
+    cat <<'KSERVE_CRD_MANIFEST_EOF'
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: localmodelcaches.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: LocalModelCache
+    listKind: LocalModelCacheList
+    plural: localmodelcaches
+    singular: localmodelcache
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              modelSize:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              nodeGroups:
+                items:
+                  type: string
+                minItems: 1
+                type: array
+              serviceAccountName:
+                type: string
+              sourceModelUri:
+                type: string
+                x-kubernetes-validations:
+                - message: StorageUri is immutable
+                  rule: self == oldSelf
+              storage:
+                properties:
+                  key:
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+            required:
+            - modelSize
+            - nodeGroups
+            - sourceModelUri
+            type: object
+          status:
+            properties:
+              copies:
+                properties:
+                  available:
+                    type: integer
+                  failed:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              inferenceServices:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              llmInferenceServices:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              nodeStatus:
+                additionalProperties:
+                  enum:
+                  - ""
+                  - NodeNotReady
+                  - NodeDownloadPending
+                  - NodeDownloading
+                  - NodeDownloaded
+                  - NodeDownloadError
+                  type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: localmodelnamespacecaches.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: LocalModelNamespaceCache
+    listKind: LocalModelNamespaceCacheList
+    plural: localmodelnamespacecaches
+    singular: localmodelnamespacecache
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              modelSize:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              nodeGroups:
+                items:
+                  type: string
+                minItems: 1
+                type: array
+              serviceAccountName:
+                type: string
+              sourceModelUri:
+                type: string
+                x-kubernetes-validations:
+                - message: StorageUri is immutable
+                  rule: self == oldSelf
+              storage:
+                properties:
+                  key:
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+            required:
+            - modelSize
+            - nodeGroups
+            - sourceModelUri
+            type: object
+          status:
+            properties:
+              copies:
+                properties:
+                  available:
+                    type: integer
+                  failed:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              inferenceServices:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              llmInferenceServices:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              nodeStatus:
+                additionalProperties:
+                  enum:
+                  - ""
+                  - NodeNotReady
+                  - NodeDownloadPending
+                  - NodeDownloading
+                  - NodeDownloaded
+                  - NodeDownloadError
+                  type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: localmodelnodegroups.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: LocalModelNodeGroup
+    listKind: LocalModelNodeGroupList
+    plural: localmodelnodegroups
+    singular: localmodelnodegroup
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              persistentVolumeClaimSpec:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  dataSource:
+                    properties:
+                      apiGroup:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSourceRef:
+                    properties:
+                      apiGroup:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  resources:
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  selector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  storageClassName:
+                    type: string
+                  volumeAttributesClassName:
+                    type: string
+                  volumeMode:
+                    type: string
+                  volumeName:
+                    type: string
+                type: object
+              persistentVolumeSpec:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  awsElasticBlockStore:
+                    properties:
+                      fsType:
+                        type: string
+                      partition:
+                        format: int32
+                        type: integer
+                      readOnly:
+                        type: boolean
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    properties:
+                      cachingMode:
+                        type: string
+                      diskName:
+                        type: string
+                      diskURI:
+                        type: string
+                      fsType:
+                        default: ext4
+                        type: string
+                      kind:
+                        type: string
+                      readOnly:
+                        default: false
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    properties:
+                      readOnly:
+                        type: boolean
+                      secretName:
+                        type: string
+                      secretNamespace:
+                        type: string
+                      shareName:
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  capacity:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  cephfs:
+                    properties:
+                      monitors:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretFile:
+                        type: string
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      user:
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  claimRef:
+                    properties:
+                      apiVersion:
+                        type: string
+                      fieldPath:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                      resourceVersion:
+                        type: string
+                      uid:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: granular
+                  csi:
+                    properties:
+                      controllerExpandSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      controllerPublishSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      driver:
+                        type: string
+                      fsType:
+                        type: string
+                      nodeExpandSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodePublishSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeStageSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      readOnly:
+                        type: boolean
+                      volumeAttributes:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      volumeHandle:
+                        type: string
+                    required:
+                    - driver
+                    - volumeHandle
+                    type: object
+                  fc:
+                    properties:
+                      fsType:
+                        type: string
+                      lun:
+                        format: int32
+                        type: integer
+                      readOnly:
+                        type: boolean
+                      targetWWNs:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      wwids:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  flexVolume:
+                    properties:
+                      driver:
+                        type: string
+                      fsType:
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    properties:
+                      datasetName:
+                        type: string
+                      datasetUUID:
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    properties:
+                      fsType:
+                        type: string
+                      partition:
+                        format: int32
+                        type: integer
+                      pdName:
+                        type: string
+                      readOnly:
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  glusterfs:
+                    properties:
+                      endpoints:
+                        type: string
+                      endpointsNamespace:
+                        type: string
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    properties:
+                      path:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    properties:
+                      chapAuthDiscovery:
+                        type: boolean
+                      chapAuthSession:
+                        type: boolean
+                      fsType:
+                        type: string
+                      initiatorName:
+                        type: string
+                      iqn:
+                        type: string
+                      iscsiInterface:
+                        default: default
+                        type: string
+                      lun:
+                        format: int32
+                        type: integer
+                      portals:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      targetPortal:
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
+                  local:
+                    properties:
+                      fsType:
+                        type: string
+                      path:
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  mountOptions:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  nfs:
+                    properties:
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      server:
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  nodeAffinity:
+                    properties:
+                      required:
+                        properties:
+                          nodeSelectorTerms:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  persistentVolumeReclaimPolicy:
+                    type: string
+                  photonPersistentDisk:
+                    properties:
+                      fsType:
+                        type: string
+                      pdID:
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  quobyte:
+                    properties:
+                      group:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      registry:
+                        type: string
+                      tenant:
+                        type: string
+                      user:
+                        type: string
+                      volume:
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    properties:
+                      fsType:
+                        type: string
+                      image:
+                        type: string
+                      keyring:
+                        default: /etc/ceph/keyring
+                        type: string
+                      monitors:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      pool:
+                        default: rbd
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      user:
+                        default: admin
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    properties:
+                      fsType:
+                        default: xfs
+                        type: string
+                      gateway:
+                        type: string
+                      protectionDomain:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sslEnabled:
+                        type: boolean
+                      storageMode:
+                        default: ThinProvisioned
+                        type: string
+                      storagePool:
+                        type: string
+                      system:
+                        type: string
+                      volumeName:
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  storageClassName:
+                    type: string
+                  storageos:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      volumeName:
+                        type: string
+                      volumeNamespace:
+                        type: string
+                    type: object
+                  volumeAttributesClassName:
+                    type: string
+                  volumeMode:
+                    type: string
+                  vsphereVolume:
+                    properties:
+                      fsType:
+                        type: string
+                      storagePolicyID:
+                        type: string
+                      storagePolicyName:
+                        type: string
+                      volumePath:
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                type: object
+              storageLimit:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+            required:
+            - persistentVolumeClaimSpec
+            - persistentVolumeSpec
+            - storageLimit
+            type: object
+          status:
+            properties:
+              available:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              used:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: localmodelnodes.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: LocalModelNode
+    listKind: LocalModelNodeList
+    plural: localmodelnodes
+    singular: localmodelnode
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              localModels:
+                items:
+                  properties:
+                    modelName:
+                      type: string
+                    namespace:
+                      type: string
+                    nodeGroup:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                    sourceModelUri:
+                      type: string
+                    storage:
+                      properties:
+                        key:
+                          type: string
+                        parameters:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                  required:
+                  - modelName
+                  - sourceModelUri
+                  type: object
+                type: array
+            required:
+            - localModels
+            type: object
+          status:
+            properties:
+              modelStatus:
+                additionalProperties:
+                  enum:
+                  - ""
+                  - ModelDownloadPending
+                  - ModelDownloading
+                  - ModelDownloaded
+                  - ModelDownloadError
+                  type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+KSERVE_CRD_MANIFEST_EOF
+}
+
+get_kserve_core_manifest() {
+    cat <<'KSERVE_CORE_MANIFEST_EOF'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/instance: kserve-localmodel-controller-manager
+    app.kubernetes.io/managed-by: kserve-localmodel-controller-manager
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/instance: kserve-localmodelnode-agent
+    app.kubernetes.io/managed-by: kserve-localmodelnode-agent
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodelnode-agent
+  namespace: kserve
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodel-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  - llminferenceservices
+  - localmodelnodegroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelcaches/status
+  - localmodelnamespacecaches/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelnodes/status
+  verbs:
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodelnode-agent-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - secrets
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterstoragecontainers
+  - localmodelnodegroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelnodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelnodes/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodel-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kserve-localmodel-manager-role
+subjects:
+- kind: ServiceAccount
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodelnode-agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kserve-localmodelnode-agent-role
+subjects:
+- kind: ServiceAccount
+  name: kserve-localmodelnode-agent
+  namespace: kserve
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: localmodel-webhook-server-service
+  namespace: kserve
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    control-plane: kserve-localmodel-controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-localmodel-controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+spec:
+  selector:
+    matchLabels:
+      control-plane: kserve-localmodel-controller-manager
+      controller-tools.k8s.io: "1.0"
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: kserve-localmodel-controller-manager
+        control-plane: kserve-localmodel-controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: kserve/kserve-localmodel-controller:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kserve-localmodel-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: localmodel-webhook-server-cert
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-localmodelnode-agent
+    controller-tools.k8s.io: "1.0"
+  name: kserve-localmodelnode-agent
+  namespace: kserve
+spec:
+  selector:
+    matchLabels:
+      control-plane: kserve-localmodelnode-agent
+      controller-tools.k8s.io: "1.0"
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: kserve-localmodelnode-agent
+        control-plane: kserve-localmodelnode-agent
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: kserve/kserve-localmodelnode-agent:latest
+        imagePullPolicy: Always
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /mnt/models
+          name: models
+          readOnly: false
+      nodeSelector:
+        kserve/localmodel: worker
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kserve-localmodelnode-agent
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - hostPath:
+          path: /models
+          type: DirectoryOrCreate
+        name: models
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: localmodel-serving-cert
+  namespace: kserve
+spec:
+  commonName: localmodel-webhook-server-service.kserve.svc
+  dnsNames:
+  - localmodel-webhook-server-service.kserve.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: localmodel-webhook-server-cert
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kserve/localmodel-serving-cert
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: localmodelcache.serving.kserve.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: localmodel-webhook-server-service
+      namespace: kserve
+      path: /validate-serving-kserve-io-v1alpha1-localmodelcache
+  failurePolicy: Fail
+  name: localmodelcache.kserve-webhook-server.validator
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - localmodelcaches
+  sideEffects: None
+KSERVE_CORE_MANIFEST_EOF
+}
+
+
+
+main "$@"

--- a/hack/setup/quick-install/definitions/localmodel/localmodel-full-install.definition
+++ b/hack/setup/quick-install/definitions/localmodel/localmodel-full-install.definition
@@ -1,0 +1,20 @@
+DESCRIPTION: Install LocalModel dependencies using helm
+RELEASE: true
+
+TOOLS:
+  - helm
+  - kustomize
+  - yq
+
+INCLUDE_DEFINITIONS:
+  - ./localmodel-dependency-install.definition
+    
+COMPONENTS:
+  - name: kserve-helm
+    env:
+      ENABLE_LLMISVC: false
+      ENABLE_KSERVE: false
+      ENABLE_LOCALMODEL: true
+      INSTALL_RUNTIMES: false
+      INSTALL_LLMISVC_CONFIGS: false
+      

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -1642,8 +1642,6 @@ main() {
         
             # Customized images are loaded onto the node, not pushed to a registry, so
             # force IfNotPresent to avoid registry pulls for locally-built image tags.
-            # TODO: remove this after the following PR is merged:
-            KSERVE_INSTALL_CI=true
             if is_positive ${KSERVE_INSTALL_CI}; then
                 find "${TARGET_CONFIG_ROOT_DIR}/config" -type f -name "*.yaml" \
                     "${FIND_PRUNE[@]}" \

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -1224,8 +1224,6 @@ main() {
         
             # Customized images are loaded onto the node, not pushed to a registry, so
             # force IfNotPresent to avoid registry pulls for locally-built image tags.
-            # TODO: remove this after the following PR is merged:
-            KSERVE_INSTALL_CI=true
             if is_positive ${KSERVE_INSTALL_CI}; then
                 find "${TARGET_CONFIG_ROOT_DIR}/config" -type f -name "*.yaml" \
                     "${FIND_PRUNE[@]}" \

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -1616,8 +1616,6 @@ main() {
         
             # Customized images are loaded onto the node, not pushed to a registry, so
             # force IfNotPresent to avoid registry pulls for locally-built image tags.
-            # TODO: remove this after the following PR is merged:
-            KSERVE_INSTALL_CI=true
             if is_positive ${KSERVE_INSTALL_CI}; then
                 find "${TARGET_CONFIG_ROOT_DIR}/config" -type f -name "*.yaml" \
                     "${FIND_PRUNE[@]}" \

--- a/hack/setup/quick-install/localmodel-dependency-install.sh
+++ b/hack/setup/quick-install/localmodel-dependency-install.sh
@@ -1,0 +1,896 @@
+#!/bin/bash
+
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install LocalModel dependencies
+#
+# AUTO-GENERATED from: localmodel-dependency-install.definition
+# DO NOT EDIT MANUALLY
+#
+# To regenerate:
+#   ./scripts/generate-install-script.py localmodel-dependency-install.definition
+#
+# Usage: localmodel-dependency-install.sh [--reinstall|--uninstall]
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+#================================================
+# Helper Functions (from common.sh)
+#================================================
+
+# Utility Functions
+# ============================================================================
+
+find_repo_root() {
+    local current_dir="${1:-$(pwd)}"
+    local skip="${2:-false}"
+
+    while [[ "$current_dir" != "/" ]]; do
+        if [[ -e "${current_dir}/.git" ]]; then
+            echo "$current_dir"
+            return 0
+        fi
+        current_dir="$(dirname "$current_dir")"
+    done
+
+    # Git repository not found
+    if [[ "$skip" == "true" ]]; then
+        log_warning "Could not find git repository root, using current directory: $PWD"
+        echo "$PWD"
+        return 0
+    else
+        log_error "Could not find git repository root"
+        exit 1
+    fi
+}
+
+ensure_dir() {
+    local dir_path="${1}"
+
+    if [[ -d "${dir_path}" ]]; then
+        return 0
+    fi
+
+    mkdir -p "${dir_path}"
+}
+
+detect_os() {
+    local os=""
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="darwin" ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
+    esac
+    echo "$os"
+}
+
+detect_arch() {
+    local arch=""
+    case "$(uname -m)" in
+        x86_64)  arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
+    esac
+    echo "$arch"
+}
+
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
+# Color codes (disable if NO_COLOR is set or not a terminal)
+if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
+    BLUE='\033[94m'
+    GREEN='\033[92m'
+    RED='\033[91m'
+    YELLOW='\033[93m'
+    RESET='\033[0m'
+else
+    BLUE=''
+    GREEN=''
+    RED=''
+    YELLOW=''
+    RESET=''
+fi
+
+log_info() {
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${RESET} $*" >&2
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
+}
+
+is_positive() {
+  local input_val="${1:-no}"
+
+  case "${input_val}" in
+    0|true|True|yes|Yes|y|Y)
+      return 0  # Success - truthy
+      ;;
+    1|false|False|no|No|n|N)
+      return 1  # Failure - falsy
+      ;;
+    *)
+      return 2  # Invalid input
+      ;;
+  esac
+}
+
+
+# ============================================================================
+# Infrastructure Installation Helper Functions
+# ============================================================================
+
+# Detect the platform (kind/minikube/openshift/kubernetes)
+# Returns: kind, minikube, openshift, or kubernetes
+detect_platform() {
+    # Check for OpenShift
+    if kubectl get clusterversion &>/dev/null; then
+        echo "openshift"
+        return 0
+    fi
+
+    # Check for Kind
+    local node_hostname
+    node_hostname=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.kubernetes\.io/hostname}' 2>/dev/null || echo "")
+    if [[ "$node_hostname" == *"kind"* ]]; then
+        echo "kind"
+        return 0
+    fi
+
+    # Check for Minikube
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null || echo "")
+    if [[ "$current_context" == *"minikube"* ]]; then
+        echo "minikube"
+        return 0
+    fi
+
+    # Default to standard Kubernetes
+    echo "kubernetes"
+    return 0
+}
+
+# Wait for pods to be created (exist)
+# Usage: wait_for_pods_created <namespace> <label-selector> [timeout_seconds]
+wait_for_pods_created() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-60}"
+    local elapsed=0
+
+    log_info "Waiting for pods with label '$label_selector' in namespace '$namespace' to be created..."
+
+    while true; do
+        # Exclude terminating pods by filtering out Terminating status
+        local pod_count=$(kubectl get pods -n "$namespace" -l "$label_selector" \
+            --no-headers 2>/dev/null | grep -v "Terminating" | wc -l)
+
+        if [ "$pod_count" -gt 0 ]; then
+            log_info "Found $pod_count pod(s) with label '$label_selector'"
+            return 0
+        fi
+
+        if [ $elapsed -ge $timeout ]; then
+            log_error "Timeout waiting for pods with label '$label_selector' to be created"
+            return 1
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+# Wait for pods to be ready
+# Usage: wait_for_pods_ready <namespace> <label-selector> [timeout]
+wait_for_pods_ready() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-180s}"
+
+    log_info "Waiting for pods with label '$label_selector' in namespace '$namespace' to be ready..."
+
+    # Get list of non-terminating pods and wait for them
+    local pods=$(kubectl get pods -n "$namespace" -l "$label_selector" \
+        --no-headers 2>/dev/null | grep -v "Terminating" | awk '{print $1}')
+
+    if [ -z "$pods" ]; then
+        log_error "No pods found with label '$label_selector' in namespace '$namespace'"
+        return 1
+    fi
+
+    for pod in $pods; do
+        kubectl wait --for=condition=Ready pod/"$pod" -n "$namespace" --timeout="$timeout" || return 1
+    done
+}
+
+# Wait for pods to be ready (combines both creation and ready checks)
+# Usage: wait_for_pods <namespace> <label-selector> [timeout]
+wait_for_pods() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-180s}"
+
+    # Convert timeout to seconds for pod creation check
+    local timeout_seconds="${timeout%s}"
+    local timeout_created=60
+
+    # If timeout is longer than 60s, use 60s for creation, rest for ready
+    # If timeout is shorter, split it
+    if [ "$timeout_seconds" -gt 60 ]; then
+        timeout_created=60
+    else
+        timeout_created=$((timeout_seconds / 3))
+    fi
+
+    # First, wait for pods to be created
+    wait_for_pods_created "$namespace" "$label_selector" "$timeout_created" || return 1
+
+    # Then, wait for pods to be ready
+    wait_for_pods_ready "$namespace" "$label_selector" "$timeout" || return 1
+
+    log_success "Pods with label '$label_selector' in namespace '$namespace' are ready!"
+}
+
+# Wait for deployment to be available using kubectl wait
+# Usage: wait_for_deployment <namespace> <deployment-name> [timeout]
+# Note: This uses kubectl wait --for=condition=Available, which checks deployment status directly
+wait_for_deployment() {
+    local namespace="$1"
+    local deployment_name="$2"
+    local timeout="${3:-180s}"
+
+    log_info "Waiting for deployment '$deployment_name' in namespace '$namespace' to be available..."
+    if kubectl wait --timeout="$timeout" -n "$namespace" deployment/"$deployment_name" --for=condition=Available; then
+        log_success "Deployment '$deployment_name' in namespace '$namespace' is available!"
+    else
+        log_error "Deployment '$deployment_name' in namespace '$namespace' failed to become available within $timeout"
+        log_error "--- Deployment status ---"
+        kubectl get deployment "$deployment_name" -n "$namespace" -o wide 2>/dev/null || true
+        log_error "--- Pod status ---"
+        kubectl get pods -n "$namespace" -l "control-plane=$deployment_name" -o wide 2>/dev/null || true
+        log_error "--- Pod describe (last 50 lines) ---"
+        kubectl describe pods -n "$namespace" -l "control-plane=$deployment_name" 2>/dev/null | tail -50 || true
+        log_error "--- Recent events in namespace '$namespace' ---"
+        kubectl get events -n "$namespace" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+        return 1
+    fi
+}
+
+# Wait for CRD to be established
+# Usage: wait_for_crd <crd-name> [timeout]
+wait_for_crd() {
+    local crd_name="$1"
+    local timeout="${2:-60s}"
+
+    log_info "Waiting for CRD '$crd_name' to be established..."
+
+    # Add small delay to allow CRD status to be initialized
+    sleep 2
+
+    # Retry logic to handle race condition where .status.conditions may not be initialized yet
+    local max_retries=10
+    local retry=0
+    while [ $retry -lt $max_retries ]; do
+        if kubectl wait --for=condition=Established --timeout="$timeout" crd/"$crd_name" 2>/dev/null; then
+            return 0
+        fi
+        retry=$((retry + 1))
+        if [ $retry -lt $max_retries ]; then
+            log_info "Retry $retry/$max_retries: Waiting for CRD status to be initialized..."
+            sleep 3
+        fi
+    done
+
+    # Final attempt with error output
+    kubectl wait --for=condition=Established --timeout="$timeout" crd/"$crd_name"
+}
+
+# Wait for multiple CRDs to be established
+# Usage: wait_for_crds <timeout> <crd1> <crd2> ...
+wait_for_crds() {
+    local timeout="$1"
+    shift
+
+    for crd in "$@"; do
+        wait_for_crd "$crd" "$timeout" || return 1
+    done
+
+    log_success "All CRDs are established!"
+}
+
+# Update multiple fields in KServe inferenceservice-config ConfigMap
+# Usage: update_isvc_config "ingress.enableGatewayApi=true" "deploy.defaultDeploymentMode=Standard"
+# Example:
+#   update_isvc_config "ingress.enableGatewayApi=true"
+#   update_isvc_config "ingress.enableGatewayApi=true" "ingress.className=\"envoy\""
+update_isvc_config() {
+    if [ $# -eq 0 ]; then
+        log_error "No update parameters provided"
+        return 1
+    fi
+
+    log_info "Updating inferenceservice-config..."
+
+    # Prepare updates as JSON array
+    local updates_file
+    updates_file=$(mktemp)
+
+    for arg in "$@"; do
+        local key="${arg%%=*}"
+        local raw_value="${arg#*=}"
+        local data_key="${key%%.*}"
+        local json_path="${key#*.}"
+        local value_json="$raw_value"
+
+        # Smart type detection: auto-quote strings, keep numbers/booleans/JSON as-is
+        if [[ ! $raw_value =~ ^\" ]] \
+           && [[ ! $raw_value =~ ^-?[0-9]+(\.[0-9]+)?$ ]] \
+           && [[ ! $raw_value =~ ^(true|false|null)$ ]] \
+           && [[ ! $raw_value =~ ^[{\[] ]]; then
+            value_json=$(jq -Rn --arg v "$raw_value" '$v')
+        fi
+
+        jq -n \
+            --arg data_key "$data_key" \
+            --arg path "$json_path" \
+            --argjson value "$value_json" \
+            '{data_key:$data_key, path:$path, value:$value}' >> "$updates_file"
+
+        log_info "  ✓ $data_key.$json_path = $value_json"
+    done
+
+    local updates_json
+    updates_json=$(jq -s '.' "$updates_file")
+    rm -f "$updates_file"
+
+    # Apply all updates with a single jq invocation
+    kubectl get configmap inferenceservice-config -n "${KSERVE_NAMESPACE}" -o json |
+        jq --argjson updates "$updates_json" '
+            # Helper function to safely set nested paths, creating intermediate objects as needed
+            def setpath_safe($parts; $value):
+                reduce range(0; ($parts|length)-1) as $i (.;
+                    $parts[:$i+1] as $prefix
+                    | if getpath($prefix) == null then setpath($prefix; {}) else . end
+                )
+                | setpath($parts; $value);
+
+            # Apply each update
+            reduce $updates[] as $item (.;
+                if .data[$item.data_key] == null or .data[$item.data_key] == "" then
+                    .data[$item.data_key] = (
+                        {}
+                        | setpath_safe($item.path | split("."); $item.value)
+                        | tojson
+                    )
+                else
+                    .data[$item.data_key] |= (
+                        fromjson
+                        | setpath_safe($item.path | split("."); $item.value)
+                        | tojson
+                    )
+                end
+            )
+        ' |
+        kubectl apply -f -
+
+    log_success "ConfigMap updated successfully"
+}
+
+# Create namespace if it does not exist (skip if already exists)
+# Usage: create_or_skip_namespace <namespace>
+create_or_skip_namespace() {
+    local namespace="$1"
+
+    if kubectl get namespace "$namespace" &>/dev/null; then
+        log_info "Namespace '$namespace' already exists"
+    else
+        log_info "Creating namespace '$namespace'..."
+        kubectl create namespace "$namespace"
+        log_success "Namespace '$namespace' created"
+    fi
+}
+
+# Check if required CLI tools exist
+# Usage: check_cli_exist <tool1> [tool2] [tool3] ...
+check_cli_exist() {
+    local missing=()
+    for cmd in "$@"; do
+        if ! command_exists "$cmd"; then
+            missing+=("$cmd")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_error "Required CLI tool(s) not found: ${missing[*]}"
+        log_error "Please install missing tool(s) first."
+        exit 1
+    fi
+}
+
+command_exists() {
+    command -v "$1" &>/dev/null
+}
+
+# Retry a command with delay between attempts
+# Usage: retry_command <max_attempts> <delay_seconds> <command...>
+# Example: retry_command 3 5 kubectl apply -k "${RUNTIMES_DIR}"
+# Returns: 0 on success, 1 on failure after all attempts
+retry_command() {
+    local max_attempts="$1"
+    local delay="$2"
+    shift 2
+    local attempt=1
+
+    while [ $attempt -le $max_attempts ]; do
+        if "$@" 2>&1; then
+            return 0
+        fi
+
+        if [ $attempt -lt $max_attempts ]; then
+            log_warning "Command failed, retrying in ${delay} seconds... (attempt $attempt/$max_attempts)"
+            sleep "$delay"
+        else
+            log_error "Command failed after $max_attempts attempts"
+            return 1
+        fi
+        attempt=$((attempt + 1))
+    done
+}
+
+# Compare semantic versions (returns 0 if v1 >= v2, 1 otherwise)
+# Usage: version_gte "v3.17.3" "v3.16.0"
+# Example: version_gte "$current_version" "$required_version" && echo "OK"
+version_gte() {
+    [ "$1" = "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" ]
+}
+
+# ============================================================================
+# Shared Resources Configuration (for dual KServe + LLMISVC installation)
+# ============================================================================
+
+determine_shared_resources_config() {
+    local install_mode="${1}"
+    local enable_kserve="${2}"
+    local enable_llmisvc="${3}"
+
+    if ! is_positive "${enable_kserve}" && ! is_positive "${enable_llmisvc}"; then
+        return
+    fi
+
+    log_info "Determining shared resources configuration (KSERVE=${enable_kserve}, LLMISVC=${enable_llmisvc})..."
+
+    if [ "${install_mode}" = "helm" ]; then
+        determine_shared_resources_helm "${enable_kserve}" "${enable_llmisvc}"
+    elif [ "${install_mode}" = "kustomize" ]; then
+        determine_shared_resources_kustomize
+    else
+        log_error "INSTALL_MODE not set. Must be 'helm' or 'kustomize'"
+        exit 1
+    fi
+}
+
+determine_shared_resources_helm() {
+    local enable_kserve="${1}"
+    local enable_llmisvc="${2}"
+
+    local kserve_installed=$(helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -c "^kserve-resources$" || true)
+    local llmisvc_installed=$(helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -c "^kserve-llmisvc-resources$" || true)
+
+    if [ "${kserve_installed}" = "0" ] && [ "${llmisvc_installed}" = "0" ]; then
+        # First installation - check which components are being enabled
+        if is_positive "${enable_kserve}" && is_positive "${enable_llmisvc}"; then
+            # Both enabled: kserve-resources installs first and creates shared resources
+            log_info "[Helm] First install (both) - kserve-resources creates shared resources, llmisvc-resources does not"
+            LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        elif is_positive "${enable_kserve}" && ! is_positive "${enable_llmisvc}"; then
+            # Only kserve enabled: kserve-resources creates shared resources
+            log_info "[Helm] First install (kserve only) - kserve-resources will create shared resources"
+            # Use default value (true) - no extra args needed
+        elif ! is_positive "${enable_kserve}" && is_positive "${enable_llmisvc}"; then
+            # Only llmisvc enabled: llmisvc-resources creates shared resources
+            log_info "[Helm] First install (llmisvc only) - llmisvc-resources will create shared resources"
+            # Use default value (true) - no extra args needed
+        else
+            # Neither enabled - shouldn't reach here
+            log_error "[Helm] No components enabled"
+            return 1
+        fi
+    elif [ "${kserve_installed}" = "1" ] && [ "${llmisvc_installed}" = "0" ]; then
+        log_info "[Helm] Only kserve-resources installed - setting createSharedResources=false for LLMISVC"
+        LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+    elif [ "${kserve_installed}" = "0" ] && [ "${llmisvc_installed}" = "1" ]; then
+        log_info "[Helm] Only kserve-llmisvc-resources installed - setting createSharedResources=false for KSERVE"
+        KSERVE_EXTRA_ARGS="${KSERVE_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+    else
+        local kserve_has_false=$(helm get values kserve-resources -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "createSharedResources: false" || true)
+
+        if [ "${kserve_has_false}" = "1" ]; then
+            log_info "[Helm] Maintaining createSharedResources=false for KSERVE"
+            KSERVE_EXTRA_ARGS="${KSERVE_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        else
+            log_info "[Helm] Setting createSharedResources=false for LLMISVC"
+            LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        fi
+    fi
+}
+
+determine_shared_resources_kustomize() {
+    KSERVE_INSTALLED=$(kubectl get deployment kserve-controller-manager -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "kserve-controller-manager" || true)
+    LLMISVC_INSTALLED=$(kubectl get deployment llmisvc-controller-manager -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "llmisvc-controller-manager" || true)
+    
+    export KSERVE_INSTALLED
+    export LLMISVC_INSTALLED
+
+    log_info "[Kustomize] Installation status(0: not installed, 1: installed): KSERVE=${KSERVE_INSTALLED}, LLMISVC=${LLMISVC_INSTALLED}"
+}
+
+# ============================================================================
+
+# Set environment variable based on priority order:
+# Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default
+# Usage: set_env_with_priority VAR_NAME COMPONENT_ENV_VALUE GLOBAL_ENV_VALUE DEFAULT_VALUE
+set_env_with_priority() {
+    local var_name="$1"
+    local component_value="$2"
+    local global_value="$3"
+    local default_value="$4"
+
+    # Get current value
+    local current_value
+    eval "current_value=\${${var_name}}"
+
+    # If current value exists and differs from default, it's a runtime value - keep it
+    if [ -n "$current_value" ] && [ -n "$default_value" ] && [ "$current_value" != "$default_value" ]; then
+        # This is a runtime value, keep it
+        return
+    fi
+
+    # Apply priority: component env > global env > default
+    if [ -n "$component_value" ]; then
+        eval "export $var_name=\"$component_value\""
+    elif [ -n "$global_value" ]; then
+        eval "export $var_name=\"$global_value\""
+    fi
+    # If both are empty, variable keeps its default value
+}
+
+#================================================
+# Determine repository root using find_repo_root
+#================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
+REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
+export REPO_ROOT
+
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
+fi
+
+export PATH="${BIN_DIR}:${PATH}"
+
+REINSTALL="${REINSTALL:-false}"
+UNINSTALL="${UNINSTALL:-false}"
+FORCE_UPGRADE="${FORCE_UPGRADE:-false}"
+
+if [[ "$*" == *"--uninstall"* ]]; then
+    UNINSTALL=true
+elif [[ "$*" == *"--reinstall"* ]]; then
+    REINSTALL=true
+elif [[ "$*" == *"--force-upgrade"* ]]; then
+    FORCE_UPGRADE=true
+fi
+
+export REINSTALL
+export UNINSTALL
+export FORCE_UPGRADE
+
+# RELEASE mode (from definition file)
+RELEASE="false"
+export RELEASE
+
+#================================================
+# Version Dependencies (from kserve-deps.env)
+#================================================
+
+GOLANGCI_LINT_VERSION=v2.9.0
+CONTROLLER_TOOLS_VERSION=v0.19.0
+ENVTEST_VERSION=release-0.19
+YQ_VERSION=v4.52.1
+HELM_VERSION=v3.16.3
+KUSTOMIZE_VERSION=v5.8.1
+HELM_DOCS_VERSION=v1.12.0
+POETRY_VERSION=1.8.3
+UV_VERSION=0.7.8
+RUFF_VERSION=0.14.13
+PINACT_VERSION=v3.9.0
+KIND_VERSION=v0.30.0
+CERT_MANAGER_VERSION=v1.17.0
+ENVOY_GATEWAY_VERSION=v1.8.1
+ENVOY_AI_GATEWAY_VERSION=v1.0.0
+KNATIVE_OPERATOR_VERSION=v1.21.1
+KNATIVE_SERVING_VERSION=1.21.1
+KEDA_OTEL_ADDON_VERSION=v0.0.6
+PROMETHEUS_VERSION=83.4.0
+PROMETHEUS_ADAPTER_VERSION=5.3.0
+JAEGER_VERSION=4.7.0
+KSERVE_VERSION=v0.20.0
+ISTIO_VERSION=1.27.1
+KEDA_VERSION=2.18.0
+OPENTELEMETRY_OPERATOR_VERSION=0.74.3
+LWS_VERSION=v0.8.0
+GATEWAY_API_VERSION=v1.5.1
+GIE_VERSION=v1.5.0
+LLMD_ROUTER_VERSION=v0.10.0
+WVA_VERSION=v0.9.0
+
+#================================================
+# Global Variables (from global-vars.env)
+#================================================
+# These provide default namespace values that can be overridden
+# by environment variables or GLOBAL_ENV settings below
+
+KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
+KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-kserve}"
+PROMETHEUS_NAMESPACE="${PROMETHEUS_NAMESPACE:-monitoring}"
+PROMETHEUS_ADAPTER_NAMESPACE="${PROMETHEUS_ADAPTER_NAMESPACE:-monitoring}"
+WVA_NAMESPACE="${WVA_NAMESPACE:-wva-system}"
+OTEL_NAMESPACE="${OTEL_NAMESPACE:-opentelemetry-operator}"
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-knative-operator}"
+SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
+ISTIO_NAMESPACE="${ISTIO_NAMESPACE:-istio-system}"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-kserve}"
+DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-Knative}"
+GATEWAY_NETWORK_LAYER="${GATEWAY_NETWORK_LAYER:-false}"
+ENABLE_KSERVE="${ENABLE_KSERVE:-true}"
+ENABLE_LLMISVC="${ENABLE_LLMISVC:-false}"
+ENABLE_LOCALMODEL="${ENABLE_LOCALMODEL:-false}"
+EMBED_MANIFESTS="${EMBED_MANIFESTS:-false}"
+EMBED_TEMPLATES="${EMBED_TEMPLATES:-false}"
+KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
+
+#================================================
+# Component-Specific Variables
+#================================================
+
+
+
+#================================================
+# Template Functions (EMBED_TEMPLATES MODE)
+#================================================
+
+
+
+#================================================
+# Component Functions
+#================================================
+
+# ----------------------------------------
+# CLI/Component: helm
+# ----------------------------------------
+
+
+
+install_helm() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local archive_name="helm-${HELM_VERSION}-${os}-${arch}.tar.gz"
+    local download_url="https://get.helm.sh/${archive_name}"
+
+    log_info "Installing Helm ${HELM_VERSION} for ${os}/${arch}..."
+
+    # Check if helm is already installed in BIN_DIR with the exact required version
+    if [[ -f "${BIN_DIR}/helm" ]]; then
+        local current_version=$("${BIN_DIR}/helm" version --template='{{.Version}}' 2>/dev/null)
+        if [[ "$current_version" == "$HELM_VERSION" ]]; then
+            log_info "Helm ${current_version} is already installed in ${BIN_DIR}"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Replacing Helm ${current_version} with ${HELM_VERSION} in ${BIN_DIR}..."
+    fi
+
+    local temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${archive_name}"
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_error "Neither wget nor curl is available" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    tar -xzf "${temp_file}" -C "${temp_dir}"
+
+    local binary_path="${temp_dir}/${os}-${arch}/helm"
+
+    if [[ ! -f "${binary_path}" ]]; then
+        log_error "helm binary not found in archive" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    chmod +x "${binary_path}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${binary_path}" "${BIN_DIR}/helm"
+    else
+        sudo mv "${binary_path}" "${BIN_DIR}/helm"
+    fi
+
+    rm -rf "${temp_dir}"
+
+    log_success "Successfully installed Helm ${HELM_VERSION} to ${BIN_DIR}/helm"
+    "${BIN_DIR}/helm" version
+}
+
+# ----------------------------------------
+# CLI/Component: yq
+# ----------------------------------------
+
+
+
+install_yq() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local binary_name="yq_${os}_${arch}"
+    local download_url="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${binary_name}"
+
+    log_info "Installing yq ${YQ_VERSION} for ${os}/${arch}..."
+
+    if [[ -x "${BIN_DIR}/yq" ]]; then
+        local current_version=$("${BIN_DIR}/yq" --version 2>&1 | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        # Normalize version format (add 'v' prefix if missing)
+        [[ -n "$current_version" && "$current_version" != v* ]] && current_version="v${current_version}"
+        if [[ -n "$current_version" ]] && version_gte "$current_version" "$YQ_VERSION"; then
+            log_info "yq ${current_version} is already installed in ${BIN_DIR} (>= ${YQ_VERSION})"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Upgrading yq from ${current_version} to ${YQ_VERSION}..."
+    fi
+
+    local temp_file=$(mktemp)
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_info "Neither wget nor curl is available" >&2
+        rm -f "${temp_file}"
+        exit 1
+    fi
+
+    chmod +x "${temp_file}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${temp_file}" "${BIN_DIR}/yq"
+    else
+        sudo mv "${temp_file}" "${BIN_DIR}/yq"
+    fi
+
+    log_success "Successfully installed yq ${YQ_VERSION} to ${BIN_DIR}/yq"
+    "${BIN_DIR}/yq" --version
+}
+
+# ----------------------------------------
+# CLI/Component: cert-manager
+# ----------------------------------------
+
+uninstall_cert_manager() {
+    log_info "Uninstalling cert-manager..."
+    helm uninstall cert-manager -n cert-manager 2>/dev/null || true
+    kubectl delete all --all -n cert-manager --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace cert-manager --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    log_success "cert-manager uninstalled"
+}
+
+install_cert_manager() {
+    if helm list -n cert-manager 2>/dev/null | grep -q "cert-manager"; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "cert-manager is already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling cert-manager..."
+            uninstall_cert_manager
+        fi
+    fi
+
+    log_info "Adding cert-manager Helm repository..."
+    helm repo add jetstack https://charts.jetstack.io --force-update
+
+    log_info "Installing cert-manager ${CERT_MANAGER_VERSION}..."
+    helm install \
+        cert-manager jetstack/cert-manager \
+        --namespace cert-manager \
+        --create-namespace \
+        --version "${CERT_MANAGER_VERSION}" \
+        --set crds.enabled=true \
+        --wait
+
+    log_success "Successfully installed cert-manager ${CERT_MANAGER_VERSION} via Helm"
+
+    wait_for_pods "cert-manager" "app in (cert-manager,webhook,cainjector)" "180s"
+
+    log_success "cert-manager is ready!"
+}
+
+
+
+#================================================
+# Main Installation Logic
+#================================================
+
+main() {
+    if [ "$UNINSTALL" = true ]; then
+        echo "=========================================="
+        echo "Uninstalling components..."
+        echo "=========================================="
+        uninstall_cert_manager
+        
+        
+        echo "=========================================="
+        echo "✅ Uninstallation completed!"
+        echo "=========================================="
+        exit 0
+    fi
+
+    echo "=========================================="
+    echo "Install LocalModel dependencies"
+    echo "=========================================="
+
+    export EMBED_TEMPLATES="true"
+
+    install_helm
+    install_yq
+    install_cert_manager
+
+    echo "=========================================="
+    echo "✅ Installation completed successfully!"
+    echo "=========================================="
+}
+
+
+
+main "$@"

--- a/hack/setup/quick-install/localmodel-full-install-helm.sh
+++ b/hack/setup/quick-install/localmodel-full-install-helm.sh
@@ -1,0 +1,1246 @@
+#!/bin/bash
+
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install LocalModel dependencies using helm
+#
+# AUTO-GENERATED from: localmodel-full-install.definition
+# DO NOT EDIT MANUALLY
+#
+# To regenerate:
+#   ./scripts/generate-install-script.py localmodel-full-install.definition
+#
+# Usage: localmodel-full-install.sh [--reinstall|--uninstall]
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+#================================================
+# Helper Functions (from common.sh)
+#================================================
+
+# Utility Functions
+# ============================================================================
+
+find_repo_root() {
+    local current_dir="${1:-$(pwd)}"
+    local skip="${2:-false}"
+
+    while [[ "$current_dir" != "/" ]]; do
+        if [[ -e "${current_dir}/.git" ]]; then
+            echo "$current_dir"
+            return 0
+        fi
+        current_dir="$(dirname "$current_dir")"
+    done
+
+    # Git repository not found
+    if [[ "$skip" == "true" ]]; then
+        log_warning "Could not find git repository root, using current directory: $PWD"
+        echo "$PWD"
+        return 0
+    else
+        log_error "Could not find git repository root"
+        exit 1
+    fi
+}
+
+ensure_dir() {
+    local dir_path="${1}"
+
+    if [[ -d "${dir_path}" ]]; then
+        return 0
+    fi
+
+    mkdir -p "${dir_path}"
+}
+
+detect_os() {
+    local os=""
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="darwin" ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
+    esac
+    echo "$os"
+}
+
+detect_arch() {
+    local arch=""
+    case "$(uname -m)" in
+        x86_64)  arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
+    esac
+    echo "$arch"
+}
+
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
+# Color codes (disable if NO_COLOR is set or not a terminal)
+if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
+    BLUE='\033[94m'
+    GREEN='\033[92m'
+    RED='\033[91m'
+    YELLOW='\033[93m'
+    RESET='\033[0m'
+else
+    BLUE=''
+    GREEN=''
+    RED=''
+    YELLOW=''
+    RESET=''
+fi
+
+log_info() {
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${RESET} $*" >&2
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
+}
+
+is_positive() {
+  local input_val="${1:-no}"
+
+  case "${input_val}" in
+    0|true|True|yes|Yes|y|Y)
+      return 0  # Success - truthy
+      ;;
+    1|false|False|no|No|n|N)
+      return 1  # Failure - falsy
+      ;;
+    *)
+      return 2  # Invalid input
+      ;;
+  esac
+}
+
+
+# ============================================================================
+# Infrastructure Installation Helper Functions
+# ============================================================================
+
+# Detect the platform (kind/minikube/openshift/kubernetes)
+# Returns: kind, minikube, openshift, or kubernetes
+detect_platform() {
+    # Check for OpenShift
+    if kubectl get clusterversion &>/dev/null; then
+        echo "openshift"
+        return 0
+    fi
+
+    # Check for Kind
+    local node_hostname
+    node_hostname=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.kubernetes\.io/hostname}' 2>/dev/null || echo "")
+    if [[ "$node_hostname" == *"kind"* ]]; then
+        echo "kind"
+        return 0
+    fi
+
+    # Check for Minikube
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null || echo "")
+    if [[ "$current_context" == *"minikube"* ]]; then
+        echo "minikube"
+        return 0
+    fi
+
+    # Default to standard Kubernetes
+    echo "kubernetes"
+    return 0
+}
+
+# Wait for pods to be created (exist)
+# Usage: wait_for_pods_created <namespace> <label-selector> [timeout_seconds]
+wait_for_pods_created() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-60}"
+    local elapsed=0
+
+    log_info "Waiting for pods with label '$label_selector' in namespace '$namespace' to be created..."
+
+    while true; do
+        # Exclude terminating pods by filtering out Terminating status
+        local pod_count=$(kubectl get pods -n "$namespace" -l "$label_selector" \
+            --no-headers 2>/dev/null | grep -v "Terminating" | wc -l)
+
+        if [ "$pod_count" -gt 0 ]; then
+            log_info "Found $pod_count pod(s) with label '$label_selector'"
+            return 0
+        fi
+
+        if [ $elapsed -ge $timeout ]; then
+            log_error "Timeout waiting for pods with label '$label_selector' to be created"
+            return 1
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+# Wait for pods to be ready
+# Usage: wait_for_pods_ready <namespace> <label-selector> [timeout]
+wait_for_pods_ready() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-180s}"
+
+    log_info "Waiting for pods with label '$label_selector' in namespace '$namespace' to be ready..."
+
+    # Get list of non-terminating pods and wait for them
+    local pods=$(kubectl get pods -n "$namespace" -l "$label_selector" \
+        --no-headers 2>/dev/null | grep -v "Terminating" | awk '{print $1}')
+
+    if [ -z "$pods" ]; then
+        log_error "No pods found with label '$label_selector' in namespace '$namespace'"
+        return 1
+    fi
+
+    for pod in $pods; do
+        kubectl wait --for=condition=Ready pod/"$pod" -n "$namespace" --timeout="$timeout" || return 1
+    done
+}
+
+# Wait for pods to be ready (combines both creation and ready checks)
+# Usage: wait_for_pods <namespace> <label-selector> [timeout]
+wait_for_pods() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-180s}"
+
+    # Convert timeout to seconds for pod creation check
+    local timeout_seconds="${timeout%s}"
+    local timeout_created=60
+
+    # If timeout is longer than 60s, use 60s for creation, rest for ready
+    # If timeout is shorter, split it
+    if [ "$timeout_seconds" -gt 60 ]; then
+        timeout_created=60
+    else
+        timeout_created=$((timeout_seconds / 3))
+    fi
+
+    # First, wait for pods to be created
+    wait_for_pods_created "$namespace" "$label_selector" "$timeout_created" || return 1
+
+    # Then, wait for pods to be ready
+    wait_for_pods_ready "$namespace" "$label_selector" "$timeout" || return 1
+
+    log_success "Pods with label '$label_selector' in namespace '$namespace' are ready!"
+}
+
+# Wait for deployment to be available using kubectl wait
+# Usage: wait_for_deployment <namespace> <deployment-name> [timeout]
+# Note: This uses kubectl wait --for=condition=Available, which checks deployment status directly
+wait_for_deployment() {
+    local namespace="$1"
+    local deployment_name="$2"
+    local timeout="${3:-180s}"
+
+    log_info "Waiting for deployment '$deployment_name' in namespace '$namespace' to be available..."
+    if kubectl wait --timeout="$timeout" -n "$namespace" deployment/"$deployment_name" --for=condition=Available; then
+        log_success "Deployment '$deployment_name' in namespace '$namespace' is available!"
+    else
+        log_error "Deployment '$deployment_name' in namespace '$namespace' failed to become available within $timeout"
+        log_error "--- Deployment status ---"
+        kubectl get deployment "$deployment_name" -n "$namespace" -o wide 2>/dev/null || true
+        log_error "--- Pod status ---"
+        kubectl get pods -n "$namespace" -l "control-plane=$deployment_name" -o wide 2>/dev/null || true
+        log_error "--- Pod describe (last 50 lines) ---"
+        kubectl describe pods -n "$namespace" -l "control-plane=$deployment_name" 2>/dev/null | tail -50 || true
+        log_error "--- Recent events in namespace '$namespace' ---"
+        kubectl get events -n "$namespace" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+        return 1
+    fi
+}
+
+# Wait for CRD to be established
+# Usage: wait_for_crd <crd-name> [timeout]
+wait_for_crd() {
+    local crd_name="$1"
+    local timeout="${2:-60s}"
+
+    log_info "Waiting for CRD '$crd_name' to be established..."
+
+    # Add small delay to allow CRD status to be initialized
+    sleep 2
+
+    # Retry logic to handle race condition where .status.conditions may not be initialized yet
+    local max_retries=10
+    local retry=0
+    while [ $retry -lt $max_retries ]; do
+        if kubectl wait --for=condition=Established --timeout="$timeout" crd/"$crd_name" 2>/dev/null; then
+            return 0
+        fi
+        retry=$((retry + 1))
+        if [ $retry -lt $max_retries ]; then
+            log_info "Retry $retry/$max_retries: Waiting for CRD status to be initialized..."
+            sleep 3
+        fi
+    done
+
+    # Final attempt with error output
+    kubectl wait --for=condition=Established --timeout="$timeout" crd/"$crd_name"
+}
+
+# Wait for multiple CRDs to be established
+# Usage: wait_for_crds <timeout> <crd1> <crd2> ...
+wait_for_crds() {
+    local timeout="$1"
+    shift
+
+    for crd in "$@"; do
+        wait_for_crd "$crd" "$timeout" || return 1
+    done
+
+    log_success "All CRDs are established!"
+}
+
+# Update multiple fields in KServe inferenceservice-config ConfigMap
+# Usage: update_isvc_config "ingress.enableGatewayApi=true" "deploy.defaultDeploymentMode=Standard"
+# Example:
+#   update_isvc_config "ingress.enableGatewayApi=true"
+#   update_isvc_config "ingress.enableGatewayApi=true" "ingress.className=\"envoy\""
+update_isvc_config() {
+    if [ $# -eq 0 ]; then
+        log_error "No update parameters provided"
+        return 1
+    fi
+
+    log_info "Updating inferenceservice-config..."
+
+    # Prepare updates as JSON array
+    local updates_file
+    updates_file=$(mktemp)
+
+    for arg in "$@"; do
+        local key="${arg%%=*}"
+        local raw_value="${arg#*=}"
+        local data_key="${key%%.*}"
+        local json_path="${key#*.}"
+        local value_json="$raw_value"
+
+        # Smart type detection: auto-quote strings, keep numbers/booleans/JSON as-is
+        if [[ ! $raw_value =~ ^\" ]] \
+           && [[ ! $raw_value =~ ^-?[0-9]+(\.[0-9]+)?$ ]] \
+           && [[ ! $raw_value =~ ^(true|false|null)$ ]] \
+           && [[ ! $raw_value =~ ^[{\[] ]]; then
+            value_json=$(jq -Rn --arg v "$raw_value" '$v')
+        fi
+
+        jq -n \
+            --arg data_key "$data_key" \
+            --arg path "$json_path" \
+            --argjson value "$value_json" \
+            '{data_key:$data_key, path:$path, value:$value}' >> "$updates_file"
+
+        log_info "  ✓ $data_key.$json_path = $value_json"
+    done
+
+    local updates_json
+    updates_json=$(jq -s '.' "$updates_file")
+    rm -f "$updates_file"
+
+    # Apply all updates with a single jq invocation
+    kubectl get configmap inferenceservice-config -n "${KSERVE_NAMESPACE}" -o json |
+        jq --argjson updates "$updates_json" '
+            # Helper function to safely set nested paths, creating intermediate objects as needed
+            def setpath_safe($parts; $value):
+                reduce range(0; ($parts|length)-1) as $i (.;
+                    $parts[:$i+1] as $prefix
+                    | if getpath($prefix) == null then setpath($prefix; {}) else . end
+                )
+                | setpath($parts; $value);
+
+            # Apply each update
+            reduce $updates[] as $item (.;
+                if .data[$item.data_key] == null or .data[$item.data_key] == "" then
+                    .data[$item.data_key] = (
+                        {}
+                        | setpath_safe($item.path | split("."); $item.value)
+                        | tojson
+                    )
+                else
+                    .data[$item.data_key] |= (
+                        fromjson
+                        | setpath_safe($item.path | split("."); $item.value)
+                        | tojson
+                    )
+                end
+            )
+        ' |
+        kubectl apply -f -
+
+    log_success "ConfigMap updated successfully"
+}
+
+# Create namespace if it does not exist (skip if already exists)
+# Usage: create_or_skip_namespace <namespace>
+create_or_skip_namespace() {
+    local namespace="$1"
+
+    if kubectl get namespace "$namespace" &>/dev/null; then
+        log_info "Namespace '$namespace' already exists"
+    else
+        log_info "Creating namespace '$namespace'..."
+        kubectl create namespace "$namespace"
+        log_success "Namespace '$namespace' created"
+    fi
+}
+
+# Check if required CLI tools exist
+# Usage: check_cli_exist <tool1> [tool2] [tool3] ...
+check_cli_exist() {
+    local missing=()
+    for cmd in "$@"; do
+        if ! command_exists "$cmd"; then
+            missing+=("$cmd")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_error "Required CLI tool(s) not found: ${missing[*]}"
+        log_error "Please install missing tool(s) first."
+        exit 1
+    fi
+}
+
+command_exists() {
+    command -v "$1" &>/dev/null
+}
+
+# Retry a command with delay between attempts
+# Usage: retry_command <max_attempts> <delay_seconds> <command...>
+# Example: retry_command 3 5 kubectl apply -k "${RUNTIMES_DIR}"
+# Returns: 0 on success, 1 on failure after all attempts
+retry_command() {
+    local max_attempts="$1"
+    local delay="$2"
+    shift 2
+    local attempt=1
+
+    while [ $attempt -le $max_attempts ]; do
+        if "$@" 2>&1; then
+            return 0
+        fi
+
+        if [ $attempt -lt $max_attempts ]; then
+            log_warning "Command failed, retrying in ${delay} seconds... (attempt $attempt/$max_attempts)"
+            sleep "$delay"
+        else
+            log_error "Command failed after $max_attempts attempts"
+            return 1
+        fi
+        attempt=$((attempt + 1))
+    done
+}
+
+# Compare semantic versions (returns 0 if v1 >= v2, 1 otherwise)
+# Usage: version_gte "v3.17.3" "v3.16.0"
+# Example: version_gte "$current_version" "$required_version" && echo "OK"
+version_gte() {
+    [ "$1" = "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" ]
+}
+
+# ============================================================================
+# Shared Resources Configuration (for dual KServe + LLMISVC installation)
+# ============================================================================
+
+determine_shared_resources_config() {
+    local install_mode="${1}"
+    local enable_kserve="${2}"
+    local enable_llmisvc="${3}"
+
+    if ! is_positive "${enable_kserve}" && ! is_positive "${enable_llmisvc}"; then
+        return
+    fi
+
+    log_info "Determining shared resources configuration (KSERVE=${enable_kserve}, LLMISVC=${enable_llmisvc})..."
+
+    if [ "${install_mode}" = "helm" ]; then
+        determine_shared_resources_helm "${enable_kserve}" "${enable_llmisvc}"
+    elif [ "${install_mode}" = "kustomize" ]; then
+        determine_shared_resources_kustomize
+    else
+        log_error "INSTALL_MODE not set. Must be 'helm' or 'kustomize'"
+        exit 1
+    fi
+}
+
+determine_shared_resources_helm() {
+    local enable_kserve="${1}"
+    local enable_llmisvc="${2}"
+
+    local kserve_installed=$(helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -c "^kserve-resources$" || true)
+    local llmisvc_installed=$(helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -c "^kserve-llmisvc-resources$" || true)
+
+    if [ "${kserve_installed}" = "0" ] && [ "${llmisvc_installed}" = "0" ]; then
+        # First installation - check which components are being enabled
+        if is_positive "${enable_kserve}" && is_positive "${enable_llmisvc}"; then
+            # Both enabled: kserve-resources installs first and creates shared resources
+            log_info "[Helm] First install (both) - kserve-resources creates shared resources, llmisvc-resources does not"
+            LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        elif is_positive "${enable_kserve}" && ! is_positive "${enable_llmisvc}"; then
+            # Only kserve enabled: kserve-resources creates shared resources
+            log_info "[Helm] First install (kserve only) - kserve-resources will create shared resources"
+            # Use default value (true) - no extra args needed
+        elif ! is_positive "${enable_kserve}" && is_positive "${enable_llmisvc}"; then
+            # Only llmisvc enabled: llmisvc-resources creates shared resources
+            log_info "[Helm] First install (llmisvc only) - llmisvc-resources will create shared resources"
+            # Use default value (true) - no extra args needed
+        else
+            # Neither enabled - shouldn't reach here
+            log_error "[Helm] No components enabled"
+            return 1
+        fi
+    elif [ "${kserve_installed}" = "1" ] && [ "${llmisvc_installed}" = "0" ]; then
+        log_info "[Helm] Only kserve-resources installed - setting createSharedResources=false for LLMISVC"
+        LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+    elif [ "${kserve_installed}" = "0" ] && [ "${llmisvc_installed}" = "1" ]; then
+        log_info "[Helm] Only kserve-llmisvc-resources installed - setting createSharedResources=false for KSERVE"
+        KSERVE_EXTRA_ARGS="${KSERVE_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+    else
+        local kserve_has_false=$(helm get values kserve-resources -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "createSharedResources: false" || true)
+
+        if [ "${kserve_has_false}" = "1" ]; then
+            log_info "[Helm] Maintaining createSharedResources=false for KSERVE"
+            KSERVE_EXTRA_ARGS="${KSERVE_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        else
+            log_info "[Helm] Setting createSharedResources=false for LLMISVC"
+            LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        fi
+    fi
+}
+
+determine_shared_resources_kustomize() {
+    KSERVE_INSTALLED=$(kubectl get deployment kserve-controller-manager -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "kserve-controller-manager" || true)
+    LLMISVC_INSTALLED=$(kubectl get deployment llmisvc-controller-manager -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "llmisvc-controller-manager" || true)
+    
+    export KSERVE_INSTALLED
+    export LLMISVC_INSTALLED
+
+    log_info "[Kustomize] Installation status(0: not installed, 1: installed): KSERVE=${KSERVE_INSTALLED}, LLMISVC=${LLMISVC_INSTALLED}"
+}
+
+# ============================================================================
+
+# Set environment variable based on priority order:
+# Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default
+# Usage: set_env_with_priority VAR_NAME COMPONENT_ENV_VALUE GLOBAL_ENV_VALUE DEFAULT_VALUE
+set_env_with_priority() {
+    local var_name="$1"
+    local component_value="$2"
+    local global_value="$3"
+    local default_value="$4"
+
+    # Get current value
+    local current_value
+    eval "current_value=\${${var_name}}"
+
+    # If current value exists and differs from default, it's a runtime value - keep it
+    if [ -n "$current_value" ] && [ -n "$default_value" ] && [ "$current_value" != "$default_value" ]; then
+        # This is a runtime value, keep it
+        return
+    fi
+
+    # Apply priority: component env > global env > default
+    if [ -n "$component_value" ]; then
+        eval "export $var_name=\"$component_value\""
+    elif [ -n "$global_value" ]; then
+        eval "export $var_name=\"$global_value\""
+    fi
+    # If both are empty, variable keeps its default value
+}
+
+#================================================
+# Determine repository root using find_repo_root
+#================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
+REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
+export REPO_ROOT
+
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
+fi
+
+export PATH="${BIN_DIR}:${PATH}"
+
+REINSTALL="${REINSTALL:-false}"
+UNINSTALL="${UNINSTALL:-false}"
+FORCE_UPGRADE="${FORCE_UPGRADE:-false}"
+
+if [[ "$*" == *"--uninstall"* ]]; then
+    UNINSTALL=true
+elif [[ "$*" == *"--reinstall"* ]]; then
+    REINSTALL=true
+elif [[ "$*" == *"--force-upgrade"* ]]; then
+    FORCE_UPGRADE=true
+fi
+
+export REINSTALL
+export UNINSTALL
+export FORCE_UPGRADE
+
+# RELEASE mode (from definition file)
+RELEASE="true"
+export RELEASE
+
+#================================================
+# Version Dependencies (from kserve-deps.env)
+#================================================
+
+GOLANGCI_LINT_VERSION=v2.9.0
+CONTROLLER_TOOLS_VERSION=v0.19.0
+ENVTEST_VERSION=release-0.19
+YQ_VERSION=v4.52.1
+HELM_VERSION=v3.16.3
+KUSTOMIZE_VERSION=v5.8.1
+HELM_DOCS_VERSION=v1.12.0
+POETRY_VERSION=1.8.3
+UV_VERSION=0.7.8
+RUFF_VERSION=0.14.13
+PINACT_VERSION=v3.9.0
+KIND_VERSION=v0.30.0
+CERT_MANAGER_VERSION=v1.17.0
+ENVOY_GATEWAY_VERSION=v1.8.1
+ENVOY_AI_GATEWAY_VERSION=v1.0.0
+KNATIVE_OPERATOR_VERSION=v1.21.1
+KNATIVE_SERVING_VERSION=1.21.1
+KEDA_OTEL_ADDON_VERSION=v0.0.6
+PROMETHEUS_VERSION=83.4.0
+PROMETHEUS_ADAPTER_VERSION=5.3.0
+JAEGER_VERSION=4.7.0
+KSERVE_VERSION=v0.20.0
+ISTIO_VERSION=1.27.1
+KEDA_VERSION=2.18.0
+OPENTELEMETRY_OPERATOR_VERSION=0.74.3
+LWS_VERSION=v0.8.0
+GATEWAY_API_VERSION=v1.5.1
+GIE_VERSION=v1.5.0
+LLMD_ROUTER_VERSION=v0.10.0
+WVA_VERSION=v0.9.0
+
+#================================================
+# Global Variables (from global-vars.env)
+#================================================
+# These provide default namespace values that can be overridden
+# by environment variables or GLOBAL_ENV settings below
+
+KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
+KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-kserve}"
+PROMETHEUS_NAMESPACE="${PROMETHEUS_NAMESPACE:-monitoring}"
+PROMETHEUS_ADAPTER_NAMESPACE="${PROMETHEUS_ADAPTER_NAMESPACE:-monitoring}"
+WVA_NAMESPACE="${WVA_NAMESPACE:-wva-system}"
+OTEL_NAMESPACE="${OTEL_NAMESPACE:-opentelemetry-operator}"
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-knative-operator}"
+SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
+ISTIO_NAMESPACE="${ISTIO_NAMESPACE:-istio-system}"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-kserve}"
+DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-Knative}"
+GATEWAY_NETWORK_LAYER="${GATEWAY_NETWORK_LAYER:-false}"
+ENABLE_KSERVE="${ENABLE_KSERVE:-true}"
+ENABLE_LLMISVC="${ENABLE_LLMISVC:-false}"
+ENABLE_LOCALMODEL="${ENABLE_LOCALMODEL:-false}"
+EMBED_MANIFESTS="${EMBED_MANIFESTS:-false}"
+EMBED_TEMPLATES="${EMBED_TEMPLATES:-false}"
+KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
+
+#================================================
+# Component-Specific Variables
+#================================================
+
+INSTALL_MODE="helm"
+USE_LOCAL_CHARTS="${USE_LOCAL_CHARTS:-false}"
+CHARTS_DIR="${REPO_ROOT}/charts"
+SET_KSERVE_VERSION="${SET_KSERVE_VERSION:-}"
+SHARED_EXTRA_ARGS="${SHARED_EXTRA_ARGS:-}"
+ENABLE_KSERVE="${ENABLE_KSERVE:-true}"
+ENABLE_LLMISVC="${ENABLE_LLMISVC:-${LLMISVC:-false}}"
+ENABLE_LOCALMODEL="${ENABLE_LOCALMODEL:-${LOCALMODEL:-false}}"
+CRD_CHARTS=()
+RESOURCE_CHARTS=()
+RESOURCE_EXTRA_ARGS_LIST=()
+TARGET_DEPLOYMENT_NAMES=()
+INSTALL_RUNTIMES="${INSTALL_RUNTIMES:-${ENABLE_KSERVE:-false}}"
+INSTALL_LLMISVC_CONFIGS="${INSTALL_LLMISVC_CONFIGS:-${ENABLE_LLMISVC:-false}}"
+RUNTIME_CONFIG_CHART_NAME="kserve-runtime-configs"
+
+#================================================
+# Template Functions (EMBED_TEMPLATES MODE)
+#================================================
+
+
+
+#================================================
+# Component Functions
+#================================================
+
+# ----------------------------------------
+# CLI/Component: helm
+# ----------------------------------------
+
+
+
+install_helm() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local archive_name="helm-${HELM_VERSION}-${os}-${arch}.tar.gz"
+    local download_url="https://get.helm.sh/${archive_name}"
+
+    log_info "Installing Helm ${HELM_VERSION} for ${os}/${arch}..."
+
+    # Check if helm is already installed in BIN_DIR with the exact required version
+    if [[ -f "${BIN_DIR}/helm" ]]; then
+        local current_version=$("${BIN_DIR}/helm" version --template='{{.Version}}' 2>/dev/null)
+        if [[ "$current_version" == "$HELM_VERSION" ]]; then
+            log_info "Helm ${current_version} is already installed in ${BIN_DIR}"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Replacing Helm ${current_version} with ${HELM_VERSION} in ${BIN_DIR}..."
+    fi
+
+    local temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${archive_name}"
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_error "Neither wget nor curl is available" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    tar -xzf "${temp_file}" -C "${temp_dir}"
+
+    local binary_path="${temp_dir}/${os}-${arch}/helm"
+
+    if [[ ! -f "${binary_path}" ]]; then
+        log_error "helm binary not found in archive" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    chmod +x "${binary_path}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${binary_path}" "${BIN_DIR}/helm"
+    else
+        sudo mv "${binary_path}" "${BIN_DIR}/helm"
+    fi
+
+    rm -rf "${temp_dir}"
+
+    log_success "Successfully installed Helm ${HELM_VERSION} to ${BIN_DIR}/helm"
+    "${BIN_DIR}/helm" version
+}
+
+# ----------------------------------------
+# CLI/Component: kustomize
+# ----------------------------------------
+
+
+
+install_kustomize() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local archive_name="kustomize_${KUSTOMIZE_VERSION}_${os}_${arch}.tar.gz"
+    local download_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${archive_name}"
+
+    log_info "Installing Kustomize ${KUSTOMIZE_VERSION} for ${os}/${arch}..."
+
+    if [[ -x "${BIN_DIR}/kustomize" ]]; then
+        local current_version=$("${BIN_DIR}/kustomize" version 2>/dev/null | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        if [[ -n "$current_version" ]] && version_gte "$current_version" "$KUSTOMIZE_VERSION"; then
+            log_info "Kustomize ${current_version} is already installed in ${BIN_DIR} (>= ${KUSTOMIZE_VERSION})"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Upgrading Kustomize from ${current_version} to ${KUSTOMIZE_VERSION}..."
+    fi
+
+    local temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${archive_name}"
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_error "Neither wget nor curl is available" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    tar -xzf "${temp_file}" -C "${temp_dir}"
+
+    local binary_path="${temp_dir}/kustomize"
+
+    if [[ ! -f "${binary_path}" ]]; then
+        log_error "kustomize binary not found in archive" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    chmod +x "${binary_path}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${binary_path}" "${BIN_DIR}/kustomize"
+    else
+        sudo mv "${binary_path}" "${BIN_DIR}/kustomize"
+    fi
+
+    rm -rf "${temp_dir}"
+
+    log_success "Successfully installed Kustomize ${KUSTOMIZE_VERSION} to ${BIN_DIR}/kustomize"
+    "${BIN_DIR}/kustomize" version
+}
+
+# ----------------------------------------
+# CLI/Component: yq
+# ----------------------------------------
+
+
+
+install_yq() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local binary_name="yq_${os}_${arch}"
+    local download_url="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${binary_name}"
+
+    log_info "Installing yq ${YQ_VERSION} for ${os}/${arch}..."
+
+    if [[ -x "${BIN_DIR}/yq" ]]; then
+        local current_version=$("${BIN_DIR}/yq" --version 2>&1 | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        # Normalize version format (add 'v' prefix if missing)
+        [[ -n "$current_version" && "$current_version" != v* ]] && current_version="v${current_version}"
+        if [[ -n "$current_version" ]] && version_gte "$current_version" "$YQ_VERSION"; then
+            log_info "yq ${current_version} is already installed in ${BIN_DIR} (>= ${YQ_VERSION})"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Upgrading yq from ${current_version} to ${YQ_VERSION}..."
+    fi
+
+    local temp_file=$(mktemp)
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_info "Neither wget nor curl is available" >&2
+        rm -f "${temp_file}"
+        exit 1
+    fi
+
+    chmod +x "${temp_file}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${temp_file}" "${BIN_DIR}/yq"
+    else
+        sudo mv "${temp_file}" "${BIN_DIR}/yq"
+    fi
+
+    log_success "Successfully installed yq ${YQ_VERSION} to ${BIN_DIR}/yq"
+    "${BIN_DIR}/yq" --version
+}
+
+# ----------------------------------------
+# CLI/Component: cert-manager
+# ----------------------------------------
+
+uninstall_cert_manager() {
+    log_info "Uninstalling cert-manager..."
+    helm uninstall cert-manager -n cert-manager 2>/dev/null || true
+    kubectl delete all --all -n cert-manager --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace cert-manager --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    log_success "cert-manager uninstalled"
+}
+
+install_cert_manager() {
+    if helm list -n cert-manager 2>/dev/null | grep -q "cert-manager"; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "cert-manager is already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling cert-manager..."
+            uninstall_cert_manager
+        fi
+    fi
+
+    log_info "Adding cert-manager Helm repository..."
+    helm repo add jetstack https://charts.jetstack.io --force-update
+
+    log_info "Installing cert-manager ${CERT_MANAGER_VERSION}..."
+    helm install \
+        cert-manager jetstack/cert-manager \
+        --namespace cert-manager \
+        --create-namespace \
+        --version "${CERT_MANAGER_VERSION}" \
+        --set crds.enabled=true \
+        --wait
+
+    log_success "Successfully installed cert-manager ${CERT_MANAGER_VERSION} via Helm"
+
+    wait_for_pods "cert-manager" "app in (cert-manager,webhook,cainjector)" "180s"
+
+    log_success "cert-manager is ready!"
+}
+
+# ----------------------------------------
+# CLI/Component: kserve-helm
+# ----------------------------------------
+
+uninstall_kserve_helm() {
+    log_info "Uninstalling KServe..."
+    if helm list -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -q "${RUNTIME_CONFIG_CHART_NAME}"; then
+        helm uninstall "${RUNTIME_CONFIG_CHART_NAME}" -n "${KSERVE_NAMESPACE}"
+        log_success "Successfully uninstalled Runtimes/LLMISVC configs"
+    fi
+
+    local all_charts=("${RESOURCE_CHARTS[@]}" "${CRD_CHARTS[@]}")
+    if [ ${#all_charts[@]} -gt 0 ]; then
+        log_info "Uninstalling charts: ${all_charts[*]}"
+    else
+        log_info "No charts to uninstall"
+        return 0
+    fi
+
+    for ((i=${#RESOURCE_CHARTS[@]}-1; i>=0; i--)); do
+        local chart="${RESOURCE_CHARTS[$i]}"
+        log_info "Uninstalling ${chart}..."
+        helm uninstall "${chart}" -n "${KSERVE_NAMESPACE}" 2>/dev/null || true
+    done
+
+    # Then uninstall CRD charts (reverse order)
+    for ((i=${#CRD_CHARTS[@]}-1; i>=0; i--)); do
+        local chart="${CRD_CHARTS[$i]}"
+        log_info "Uninstalling ${chart}..."
+        helm uninstall "${chart}" -n "${KSERVE_NAMESPACE}" 2>/dev/null || true
+    done
+
+    log_success "KServe charts uninstalled"
+}
+
+install_kserve_helm() {
+    build_helm_config_args() {
+        local -a config_args=()
+
+        # Update deployment mode if needed
+        if [ "${DEPLOYMENT_MODE}" = "Standard" ] || [ "${DEPLOYMENT_MODE}" = "RawDeployment" ]; then
+            log_info "Adding deployment mode configuration: ${DEPLOYMENT_MODE}"
+            config_args+=(--set "kserve.controller.deploymentMode=${DEPLOYMENT_MODE}")
+        fi
+
+        # Enable Gateway API for KServe(ISVC) if needed
+        if [ "${GATEWAY_NETWORK_LAYER}" != "false" ] && ! is_positive "${ENABLE_LLMISVC}"; then
+            log_info "Adding Gateway API configuration: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.enableGatewayApi=true")
+            config_args+=(--set "kserve.controller.gateway.ingressGateway.className=${GATEWAY_NETWORK_LAYER}")
+        fi
+
+        if is_positive "${ENABLE_LOCALMODEL}"; then
+            config_args+=(--set "kserve.localmodel.enabled=true")
+            config_args+=(--set "kserve.localmodel.defaultJobImage=kserve/storage-initializer")
+            config_args+=(--set "kserve.localmodel.defaultJobImageTag=${KSERVE_VERSION}")
+        fi
+        # Add custom configurations if provided
+        if [ -n "${KSERVE_CUSTOM_ISVC_CONFIGS}" ]; then
+            log_info "Adding custom configurations: ${KSERVE_CUSTOM_ISVC_CONFIGS}"
+            IFS='|' read -ra custom_configs <<< "${KSERVE_CUSTOM_ISVC_CONFIGS}"
+            for config in "${custom_configs[@]}"; do
+                config_args+=(--set "${config}")
+            done
+        fi
+
+        # Only print if array has elements
+        if [ ${#config_args[@]} -gt 0 ]; then
+            printf '%s\n' "${config_args[@]}"
+        fi
+    }
+
+    if [ ${#RESOURCE_CHARTS[@]} -eq 0 ] && [ ${#CRD_CHARTS[@]} -eq 0 ]; then
+        log_error "No charts selected for installation. Please enable at least one component (ENABLE_KSERVE, ENABLE_LLMISVC, or ENABLE_LOCALMODEL)."
+        exit 1
+    fi
+
+    if [ ${#RESOURCE_CHARTS[@]} -gt 0 ]; then
+        local main_chart="${RESOURCE_CHARTS[0]}"
+        # Use exact match for helm release name to avoid partial matches
+        if helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -x "${main_chart}" &>/dev/null; then
+            if ! is_positive "$REINSTALL"; then
+                if is_positive "$FORCE_UPGRADE"; then
+                    log_info "Force upgrading KServe..."
+                else
+                    log_info "KServe is already installed. Use --reinstall to reinstall or --force-upgrade to upgrade."
+                    return 0
+                fi
+            else
+                log_info "Reinstalling KServe..."
+                uninstall_kserve_helm
+            fi
+        fi
+    fi
+
+    # Determine chart repository
+    local CHART_REPO="oci://ghcr.io/kserve/charts"
+    if is_positive "${USE_LOCAL_CHARTS}"; then
+        CHART_REPO="${CHARTS_DIR}"
+        log_info "Installing KServe using local charts..."
+        log_info "📍 Using local charts from ${CHARTS_DIR}/"
+    else
+        log_info "Installing KServe ${KSERVE_VERSION} from OCI registry..."
+    fi
+
+    # Build chart version flag (only for remote charts, skip for 'latest')
+    local VERSION_FLAG=""
+    if ! is_positive "${USE_LOCAL_CHARTS}"; then
+        VERSION_FLAG="--version ${KSERVE_VERSION}"
+    fi
+
+    # Install CRD charts
+    for chart in "${CRD_CHARTS[@]}"; do
+        log_info "Installing ${chart}..."
+        helm upgrade -i "${chart}" "${CHART_REPO}/${chart}" \
+            --namespace "${KSERVE_NAMESPACE}" \
+            --create-namespace \
+            --wait \
+            ${VERSION_FLAG} \
+            ${SHARED_EXTRA_ARGS}
+    done
+
+    # Build configuration arguments for KServe/LLMIsvc
+    readarray -t helm_config_args < <(build_helm_config_args)
+
+    # Adopt any pre-existing GIE CRDs into the llmisvc-resources Helm release
+    if is_positive "${ENABLE_LLMISVC}"; then
+        adopt_existing_crds_for_release "kserve-llmisvc-resources" "${KSERVE_NAMESPACE}" "${GIE_CRDS[@]}"
+    fi
+
+    # Install resource charts
+    for i in "${!RESOURCE_CHARTS[@]}"; do
+        local chart="${RESOURCE_CHARTS[$i]}"
+        local extra_args="${RESOURCE_EXTRA_ARGS_LIST[$i]}"
+
+        # Apply config args only to kserve-resources chart (InferenceService configs)
+        local -a extra_helm_args=()
+        if [[ "${chart}" == "kserve-resources" ]]; then
+            extra_helm_args=("${helm_config_args[@]}")
+        fi
+
+        log_info "Installing ${chart}..."
+        for attempt in 1 2; do
+            if helm upgrade -i "${chart}" "${CHART_REPO}/${chart}" \
+                --namespace "${KSERVE_NAMESPACE}" \
+                --create-namespace \
+                --wait \
+                ${VERSION_FLAG} \
+                --set kserve.version="${KSERVE_VERSION}" \
+                ${SHARED_EXTRA_ARGS} \
+                ${extra_args} \
+                "${extra_helm_args[@]}"; then
+                break
+            elif [ $attempt -eq 2 ]; then
+                log_error "Failed to install/upgrade ${chart} ${KSERVE_VERSION} after 2 attempts"
+                exit 1
+            fi
+            sleep 5
+        done
+    done
+
+    log_success "Successfully installed KServe"
+
+    # Helm's sortManifestsByKind applies the llmisvc-controller-manager Deployment
+    # (a known kind) before cert-manager's Certificate CR (a custom kind, sorted
+    # last), so the pod can be scheduled and attempt to mount
+    # llmisvc-webhook-server-cert before cert-manager has issued it, hitting
+    # FailedMount and kubelet's mount-retry backoff. Wait for the Certificate to
+    # be issued and restart the deployment to reset that backoff before waiting
+    # for it to become ready.
+    if is_positive "${ENABLE_LLMISVC}"; then
+        log_info "Waiting for llmisvc webhook Certificate to be ready..."
+        kubectl wait --for=condition=Ready certificate/llmisvc-serving-cert \
+            -n "${KSERVE_NAMESPACE}" --timeout=180s
+
+        log_info "Restarting llmisvc-controller-manager to pick up the freshly-issued cert..."
+        kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+
+        # Wait for the NEW ReplicaSet to be fully rolled out. The wait_for_deployment
+        # helper below uses --for=condition=Available, which is satisfied by the OLD
+        # ReplicaSet's Ready pod during the rolling restart: it returns instantly but
+        # does not guarantee the new pod is serving the webhook. The subsequent
+        # kserve-runtime-configs install then applies LLMInferenceServiceConfig presets
+        # whose validating webhook must authorize each, and can hit the webhook Service
+        # before the new pod is a ready endpoint (dial ...:443: connect: connection refused).
+        log_info "Waiting for llmisvc-controller-manager rollout to complete..."
+        kubectl rollout status deployment/llmisvc-controller-manager \
+            -n "${KSERVE_NAMESPACE}" --timeout=300s
+
+        # Additionally wait for the webhook Service to have ready endpoints, covering the
+        # window between pod-ready and kube-proxy programming the Service endpoints.
+        log_info "Waiting for llmisvc webhook Service endpoints..."
+        kubectl wait --for=jsonpath='{.subsets[0].addresses}' \
+            endpoints/llmisvc-webhook-server-service \
+            -n "${KSERVE_NAMESPACE}" --timeout=60s
+        log_info "llmisvc webhook is ready."
+    fi
+
+    # Wait for all controller managers to be ready
+    log_info "Waiting for KServe controllers to be ready..."
+    for deploy in "${TARGET_DEPLOYMENT_NAMES[@]}"; do
+        wait_for_deployment "${KSERVE_NAMESPACE}" "${deploy}" "300s"
+    done
+
+    log_success "KServe is ready!"
+
+    # Install Runtimes and LLMISVC configs if needed
+    if is_positive "${INSTALL_RUNTIMES}" || is_positive "${INSTALL_LLMISVC_CONFIGS}"; then
+        log_info "Installing Runtimes(${INSTALL_RUNTIMES}) and LLMISVC configs(${INSTALL_LLMISVC_CONFIGS})..."
+        helm upgrade -i ${RUNTIME_CONFIG_CHART_NAME} \
+            ${CHART_REPO}/${RUNTIME_CONFIG_CHART_NAME} \
+            --namespace "${KSERVE_NAMESPACE}" \
+            --create-namespace \
+            --wait \
+            ${VERSION_FLAG} \
+            --set kserve.version="${KSERVE_VERSION}" \
+            --set kserve.servingruntime.enabled=${INSTALL_RUNTIMES} \
+            --set kserve.llmisvcConfigs.enabled=${INSTALL_LLMISVC_CONFIGS}
+        log_success "Successfully installed Runtimes/LLMISVC configs"
+    fi
+}
+
+
+
+#================================================
+# Main Installation Logic
+#================================================
+
+main() {
+    if [ "$UNINSTALL" = true ]; then
+        echo "=========================================="
+        echo "Uninstalling components..."
+        echo "=========================================="
+        uninstall_kserve_helm
+        uninstall_cert_manager
+        
+        
+        
+        echo "=========================================="
+        echo "✅ Uninstallation completed!"
+        echo "=========================================="
+        exit 0
+    fi
+
+    echo "=========================================="
+    echo "Install LocalModel dependencies using helm"
+    echo "=========================================="
+
+    export EMBED_TEMPLATES="true"
+
+    install_helm
+    install_kustomize
+    install_yq
+    install_cert_manager
+    (
+        set_env_with_priority "ENABLE_LLMISVC" "False" "" ""
+        set_env_with_priority "ENABLE_KSERVE" "False" "" "true"
+        set_env_with_priority "ENABLE_LOCALMODEL" "True" "" ""
+        set_env_with_priority "INSTALL_RUNTIMES" "False" "" ""
+        set_env_with_priority "INSTALL_LLMISVC_CONFIGS" "False" "" ""
+        determine_shared_resources_config "${INSTALL_MODE}" "${ENABLE_KSERVE}" "${ENABLE_LLMISVC}"
+        
+        if [ "${SET_KSERVE_VERSION}" != "" ]; then
+            log_info "Setting KServe version to ${SET_KSERVE_VERSION}"
+            KSERVE_VERSION="${SET_KSERVE_VERSION}"
+        fi
+        
+        # Build chart arrays based on ENABLE_* flags
+        # When a specific version is set, override imagePullPolicy to IfNotPresent
+        # to match kustomize version-template overlay behavior for dev/test scenarios
+        PULL_POLICY_KSERVE=""
+        PULL_POLICY_LLMISVC=""
+        PULL_POLICY_LOCALMODEL=""
+        if [ -n "${SET_KSERVE_VERSION}" ]; then
+            PULL_POLICY_KSERVE="--set kserve.controller.imagePullPolicy=IfNotPresent"
+            PULL_POLICY_LLMISVC="--set kserve.llmisvc.controller.imagePullPolicy=IfNotPresent"
+            PULL_POLICY_LOCALMODEL="--set kserve.localmodel.controller.imagePullPolicy=IfNotPresent --set kserve.localmodelnode.controller.imagePullPolicy=IfNotPresent"
+        fi
+        
+        if is_positive "${ENABLE_KSERVE}"; then
+            log_info "KServe is enabled"
+            CRD_CHARTS+=("kserve-crd")
+            RESOURCE_CHARTS+=("kserve-resources")
+            RESOURCE_EXTRA_ARGS_LIST+=("${KSERVE_EXTRA_ARGS:-} ${PULL_POLICY_KSERVE}")
+            TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
+        fi
+        
+        if is_positive "${ENABLE_LLMISVC}"; then
+            log_info "LLMIsvc is enabled"
+            CRD_CHARTS+=("kserve-llmisvc-crd")
+            RESOURCE_CHARTS+=("kserve-llmisvc-resources")
+            RESOURCE_EXTRA_ARGS_LIST+=("${LLMISVC_EXTRA_ARGS:-} ${PULL_POLICY_LLMISVC}")
+            TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
+        fi
+        
+        if is_positive "${ENABLE_LOCALMODEL}"; then
+            log_info "LocalModel is enabled"
+            CRD_CHARTS+=("kserve-localmodel-crd")
+            RESOURCE_CHARTS+=("kserve-localmodel-resources")
+            RESOURCE_EXTRA_ARGS_LIST+=("${LOCALMODEL_EXTRA_ARGS:-} ${PULL_POLICY_LOCALMODEL}")
+            TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
+        fi
+
+        install_kserve_helm
+    )
+
+    echo "=========================================="
+    echo "✅ Installation completed successfully!"
+    echo "=========================================="
+}
+
+
+
+main "$@"

--- a/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
@@ -1,0 +1,6866 @@
+#!/bin/bash
+
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install LocalModel and all related dependencies with manifests included in the script.
+#
+# AUTO-GENERATED from: localmodel-full-install-with-manifests.definition
+# DO NOT EDIT MANUALLY
+#
+# To regenerate:
+#   ./scripts/generate-install-script.py localmodel-full-install-with-manifests.definition
+#
+# Usage: localmodel-full-install-with-manifests.sh [--reinstall|--uninstall]
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+#================================================
+# Helper Functions (from common.sh)
+#================================================
+
+# Utility Functions
+# ============================================================================
+
+find_repo_root() {
+    local current_dir="${1:-$(pwd)}"
+    local skip="${2:-false}"
+
+    while [[ "$current_dir" != "/" ]]; do
+        if [[ -e "${current_dir}/.git" ]]; then
+            echo "$current_dir"
+            return 0
+        fi
+        current_dir="$(dirname "$current_dir")"
+    done
+
+    # Git repository not found
+    if [[ "$skip" == "true" ]]; then
+        log_warning "Could not find git repository root, using current directory: $PWD"
+        echo "$PWD"
+        return 0
+    else
+        log_error "Could not find git repository root"
+        exit 1
+    fi
+}
+
+ensure_dir() {
+    local dir_path="${1}"
+
+    if [[ -d "${dir_path}" ]]; then
+        return 0
+    fi
+
+    mkdir -p "${dir_path}"
+}
+
+detect_os() {
+    local os=""
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="darwin" ;;
+        *)       log_error "Unsupported OS detected: $(uname -s)" ; exit 1 ;;
+    esac
+    echo "$os"
+}
+
+detect_arch() {
+    local arch=""
+    case "$(uname -m)" in
+        x86_64)  arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *)       log_error "Unsupported architecture detected: $(uname -m)" ; exit 1 ;;
+    esac
+    echo "$arch"
+}
+
+cleanup_bin_dir() {
+    # Remove BIN_DIR if it was created by this script
+    if [[ "${BIN_DIR_CREATED_BY_SCRIPT:-false}" == "true" ]] && [[ -d "${BIN_DIR:-}" ]]; then
+        log_info "Cleaning up BIN_DIR: ${BIN_DIR}"
+        rm -rf "${BIN_DIR}"
+    fi
+}
+
+cleanup() {
+    # Call all cleanup functions
+    cleanup_bin_dir
+}
+
+# Set up trap to run cleanup on exit
+trap cleanup EXIT
+
+# Color codes (disable if NO_COLOR is set or not a terminal)
+if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
+    BLUE='\033[94m'
+    GREEN='\033[92m'
+    RED='\033[91m'
+    YELLOW='\033[93m'
+    RESET='\033[0m'
+else
+    BLUE=''
+    GREEN=''
+    RED=''
+    YELLOW=''
+    RESET=''
+fi
+
+log_info() {
+    echo -e "${BLUE}[INFO]${RESET} $*" >&2
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${RESET} $*" >&2
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${RESET} $*" >&2
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${RESET} $*" >&2
+}
+
+is_positive() {
+  local input_val="${1:-no}"
+
+  case "${input_val}" in
+    0|true|True|yes|Yes|y|Y)
+      return 0  # Success - truthy
+      ;;
+    1|false|False|no|No|n|N)
+      return 1  # Failure - falsy
+      ;;
+    *)
+      return 2  # Invalid input
+      ;;
+  esac
+}
+
+
+# ============================================================================
+# Infrastructure Installation Helper Functions
+# ============================================================================
+
+# Detect the platform (kind/minikube/openshift/kubernetes)
+# Returns: kind, minikube, openshift, or kubernetes
+detect_platform() {
+    # Check for OpenShift
+    if kubectl get clusterversion &>/dev/null; then
+        echo "openshift"
+        return 0
+    fi
+
+    # Check for Kind
+    local node_hostname
+    node_hostname=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.kubernetes\.io/hostname}' 2>/dev/null || echo "")
+    if [[ "$node_hostname" == *"kind"* ]]; then
+        echo "kind"
+        return 0
+    fi
+
+    # Check for Minikube
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null || echo "")
+    if [[ "$current_context" == *"minikube"* ]]; then
+        echo "minikube"
+        return 0
+    fi
+
+    # Default to standard Kubernetes
+    echo "kubernetes"
+    return 0
+}
+
+# Wait for pods to be created (exist)
+# Usage: wait_for_pods_created <namespace> <label-selector> [timeout_seconds]
+wait_for_pods_created() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-60}"
+    local elapsed=0
+
+    log_info "Waiting for pods with label '$label_selector' in namespace '$namespace' to be created..."
+
+    while true; do
+        # Exclude terminating pods by filtering out Terminating status
+        local pod_count=$(kubectl get pods -n "$namespace" -l "$label_selector" \
+            --no-headers 2>/dev/null | grep -v "Terminating" | wc -l)
+
+        if [ "$pod_count" -gt 0 ]; then
+            log_info "Found $pod_count pod(s) with label '$label_selector'"
+            return 0
+        fi
+
+        if [ $elapsed -ge $timeout ]; then
+            log_error "Timeout waiting for pods with label '$label_selector' to be created"
+            return 1
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+}
+
+# Wait for pods to be ready
+# Usage: wait_for_pods_ready <namespace> <label-selector> [timeout]
+wait_for_pods_ready() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-180s}"
+
+    log_info "Waiting for pods with label '$label_selector' in namespace '$namespace' to be ready..."
+
+    # Get list of non-terminating pods and wait for them
+    local pods=$(kubectl get pods -n "$namespace" -l "$label_selector" \
+        --no-headers 2>/dev/null | grep -v "Terminating" | awk '{print $1}')
+
+    if [ -z "$pods" ]; then
+        log_error "No pods found with label '$label_selector' in namespace '$namespace'"
+        return 1
+    fi
+
+    for pod in $pods; do
+        kubectl wait --for=condition=Ready pod/"$pod" -n "$namespace" --timeout="$timeout" || return 1
+    done
+}
+
+# Wait for pods to be ready (combines both creation and ready checks)
+# Usage: wait_for_pods <namespace> <label-selector> [timeout]
+wait_for_pods() {
+    local namespace="$1"
+    local label_selector="$2"
+    local timeout="${3:-180s}"
+
+    # Convert timeout to seconds for pod creation check
+    local timeout_seconds="${timeout%s}"
+    local timeout_created=60
+
+    # If timeout is longer than 60s, use 60s for creation, rest for ready
+    # If timeout is shorter, split it
+    if [ "$timeout_seconds" -gt 60 ]; then
+        timeout_created=60
+    else
+        timeout_created=$((timeout_seconds / 3))
+    fi
+
+    # First, wait for pods to be created
+    wait_for_pods_created "$namespace" "$label_selector" "$timeout_created" || return 1
+
+    # Then, wait for pods to be ready
+    wait_for_pods_ready "$namespace" "$label_selector" "$timeout" || return 1
+
+    log_success "Pods with label '$label_selector' in namespace '$namespace' are ready!"
+}
+
+# Wait for deployment to be available using kubectl wait
+# Usage: wait_for_deployment <namespace> <deployment-name> [timeout]
+# Note: This uses kubectl wait --for=condition=Available, which checks deployment status directly
+wait_for_deployment() {
+    local namespace="$1"
+    local deployment_name="$2"
+    local timeout="${3:-180s}"
+
+    log_info "Waiting for deployment '$deployment_name' in namespace '$namespace' to be available..."
+    if kubectl wait --timeout="$timeout" -n "$namespace" deployment/"$deployment_name" --for=condition=Available; then
+        log_success "Deployment '$deployment_name' in namespace '$namespace' is available!"
+    else
+        log_error "Deployment '$deployment_name' in namespace '$namespace' failed to become available within $timeout"
+        log_error "--- Deployment status ---"
+        kubectl get deployment "$deployment_name" -n "$namespace" -o wide 2>/dev/null || true
+        log_error "--- Pod status ---"
+        kubectl get pods -n "$namespace" -l "control-plane=$deployment_name" -o wide 2>/dev/null || true
+        log_error "--- Pod describe (last 50 lines) ---"
+        kubectl describe pods -n "$namespace" -l "control-plane=$deployment_name" 2>/dev/null | tail -50 || true
+        log_error "--- Recent events in namespace '$namespace' ---"
+        kubectl get events -n "$namespace" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+        return 1
+    fi
+}
+
+# Wait for CRD to be established
+# Usage: wait_for_crd <crd-name> [timeout]
+wait_for_crd() {
+    local crd_name="$1"
+    local timeout="${2:-60s}"
+
+    log_info "Waiting for CRD '$crd_name' to be established..."
+
+    # Add small delay to allow CRD status to be initialized
+    sleep 2
+
+    # Retry logic to handle race condition where .status.conditions may not be initialized yet
+    local max_retries=10
+    local retry=0
+    while [ $retry -lt $max_retries ]; do
+        if kubectl wait --for=condition=Established --timeout="$timeout" crd/"$crd_name" 2>/dev/null; then
+            return 0
+        fi
+        retry=$((retry + 1))
+        if [ $retry -lt $max_retries ]; then
+            log_info "Retry $retry/$max_retries: Waiting for CRD status to be initialized..."
+            sleep 3
+        fi
+    done
+
+    # Final attempt with error output
+    kubectl wait --for=condition=Established --timeout="$timeout" crd/"$crd_name"
+}
+
+# Wait for multiple CRDs to be established
+# Usage: wait_for_crds <timeout> <crd1> <crd2> ...
+wait_for_crds() {
+    local timeout="$1"
+    shift
+
+    for crd in "$@"; do
+        wait_for_crd "$crd" "$timeout" || return 1
+    done
+
+    log_success "All CRDs are established!"
+}
+
+# Update multiple fields in KServe inferenceservice-config ConfigMap
+# Usage: update_isvc_config "ingress.enableGatewayApi=true" "deploy.defaultDeploymentMode=Standard"
+# Example:
+#   update_isvc_config "ingress.enableGatewayApi=true"
+#   update_isvc_config "ingress.enableGatewayApi=true" "ingress.className=\"envoy\""
+update_isvc_config() {
+    if [ $# -eq 0 ]; then
+        log_error "No update parameters provided"
+        return 1
+    fi
+
+    log_info "Updating inferenceservice-config..."
+
+    # Prepare updates as JSON array
+    local updates_file
+    updates_file=$(mktemp)
+
+    for arg in "$@"; do
+        local key="${arg%%=*}"
+        local raw_value="${arg#*=}"
+        local data_key="${key%%.*}"
+        local json_path="${key#*.}"
+        local value_json="$raw_value"
+
+        # Smart type detection: auto-quote strings, keep numbers/booleans/JSON as-is
+        if [[ ! $raw_value =~ ^\" ]] \
+           && [[ ! $raw_value =~ ^-?[0-9]+(\.[0-9]+)?$ ]] \
+           && [[ ! $raw_value =~ ^(true|false|null)$ ]] \
+           && [[ ! $raw_value =~ ^[{\[] ]]; then
+            value_json=$(jq -Rn --arg v "$raw_value" '$v')
+        fi
+
+        jq -n \
+            --arg data_key "$data_key" \
+            --arg path "$json_path" \
+            --argjson value "$value_json" \
+            '{data_key:$data_key, path:$path, value:$value}' >> "$updates_file"
+
+        log_info "  ✓ $data_key.$json_path = $value_json"
+    done
+
+    local updates_json
+    updates_json=$(jq -s '.' "$updates_file")
+    rm -f "$updates_file"
+
+    # Apply all updates with a single jq invocation
+    kubectl get configmap inferenceservice-config -n "${KSERVE_NAMESPACE}" -o json |
+        jq --argjson updates "$updates_json" '
+            # Helper function to safely set nested paths, creating intermediate objects as needed
+            def setpath_safe($parts; $value):
+                reduce range(0; ($parts|length)-1) as $i (.;
+                    $parts[:$i+1] as $prefix
+                    | if getpath($prefix) == null then setpath($prefix; {}) else . end
+                )
+                | setpath($parts; $value);
+
+            # Apply each update
+            reduce $updates[] as $item (.;
+                if .data[$item.data_key] == null or .data[$item.data_key] == "" then
+                    .data[$item.data_key] = (
+                        {}
+                        | setpath_safe($item.path | split("."); $item.value)
+                        | tojson
+                    )
+                else
+                    .data[$item.data_key] |= (
+                        fromjson
+                        | setpath_safe($item.path | split("."); $item.value)
+                        | tojson
+                    )
+                end
+            )
+        ' |
+        kubectl apply -f -
+
+    log_success "ConfigMap updated successfully"
+}
+
+# Create namespace if it does not exist (skip if already exists)
+# Usage: create_or_skip_namespace <namespace>
+create_or_skip_namespace() {
+    local namespace="$1"
+
+    if kubectl get namespace "$namespace" &>/dev/null; then
+        log_info "Namespace '$namespace' already exists"
+    else
+        log_info "Creating namespace '$namespace'..."
+        kubectl create namespace "$namespace"
+        log_success "Namespace '$namespace' created"
+    fi
+}
+
+# Check if required CLI tools exist
+# Usage: check_cli_exist <tool1> [tool2] [tool3] ...
+check_cli_exist() {
+    local missing=()
+    for cmd in "$@"; do
+        if ! command_exists "$cmd"; then
+            missing+=("$cmd")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_error "Required CLI tool(s) not found: ${missing[*]}"
+        log_error "Please install missing tool(s) first."
+        exit 1
+    fi
+}
+
+command_exists() {
+    command -v "$1" &>/dev/null
+}
+
+# Retry a command with delay between attempts
+# Usage: retry_command <max_attempts> <delay_seconds> <command...>
+# Example: retry_command 3 5 kubectl apply -k "${RUNTIMES_DIR}"
+# Returns: 0 on success, 1 on failure after all attempts
+retry_command() {
+    local max_attempts="$1"
+    local delay="$2"
+    shift 2
+    local attempt=1
+
+    while [ $attempt -le $max_attempts ]; do
+        if "$@" 2>&1; then
+            return 0
+        fi
+
+        if [ $attempt -lt $max_attempts ]; then
+            log_warning "Command failed, retrying in ${delay} seconds... (attempt $attempt/$max_attempts)"
+            sleep "$delay"
+        else
+            log_error "Command failed after $max_attempts attempts"
+            return 1
+        fi
+        attempt=$((attempt + 1))
+    done
+}
+
+# Compare semantic versions (returns 0 if v1 >= v2, 1 otherwise)
+# Usage: version_gte "v3.17.3" "v3.16.0"
+# Example: version_gte "$current_version" "$required_version" && echo "OK"
+version_gte() {
+    [ "$1" = "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" ]
+}
+
+# ============================================================================
+# Shared Resources Configuration (for dual KServe + LLMISVC installation)
+# ============================================================================
+
+determine_shared_resources_config() {
+    local install_mode="${1}"
+    local enable_kserve="${2}"
+    local enable_llmisvc="${3}"
+
+    if ! is_positive "${enable_kserve}" && ! is_positive "${enable_llmisvc}"; then
+        return
+    fi
+
+    log_info "Determining shared resources configuration (KSERVE=${enable_kserve}, LLMISVC=${enable_llmisvc})..."
+
+    if [ "${install_mode}" = "helm" ]; then
+        determine_shared_resources_helm "${enable_kserve}" "${enable_llmisvc}"
+    elif [ "${install_mode}" = "kustomize" ]; then
+        determine_shared_resources_kustomize
+    else
+        log_error "INSTALL_MODE not set. Must be 'helm' or 'kustomize'"
+        exit 1
+    fi
+}
+
+determine_shared_resources_helm() {
+    local enable_kserve="${1}"
+    local enable_llmisvc="${2}"
+
+    local kserve_installed=$(helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -c "^kserve-resources$" || true)
+    local llmisvc_installed=$(helm list -n "${KSERVE_NAMESPACE}" -q 2>/dev/null | grep -c "^kserve-llmisvc-resources$" || true)
+
+    if [ "${kserve_installed}" = "0" ] && [ "${llmisvc_installed}" = "0" ]; then
+        # First installation - check which components are being enabled
+        if is_positive "${enable_kserve}" && is_positive "${enable_llmisvc}"; then
+            # Both enabled: kserve-resources installs first and creates shared resources
+            log_info "[Helm] First install (both) - kserve-resources creates shared resources, llmisvc-resources does not"
+            LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        elif is_positive "${enable_kserve}" && ! is_positive "${enable_llmisvc}"; then
+            # Only kserve enabled: kserve-resources creates shared resources
+            log_info "[Helm] First install (kserve only) - kserve-resources will create shared resources"
+            # Use default value (true) - no extra args needed
+        elif ! is_positive "${enable_kserve}" && is_positive "${enable_llmisvc}"; then
+            # Only llmisvc enabled: llmisvc-resources creates shared resources
+            log_info "[Helm] First install (llmisvc only) - llmisvc-resources will create shared resources"
+            # Use default value (true) - no extra args needed
+        else
+            # Neither enabled - shouldn't reach here
+            log_error "[Helm] No components enabled"
+            return 1
+        fi
+    elif [ "${kserve_installed}" = "1" ] && [ "${llmisvc_installed}" = "0" ]; then
+        log_info "[Helm] Only kserve-resources installed - setting createSharedResources=false for LLMISVC"
+        LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+    elif [ "${kserve_installed}" = "0" ] && [ "${llmisvc_installed}" = "1" ]; then
+        log_info "[Helm] Only kserve-llmisvc-resources installed - setting createSharedResources=false for KSERVE"
+        KSERVE_EXTRA_ARGS="${KSERVE_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+    else
+        local kserve_has_false=$(helm get values kserve-resources -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "createSharedResources: false" || true)
+
+        if [ "${kserve_has_false}" = "1" ]; then
+            log_info "[Helm] Maintaining createSharedResources=false for KSERVE"
+            KSERVE_EXTRA_ARGS="${KSERVE_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        else
+            log_info "[Helm] Setting createSharedResources=false for LLMISVC"
+            LLMISVC_EXTRA_ARGS="${LLMISVC_EXTRA_ARGS:-} --set kserve.createSharedResources=false"
+        fi
+    fi
+}
+
+determine_shared_resources_kustomize() {
+    KSERVE_INSTALLED=$(kubectl get deployment kserve-controller-manager -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "kserve-controller-manager" || true)
+    LLMISVC_INSTALLED=$(kubectl get deployment llmisvc-controller-manager -n "${KSERVE_NAMESPACE}" 2>/dev/null | grep -c "llmisvc-controller-manager" || true)
+    
+    export KSERVE_INSTALLED
+    export LLMISVC_INSTALLED
+
+    log_info "[Kustomize] Installation status(0: not installed, 1: installed): KSERVE=${KSERVE_INSTALLED}, LLMISVC=${LLMISVC_INSTALLED}"
+}
+
+# ============================================================================
+
+# Set environment variable based on priority order:
+# Priority: 1. Runtime env > 2. Component env > 3. Global env > 4. Component default
+# Usage: set_env_with_priority VAR_NAME COMPONENT_ENV_VALUE GLOBAL_ENV_VALUE DEFAULT_VALUE
+set_env_with_priority() {
+    local var_name="$1"
+    local component_value="$2"
+    local global_value="$3"
+    local default_value="$4"
+
+    # Get current value
+    local current_value
+    eval "current_value=\${${var_name}}"
+
+    # If current value exists and differs from default, it's a runtime value - keep it
+    if [ -n "$current_value" ] && [ -n "$default_value" ] && [ "$current_value" != "$default_value" ]; then
+        # This is a runtime value, keep it
+        return
+    fi
+
+    # Apply priority: component env > global env > default
+    if [ -n "$component_value" ]; then
+        eval "export $var_name=\"$component_value\""
+    elif [ -n "$global_value" ]; then
+        eval "export $var_name=\"$global_value\""
+    fi
+    # If both are empty, variable keeps its default value
+}
+
+#================================================
+# Determine repository root using find_repo_root
+#================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")" && pwd)"
+REPO_ROOT="$(find_repo_root "${SCRIPT_DIR}" "true")"
+export REPO_ROOT
+
+# Set up BIN_DIR - use repo bin if it exists, otherwise use temp directory
+if [[ -d "${REPO_ROOT}/bin" ]]; then
+    export BIN_DIR="${REPO_ROOT}/bin"
+else
+    export BIN_DIR="$(mktemp -d)"
+    log_info "Using temp BIN_DIR: ${BIN_DIR}"
+fi
+
+export PATH="${BIN_DIR}:${PATH}"
+
+REINSTALL="${REINSTALL:-false}"
+UNINSTALL="${UNINSTALL:-false}"
+FORCE_UPGRADE="${FORCE_UPGRADE:-false}"
+
+if [[ "$*" == *"--uninstall"* ]]; then
+    UNINSTALL=true
+elif [[ "$*" == *"--reinstall"* ]]; then
+    REINSTALL=true
+elif [[ "$*" == *"--force-upgrade"* ]]; then
+    FORCE_UPGRADE=true
+fi
+
+export REINSTALL
+export UNINSTALL
+export FORCE_UPGRADE
+
+# RELEASE mode (from definition file)
+RELEASE="false"
+export RELEASE
+
+#================================================
+# Version Dependencies (from kserve-deps.env)
+#================================================
+
+GOLANGCI_LINT_VERSION=v2.9.0
+CONTROLLER_TOOLS_VERSION=v0.19.0
+ENVTEST_VERSION=release-0.19
+YQ_VERSION=v4.52.1
+HELM_VERSION=v3.16.3
+KUSTOMIZE_VERSION=v5.8.1
+HELM_DOCS_VERSION=v1.12.0
+POETRY_VERSION=1.8.3
+UV_VERSION=0.7.8
+RUFF_VERSION=0.14.13
+PINACT_VERSION=v3.9.0
+KIND_VERSION=v0.30.0
+CERT_MANAGER_VERSION=v1.17.0
+ENVOY_GATEWAY_VERSION=v1.8.1
+ENVOY_AI_GATEWAY_VERSION=v1.0.0
+KNATIVE_OPERATOR_VERSION=v1.21.1
+KNATIVE_SERVING_VERSION=1.21.1
+KEDA_OTEL_ADDON_VERSION=v0.0.6
+PROMETHEUS_VERSION=83.4.0
+PROMETHEUS_ADAPTER_VERSION=5.3.0
+JAEGER_VERSION=4.7.0
+KSERVE_VERSION=v0.20.0
+ISTIO_VERSION=1.27.1
+KEDA_VERSION=2.18.0
+OPENTELEMETRY_OPERATOR_VERSION=0.74.3
+LWS_VERSION=v0.8.0
+GATEWAY_API_VERSION=v1.5.1
+GIE_VERSION=v1.5.0
+LLMD_ROUTER_VERSION=v0.10.0
+WVA_VERSION=v0.9.0
+
+#================================================
+# Global Variables (from global-vars.env)
+#================================================
+# These provide default namespace values that can be overridden
+# by environment variables or GLOBAL_ENV settings below
+
+KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
+KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-kserve}"
+PROMETHEUS_NAMESPACE="${PROMETHEUS_NAMESPACE:-monitoring}"
+PROMETHEUS_ADAPTER_NAMESPACE="${PROMETHEUS_ADAPTER_NAMESPACE:-monitoring}"
+WVA_NAMESPACE="${WVA_NAMESPACE:-wva-system}"
+OTEL_NAMESPACE="${OTEL_NAMESPACE:-opentelemetry-operator}"
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-knative-operator}"
+SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
+ISTIO_NAMESPACE="${ISTIO_NAMESPACE:-istio-system}"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-kserve}"
+DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-Knative}"
+GATEWAY_NETWORK_LAYER="${GATEWAY_NETWORK_LAYER:-false}"
+ENABLE_KSERVE="${ENABLE_KSERVE:-true}"
+ENABLE_LLMISVC="${ENABLE_LLMISVC:-false}"
+ENABLE_LOCALMODEL="${ENABLE_LOCALMODEL:-false}"
+EMBED_MANIFESTS="${EMBED_MANIFESTS:-false}"
+EMBED_TEMPLATES="${EMBED_TEMPLATES:-false}"
+KSERVE_CUSTOM_ISVC_CONFIGS="${KSERVE_CUSTOM_ISVC_CONFIGS:-}"
+
+#================================================
+# Component-Specific Variables
+#================================================
+
+SET_KSERVE_VERSION="${SET_KSERVE_VERSION:-}"
+SET_KSERVE_REGISTRY="${SET_KSERVE_REGISTRY:-}"
+ENABLE_KSERVE="${ENABLE_KSERVE:-${KSERVE:-true}}"
+ENABLE_LLMISVC="${ENABLE_LLMISVC:-${LLMISVC:-false}}"
+ENABLE_LOCALMODEL="${ENABLE_LOCALMODEL:-${LOCALMODEL:-false}}"
+KSERVE_OVERLAY_DIR="${KSERVE_OVERLAY_DIR:-}"
+USE_LOCAL_CONFIGMAP="${USE_LOCAL_CONFIGMAP:-false}"
+KSERVE_INSTALLED="${KSERVE_INSTALLED:-0}"
+LLMISVC_INSTALLED="${LLMISVC_INSTALLED:-0}"
+INSTALL_RUNTIMES="${INSTALL_RUNTIMES:-${ENABLE_KSERVE:-false}}"
+INSTALL_LLMISVC_CONFIGS="${INSTALL_LLMISVC_CONFIGS:-${ENABLE_LLMISVC:-false}}"
+FORCE_UPGRADE="${FORCE_UPGRADE:-false}"
+USE_CUSTOM_MANIFESTS="${USE_CUSTOM_MANIFESTS:-false}"
+UPDATE_CONFIGMAP_IMAGES="${UPDATE_CONFIGMAP_IMAGES:-true}"
+KSERVE_INSTALL_CI="${KSERVE_INSTALL_CI:-false}"
+TARGET_CONFIG_ROOT_DIR=${REPO_ROOT}
+TEMP_TARGET_CONFIG_DIR="${TEMP_TARGET_CONFIG_DIR:-/tmp/kserve_customization}"
+TARGET_CRD_DIRS=()
+TARGET_DEPLOYMENT_NAMES=()
+TARGET_OVERLAY_DIRS=()
+TARGET_CRDS_TO_VERIFY=()
+
+#================================================
+# Template Functions (EMBED_TEMPLATES MODE)
+#================================================
+
+
+
+#================================================
+# Component Functions
+#================================================
+
+# ----------------------------------------
+# CLI/Component: helm
+# ----------------------------------------
+
+
+
+install_helm() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local archive_name="helm-${HELM_VERSION}-${os}-${arch}.tar.gz"
+    local download_url="https://get.helm.sh/${archive_name}"
+
+    log_info "Installing Helm ${HELM_VERSION} for ${os}/${arch}..."
+
+    # Check if helm is already installed in BIN_DIR with the exact required version
+    if [[ -f "${BIN_DIR}/helm" ]]; then
+        local current_version=$("${BIN_DIR}/helm" version --template='{{.Version}}' 2>/dev/null)
+        if [[ "$current_version" == "$HELM_VERSION" ]]; then
+            log_info "Helm ${current_version} is already installed in ${BIN_DIR}"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Replacing Helm ${current_version} with ${HELM_VERSION} in ${BIN_DIR}..."
+    fi
+
+    local temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${archive_name}"
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_error "Neither wget nor curl is available" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    tar -xzf "${temp_file}" -C "${temp_dir}"
+
+    local binary_path="${temp_dir}/${os}-${arch}/helm"
+
+    if [[ ! -f "${binary_path}" ]]; then
+        log_error "helm binary not found in archive" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    chmod +x "${binary_path}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${binary_path}" "${BIN_DIR}/helm"
+    else
+        sudo mv "${binary_path}" "${BIN_DIR}/helm"
+    fi
+
+    rm -rf "${temp_dir}"
+
+    log_success "Successfully installed Helm ${HELM_VERSION} to ${BIN_DIR}/helm"
+    "${BIN_DIR}/helm" version
+}
+
+# ----------------------------------------
+# CLI/Component: kustomize
+# ----------------------------------------
+
+
+
+install_kustomize() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local archive_name="kustomize_${KUSTOMIZE_VERSION}_${os}_${arch}.tar.gz"
+    local download_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${archive_name}"
+
+    log_info "Installing Kustomize ${KUSTOMIZE_VERSION} for ${os}/${arch}..."
+
+    if [[ -x "${BIN_DIR}/kustomize" ]]; then
+        local current_version=$("${BIN_DIR}/kustomize" version 2>/dev/null | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        if [[ -n "$current_version" ]] && version_gte "$current_version" "$KUSTOMIZE_VERSION"; then
+            log_info "Kustomize ${current_version} is already installed in ${BIN_DIR} (>= ${KUSTOMIZE_VERSION})"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Upgrading Kustomize from ${current_version} to ${KUSTOMIZE_VERSION}..."
+    fi
+
+    local temp_dir=$(mktemp -d)
+    local temp_file="${temp_dir}/${archive_name}"
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_error "Neither wget nor curl is available" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    tar -xzf "${temp_file}" -C "${temp_dir}"
+
+    local binary_path="${temp_dir}/kustomize"
+
+    if [[ ! -f "${binary_path}" ]]; then
+        log_error "kustomize binary not found in archive" >&2
+        rm -rf "${temp_dir}"
+        exit 1
+    fi
+
+    chmod +x "${binary_path}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${binary_path}" "${BIN_DIR}/kustomize"
+    else
+        sudo mv "${binary_path}" "${BIN_DIR}/kustomize"
+    fi
+
+    rm -rf "${temp_dir}"
+
+    log_success "Successfully installed Kustomize ${KUSTOMIZE_VERSION} to ${BIN_DIR}/kustomize"
+    "${BIN_DIR}/kustomize" version
+}
+
+# ----------------------------------------
+# CLI/Component: yq
+# ----------------------------------------
+
+
+
+install_yq() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local binary_name="yq_${os}_${arch}"
+    local download_url="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${binary_name}"
+
+    log_info "Installing yq ${YQ_VERSION} for ${os}/${arch}..."
+
+    if [[ -x "${BIN_DIR}/yq" ]]; then
+        local current_version=$("${BIN_DIR}/yq" --version 2>&1 | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        # Normalize version format (add 'v' prefix if missing)
+        [[ -n "$current_version" && "$current_version" != v* ]] && current_version="v${current_version}"
+        if [[ -n "$current_version" ]] && version_gte "$current_version" "$YQ_VERSION"; then
+            log_info "yq ${current_version} is already installed in ${BIN_DIR} (>= ${YQ_VERSION})"
+            return 0
+        fi
+        [[ -n "$current_version" ]] && log_info "Upgrading yq from ${current_version} to ${YQ_VERSION}..."
+    fi
+
+    local temp_file=$(mktemp)
+
+    if command -v wget &>/dev/null; then
+        wget -q "${download_url}" -O "${temp_file}"
+    elif command -v curl &>/dev/null; then
+        curl -sL "${download_url}" -o "${temp_file}"
+    else
+        log_info "Neither wget nor curl is available" >&2
+        rm -f "${temp_file}"
+        exit 1
+    fi
+
+    chmod +x "${temp_file}"
+
+    if [[ -w "${BIN_DIR}" ]]; then
+        mv "${temp_file}" "${BIN_DIR}/yq"
+    else
+        sudo mv "${temp_file}" "${BIN_DIR}/yq"
+    fi
+
+    log_success "Successfully installed yq ${YQ_VERSION} to ${BIN_DIR}/yq"
+    "${BIN_DIR}/yq" --version
+}
+
+# ----------------------------------------
+# CLI/Component: cert-manager
+# ----------------------------------------
+
+uninstall_cert_manager() {
+    log_info "Uninstalling cert-manager..."
+    helm uninstall cert-manager -n cert-manager 2>/dev/null || true
+    kubectl delete all --all -n cert-manager --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace cert-manager --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    log_success "cert-manager uninstalled"
+}
+
+install_cert_manager() {
+    if helm list -n cert-manager 2>/dev/null | grep -q "cert-manager"; then
+        if [ "$REINSTALL" = false ]; then
+            log_info "cert-manager is already installed. Use --reinstall to reinstall."
+            return 0
+        else
+            log_info "Reinstalling cert-manager..."
+            uninstall_cert_manager
+        fi
+    fi
+
+    log_info "Adding cert-manager Helm repository..."
+    helm repo add jetstack https://charts.jetstack.io --force-update
+
+    log_info "Installing cert-manager ${CERT_MANAGER_VERSION}..."
+    helm install \
+        cert-manager jetstack/cert-manager \
+        --namespace cert-manager \
+        --create-namespace \
+        --version "${CERT_MANAGER_VERSION}" \
+        --set crds.enabled=true \
+        --wait
+
+    log_success "Successfully installed cert-manager ${CERT_MANAGER_VERSION} via Helm"
+
+    wait_for_pods "cert-manager" "app in (cert-manager,webhook,cainjector)" "180s"
+
+    log_success "cert-manager is ready!"
+}
+
+# ----------------------------------------
+# CLI/Component: kserve-kustomize
+# ----------------------------------------
+
+uninstall_kserve_kustomize() {
+    log_info "Uninstalling KServe..."
+
+    # EMBED_MANIFESTS: use embedded manifests
+    if is_positive "$EMBED_MANIFESTS"; then
+        if type uninstall_kserve_manifest &>/dev/null; then
+            uninstall_kserve_manifest
+        else
+            log_error "EMBED_MANIFESTS enabled but uninstall_kserve_manifest function not found"
+            log_error "This script should be called from a generated installation script"
+            exit 1
+        fi
+    else
+        # Uninstall Runtimes and LLMISVC configs first
+        if is_positive "${INSTALL_RUNTIMES}"; then
+            log_info "Uninstalling ClusterServingRuntimes..."
+            kubectl delete -k config/runtimes --force --grace-period=0 2>/dev/null || true
+        fi
+        if is_positive "${INSTALL_LLMISVC_CONFIGS}"; then
+            log_info "Uninstalling LLMISVC configs..."
+            kubectl delete -k config/llmisvcconfig --force --grace-period=0 2>/dev/null || true
+        fi
+
+        # Uninstall overlay resources in reverse order
+        for ((i=${#TARGET_OVERLAY_DIRS[@]}-1; i>=0; i--)); do
+            log_info "Uninstalling resources from ${TARGET_OVERLAY_DIRS[$i]}..."
+            kustomize build "${TARGET_OVERLAY_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
+        done
+
+        # Uninstall CRDs in reverse order
+        for ((i=${#TARGET_CRD_DIRS[@]}-1; i>=0; i--)); do
+            log_info "Uninstalling CRDs from ${TARGET_CRD_DIRS[$i]}..."
+            kustomize build "${TARGET_CRD_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
+        done
+    fi
+
+    kubectl delete all --all -n "${KSERVE_NAMESPACE}" --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace "${KSERVE_NAMESPACE}" --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    log_success "KServe uninstalled"
+}
+
+install_kserve_kustomize() {
+    # Determine installation status
+    determine_shared_resources_config "${INSTALL_MODE}" "${ENABLE_KSERVE}" "${ENABLE_LLMISVC}"
+
+    # Check if already installed
+    local already_installed=false
+    if [ "${KSERVE_INSTALLED}" = "1" ] || [ "${LLMISVC_INSTALLED}" = "1" ]; then
+        already_installed=true
+    fi
+
+    if [ "${already_installed}" = "true" ]; then
+        if ! is_positive "$REINSTALL"; then
+            if is_positive "$FORCE_UPGRADE"; then
+                log_info "Force upgrading KServe..."
+            else
+                log_info "KServe is already installed. Use --reinstall to reinstall or --force-upgrade to upgrade."
+                return 0
+            fi
+        else
+            log_info "Reinstalling KServe..."
+            uninstall_kserve_kustomize
+        fi
+    fi
+
+    # EMBED_MANIFESTS: use embedded manifests from generated script
+    if is_positive "$EMBED_MANIFESTS"; then
+        log_info "Installing KServe using embedded manifests..."
+
+        # Call manifest functions (these should be available in generated script)
+        if type install_kserve_manifest &>/dev/null; then
+            install_kserve_manifest
+        else
+            log_error "EMBED_MANIFESTS enabled but install_kserve_manifest function not found"
+            log_error "This script should be called from a generated installation script"
+            exit 1
+        fi
+    else
+        log_info "Installing KServe via Kustomize..."
+
+        # Install CRDs and wait for them
+        log_info "Installing KServe CRDs..."
+        for i in "${!TARGET_CRD_DIRS[@]}"; do
+            crd_dir="${TARGET_CRD_DIRS[$i]}"
+            log_info "  - Installing CRDs from ${crd_dir}..."
+            kustomize build "${crd_dir}" | kubectl apply --server-side --force-conflicts -f -
+
+            # Collect CRDs to verify
+            crds="${TARGET_CRDS_TO_VERIFY[$i]}"
+            if [ -n "${crds}" ]; then
+                log_info "Waiting for required CRDs..."
+                wait_for_crds "60s" ${crds}
+            fi
+        done
+
+        # Install resources from overlays
+        log_info "Installing KServe resources..."
+        for i in "${!TARGET_OVERLAY_DIRS[@]}"; do
+            overlay_dir="${TARGET_OVERLAY_DIRS[$i]}"
+
+            # Install overlay
+            log_info "  - Installing resources from ${overlay_dir}..."
+            kustomize build "${overlay_dir}" | kubectl apply --server-side -f -
+
+            # Wait for corresponding deployment
+            if [ ${#TARGET_DEPLOYMENT_NAMES[@]} -gt $i ] && [ -n "${TARGET_DEPLOYMENT_NAMES[$i]}" ]; then
+                for d in ${TARGET_DEPLOYMENT_NAMES[$i]}; do
+                    wait_for_deployment "${KSERVE_NAMESPACE}" "${d}" "300s"
+                done
+            fi
+        done
+    fi
+
+    if ! is_positive "${USE_LOCAL_CONFIGMAP}"; then
+        # Build list of config updates
+        local config_updates=()
+
+        # Update deployment mode if needed
+        if [ "${DEPLOYMENT_MODE}" = "Standard" ] || [ "${DEPLOYMENT_MODE}" = "RawDeployment" ]; then
+            log_info "Adding deployment mode update: ${DEPLOYMENT_MODE}"
+            config_updates+=("deploy.defaultDeploymentMode=${DEPLOYMENT_MODE}")
+        fi
+
+        # Enable Gateway API for KServe(ISVC) if needed
+        if [ "${GATEWAY_NETWORK_LAYER}" != "false" ] && ! is_positive "${ENABLE_LLMISVC}"; then
+            log_info "Adding Gateway API updates: enableGatewayApi=true, ingressClassName=${GATEWAY_NETWORK_LAYER}"
+            config_updates+=("ingress.enableGatewayApi=true")
+            config_updates+=("ingress.ingressClassName=${GATEWAY_NETWORK_LAYER}")
+        fi
+        if is_positive "${ENABLE_LOCALMODEL}"; then
+            log_info "Adding LocalModel updates: enabled=true, defaultJobImage=kserve/storage-initializer:${KSERVE_VERSION}"
+            config_updates+=("localModel.enabled=true")
+            config_updates+=("localModel.defaultJobImage=kserve/storage-initializer:${KSERVE_VERSION}")
+        fi
+        # Add custom configurations if provided
+        if [ -n "${KSERVE_CUSTOM_ISVC_CONFIGS}" ]; then
+            log_info "Adding custom configurations: ${KSERVE_CUSTOM_ISVC_CONFIGS}"
+            IFS='|' read -ra custom_configs <<< "${KSERVE_CUSTOM_ISVC_CONFIGS}"
+            config_updates+=("${custom_configs[@]}")
+        fi
+
+        # Apply all config updates at once if there are any
+        if [ ${#config_updates[@]} -gt 0 ]; then
+            log_info "Applying ${#config_updates[@]} configuration update(s):"
+            for update in "${config_updates[@]}"; do
+                log_info "  - ${update}"
+            done
+            update_isvc_config "${config_updates[@]}"
+            for i in "${!TARGET_OVERLAY_DIRS[@]}"; do
+                if [ ${#TARGET_DEPLOYMENT_NAMES[@]} -gt $i ] && [ -n "${TARGET_DEPLOYMENT_NAMES[$i]}" ]; then
+                    for d in ${TARGET_DEPLOYMENT_NAMES[$i]}; do
+                        wait_for_deployment "${KSERVE_NAMESPACE}" "${d}" "300s"
+                    done
+                fi
+            done
+            log_success "KServe configuration updated"
+        else
+            if is_positive "${ENABLE_LLMISVC}" && ! is_positive "${ENABLE_KSERVE}"; then
+                log_info "No configuration updates needed for LLMISVC (GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+            else
+                log_info "No configuration updates needed (DEPLOYMENT_MODE=${DEPLOYMENT_MODE}, GATEWAY_NETWORK_LAYER=${GATEWAY_NETWORK_LAYER})"
+            fi
+        fi
+    fi
+    # Final Check:Wait for controller manager to be ready
+    for deployment in $(kubectl get deployments -n "${KSERVE_NAMESPACE}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+        if echo "$deployment" | grep -q controller-manager; then
+            log_info "Waiting for deployment: $deployment"
+            wait_for_deployment "${KSERVE_NAMESPACE}" "$deployment" "300s"
+        fi
+    done
+    log_success "KServe is ready!"
+
+    # Wait for kserve webhook endpoint to be ready
+    sleep 2
+
+    if is_positive "${INSTALL_RUNTIMES}"; then
+        log_info "Installing ClusterServingRuntimes..."
+        if [ $EMBED_MANIFESTS = "true" ]; then
+            create_kserve_runtime_manifests
+        else
+            retry_command 3 5 kubectl apply --server-side=true -k "${RUNTIMES_DIR}"
+        fi
+    fi
+
+    if is_positive "${INSTALL_LLMISVC_CONFIGS}"; then
+        log_info "Installing LLMISVC configs..."
+         if [ $EMBED_MANIFESTS = "true" ]; then
+            create_kserve_llmisvcconfig_manifests
+        else
+            retry_command 3 5 kubectl apply --server-side=true -k "${REPO_ROOT}/config/llmisvcconfig"
+        fi
+    fi
+
+    # Cleanup temporary manifests after all resources are installed
+    if is_positive "${USE_CUSTOM_MANIFESTS}"; then
+        rm -rf "${TEMP_TARGET_CONFIG_DIR}"
+        log_info "Customized KServe config directory cleaned up"
+    fi
+}
+
+
+
+#================================================
+# Main Installation Logic
+#================================================
+
+main() {
+    if [ "$UNINSTALL" = true ]; then
+        echo "=========================================="
+        echo "Uninstalling components..."
+        echo "=========================================="
+        uninstall_kserve_manifest
+        uninstall_cert_manager
+        
+        
+        
+        echo "=========================================="
+        echo "✅ Uninstallation completed!"
+        echo "=========================================="
+        exit 0
+    fi
+
+    echo "=========================================="
+    echo "Install LocalModel and all related dependencies with manifests included in the script."
+    echo "=========================================="
+
+    export EMBED_TEMPLATES="true"
+    export EMBED_MANIFESTS="true"
+    export INSTALL_MODE="kustomize"
+
+    install_helm
+    install_kustomize
+    install_yq
+    install_cert_manager
+    (
+        set_env_with_priority "ENABLE_LLMISVC" "False" "" ""
+        set_env_with_priority "ENABLE_KSERVE" "False" "" ""
+        set_env_with_priority "ENABLE_LOCALMODEL" "True" "" ""
+        set_env_with_priority "INSTALL_RUNTIMES" "False" "" ""
+        set_env_with_priority "INSTALL_LLMISVC_CONFIGS" "False" "" ""
+        KSERVE_CRDS="inferenceservices.serving.kserve.io servingruntimes.serving.kserve.io clusterservingruntimes.serving.kserve.io inferencegraphs.serving.kserve.io trainedmodels.serving.kserve.io"
+        LLMISVC_CRDS="llminferenceservices.serving.kserve.io llminferenceserviceconfigs.serving.kserve.io"
+        LOCALMODEL_CRDS="localmodelcaches.serving.kserve.io localmodelnodegroups.serving.kserve.io localmodelnodes.serving.kserve.io"
+        
+        # Override KSERVE_VERSION if SET_KSERVE_VERSION is provided
+        if [ -n "${SET_KSERVE_VERSION}" ]; then
+            KSERVE_VERSION="${SET_KSERVE_VERSION}"
+        fi
+        
+        # Copy config folder to  if version/registry override is needed
+        if ! is_positive "$EMBED_MANIFESTS" && [ -z "${KSERVE_OVERLAY_DIR}" ] && ([ -n "${SET_KSERVE_VERSION}" ] || [ -n "${SET_KSERVE_REGISTRY}" ]); then
+            # Clean up temporary config directory if it exists
+            if [ -d "${TEMP_TARGET_CONFIG_DIR}" ]; then
+                rm -rf ${TEMP_TARGET_CONFIG_DIR}
+            fi
+            mkdir -p ${TEMP_TARGET_CONFIG_DIR}
+            cp -r ${REPO_ROOT}/config ${TEMP_TARGET_CONFIG_DIR}/config
+            TARGET_CONFIG_ROOT_DIR="${TEMP_TARGET_CONFIG_DIR}"
+        
+            FIND_PRUNE=()
+            if ! is_positive "${UPDATE_CONFIGMAP_IMAGES}"; then
+                FIND_PRUNE+=( ! -path '*/configmap/*' )
+            fi
+        
+            # Update image registry if SET_KSERVE_REGISTRY is provided
+            if [ -n "${SET_KSERVE_REGISTRY}" ]; then
+                find "${TARGET_CONFIG_ROOT_DIR}/config" -type f -name "*.yaml" \
+                    "${FIND_PRUNE[@]}" \
+                    -exec sed -i \
+                    -e "s|\"image\": \"kserve/|\"image\": \"${SET_KSERVE_REGISTRY}/|g" \
+                    -e "s|image: kserve/|image: ${SET_KSERVE_REGISTRY}/|g" \
+                    -e "s|image: ko://github.com/kserve/|image: ${SET_KSERVE_REGISTRY}/|g" {} \;
+            fi
+            # Update image version if SET_KSERVE_VERSION is provided
+            if [ -n "${SET_KSERVE_VERSION}" ]; then
+                find "${TARGET_CONFIG_ROOT_DIR}/config" -type f -name "*.yaml" \
+                    "${FIND_PRUNE[@]}" \
+                    -exec sed -i \
+                -e "s/:latest/:${SET_KSERVE_VERSION}/g" {} \;
+            fi
+        
+            # Customized images are loaded onto the node, not pushed to a registry, so
+            # force IfNotPresent to avoid registry pulls for locally-built image tags.
+            if is_positive ${KSERVE_INSTALL_CI}; then
+                find "${TARGET_CONFIG_ROOT_DIR}/config" -type f -name "*.yaml" \
+                    "${FIND_PRUNE[@]}" \
+                    -exec sed -i \
+                    -e "s/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g" {} \;
+            fi
+            USE_CUSTOM_MANIFESTS="true"
+        fi
+        
+        KSERVE_CONFIG_DIR="${TARGET_CONFIG_ROOT_DIR}/config/overlays/standalone/kserve"
+        LLMISVC_CONFIG_DIR="${TARGET_CONFIG_ROOT_DIR}/config/overlays/standalone/llmisvc"
+        LOCALMODEL_CONFIG_DIR="${TARGET_CONFIG_ROOT_DIR}/config/overlays/addons/localmodel"
+        RUNTIMES_DIR="${TARGET_CONFIG_ROOT_DIR}/config/runtimes"
+        
+        if [ -n "${KSERVE_OVERLAY_DIR}" ]; then
+            TARGET_OVERLAY_DIRS+=("${REPO_ROOT}/config/overlays/${KSERVE_OVERLAY_DIR}")
+            if [ "${KSERVE_OVERLAY_DIR}" == "test" ]; then
+                # Auto-enable localmodel for test overlay
+                ENABLE_LOCALMODEL="true"
+        
+                # Update test overlay image tags if version is set
+                if [ -n "${SET_KSERVE_VERSION}" ]; then
+                    log_info "Updating test overlay image tags to ${SET_KSERVE_VERSION}..."
+                    sed -i -e "s/latest/${SET_KSERVE_VERSION}/g" config/overlays/test/configmap/inferenceservice.yaml
+                    sed -i -e "s/latest/${SET_KSERVE_VERSION}/g" config/overlays/test/clusterresources/kustomization.yaml
+                fi
+        
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full")
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/localmodel")
+                TARGET_CRDS_TO_VERIFY+=("${KSERVE_CRDS}")
+                TARGET_CRDS_TO_VERIFY+=("${LOCALMODEL_CRDS}")
+                test_overlay_deployments="kserve-controller-manager kserve-localmodel-controller-manager"
+                if is_positive "${ENABLE_LLMISVC}"; then
+                    TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                    TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                    test_overlay_deployments+=" llmisvc-controller-manager"
+                fi
+                TARGET_DEPLOYMENT_NAMES+=("${test_overlay_deployments}")
+            elif [ "${KSERVE_OVERLAY_DIR}" == "test-modelcache" ]; then
+                ENABLE_LOCALMODEL="true"
+                ENABLE_LLMISVC="true"
+                INSTALL_LLMISVC_CONFIGS="true"
+        
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full")
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/localmodel")
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                TARGET_CRDS_TO_VERIFY+=("${KSERVE_CRDS}")
+                TARGET_CRDS_TO_VERIFY+=("${LOCALMODEL_CRDS}")
+                TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager kserve-localmodel-controller-manager llmisvc-controller-manager")
+            elif [ "${KSERVE_OVERLAY_DIR}" == "test-llmisvc" ]; then
+                # Update test-llmisvc overlay image tags if version is set
+                if [ -n "${SET_KSERVE_VERSION}" ]; then
+                    log_info "Updating test-llmisvc overlay image tags to ${SET_KSERVE_VERSION}..."
+                    sed -i -e "s/latest/${SET_KSERVE_VERSION}/g" config/overlays/test-llmisvc/llmisvc_image_patch.yaml
+                    sed -i -e "s/latest/${SET_KSERVE_VERSION}/g" config/configmap/inferenceservice.yaml
+                fi
+                TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
+            elif [ "${KSERVE_OVERLAY_DIR}" == "temp" ]; then
+                RUNTIMES_DIR="${REPO_ROOT}/config/overlays/temp/cluster-resources"
+                if is_positive "${ENABLE_KSERVE}"; then
+                    TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full")
+                    TARGET_CRDS_TO_VERIFY+=("${KSERVE_CRDS}")
+                    TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
+                fi
+                if is_positive "${ENABLE_LLMISVC}"; then
+                    TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/llmisvc")
+                    TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                    TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
+                fi
+                if is_positive "${ENABLE_LOCALMODEL}"; then
+                    TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/localmodel")
+                    TARGET_CRDS_TO_VERIFY+=("${LOCALMODEL_CRDS}")
+                    TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
+                fi
+            fi
+        else
+            if is_positive "${ENABLE_KSERVE}"; then
+                TARGET_CRD_DIRS+=("${TARGET_CONFIG_ROOT_DIR}/config/crd/full")
+                TARGET_CRDS_TO_VERIFY+=("${KSERVE_CRDS}")
+                TARGET_DEPLOYMENT_NAMES+=("kserve-controller-manager")
+                if [ "${LLMISVC_INSTALLED}" = "1" ]; then
+                    KSERVE_CONFIG_DIR="${TARGET_CONFIG_ROOT_DIR}/config/overlays/addons/kserve"
+                fi
+                TARGET_OVERLAY_DIRS+=("${KSERVE_CONFIG_DIR}")
+            fi
+        
+            if is_positive "${ENABLE_LLMISVC}"; then
+                TARGET_CRD_DIRS+=("${TARGET_CONFIG_ROOT_DIR}/config/crd/full/llmisvc")
+                TARGET_CRDS_TO_VERIFY+=("${LLMISVC_CRDS}")
+                TARGET_DEPLOYMENT_NAMES+=("llmisvc-controller-manager")
+                if [ "${KSERVE_INSTALLED}" = "1" ]; then
+                    LLMISVC_CONFIG_DIR="${TARGET_CONFIG_ROOT_DIR}/config/overlays/addons/llmisvc"
+                fi
+                TARGET_OVERLAY_DIRS+=("${LLMISVC_CONFIG_DIR}")
+            fi
+        
+            if is_positive "${ENABLE_LOCALMODEL}"; then
+                TARGET_CRD_DIRS+=("${TARGET_CONFIG_ROOT_DIR}/config/crd/full/localmodel")
+                TARGET_CRDS_TO_VERIFY+=("${LOCALMODEL_CRDS}")
+                TARGET_OVERLAY_DIRS+=("${LOCALMODEL_CONFIG_DIR}")
+                TARGET_DEPLOYMENT_NAMES+=("kserve-localmodel-controller-manager")
+            fi
+        fi
+        
+        # Add ClusterStorageContainer CRD if either KServe or LLMISVC is enabled
+        if is_positive "${ENABLE_KSERVE}" || is_positive "${ENABLE_LLMISVC}"; then
+            TARGET_CRD_DIRS+=("${REPO_ROOT}/config/crd/full/clusterstoragecontainer")
+            TARGET_CRDS_TO_VERIFY+=("clusterstoragecontainers.serving.kserve.io")
+        fi
+
+        install_kserve_kustomize
+    )
+
+    echo "=========================================="
+    echo "✅ Installation completed successfully!"
+    echo "=========================================="
+}
+
+# ============================================================================
+# KServe Manifest Functions (EMBED_MANIFESTS MODE)
+# ============================================================================
+
+install_kserve_manifest() {
+    log_info "Installing KServe CRDs..."
+    get_kserve_crd_manifest | kubectl apply --server-side -f -
+
+    log_info "Installing KServe core components..."
+    get_kserve_core_manifest | kubectl apply --server-side -f -
+
+    log_success "KServe CRD and core components installed successfully!"
+}
+
+uninstall_kserve_manifest() {
+    # Uninstall in reverse order of dependencies
+    log_info "Uninstalling KServe LLMISvcConfig manifests..."
+    if [ "${LLMISVC:-false}" = "true" ] && type get_kserve_llmisvcconfig_manifests &>/dev/null; then
+        get_kserve_llmisvcconfig_manifests | kubectl delete -f - || true
+    fi
+
+    log_info "Uninstalling KServe runtime manifests..."
+    if [ "${INSTALL_RUNTIMES:-false}" = "true" ] && type get_kserve_runtime_manifests &>/dev/null; then
+        get_kserve_runtime_manifests | kubectl delete -f - || true
+    fi
+
+    log_info "Uninstalling KServe core components..."
+    get_kserve_core_manifest | kubectl delete -f - || true
+
+    log_info "Uninstalling KServe CRDs..."
+    get_kserve_crd_manifest | kubectl delete -f - || true
+
+    log_success "KServe manifests uninstalled successfully!"
+}
+
+get_kserve_runtime_manifests() {
+    cat <<'KSERVE_RUNTIME_MANIFEST_EOF'
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: autogluonserver
+  name: kserve-autogluonserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    image: kserve/autogluonserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: autogluon
+    priority: 1
+    version: "1"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: huggingfaceserver
+  name: kserve-huggingfaceserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    env:
+    - name: LMCACHE_USE_EXPERIMENTAL
+      value: "True"
+    image: kserve/huggingfaceserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: devshm
+  hostIPC: false
+  protocolVersions:
+  - v2
+  - v1
+  supportedModelFormats:
+  - autoSelect: true
+    name: huggingface
+    priority: 1
+    version: "1"
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: devshm
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: huggingfaceserver
+  name: kserve-huggingfaceserver-multinode
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    command:
+    - bash
+    - -c
+    - "export MODEL_DIR_ARG=\"\"\nif [[ ! -z ${MODEL_ID} ]]\nthen\n  export MODEL_DIR_ARG=\"--model_dir=${MODEL_ID}\"\nfi\n\nif
+      [[ ! -z ${MODEL_DIR} ]]\nthen\n  export MODEL_DIR_ARG=\"--model_dir=${MODEL_DIR}\"\nfi\n\nexport
+      RAY_ADDRESS=${POD_IP}:${RAY_PORT}\nray start --head --disable-usage-stats --include-dashboard
+      false \npython ./huggingfaceserver/health_check.py registered_nodes --retries
+      200  --probe_name runtime_start\n\npython -m huggingfaceserver ${MODEL_DIR_ARG}
+      --tensor-parallel-size=${TENSOR_PARALLEL_SIZE} --pipeline-parallel-size=${PIPELINE_PARALLEL_SIZE}
+      $0 $@\n"
+    env:
+    - name: RAY_PORT
+      value: "6379"
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: VLLM_CONFIG_ROOT
+      value: /tmp
+    - name: HF_HUB_CACHE
+      value: /tmp
+    image: kserve/huggingfaceserver:latest-gpu
+    livenessProbe:
+      exec:
+        command:
+        - bash
+        - -c
+        - |
+          python ./huggingfaceserver/health_check.py registered_node_and_runtime_health --health_check_url http://localhost:8080 --probe_name head_liveness
+      failureThreshold: 2
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 15
+    name: kserve-container
+    readinessProbe:
+      exec:
+        command:
+        - bash
+        - -c
+        - |
+          python ./huggingfaceserver/health_check.py runtime_health --health_check_url http://localhost:8080 --probe_name head_readiness
+      failureThreshold: 2
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 15
+    resources:
+      limits:
+        cpu: "4"
+        memory: 12Gi
+      requests:
+        cpu: "2"
+        memory: 6Gi
+    startupProbe:
+      exec:
+        command:
+        - bash
+        - -c
+        - |
+          python ./huggingfaceserver/health_check.py registered_node_and_runtime_health --health_check_url http://localhost:8080 --probe_name head_startup
+      failureThreshold: 40
+      initialDelaySeconds: 60
+      periodSeconds: 30
+      successThreshold: 1
+      timeoutSeconds: 30
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: shm
+  protocolVersions:
+  - v2
+  - v1
+  supportedModelFormats:
+  - autoSelect: true
+    name: huggingface
+    priority: 2
+    version: "1"
+  volumes:
+  - emptyDir:
+      medium: Memory
+      sizeLimit: 3Gi
+    name: shm
+  workerSpec:
+    containers:
+    - command:
+      - bash
+      - -c
+      - "export RAY_HEAD_ADDRESS=${HEAD_SVC}.${POD_NAMESPACE}.svc.cluster.local:6379\nSECONDS=0\n\nwhile
+        true; do              \n  if (( SECONDS <= 240 )); then\n    if ray health-check
+        --address \"${RAY_HEAD_ADDRESS}\" > /dev/null 2>&1; then\n      echo \"Ray
+        Global Control Service(GCS) is ready.\"\n      break\n    fi\n    echo \"$SECONDS
+        seconds elapsed: Waiting for Ray Global Control Service(GCS) to be ready.\"\n
+        \ else\n    if ray health-check --address \"${RAY_HEAD_ADDRESS}\"; then\n
+        \     echo \"Ray Global Control Service(GCS) is ready. Any error messages
+        above can be safely ignored.\"\n      break\n    fi\n    echo \"$SECONDS seconds
+        elapsed: Still waiting for Ray Global Control Service(GCS) to be ready.\"\n
+        \ fi\n\n  sleep 5\ndone\n\necho \"Attempting to connect to Ray cluster at
+        $RAY_HEAD_ADDRESS ...\"\nray start --address=\"${RAY_HEAD_ADDRESS}\" --block\n"
+      env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      image: kserve/huggingfaceserver:latest-gpu
+      livenessProbe:
+        exec:
+          command:
+          - bash
+          - -c
+          - |
+            export RAY_ADDRESS=${HEAD_SVC}.${POD_NAMESPACE}.svc.cluster.local:6379
+            python ./huggingfaceserver/health_check.py registered_nodes --probe_name worker_liveness
+        failureThreshold: 2
+        periodSeconds: 5
+        successThreshold: 1
+        timeoutSeconds: 15
+      name: worker-container
+      resources:
+        limits:
+          cpu: "4"
+          memory: 12Gi
+        requests:
+          cpu: "2"
+          memory: 6Gi
+      startupProbe:
+        exec:
+          command:
+          - bash
+          - -c
+          - |
+            export RAY_HEAD_NODE=${HEAD_SVC}.${POD_NAMESPACE}.svc.cluster.local
+            export RAY_ADDRESS=${RAY_HEAD_NODE}:6379
+            python ./huggingfaceserver/health_check.py registered_node_and_runtime_models --runtime_url http://${RAY_HEAD_NODE}:8080/v1/models --probe_name worker_startup
+        failureThreshold: 40
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        successThreshold: 1
+        timeoutSeconds: 30
+      volumeMounts:
+      - mountPath: /dev/shm
+        name: shm
+    pipelineParallelSize: 1
+    tensorParallelSize: 1
+    volumes:
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 3Gi
+      name: shm
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: lgbserver
+  name: kserve-lgbserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    - --nthread=1
+    image: kserve/lgbserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: lightgbm
+    priority: 1
+    version: "4"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: mlserver
+  name: kserve-mlserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - env:
+    - name: MLSERVER_MODEL_IMPLEMENTATION
+      value: '{{.Labels.modelClass}}'
+    - name: MLSERVER_HTTP_PORT
+      value: "8080"
+    - name: MLSERVER_GRPC_PORT
+      value: "9000"
+    image: docker.io/seldonio/mlserver:1.7.1
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: sklearn
+    priority: 2
+    version: "0"
+  - autoSelect: true
+    name: sklearn
+    priority: 2
+    version: "1"
+  - autoSelect: true
+    name: xgboost
+    priority: 2
+    version: "1"
+  - autoSelect: true
+    name: xgboost
+    priority: 2
+    version: "2"
+  - autoSelect: true
+    name: lightgbm
+    priority: 2
+    version: "3"
+  - autoSelect: true
+    name: lightgbm
+    priority: 2
+    version: "4"
+  - autoSelect: true
+    name: mlflow
+    priority: 1
+    version: "1"
+  - autoSelect: true
+    name: mlflow
+    priority: 1
+    version: "2"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: paddleserver
+  name: kserve-paddleserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    image: kserve/paddleserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: paddle
+    priority: 1
+    version: "2"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: pmmlserver
+  name: kserve-pmmlserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    image: kserve/pmmlserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: pmml
+    priority: 1
+    version: "3"
+  - autoSelect: true
+    name: pmml
+    priority: 1
+    version: "4"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: predictiveserver
+  name: kserve-predictiveserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    - --framework={{.Annotations.modelFormat}}
+    - --nthread=1
+    image: kserve/predictiveserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  multiModel: false
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: false
+    name: sklearn
+    priority: 3
+    version: "1"
+  - autoSelect: false
+    name: xgboost
+    priority: 3
+    version: "2"
+  - autoSelect: false
+    name: lightgbm
+    priority: 3
+    version: "4"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: sklearnserver
+  name: kserve-sklearnserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    image: kserve/sklearnserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: sklearn
+    priority: 1
+    version: "1"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: tensorflow-serving
+  name: kserve-tensorflow-serving
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --port=9000
+    - --rest_api_port=8080
+    - --model_base_path=/mnt/models
+    - --rest_api_timeout_in_ms=60000
+    command:
+    - /usr/bin/tensorflow_model_server
+    image: tensorflow/serving:2.6.2
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 1000
+  protocolVersions:
+  - v1
+  - grpc-v1
+  supportedModelFormats:
+  - autoSelect: true
+    name: tensorflow
+    priority: 2
+    version: "1"
+  - autoSelect: true
+    name: tensorflow
+    priority: 2
+    version: "2"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: torchserve
+  name: kserve-torchserve
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8082"
+  containers:
+  - args:
+    - torchserve
+    - --start
+    - --model-store=/mnt/models/model-store
+    - --ts-config=/mnt/models/config/config.properties
+    env:
+    - name: TS_SERVICE_ENVELOPE
+      value: '{{.Labels.serviceEnvelope}}'
+    image: pytorch/torchserve-kfs:0.9.0
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 1000
+  protocolVersions:
+  - v1
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: pytorch
+    priority: 2
+    version: "1"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: tritonserver
+  name: kserve-tritonserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8002"
+  containers:
+  - args:
+    - tritonserver
+    - --model-store=/mnt/models
+    - --grpc-port=9000
+    - --http-port=8080
+    - --allow-grpc=true
+    - --allow-http=true
+    image: nvcr.io/nvidia/tritonserver:23.05-py3
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 1000
+  protocolVersions:
+  - v2
+  - grpc-v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: tensorrt
+    priority: 1
+    version: "8"
+  - autoSelect: true
+    name: tensorflow
+    priority: 1
+    version: "1"
+  - autoSelect: true
+    name: tensorflow
+    priority: 1
+    version: "2"
+  - autoSelect: true
+    name: onnx
+    priority: 1
+    version: "1"
+  - name: pytorch
+    version: "1"
+  - autoSelect: true
+    name: triton
+    priority: 1
+    version: "2"
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: vllmserver
+  name: kserve-vllmserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --port=8080
+    - --served-model-name={{.Name}}
+    - --model=/mnt/models
+    command:
+    - python
+    - -m
+    - vllm.entrypoints.openai.api_server
+    env:
+    - name: LMCACHE_USE_EXPERIMENTAL
+      value: "True"
+    - name: HF_HOME
+      value: /tmp
+    - name: VLLM_CONFIG_ROOT
+      value: /tmp
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    image: vllm/vllm-openai:latest
+    name: kserve-container
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /v1/models
+        port: 8080
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+    startupProbe:
+      failureThreshold: 60
+      httpGet:
+        path: /v1/models
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      successThreshold: 1
+      timeoutSeconds: 10
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: devshm
+  hostIPC: false
+  supportedModelFormats:
+  - autoSelect: true
+    name: vLLM
+    priority: 1
+    version: "1"
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: devshm
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  annotations:
+    serving.kserve.io/server-type: xgbserver
+  name: kserve-xgbserver
+spec:
+  annotations:
+    prometheus.kserve.io/path: /metrics
+    prometheus.kserve.io/port: "8080"
+  containers:
+  - args:
+    - --model_name={{.Name}}
+    - --model_dir=/mnt/models
+    - --http_port=8080
+    - --nthread=1
+    image: kserve/xgbserver:latest
+    name: kserve-container
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+  protocolVersions:
+  - v1
+  - v2
+  supportedModelFormats:
+  - autoSelect: true
+    name: xgboost
+    priority: 1
+    version: "2"
+KSERVE_RUNTIME_MANIFEST_EOF
+}
+
+get_kserve_llmisvcconfig_manifests() {
+    cat <<'KSERVE_LLMISVCCONFIG_MANIFEST_EOF'
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-decode-template
+  namespace: kserve
+spec:
+  annotations:
+    serving.kserve.io/model-based-routing-enabled: "true"
+  template:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8001 \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+        timeoutSeconds: 1
+      name: main
+      ports:
+      - containerPort: 8001
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 1
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    initContainers:
+    - command:
+      - /app/pd-sidecar
+      - --port=8000
+      - --vllm-port=8001
+      - --kv-connector=nixlv2
+      - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
+      - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
+        end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--enable-tls=decoder{{- end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--enable-tls=prefiller{{- end }}'
+      env:
+      - name: INFERENCE_POOL_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: SSL_CERT_DIR
+        value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.10.0
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 10
+      name: llm-d-routing-sidecar
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 5
+      resources: {}
+      restartPolicy: Always
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 1Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-decode-worker-data-parallel
+  namespace: kserve
+spec:
+  annotations:
+    serving.kserve.io/model-based-routing-enabled: "true"
+  template:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        # In some versions, ZMQ bind doesn't resolve the address through DNS
+        # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+        RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+        for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+          DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+          if [ -n "$DP_ADDRESS" ]; then
+            echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+            break
+          else
+            echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+            sleep 1
+          fi
+        done
+
+        if [ -z "$DP_ADDRESS" ]; then
+          echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+          DP_ADDRESS=${LWS_LEADER_ADDRESS}
+          echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+        fi
+
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        START_RANK=0
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve \
+          /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8001 \
+          --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
+          {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+          {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+          --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
+          --data-parallel-address ${DP_ADDRESS} \
+          --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+          --data-parallel-start-rank $START_RANK \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+        timeoutSeconds: 1
+      name: main
+      ports:
+      - containerPort: 8001
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 1
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - IPC_LOCK
+          - SYS_RAWIO
+          - NET_RAW
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 8001
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    initContainers:
+    - command:
+      - /app/pd-sidecar
+      - --port=8000
+      - --vllm-port=8001
+      - --kv-connector=nixlv2
+      - --enable-ssrf-protection=true
+      - --pool-group=inference.networking.x-k8s.io
+      - --inference-pool={{ .GlobalConfig.InferencePoolNamespacedName }}
+      - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
+        end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--enable-tls=decoder{{- end }}'
+      - '{{ if .GlobalConfig.EnableTLS }}--enable-tls=prefiller{{- end }}'
+      env:
+      - name: INFERENCE_POOL_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - name: SSL_CERT_DIR
+        value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+      image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.10.0
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 10
+      name: llm-d-routing-sidecar
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        timeoutSeconds: 5
+      restartPolicy: Always
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+  worker:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        # In some versions, ZMQ bind doesn't resolve the address through DNS
+        # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+        RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+        for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+          DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+          if [ -n "$DP_ADDRESS" ]; then
+            echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+            break
+          else
+            echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+            sleep 1
+          fi
+        done
+
+        if [ -z "$DP_ADDRESS" ]; then
+          echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+          DP_ADDRESS=${LWS_LEADER_ADDRESS}
+          echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+        fi
+
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve \
+          /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8001 \
+          {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+          {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+          --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
+          --data-parallel-address ${DP_ADDRESS} \
+          --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+          --data-parallel-start-rank $START_RANK \
+          --headless \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
+        value: "1"
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      name: main
+      ports:
+      - containerPort: 8001
+        protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - IPC_LOCK
+          - SYS_RAWIO
+          - NET_RAW
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-prefill-template
+  namespace: kserve
+spec:
+  prefill:
+    annotations:
+      serving.kserve.io/model-based-routing-enabled: "true"
+    template:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |-
+          if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+            echo "Trying to infer RoCE configs ... "
+            grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+            grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+            cat /proc/driver/nvidia/params
+
+            KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+            echo "[Infer RoCE] Discovering active HCAs ..."
+            active_hcas=()
+            # Loop through all mlx5 devices found in sysfs
+            for hca_dir in /sys/class/infiniband/mlx5_*; do
+                # Ensure it's a directory before proceeding
+                if [ -d "$hca_dir" ]; then
+                    hca_name=$(basename "$hca_dir")
+                    port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                    type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                    echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                    if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                        echo "[Infer RoCE] Found active HCA: $hca_name"
+                        active_hcas+=("$hca_name")
+                    else
+                        echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                    fi
+                fi
+            done
+
+            # Check if we found any active HCAs
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                # Join the array elements with a comma
+                hca_port_pairs=()
+                for hca in "${active_hcas[@]}"; do
+                  hca_port_pairs+=("${hca}:1")
+                done
+
+                active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+                hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+                echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+                export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+                export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+                export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+                echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+                echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+                echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+            else
+                echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+            fi
+
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+                # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+                declare -A gid_index_count
+                declare -A hca_gid_index
+
+                for hca_name in "${active_hcas[@]}"; do
+                    echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                    # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                    for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                        if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                            idx=$(basename "$tpath")
+                            gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                            # Check for IPv4 GID (contains ffff:)
+                            if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                                gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                                echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                                hca_gid_index["${hca_name}"]="${idx}"
+                                gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                                break  # Use first found IPv4 GID per HCA
+                            fi
+                        fi
+                    done
+                done
+
+                # Find the most common GID index (most likely to be consistent across nodes)
+                best_gid_index=""
+                max_count=0
+                for idx in "${!gid_index_count[@]}"; do
+                    count=${gid_index_count["${idx}"]}
+                    echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                    if [ $count -gt $max_count ]; then
+                        max_count=$count
+                        best_gid_index="$idx"
+                    fi
+                done
+
+                # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+                if [ ${#gid_index_count[@]} -gt 1 ]; then
+                    echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                    # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                    if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                        best_gid_index="3"
+                        echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                    fi
+                fi
+
+                # Check if GID_INDEX is already set via environment variables
+                if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                    echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+                elif [ -n "$best_gid_index" ]; then
+                    echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                    export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                    echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+                else
+                    echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+                fi
+            else
+                echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+            fi
+          fi
+
+          # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+          # Older versions still need the blanket --disable-uvicorn-access-log.
+          ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+          fi
+          echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+          # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+          SHUTDOWN_TIMEOUT_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
+          fi
+
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          KV_TRANSFER_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+          fi
+
+          eval "exec vllm serve /mnt/models \
+            --served-model-name "{{ .Spec.Model.Name }}" \
+            --port 8000 \
+            ${ACCESS_LOG_ARGS} \
+            ${SHUTDOWN_TIMEOUT_ARGS} \
+            ${KV_TRANSFER_ARGS} \
+            {{- if and .Spec.Prefill .Spec.Prefill.Parallelism .Spec.Prefill.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${VLLM_ADDITIONAL_ARGS} \
+            $@"
+        - --
+        env:
+        - name: HOME
+          value: /home
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: HF_HUB_CACHE
+          value: /models
+        image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "15"
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 10
+          timeoutSeconds: 1
+        name: main
+        ports:
+        - containerPort: 8000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 10
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /home
+          name: home
+        - mountPath: /tmp
+          name: tmp-dir
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /models
+          name: model-cache
+        - mountPath: /var/run/kserve/tls
+          name: tls-certs
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - emptyDir: {}
+        name: home
+      - emptyDir: {}
+        name: tmp-dir
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1Gi
+        name: dshm
+      - emptyDir: {}
+        name: model-cache
+      - name: tls-certs
+        secret:
+          secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-prefill-worker-data-parallel
+  namespace: kserve
+spec:
+  prefill:
+    annotations:
+      serving.kserve.io/model-based-routing-enabled: "true"
+    template:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |-
+          # In some versions, ZMQ bind doesn't resolve the address through DNS
+          # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+          RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+          for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+            DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+            if [ -n "$DP_ADDRESS" ]; then
+              echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+              break
+            else
+              echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+              sleep 1
+            fi
+          done
+
+          if [ -z "$DP_ADDRESS" ]; then
+            echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+            DP_ADDRESS=${LWS_LEADER_ADDRESS}
+            echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+          fi
+
+          if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+            echo "Trying to infer RoCE configs ... "
+            grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+            grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+            cat /proc/driver/nvidia/params
+
+            KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+            echo "[Infer RoCE] Discovering active HCAs ..."
+            active_hcas=()
+            # Loop through all mlx5 devices found in sysfs
+            for hca_dir in /sys/class/infiniband/mlx5_*; do
+                # Ensure it's a directory before proceeding
+                if [ -d "$hca_dir" ]; then
+                    hca_name=$(basename "$hca_dir")
+                    port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                    type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                    echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                    if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                        echo "[Infer RoCE] Found active HCA: $hca_name"
+                        active_hcas+=("$hca_name")
+                    else
+                        echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                    fi
+                fi
+            done
+
+            # Check if we found any active HCAs
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                # Join the array elements with a comma
+                hca_port_pairs=()
+                for hca in "${active_hcas[@]}"; do
+                  hca_port_pairs+=("${hca}:1")
+                done
+
+                active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+                hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+                echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+                export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+                export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+                export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+                echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+                echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+                echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+            else
+                echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+            fi
+
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+                # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+                declare -A gid_index_count
+                declare -A hca_gid_index
+
+                for hca_name in "${active_hcas[@]}"; do
+                    echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                    # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                    for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                        if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                            idx=$(basename "$tpath")
+                            gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                            # Check for IPv4 GID (contains ffff:)
+                            if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                                gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                                echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                                hca_gid_index["${hca_name}"]="${idx}"
+                                gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                                break  # Use first found IPv4 GID per HCA
+                            fi
+                        fi
+                    done
+                done
+
+                # Find the most common GID index (most likely to be consistent across nodes)
+                best_gid_index=""
+                max_count=0
+                for idx in "${!gid_index_count[@]}"; do
+                    count=${gid_index_count["${idx}"]}
+                    echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                    if [ $count -gt $max_count ]; then
+                        max_count=$count
+                        best_gid_index="$idx"
+                    fi
+                done
+
+                # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+                if [ ${#gid_index_count[@]} -gt 1 ]; then
+                    echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                    # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                    if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                        best_gid_index="3"
+                        echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                    fi
+                fi
+
+                # Check if GID_INDEX is already set via environment variables
+                if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                    echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+                elif [ -n "$best_gid_index" ]; then
+                    echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                    export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                    echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+                else
+                    echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+                fi
+            else
+                echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+            fi
+          fi
+
+          START_RANK=0
+
+          # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+          # Older versions still need the blanket --disable-uvicorn-access-log.
+          ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+          fi
+          echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+          # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+          SHUTDOWN_TIMEOUT_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Template 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
+          fi
+
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          KV_TRANSFER_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+          fi
+
+          eval "exec vllm serve \
+            /mnt/models \
+            --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+            --port 8000 \
+            --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
+            {{- if .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+            {{- if .Spec.Prefill.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
+            --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
+            --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
+            --data-parallel-address ${DP_ADDRESS} \
+            --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+            --data-parallel-start-rank $START_RANK \
+            ${ACCESS_LOG_ARGS} \
+            ${SHUTDOWN_TIMEOUT_ARGS} \
+            ${KV_TRANSFER_ARGS} \
+            {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${VLLM_ADDITIONAL_ARGS} \
+            $@"
+        - --
+        env:
+        - name: HOME
+          value: /home
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: HF_HUB_CACHE
+          value: /models
+        image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "15"
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 10
+          timeoutSeconds: 1
+        name: main
+        ports:
+        - containerPort: 8000
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - IPC_LOCK
+            - SYS_RAWIO
+            - NET_RAW
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+          periodSeconds: 10
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /home
+          name: home
+        - mountPath: /tmp
+          name: tmp-dir
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /models
+          name: model-cache
+        - mountPath: /var/run/kserve/tls
+          name: tls-certs
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - emptyDir: {}
+        name: home
+      - emptyDir: {}
+        name: tmp-dir
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 8Gi
+        name: dshm
+      - emptyDir: {}
+        name: model-cache
+      - name: tls-certs
+        secret:
+          secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+    worker:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |-
+          # In some versions, ZMQ bind doesn't resolve the address through DNS
+          # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+          RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+          for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+            DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+            if [ -n "$DP_ADDRESS" ]; then
+              echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+              break
+            else
+              echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+              sleep 1
+            fi
+          done
+
+          if [ -z "$DP_ADDRESS" ]; then
+            echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+            DP_ADDRESS=${LWS_LEADER_ADDRESS}
+            echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+          fi
+
+          if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+            echo "Trying to infer RoCE configs ... "
+            grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+            grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+            cat /proc/driver/nvidia/params
+
+            KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+            echo "[Infer RoCE] Discovering active HCAs ..."
+            active_hcas=()
+            # Loop through all mlx5 devices found in sysfs
+            for hca_dir in /sys/class/infiniband/mlx5_*; do
+                # Ensure it's a directory before proceeding
+                if [ -d "$hca_dir" ]; then
+                    hca_name=$(basename "$hca_dir")
+                    port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                    type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                    echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                    if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                        echo "[Infer RoCE] Found active HCA: $hca_name"
+                        active_hcas+=("$hca_name")
+                    else
+                        echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                    fi
+                fi
+            done
+
+            # Check if we found any active HCAs
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                # Join the array elements with a comma
+                hca_port_pairs=()
+                for hca in "${active_hcas[@]}"; do
+                  hca_port_pairs+=("${hca}:1")
+                done
+
+                active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+                hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+                echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+                export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+                export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+                export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+                echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+                echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+                echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+            else
+                echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+            fi
+
+            if [ ${#active_hcas[@]} -gt 0 ]; then
+                echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+                # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+                declare -A gid_index_count
+                declare -A hca_gid_index
+
+                for hca_name in "${active_hcas[@]}"; do
+                    echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                    # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                    for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                        if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                            idx=$(basename "$tpath")
+                            gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                            # Check for IPv4 GID (contains ffff:)
+                            if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                                gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                                echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                                hca_gid_index["${hca_name}"]="${idx}"
+                                gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                                break  # Use first found IPv4 GID per HCA
+                            fi
+                        fi
+                    done
+                done
+
+                # Find the most common GID index (most likely to be consistent across nodes)
+                best_gid_index=""
+                max_count=0
+                for idx in "${!gid_index_count[@]}"; do
+                    count=${gid_index_count["${idx}"]}
+                    echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                    if [ $count -gt $max_count ]; then
+                        max_count=$count
+                        best_gid_index="$idx"
+                    fi
+                done
+
+                # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+                if [ ${#gid_index_count[@]} -gt 1 ]; then
+                    echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                    # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                    if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                        best_gid_index="3"
+                        echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                    fi
+                fi
+
+                # Check if GID_INDEX is already set via environment variables
+                if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                    echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                    echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+                elif [ -n "$best_gid_index" ]; then
+                    echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                    export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                    export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                    export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                    echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+                else
+                    echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+                fi
+            else
+                echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+            fi
+          fi
+
+          START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} ))
+
+          # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+          # Older versions still need the blanket --disable-uvicorn-access-log.
+          ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+          VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+          echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+            ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+          fi
+          echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+          # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+          SHUTDOWN_TIMEOUT_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+            SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ if .Spec.Prefill }}{{ shutdownTimeout .Spec.Prefill.Worker 15 }}{{ else }}{{ shutdownTimeout nil 15 }}{{ end }}"
+          fi
+
+          # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+          KV_TRANSFER_ARGS=""
+          if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+            if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+              KV_TRANSFER_ARGS="{{ if .Spec.Prefill }}{{ kvTransferConfig .Spec.Prefill.KVCacheOffloading }}{{ end }}"
+            fi
+          fi
+
+          eval "exec vllm serve \
+            /mnt/models \
+            --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+            --port 8000 \
+            {{- if .Spec.Prefill.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+            {{- if .Spec.Prefill.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
+            --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
+            --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
+            --data-parallel-address ${DP_ADDRESS} \
+            --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+            --data-parallel-start-rank $START_RANK \
+            --headless \
+            ${ACCESS_LOG_ARGS} \
+            ${SHUTDOWN_TIMEOUT_ARGS} \
+            ${KV_TRANSFER_ARGS} \
+            {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+            {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+            ${VLLM_ADDITIONAL_ARGS} \
+            $@"
+        - --
+        env:
+        - name: HOME
+          value: /home
+        - name: VLLM_LOGGING_LEVEL
+          value: INFO
+        - name: HF_HUB_CACHE
+          value: /models
+        image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sleep
+              - "15"
+        name: main
+        ports:
+        - containerPort: 8000
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - IPC_LOCK
+            - SYS_RAWIO
+            - NET_RAW
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /home
+          name: home
+        - mountPath: /tmp
+          name: tmp-dir
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /models
+          name: model-cache
+        - mountPath: /var/run/kserve/tls
+          name: tls-certs
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - emptyDir: {}
+        name: home
+      - emptyDir: {}
+        name: tmp-dir
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 8Gi
+        name: dshm
+      - emptyDir: {}
+        name: model-cache
+      - name: tls-certs
+        secret:
+          secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-router-route
+  namespace: kserve
+spec:
+  router:
+    route:
+      http:
+        spec:
+          parentRefs:
+          - group: gateway.networking.k8s.io
+            kind: Gateway
+            name: '{{ .GlobalConfig.IngressGatewayName }}'
+            namespace: '{{ .GlobalConfig.IngressGatewayNamespace }}'
+          rules:
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/completions
+            name: v1-completions-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/chat/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/chat/completions
+            name: v1-chat-completions-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
+            name: v1-responses-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/messages
+            name: v1-messages-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            matches:
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/chat/completions/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/responses/
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+              path:
+                type: Exact
+                value: /v1/messages/
+            name: v1-model-routing
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/completions
+            name: v1-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/chat/completions
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/chat/completions
+            name: v1-chat-completions-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/responses
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/responses
+            name: v1-responses-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - group: inference.networking.k8s.io
+              kind: InferencePool
+              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /v1/messages
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}/v1/messages
+            name: v1-messages-publisher-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+            name: v1-publisher-path-catch-all
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            filters:
+            - type: URLRewrite
+              urlRewrite:
+                path:
+                  replacePrefixMatch: /
+                  type: ReplacePrefixMatch
+            matches:
+            - path:
+                type: PathPrefix
+                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}
+            name: v1-catch-all-path
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+          - backendRefs:
+            - kind: Service
+              name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
+              port: 8000
+              weight: 1
+            matches:
+            - headers:
+              - name: '{{ .GlobalConfig.ModelBasedRoutingHeaderName }}'
+                type: Exact
+                value: publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name
+                  }}
+            name: v1-catch-all-model-routing
+            timeouts:
+              backendRequest: 0s
+              request: 0s
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-scheduler
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      annotations:
+        app.kubernetes.io/version: 0.10.0
+      pool:
+        spec:
+          endpointPickerRef:
+            failureMode: FailOpen
+            kind: Service
+            name: '{{ ChildName .ObjectMeta.Name `-epp-service` }}'
+            port:
+              number: 9002
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ .ObjectMeta.Name }}'
+              app.kubernetes.io/part-of: llminferenceservice
+              kserve.io/component: workload
+          targetPorts:
+          - number: 8000
+      template:
+        containers:
+        - command:
+          - /app/epp
+          - --pool-name
+          - '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
+          - --pool-namespace
+          - '{{ .ObjectMeta.Namespace }}'
+          - --zap-encoder
+          - json
+          - --grpc-port
+          - "9002"
+          - --grpc-health-port
+          - "9003"
+          - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
+            end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end
+            }}'
+          env:
+          - name: SSL_CERT_DIR
+            value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
+          image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.10.0
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sleep
+                - "15"
+          livenessProbe:
+            failureThreshold: 3
+            grpc:
+              port: 9003
+              service: liveness
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: main
+          ports:
+          - containerPort: 9002
+            name: grpc
+            protocol: TCP
+          - containerPort: 9003
+            name: grpc-health
+            protocol: TCP
+          - containerPort: 9090
+            name: metrics
+            protocol: TCP
+          - containerPort: 5557
+            name: zmq
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            grpc:
+              port: 9003
+              service: readiness
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 6
+              memory: 16Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /var/run/kserve/tls
+            name: tls-certs
+            readOnly: true
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - name: tls-certs
+          secret:
+            secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs`
+              }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-scheduler-latency-predictor
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      template:
+        containers:
+        - env:
+          - name: PREDICTION_SERVER_URL
+            value: http://localhost:8001
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MAX_SAMPLE_SIZE
+            value: "10000"
+          - name: LATENCY_MAX_CONCURRENT_DISPATCHES
+            value: "36"
+          - name: LATENCY_COALESCE_WINDOW_MS
+            value: "1"
+          name: main
+        - env:
+          - name: LATENCY_RETRAINING_INTERVAL_SEC
+            value: "10"
+          - name: LATENCY_MIN_SAMPLES_FOR_RETRAIN
+            value: "100"
+          - name: LATENCY_TTFT_MODEL_PATH
+            value: /models/ttft.joblib
+          - name: LATENCY_TPOT_MODEL_PATH
+            value: /models/tpot.joblib
+          - name: LATENCY_TTFT_SCALER_PATH
+            value: /models/ttft_scaler.joblib
+          - name: LATENCY_TPOT_SCALER_PATH
+            value: /models/tpot_scaler.joblib
+          - name: LATENCY_TTFT_GATED_MODEL_PATH
+            value: /models/ttft_gated.joblib
+          - name: LATENCY_TPOT_GATED_MODEL_PATH
+            value: /models/tpot_gated.joblib
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET
+            value: "500"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: ghcr.io/llm-d/llm-d-latency-predictor-training-server:0.9.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          name: training-server
+          ports:
+          - containerPort: 8000
+            name: training-port
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 4000m
+              memory: 8Gi
+            requests:
+              cpu: 2000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz
+              port: 8000
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /models
+            name: training-server-storage
+          - mountPath: /tmp
+            name: training-server-tmp
+        - env:
+          - name: TRAINING_SERVER_URL
+            value: http://localhost:8000
+          - name: LATENCY_MODEL_TYPE
+            value: xgboost
+          - name: PREDICT_HOST
+            value: 0.0.0.0
+          - name: PREDICT_PORT
+            value: "8001"
+          - name: LOCAL_TTFT_MODEL_PATH
+            value: /server_models/ttft.joblib
+          - name: LOCAL_TPOT_MODEL_PATH
+            value: /server_models/tpot.joblib
+          - name: LOCAL_TTFT_SCALER_PATH
+            value: /server_models/ttft_scaler.joblib
+          - name: LOCAL_TPOT_SCALER_PATH
+            value: /server_models/tpot_scaler.joblib
+          - name: LOCAL_TTFT_GATED_MODEL_PATH
+            value: /server_models/ttft_gated.joblib
+          - name: LOCAL_TPOT_GATED_MODEL_PATH
+            value: /server_models/tpot_gated.joblib
+          - name: UVICORN_WORKERS
+            value: "28"
+          - name: OMP_NUM_THREADS
+            value: "1"
+          - name: MODEL_SYNC_INTERVAL_SEC
+            value: "30"
+          - name: LATENCY_OBJECTIVE_TYPE
+            value: mean
+          image: ghcr.io/llm-d/llm-d-latency-predictor-prediction-server:0.9.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 8001
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          name: prediction-server
+          ports:
+          - containerPort: 8001
+            name: predict-port
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 28000m
+              memory: 8Gi
+            requests:
+              cpu: 8000m
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /readyz
+              port: 8001
+            periodSeconds: 10
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /server_models
+            name: prediction-server-storage
+          - mountPath: /tmp
+            name: prediction-server-tmp
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - emptyDir:
+            sizeLimit: 20Gi
+          name: training-server-storage
+        - emptyDir:
+            sizeLimit: 10Gi
+          name: prediction-server-storage
+        - emptyDir: {}
+          name: training-server-tmp
+        - emptyDir: {}
+          name: prediction-server-tmp
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-template
+  namespace: kserve
+spec:
+  annotations:
+    serving.kserve.io/model-based-routing-enabled: "true"
+  template:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8000 \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{- if and .Spec.Parallelism .Spec.Parallelism.Tensor }} --tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+        timeoutSeconds: 1
+      name: main
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 1
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 1Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - emptyDir: {}
+      name: tmp-dir
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-tokenizer
+  namespace: kserve
+spec:
+  router:
+    scheduler:
+      tokenizer:
+        template:
+          automountServiceAccountToken: false
+          containers:
+          - args: []
+            command:
+            - /bin/bash
+            - -c
+            - |-
+              exec vllm launch render /mnt/models/base \
+                --port=8000 \
+                {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh \
+                --ssl-certfile /var/run/kserve/tls/tls.crt \
+                --ssl-keyfile /var/run/kserve/tls/tls.key{{ end }}
+            env:
+            - name: HF_HOME
+              value: /tmp/hf
+            - name: DO_NOT_TRACK
+              value: "1"
+            image: docker.io/vllm/vllm-openai-cpu:v0.23.0@sha256:89e1fbe829038b1a560601990c8ec89625c622a969fcbc8f10ce48b6139795be
+            imagePullPolicy: IfNotPresent
+            name: main
+            ports:
+            - containerPort: 8000
+              name: render-http
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 60
+              httpGet:
+                path: /health
+                port: render-http
+                scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end
+                  }}'
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              timeoutSeconds: 5
+            resources:
+              limits:
+                cpu: "4"
+                memory: 12Gi
+              requests:
+                cpu: "1"
+                memory: 4Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              seccompProfile:
+                type: RuntimeDefault
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+            - mountPath: /var/run/kserve/tls
+              name: tls-certs
+              readOnly: true
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          volumes:
+          - emptyDir: {}
+            name: tmp-dir
+          - name: tls-certs
+            secret:
+              secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs`
+                }}'
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-tracing
+  namespace: kserve
+spec:
+  tracing:
+    exporter: otlp
+    exporterEndpoint: http://otel-collector:4317
+    sampler: parentbased_traceidratio
+    samplerArg: "0.05"
+---
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-worker-data-parallel
+  namespace: kserve
+spec:
+  annotations:
+    serving.kserve.io/model-based-routing-enabled: "true"
+  template:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        # In some versions, ZMQ bind doesn't resolve the address through DNS
+        # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+        RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+        for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+          DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+          if [ -n "$DP_ADDRESS" ]; then
+            echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+            break
+          else
+            echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+            sleep 1
+          fi
+        done
+
+        if [ -z "$DP_ADDRESS" ]; then
+          echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+          DP_ADDRESS=${LWS_LEADER_ADDRESS}
+          echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+        fi
+
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        START_RANK=0
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Template 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve \
+          /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8000 \
+          --api-server-count ${VLLM_API_SERVER_COUNT:-8} \
+          {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel{{- end }} \
+          {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+          --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
+          --data-parallel-address ${DP_ADDRESS} \
+          --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+          --data-parallel-start-rank $START_RANK \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+        timeoutSeconds: 1
+      name: main
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 2
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 1
+        timeoutSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - IPC_LOCK
+          - SYS_RAWIO
+          - NET_RAW
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        failureThreshold: 60
+        httpGet:
+          path: /health
+          port: 8000
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
+        periodSeconds: 10
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+  worker:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        # In some versions, ZMQ bind doesn't resolve the address through DNS
+        # Retry DP_ADDRESS resolution (configurable attempts, default 30)
+        RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
+        for ((i=1; i<=RESOLVE_ATTEMPTS; i++)); do
+          DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+          if [ -n "$DP_ADDRESS" ]; then
+            echo "DP_ADDRESS=${DP_ADDRESS} (resolved on attempt $i)"
+            break
+          else
+            echo "DP_ADDRESS resolution failed on attempt $i, retrying..."
+            sleep 1
+          fi
+        done
+
+        if [ -z "$DP_ADDRESS" ]; then
+          echo "WARNING: Failed to resolve DP_ADDRESS after ${RESOLVE_ATTEMPTS} attempts, falling back to LWS_LEADER_ADDRESS"
+          DP_ADDRESS=${LWS_LEADER_ADDRESS}
+          echo "DP_ADDRESS=${DP_ADDRESS} (fallback)"
+        fi
+
+        if [ "$KSERVE_INFER_ROCE" = "true" ]; then
+          echo "Trying to infer RoCE configs ... "
+          grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
+          grep -H . /sys/class/infiniband/*/ports/*/gid_attrs/types/* 2>/dev/null
+
+          cat /proc/driver/nvidia/params
+
+          KSERVE_INFER_IB_GID_INDEX_GREP=${KSERVE_INFER_IB_GID_INDEX_GREP:-"RoCE v2"}
+
+          echo "[Infer RoCE] Discovering active HCAs ..."
+          active_hcas=()
+          # Loop through all mlx5 devices found in sysfs
+          for hca_dir in /sys/class/infiniband/mlx5_*; do
+              # Ensure it's a directory before proceeding
+              if [ -d "$hca_dir" ]; then
+                  hca_name=$(basename "$hca_dir")
+                  port_state_file="$hca_dir/ports/1/state" # Assume port 1
+                  type_file="$hca_dir/ports/1/gid_attrs/types/*"
+
+                  echo "[Infer RoCE] Check if the port state file ${port_state_file} exists and contains 'ACTIVE'"
+                  if [ -f "$port_state_file" ] && grep -q "ACTIVE" "$port_state_file" && grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" ${type_file} 2>/dev/null; then
+                      echo "[Infer RoCE] Found active HCA: $hca_name"
+                      active_hcas+=("$hca_name")
+                  else
+                      echo "[Infer RoCE] Skipping inactive or down HCA: $hca_name"
+                  fi
+              fi
+          done
+
+          # Check if we found any active HCAs
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              # Join the array elements with a comma
+              hca_port_pairs=()
+              for hca in "${active_hcas[@]}"; do
+                hca_port_pairs+=("${hca}:1")
+              done
+
+              active_hca_list=$(IFS=,; echo "${active_hcas[*]}")
+              hca_port_pairs_list=$(IFS=,; echo "${hca_port_pairs[*]}")
+              echo "[Infer RoCE] Setting active HCAs: ${active_hca_list}"
+              export NCCL_IB_HCA=${NCCL_IB_HCA:-${active_hca_list}}
+              export NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST:-${hca_port_pairs_list}}
+              export UCX_NET_DEVICES=${UCX_NET_DEVICES:-${hca_port_pairs_list}}
+
+              echo "[Infer RoCE] NCCL_IB_HCA=${NCCL_IB_HCA}"
+              echo "[Infer RoCE] NVSHMEM_HCA_LIST=${NVSHMEM_HCA_LIST}"
+              echo "[Infer RoCE] UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+          else
+              echo "[Infer RoCE] WARNING: No active RoCE HCAs found. NCCL_IB_HCA will not be set."
+          fi
+
+          if [ ${#active_hcas[@]} -gt 0 ]; then
+              echo "[Infer RoCE] Finding GID_INDEX for each active HCA (SR-IOV compatible)..."
+
+              # For SR-IOV environments, find the most common IPv4 RoCE v2 GID index across all HCAs
+              declare -A gid_index_count
+              declare -A hca_gid_index
+
+              for hca_name in "${active_hcas[@]}"; do
+                  echo "[Infer RoCE] Processing HCA: ${hca_name}"
+
+                  # Find all RoCE v2 IPv4 GIDs for this HCA and count by index
+                  for tpath in /sys/class/infiniband/${hca_name}/ports/1/gid_attrs/types/*; do
+                      if grep -q "${KSERVE_INFER_IB_GID_INDEX_GREP}" "$tpath" 2>/dev/null; then
+                          idx=$(basename "$tpath")
+                          gid_file="/sys/class/infiniband/${hca_name}/ports/1/gids/${idx}"
+                          # Check for IPv4 GID (contains ffff:)
+                          if [ -f "$gid_file" ] && grep -q "ffff:" "$gid_file"; then
+                              gid_value=$(cat "$gid_file" 2>/dev/null || echo "")
+                              echo "[Infer RoCE] Found IPv4 RoCE v2 GID for ${hca_name}: index=${idx}, gid=${gid_value}"
+                              hca_gid_index["${hca_name}"]="${idx}"
+                              gid_index_count["${idx}"]=$((${gid_index_count["${idx}"]} + 1))
+                              break  # Use first found IPv4 GID per HCA
+                          fi
+                      fi
+                  done
+              done
+
+              # Find the most common GID index (most likely to be consistent across nodes)
+              best_gid_index=""
+              max_count=0
+              for idx in "${!gid_index_count[@]}"; do
+                  count=${gid_index_count["${idx}"]}
+                  echo "[Infer RoCE] GID_INDEX ${idx} found on ${count} HCAs"
+                  if [ $count -gt $max_count ]; then
+                      max_count=$count
+                      best_gid_index="$idx"
+                  fi
+              done
+
+              # Use deterministic fallback if tied - prefer index 3 (SR-IOV standard)
+              if [ ${#gid_index_count[@]} -gt 1 ]; then
+                  echo "[Infer RoCE] Multiple GID indices found, selecting most common: ${best_gid_index}"
+                  # If there's a tie, prefer index 3 as it's most common in SR-IOV setups
+                  if [ -n "${gid_index_count['3']}" ] && [ "${gid_index_count['3']}" -eq "$max_count" ]; then
+                      best_gid_index="3"
+                      echo "[Infer RoCE] Using deterministic fallback: GID_INDEX=3 (SR-IOV standard)"
+                  fi
+              fi
+
+              # Check if GID_INDEX is already set via environment variables
+              if [ -n "${NCCL_IB_GID_INDEX}" ]; then
+                  echo "[Infer RoCE] Using pre-configured NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} from environment"
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$NCCL_IB_GID_INDEX}
+                  echo "[Infer RoCE] Using pre-configured GID_INDEX=${NCCL_IB_GID_INDEX} for NCCL, NVSHMEM, and UCX"
+              elif [ -n "$best_gid_index" ]; then
+                  echo "[Infer RoCE] Selected GID_INDEX: ${best_gid_index} (found on ${max_count} HCAs)"
+
+                  export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-$best_gid_index}
+                  export NVSHMEM_IB_GID_INDEX=${NVSHMEM_IB_GID_INDEX:-$best_gid_index}
+                  export UCX_IB_GID_INDEX=${UCX_IB_GID_INDEX:-$best_gid_index}
+
+                  echo "[Infer RoCE] Exported GID_INDEX=${best_gid_index} for NCCL, NVSHMEM, and UCX"
+              else
+                  echo "[Infer RoCE] ERROR: No valid IPv4 ${KSERVE_INFER_IB_GID_INDEX_GREP} GID_INDEX found on any HCA."
+              fi
+          else
+              echo "[Infer RoCE] No active HCAs found, skipping GID_INDEX inference."
+          fi
+        fi
+
+        START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
+
+        # --disable-access-log-for-endpoints landed in vLLM 0.16.0 (vllm-project/vllm#30011).
+        # Older versions still need the blanket --disable-uvicorn-access-log.
+        ACCESS_LOG_ARGS="--disable-uvicorn-access-log"
+        VLLM_VERSION=$(vllm --version 2>/dev/null | tail -1 | awk '{print $NF}')
+        echo "[access-log-detect] vllm version='${VLLM_VERSION}'"
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.16.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.16.0" ]; then
+          ACCESS_LOG_ARGS="--disable-access-log-for-endpoints /health,/metrics,/ping"
+        fi
+        echo "[access-log-detect] selected ACCESS_LOG_ARGS='${ACCESS_LOG_ARGS}'"
+
+        # --shutdown-timeout landed in vLLM 0.18.0 (vllm-project/vllm#36666).
+        SHUTDOWN_TIMEOUT_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.18.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.18.0" ]; then
+          SHUTDOWN_TIMEOUT_ARGS="--shutdown-timeout {{ shutdownTimeout .Spec.Worker 15 }}"
+        fi
+
+        # --kv-transfer-config with OffloadingConnector requires vLLM 0.22.0+ (vllm-project/vllm#40020).
+        KV_TRANSFER_ARGS=""
+        if [[ "$VLLM_VERSION" =~ ^[0-9]+\.[0-9]+ ]] && [ "$(printf '%s\n%s\n' "0.22.0" "${VLLM_VERSION}" | sort -V | head -1)" = "0.22.0" ]; then
+          if [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv-transfer-config"* ]] && [[ "${VLLM_ADDITIONAL_ARGS:-}" != *"--kv_transfer_config"* ]] && [[ "$*" != *"--kv-transfer-config"* ]] && [[ "$*" != *"--kv_transfer_config"* ]]; then
+            KV_TRANSFER_ARGS="{{ kvTransferConfig .Spec.KVCacheOffloading }}"
+          fi
+        fi
+
+        eval "exec vllm serve \
+          /mnt/models \
+          --served-model-name "{{ .Spec.Model.Name }}" "publishers/{{ .ObjectMeta.Namespace }}/models/{{ .Spec.Model.Name }}" \
+          --port 8000 \
+          {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel{{- end }} \
+          {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
+          --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+          --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
+          --data-parallel-address ${DP_ADDRESS} \
+          --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
+          --data-parallel-start-rank $START_RANK \
+          --headless \
+          ${ACCESS_LOG_ARGS} \
+          ${SHUTDOWN_TIMEOUT_ARGS} \
+          ${KV_TRANSFER_ARGS} \
+          {{ if .GlobalConfig.EnableTLS }}--enable-ssl-refresh{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-certfile /var/run/kserve/tls/tls.crt{{- end }} \
+          {{ if .GlobalConfig.EnableTLS }}--ssl-keyfile /var/run/kserve/tls/tls.key{{- end }} \
+          ${VLLM_ADDITIONAL_ARGS} \
+          $@"
+      - --
+      env:
+      - name: HOME
+        value: /home
+      - name: VLLM_LOGGING_LEVEL
+        value: INFO
+      - name: HF_HUB_CACHE
+        value: /models
+      image: ghcr.io/llm-d/llm-d-cuda:v0.9.0
+      imagePullPolicy: IfNotPresent
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sleep
+            - "15"
+      name: main
+      ports:
+      - containerPort: 8000
+        protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          add:
+          - IPC_LOCK
+          - SYS_RAWIO
+          - NET_RAW
+          drop:
+          - ALL
+        readOnlyRootFilesystem: false
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /home
+        name: home
+      - mountPath: /tmp
+        name: tmp-dir
+      - mountPath: /dev/shm
+        name: dshm
+      - mountPath: /models
+        name: model-cache
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true
+    terminationGracePeriodSeconds: 60
+    volumes:
+    - emptyDir: {}
+      name: home
+    - emptyDir: {}
+      name: tmp-dir
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+      name: dshm
+    - emptyDir: {}
+      name: model-cache
+    - name: tls-certs
+      secret:
+        secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+KSERVE_LLMISVCCONFIG_MANIFEST_EOF
+}
+
+create_kserve_runtime_manifests() {
+    get_kserve_runtime_manifests | kubectl apply --server-side -f -
+}
+
+create_kserve_llmisvcconfig_manifests() {
+    get_kserve_llmisvcconfig_manifests | kubectl apply --server-side -f -
+}
+
+get_kserve_crd_manifest() {
+    cat <<'KSERVE_CRD_MANIFEST_EOF'
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: localmodelcaches.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: LocalModelCache
+    listKind: LocalModelCacheList
+    plural: localmodelcaches
+    singular: localmodelcache
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              modelSize:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              nodeGroups:
+                items:
+                  type: string
+                minItems: 1
+                type: array
+              serviceAccountName:
+                type: string
+              sourceModelUri:
+                type: string
+                x-kubernetes-validations:
+                - message: StorageUri is immutable
+                  rule: self == oldSelf
+              storage:
+                properties:
+                  key:
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+            required:
+            - modelSize
+            - nodeGroups
+            - sourceModelUri
+            type: object
+          status:
+            properties:
+              copies:
+                properties:
+                  available:
+                    type: integer
+                  failed:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              inferenceServices:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              llmInferenceServices:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              nodeStatus:
+                additionalProperties:
+                  enum:
+                  - ""
+                  - NodeNotReady
+                  - NodeDownloadPending
+                  - NodeDownloading
+                  - NodeDownloaded
+                  - NodeDownloadError
+                  type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: localmodelnamespacecaches.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: LocalModelNamespaceCache
+    listKind: LocalModelNamespaceCacheList
+    plural: localmodelnamespacecaches
+    singular: localmodelnamespacecache
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              modelSize:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              nodeGroups:
+                items:
+                  type: string
+                minItems: 1
+                type: array
+              serviceAccountName:
+                type: string
+              sourceModelUri:
+                type: string
+                x-kubernetes-validations:
+                - message: StorageUri is immutable
+                  rule: self == oldSelf
+              storage:
+                properties:
+                  key:
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+            required:
+            - modelSize
+            - nodeGroups
+            - sourceModelUri
+            type: object
+          status:
+            properties:
+              copies:
+                properties:
+                  available:
+                    type: integer
+                  failed:
+                    type: integer
+                  total:
+                    type: integer
+                type: object
+              inferenceServices:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              llmInferenceServices:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                type: array
+              nodeStatus:
+                additionalProperties:
+                  enum:
+                  - ""
+                  - NodeNotReady
+                  - NodeDownloadPending
+                  - NodeDownloading
+                  - NodeDownloaded
+                  - NodeDownloadError
+                  type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: localmodelnodegroups.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: LocalModelNodeGroup
+    listKind: LocalModelNodeGroupList
+    plural: localmodelnodegroups
+    singular: localmodelnodegroup
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              persistentVolumeClaimSpec:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  dataSource:
+                    properties:
+                      apiGroup:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSourceRef:
+                    properties:
+                      apiGroup:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  resources:
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  selector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  storageClassName:
+                    type: string
+                  volumeAttributesClassName:
+                    type: string
+                  volumeMode:
+                    type: string
+                  volumeName:
+                    type: string
+                type: object
+              persistentVolumeSpec:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  awsElasticBlockStore:
+                    properties:
+                      fsType:
+                        type: string
+                      partition:
+                        format: int32
+                        type: integer
+                      readOnly:
+                        type: boolean
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    properties:
+                      cachingMode:
+                        type: string
+                      diskName:
+                        type: string
+                      diskURI:
+                        type: string
+                      fsType:
+                        default: ext4
+                        type: string
+                      kind:
+                        type: string
+                      readOnly:
+                        default: false
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    properties:
+                      readOnly:
+                        type: boolean
+                      secretName:
+                        type: string
+                      secretNamespace:
+                        type: string
+                      shareName:
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  capacity:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  cephfs:
+                    properties:
+                      monitors:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretFile:
+                        type: string
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      user:
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  claimRef:
+                    properties:
+                      apiVersion:
+                        type: string
+                      fieldPath:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                      resourceVersion:
+                        type: string
+                      uid:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: granular
+                  csi:
+                    properties:
+                      controllerExpandSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      controllerPublishSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      driver:
+                        type: string
+                      fsType:
+                        type: string
+                      nodeExpandSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodePublishSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeStageSecretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      readOnly:
+                        type: boolean
+                      volumeAttributes:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      volumeHandle:
+                        type: string
+                    required:
+                    - driver
+                    - volumeHandle
+                    type: object
+                  fc:
+                    properties:
+                      fsType:
+                        type: string
+                      lun:
+                        format: int32
+                        type: integer
+                      readOnly:
+                        type: boolean
+                      targetWWNs:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      wwids:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  flexVolume:
+                    properties:
+                      driver:
+                        type: string
+                      fsType:
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    properties:
+                      datasetName:
+                        type: string
+                      datasetUUID:
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    properties:
+                      fsType:
+                        type: string
+                      partition:
+                        format: int32
+                        type: integer
+                      pdName:
+                        type: string
+                      readOnly:
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  glusterfs:
+                    properties:
+                      endpoints:
+                        type: string
+                      endpointsNamespace:
+                        type: string
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    properties:
+                      path:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    properties:
+                      chapAuthDiscovery:
+                        type: boolean
+                      chapAuthSession:
+                        type: boolean
+                      fsType:
+                        type: string
+                      initiatorName:
+                        type: string
+                      iqn:
+                        type: string
+                      iscsiInterface:
+                        default: default
+                        type: string
+                      lun:
+                        format: int32
+                        type: integer
+                      portals:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      targetPortal:
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
+                  local:
+                    properties:
+                      fsType:
+                        type: string
+                      path:
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  mountOptions:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  nfs:
+                    properties:
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      server:
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  nodeAffinity:
+                    properties:
+                      required:
+                        properties:
+                          nodeSelectorTerms:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  persistentVolumeReclaimPolicy:
+                    type: string
+                  photonPersistentDisk:
+                    properties:
+                      fsType:
+                        type: string
+                      pdID:
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  quobyte:
+                    properties:
+                      group:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      registry:
+                        type: string
+                      tenant:
+                        type: string
+                      user:
+                        type: string
+                      volume:
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    properties:
+                      fsType:
+                        type: string
+                      image:
+                        type: string
+                      keyring:
+                        default: /etc/ceph/keyring
+                        type: string
+                      monitors:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      pool:
+                        default: rbd
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      user:
+                        default: admin
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    properties:
+                      fsType:
+                        default: xfs
+                        type: string
+                      gateway:
+                        type: string
+                      protectionDomain:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sslEnabled:
+                        type: boolean
+                      storageMode:
+                        default: ThinProvisioned
+                        type: string
+                      storagePool:
+                        type: string
+                      system:
+                        type: string
+                      volumeName:
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  storageClassName:
+                    type: string
+                  storageos:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      volumeName:
+                        type: string
+                      volumeNamespace:
+                        type: string
+                    type: object
+                  volumeAttributesClassName:
+                    type: string
+                  volumeMode:
+                    type: string
+                  vsphereVolume:
+                    properties:
+                      fsType:
+                        type: string
+                      storagePolicyID:
+                        type: string
+                      storagePolicyName:
+                        type: string
+                      volumePath:
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                type: object
+              storageLimit:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+            required:
+            - persistentVolumeClaimSpec
+            - persistentVolumeSpec
+            - storageLimit
+            type: object
+          status:
+            properties:
+              available:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              used:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: localmodelnodes.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: LocalModelNode
+    listKind: LocalModelNodeList
+    plural: localmodelnodes
+    singular: localmodelnode
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              localModels:
+                items:
+                  properties:
+                    modelName:
+                      type: string
+                    namespace:
+                      type: string
+                    nodeGroup:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                    sourceModelUri:
+                      type: string
+                    storage:
+                      properties:
+                        key:
+                          type: string
+                        parameters:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                  required:
+                  - modelName
+                  - sourceModelUri
+                  type: object
+                type: array
+            required:
+            - localModels
+            type: object
+          status:
+            properties:
+              modelStatus:
+                additionalProperties:
+                  enum:
+                  - ""
+                  - ModelDownloadPending
+                  - ModelDownloading
+                  - ModelDownloaded
+                  - ModelDownloadError
+                  type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+KSERVE_CRD_MANIFEST_EOF
+}
+
+get_kserve_core_manifest() {
+    cat <<'KSERVE_CORE_MANIFEST_EOF'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/instance: kserve-localmodel-controller-manager
+    app.kubernetes.io/managed-by: kserve-localmodel-controller-manager
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/instance: kserve-localmodelnode-agent
+    app.kubernetes.io/managed-by: kserve-localmodelnode-agent
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodelnode-agent
+  namespace: kserve
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodel-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  - llminferenceservices
+  - localmodelnodegroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelcaches/status
+  - localmodelnamespacecaches/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelnodes/status
+  verbs:
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodelnode-agent-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - secrets
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterstoragecontainers
+  - localmodelnodegroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelnodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - localmodelnodes/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodel-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kserve-localmodel-manager-role
+subjects:
+- kind: ServiceAccount
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodelnode-agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kserve-localmodelnode-agent-role
+subjects:
+- kind: ServiceAccount
+  name: kserve-localmodelnode-agent
+  namespace: kserve
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: localmodel-webhook-server-service
+  namespace: kserve
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    control-plane: kserve-localmodel-controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-localmodel-controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+spec:
+  selector:
+    matchLabels:
+      control-plane: kserve-localmodel-controller-manager
+      controller-tools.k8s.io: "1.0"
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: kserve-localmodel-controller-manager
+        control-plane: kserve-localmodel-controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: kserve/kserve-localmodel-controller:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kserve-localmodel-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: localmodel-webhook-server-cert
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+    control-plane: kserve-localmodelnode-agent
+    controller-tools.k8s.io: "1.0"
+  name: kserve-localmodelnode-agent
+  namespace: kserve
+spec:
+  selector:
+    matchLabels:
+      control-plane: kserve-localmodelnode-agent
+      controller-tools.k8s.io: "1.0"
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: kserve-localmodelnode-agent
+        control-plane: kserve-localmodelnode-agent
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: kserve/kserve-localmodelnode-agent:latest
+        imagePullPolicy: Always
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /mnt/models
+          name: models
+          readOnly: false
+      nodeSelector:
+        kserve/localmodel: worker
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kserve-localmodelnode-agent
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - hostPath:
+          path: /models
+          type: DirectoryOrCreate
+        name: models
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: localmodel-serving-cert
+  namespace: kserve
+spec:
+  commonName: localmodel-webhook-server-service.kserve.svc
+  dnsNames:
+  - localmodel-webhook-server-service.kserve.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: localmodel-webhook-server-cert
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kserve/localmodel-serving-cert
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: localmodelcache.serving.kserve.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: localmodel-webhook-server-service
+      namespace: kserve
+      path: /validate-serving-kserve-io-v1alpha1-localmodelcache
+  failurePolicy: Fail
+  name: localmodelcache.kserve-webhook-server.validator
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - localmodelcaches
+  sideEffects: None
+KSERVE_CORE_MANIFEST_EOF
+}
+
+
+
+main "$@"

--- a/hack/setup/scripts/install-script-generator/pkg/manifest_builder.py
+++ b/hack/setup/scripts/install-script-generator/pkg/manifest_builder.py
@@ -100,48 +100,68 @@ def filter_out_crds(manifest: str) -> str:
     return YAML_SEPARATOR.join(filtered_documents)
 
 
-def get_llmisvc_value(config: dict[str, Any], components: list[dict[str, Any]]) -> str:
-    """Extract ENABLE_LLMISVC value from definition config.
+def _get_component_env_value(
+    config: dict[str, Any],
+    components: list[dict[str, Any]],
+    env_key: str,
+    default: str = "false",
+) -> str:
+    """Extract a single env value from definition config.
 
     Priority:
-    1. kserve-helm component env
-    2. kserve-kustomize component env
-    3. GLOBAL_ENV
-    4. Default: "false"
+    1. kserve-helm / kserve-kustomize component env (first match wins)
+    2. GLOBAL_ENV
+    3. default
+
+    Args:
+        config: Parsed definition config
+        components: List of component configs
+        env_key: Environment variable name to resolve
+        default: Default value if not found
+
+    Returns:
+        Normalized boolean string ("true" or "false")
+    """
+    for comp in components:
+        comp_name = comp.get("name", "")
+        if comp_name in ["kserve-helm", "kserve-kustomize"]:
+            comp_env = comp.get("env", {})
+            if env_key in comp_env:
+                return to_bool_string(comp_env[env_key])
+
+    global_env = config.get("global_env", {})
+    if env_key in global_env:
+        return to_bool_string(global_env[env_key])
+
+    return default
+
+
+def get_embed_component_values(
+    config: dict[str, Any], components: list[dict[str, Any]]
+) -> tuple[str, str]:
+    """Extract ENABLE_LLMISVC and ENABLE_LOCALMODEL from definition config.
 
     Args:
         config: Parsed definition config
         components: List of component configs
 
     Returns:
-        ENABLE_LLMISVC value ("true" or "false")
+        Tuple of (ENABLE_LLMISVC, ENABLE_LOCALMODEL) as "true" or "false"
     """
-    # Check kserve-helm or kserve-kustomize component env first (priority order)
-    for comp in components:
-        comp_name = comp.get("name", "")
-        if comp_name in ["kserve-helm", "kserve-kustomize"]:
-            comp_env = comp.get("env", {})
-            if "ENABLE_LLMISVC" in comp_env:
-                # Found in component env - use it and stop (first match wins)
-                return to_bool_string(comp_env["ENABLE_LLMISVC"])
-
-    # If not found in any component, check GLOBAL_ENV
-    global_env = config.get("global_env", {})
-    if "ENABLE_LLMISVC" in global_env:
-        return to_bool_string(global_env["ENABLE_LLMISVC"])
-
-    # Default
-    return "false"
+    llmisvc = _get_component_env_value(config, components, "ENABLE_LLMISVC")
+    localmodel = _get_component_env_value(config, components, "ENABLE_LOCALMODEL")
+    return llmisvc, localmodel
 
 
 def select_kserve_directories(
-    repo_root: Path, llmisvc: str
+    repo_root: Path, llmisvc: str, localmodel: str
 ) -> tuple[list[Path], list[Path]]:
     """Select KServe CRD and config directories based on ENABLE_LLMISVC.
 
     Args:
         repo_root: Repository root path
         llmisvc: ENABLE_LLMISVC value ("true" or "false")
+        localmodel: ENABLE_LOCALMODEL value ("true" or "false")
 
     Returns:
         Tuple of (crd_dirs, config_dirs)
@@ -152,6 +172,9 @@ def select_kserve_directories(
             repo_root / "config/crd/full/llmisvc",
         ]
         config_dirs = [repo_root / "config/overlays/standalone/llmisvc"]
+    elif localmodel == "true":
+        crd_dirs = [repo_root / "config/crd/full/localmodel"]
+        config_dirs = [repo_root / "config/overlays/addons/localmodel"]
     else:
         crd_dirs = [repo_root / "config/crd/full"]
         config_dirs = [repo_root / "config/overlays/standalone/kserve"]
@@ -172,8 +195,8 @@ def build_kserve_manifests(
     Returns:
         Tuple of (crd_manifest, core_manifest, runtime_manifest, llmisvcconfig_manifest)
     """
-    llmisvc = get_llmisvc_value(config, components)
-    crd_dirs, config_dirs = select_kserve_directories(repo_root, llmisvc)
+    llmisvc, localmodel = get_embed_component_values(config, components)
+    crd_dirs, config_dirs = select_kserve_directories(repo_root, llmisvc, localmodel)
 
     # Build CRD manifests from all CRD directories
     crd_manifests = []

--- a/hack/setup/scripts/install-script-generator/tests/test_manifest_builder.py
+++ b/hack/setup/scripts/install-script-generator/tests/test_manifest_builder.py
@@ -26,6 +26,45 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from pkg import manifest_builder  # noqa: E402
 
 
+def test_get_embed_component_values_from_component_env():
+    """Test resolving ENABLE_LLMISVC and ENABLE_LOCALMODEL from component env."""
+    config = {"global_env": {}}
+    components = [
+        {
+            "name": "kserve-kustomize",
+            "env": {"ENABLE_LLMISVC": "true", "ENABLE_LOCALMODEL": "False"},
+        }
+    ]
+
+    llmisvc, localmodel = manifest_builder.get_embed_component_values(
+        config, components
+    )
+
+    assert llmisvc == "true"
+    assert localmodel == "false"
+
+
+def test_get_embed_component_values_from_global_env():
+    """Test resolving values from GLOBAL_ENV when not in component env."""
+    config = {"global_env": {"ENABLE_LLMISVC": "yes", "ENABLE_LOCALMODEL": "1"}}
+    components = [{"name": "kserve-helm", "env": {}}]
+
+    llmisvc, localmodel = manifest_builder.get_embed_component_values(
+        config, components
+    )
+
+    assert llmisvc == "true"
+    assert localmodel == "true"
+
+
+def test_get_embed_component_values_defaults():
+    """Test default false when env keys are missing."""
+    llmisvc, localmodel = manifest_builder.get_embed_component_values({}, [])
+
+    assert llmisvc == "false"
+    assert localmodel == "false"
+
+
 def test_build_kserve_runtime_manifests_success(tmp_path, monkeypatch):
     """Test building runtime manifests successfully."""
     runtime_dir = tmp_path / "config/runtimes"


### PR DESCRIPTION
**What this PR does / why we need it**:

`hack/kserve-install.sh` did not install a specific past release using the frozen manifests under install/${VERSION}/. Developers testing or deploying an older KServe version had to run those scripts manually, and LocalModel could not be embedded correctly in generated full-install scripts.

- kserve-install.sh uses install/${VERSION}/ when --kserve-version differs from kserve-deps.env (no custom registry).
- Adds LocalModel quick-install definitions/scripts with embedded manifests.
- manifest_builder embeds LocalModel overlays when ENABLE_LOCALMODEL=true.
- Rejects --type localmodel if KServe version < v0.21.0.
  - from 0.21.0, the new localmodelcache script will be attached to the release.
  - 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note

```
