### PR TITLE
fix(autoscaler): validate external metric defaults and unsupported sources

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -448,13 +448,16 @@ func validateAutoScalingCompExtension(annotations map[string]string, compExtSpec
 	annotationClass := annotations[autoscaling.ClassAnnotationKey]
 	autoscalerClass := annotations[constants.AutoscalerClass]
 
-	switch deploymentMode {
+	switch string(constants.ParseDeploymentMode(deploymentMode)) {
 	case string(constants.Standard):
 		switch autoscalerClass {
-		case string(constants.AutoscalerClassHPA):
-			return validateScalingHPACompExtension(compExtSpec)
 		case string(constants.AutoscalerClassKeda):
 			return validateScalingKedaCompExtension(compExtSpec)
+		case string(constants.AutoscalerClassHPA), "":
+			// Default autoscaler class is HPA. Run HPA validation so that
+			// unsupported metric sources (e.g. External without KEDA) are
+			// rejected with a clear error instead of causing a controller panic.
+			return validateScalingHPACompExtension(compExtSpec)
 		}
 	default:
 		if annotationClass == autoscaling.HPA {

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -361,6 +361,45 @@ func TestAutoscalerClassHPA(t *testing.T) {
 			},
 			errMatcher: gomega.MatchError("[test] is not a supported autoscaler class type"),
 		},
+		"External metric without autoscalerClass keda is rejected (RawDeployment)": {
+			isvc: &InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": "RawDeployment",
+					},
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ComponentExtensionSpec: ComponentExtensionSpec{
+							AutoScaling: &AutoScalingSpec{
+								Metrics: []MetricsSpec{
+									{
+										Type: ExternalMetricSourceType,
+										External: &ExternalMetricSource{
+											Metric: ExternalMetrics{},
+											Target: MetricTarget{
+												Type:  ValueMetricType,
+												Value: NewMetricQuantity("10"),
+											},
+										},
+									},
+								},
+							},
+						},
+						Tensorflow: &TFServingSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://testbucket/testmodel"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			},
+			errMatcher: gomega.MatchError("invalid HPA metric source type with value [External]," +
+				"valid metric source types are Resource"),
+		},
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

When an `InferenceService` uses `deploymentMode: RawDeployment` (or the legacy `RawDeployment` value) and configures `autoScaling.metrics` with an `External` source without setting `serving.kserve.io/autoscalerClass: keda`, the KServe controller panics because the HPA reconciler receives a metric whose `Resource` field is nil.

The root cause is that `validateAutoScalingCompExtension` only ran HPA validation when `autoscalerClass: hpa` was explicitly set. With the default class (empty annotation) the validator returned early, so the invalid config was accepted.

Closes #4548

## Changes

- Parse and normalize `deploymentMode` with `constants.ParseDeploymentMode`, which maps the legacy `RawDeployment` value to `Standard`.
- For the `Standard` deployment path, run HPA validation not only when `autoscalerClass: hpa` is explicit, but also when the annotation is empty/missing (the default is HPA).
- Added a regression test that creates a `RawDeployment` `InferenceService` with an `External` metric and no `autoscalerClass`, asserting that validation returns a clear error instead of letting the config through.

## Testing

```bash
go test ./pkg/apis/serving/v1beta1 -run TestAutoscalerClassHPA -v
```

All scenarios pass, including the new `External metric without autoscalerClass keda is rejected (RawDeployment)` case.
