### PR TITLE
fix(huggingfaceserver): support the vLLM >= 0.25 renderer API

### DIFF
--- a/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
+++ b/python/huggingfaceserver/huggingfaceserver/vllm/vllm_model.py
@@ -142,12 +142,29 @@ class VLLMModel(OpenAIEncoderModel, OpenAIGenerativeModel):  # pylint:disable=c-
             )
             await self.openai_serving_models.init_static_loras()
 
-            from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+            # vLLM 0.25.0 replaced ``OpenAIServingRender``
+            # (``vllm.entrypoints.serve.render.serving``) with ``OnlineRenderer``
+            # (``vllm.renderers.online_renderer``), dropped its ``model_registry``
+            # argument, and renamed the keyword that ``OpenAIServingChat`` and
+            # ``OpenAIServingCompletion`` expect to ``online_renderer``.
+            try:
+                from vllm.renderers.online_renderer import OnlineRenderer
 
-            openai_serving_render = OpenAIServingRender(
+                renderer_cls = OnlineRenderer
+                renderer_kwarg = "online_renderer"
+                extra_renderer_args = {}
+            except ImportError:  # vLLM < 0.25.0
+                from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+
+                renderer_cls = OpenAIServingRender
+                renderer_kwarg = "openai_serving_render"
+                extra_renderer_args = {
+                    "model_registry": self.openai_serving_models.registry,
+                }
+
+            serving_renderer = renderer_cls(
                 model_config=vllm_config.model_config,
                 renderer=self.engine_client.renderer,
-                model_registry=self.openai_serving_models.registry,
                 request_logger=self.request_logger,
                 chat_template=resolved_chat_template,
                 chat_template_content_format=self.args.chat_template_content_format,
@@ -157,14 +174,16 @@ class VLLMModel(OpenAIEncoderModel, OpenAIGenerativeModel):  # pylint:disable=c-
                 tool_parser=self.args.tool_call_parser,
                 reasoning_parser=self.args.structured_outputs_config.reasoning_parser,
                 log_error_stack=self.args.log_error_stack,
+                **extra_renderer_args,
             )
+            renderer_kwargs = {renderer_kwarg: serving_renderer}
 
             self.openai_serving_chat = (
                 OpenAIServingChat(
                     self.engine_client,
                     self.openai_serving_models,
                     self.args.response_role,
-                    openai_serving_render=openai_serving_render,
+                    **renderer_kwargs,
                     request_logger=self.request_logger,
                     chat_template=resolved_chat_template,
                     chat_template_content_format=self.args.chat_template_content_format,
@@ -186,7 +205,7 @@ class VLLMModel(OpenAIEncoderModel, OpenAIGenerativeModel):  # pylint:disable=c-
                 OpenAIServingCompletion(
                     self.engine_client,
                     self.openai_serving_models,
-                    openai_serving_render=openai_serving_render,
+                    **renderer_kwargs,
                     request_logger=self.request_logger,
                     return_tokens_as_token_ids=self.args.return_tokens_as_token_ids,
                     enable_prompt_tokens_details=self.args.enable_prompt_tokens_details,


### PR DESCRIPTION
**What this PR does / why we need it**:

`huggingfaceserver` uses a vLLM renderer API that was removed in vLLM **0.25.0**, the release right after KServe's `vllm==0.24.0` pin. Serving any generative model with a newer vLLM fails at engine startup with `ModuleNotFoundError: No module named 'vllm.entrypoints.serve.render'`, and this is the default path (`--backend` defaults to `auto`).

Between 0.24.0 and 0.25.0 vLLM:

1. replaced `vllm.entrypoints.serve.render.serving.OpenAIServingRender` with `vllm.renderers.online_renderer.OnlineRenderer` (the entire `vllm/entrypoints/serve/render/` package is gone),
2. dropped the renderer's positional `model_registry` argument, and
3. renamed the required keyword-only argument of `OpenAIServingChat.__init__` and `OpenAIServingCompletion.__init__` from `openai_serving_render` to `online_renderer`.

Everything else about those three signatures is unchanged.

This PR selects the renderer class and its keyword at runtime, so `VLLMModel.start_engine()` works on both vLLM 0.24 and >= 0.25. It deliberately **leaves the `vllm==0.24.0` pin alone**, so it is a no-op for the versions KServe resolves and publishes today and does not touch any `uv.lock`, Dockerfile or CI pin. It only unblocks images rebuilt with `--build-arg VLLM_VERSION=0.25.0` or newer.

The alternative — bumping the pin to 0.27.1 and doing a bare rename — regenerates ~20 `uv.lock` files, touches both huggingface Dockerfiles and `tests/setup_vllm.sh`, and needs GPU/CPU e2e validation. I am happy to do that instead or as a follow-up if maintainers prefer; with this PR in, that bump becomes a pin-only change. The `try`/`except ImportError` shape matches the existing compatibility idiom in this subpackage (`vllm/utils.py`, `__main__.py`).

**Which issue(s) this PR fixes**:

Fixes #6065

**Feature/Issue validation/testing**:

I want to be upfront: **I could not test this at runtime.** I have no GPU available, and this code path needs a live vLLM engine. What I did instead is a static verification of the exact call sites against vLLM's published sources at each tag:

- [x] Enumerated every module `huggingfaceserver` imports from `vllm` and checked each path against the git trees of vLLM 0.24.0, 0.25.0, 0.26.0 and 0.27.1. Only the renderer module moved; all others still exist.
- [x] Parsed the real `__init__` definitions out of vLLM 0.24.0 / 0.25.0 / 0.27.1 with `ast`, rebuilt them as `inspect.Signature` objects, and bound the exact arguments this file passes. Both branches of the new code bind cleanly on all three tags. As a control, the current `master` arguments fail to bind on 0.25.0 and 0.27.1 with `missing a required keyword-only argument: 'online_renderer'`, which is the bug.
- [x] Did the same for the neighbouring call sites that were *not* changed — `OpenAIServingModels`, `ServingEmbedding` / `PoolingServing`, `ServingScores`, `AsyncLLM.from_vllm_config`, `create_chat_completion`, `create_completion`, `PoolingServing.__call__` — plus `ChatTemplateConfig`, `load_chat_template`, `EngineClient.renderer`, `EngineClient.get_supported_tasks`, and every `FrontendArgs`/`EngineArgs` field read via `self.args.*`. All unchanged between 0.24.0 and 0.27.1, which is why the diff is this small.
- [x] `ruff format --check` and `ruff check` with the repo's `ruff.toml`.
- [ ] Runtime / e2e against vLLM >= 0.25. **Not done** — no GPU. This is the reason the PR is a draft; a maintainer with GPU CI running an actual chat/completions request against 0.27.1 is what it needs.

Note that CI does not cover the new branch either way: the unit-test job runs with `-k 'not test_vllm'`, and `tests/setup_vllm.sh` and both Dockerfiles still install 0.24.0, which exercises only the `except ImportError` path. That path is byte-for-byte the current behaviour.

No unit test is included because the renderer construction is inline in `start_engine()` and needs a live engine client. If you would like one, I can extract the selection into a small helper and unit-test it with fakes — say the word and I will add it.

**Special notes for your reviewer**:

I am not a KServe contributor; I found this while packaging KServe components. Please push back on the approach if you would rather see a straight pin bump.
