### PR TITLE
chore(llmisvc): remove deprecated plugin and rename flag

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -240,7 +240,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
@@ -588,7 +588,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -277,7 +277,7 @@ spec:
         command:
           - "/app/pd-sidecar"
           - "--port=8000"
-          - "--vllm-port=8001"
+          - "--model-server-port=8001"
           - "--kv-connector=nixlv2"
           - "--enable-ssrf-protection=true"
           - "--pool-group=inference.networking.x-k8s.io"

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -47,7 +47,7 @@ spec:
         command:
           - "/app/pd-sidecar"
           - "--port=8000"
-          - "--vllm-port=8001"
+          - "--model-server-port=8001"
           - "--kv-connector=nixlv2"
           - "--enable-ssrf-protection=true"
           - "--pool-group=inference.networking.x-k8s.io"

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2861,7 +2861,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
@@ -3209,7 +3209,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2443,7 +2443,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
@@ -2791,7 +2791,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io

--- a/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/llmisvc-full-install-with-manifests.sh
@@ -2835,7 +2835,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
@@ -3183,7 +3183,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io

--- a/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
@@ -2443,7 +2443,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
@@ -2791,7 +2791,7 @@ spec:
     - command:
       - /app/pd-sidecar
       - --port=8000
-      - --vllm-port=8001
+      - --model-server-port=8001
       - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -104,7 +104,7 @@ func TestPresetFiles(t *testing.T) {
 									Command: []string{
 										"/app/pd-sidecar",
 										"--port=8000",
-										"--vllm-port=8001",
+										"--model-server-port=8001",
 										"--kv-connector=nixlv2",
 										"--enable-ssrf-protection=true",
 										"--pool-group=inference.networking.x-k8s.io",

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -482,8 +482,7 @@ schedulingProfiles:
 			// Verify P/D config (should contain prefill-filter, decode-filter, disagg-profile-handler, etc.)
 			configText, found := getSchedulerConfigText(expectedDeployment)
 			Expect(found).To(BeTrue(), "Expected P/D config in scheduler deployment")
-			// P/D config should contain these plugins (using new v0.7.0 names)
-			Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+			// P/D config should contain these plugins
 			Expect(configText).To(ContainSubstring("prefill-filter"))
 			Expect(configText).To(ContainSubstring("decode-filter"))
 			Expect(configText).To(ContainSubstring("disagg-profile-handler"))

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -1088,32 +1088,39 @@ func WithRenamePlugin(oldType, newType string) mutateSchedulerConfigFunc {
 // schedulingProfiles.
 func WithRemovePlugin(pluginType string) mutateSchedulerConfigFunc {
 	return func(_ context.Context, u *unstructured.Unstructured) error {
+		removedNames := map[string]bool{pluginType: true}
+
 		val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
-		if err != nil || !found {
+		if err != nil {
 			return err
 		}
-		plugins, ok := val.([]interface{})
-		if !ok {
-			return nil
-		}
-
-		filtered := make([]interface{}, 0, len(plugins))
-		for _, plugin := range plugins {
-			pluginMap, ok := plugin.(map[string]interface{})
-			if !ok {
-				filtered = append(filtered, plugin)
-				continue
+		if found {
+			if plugins, ok := val.([]interface{}); ok {
+				filtered := make([]interface{}, 0, len(plugins))
+				for _, plugin := range plugins {
+					pluginMap, ok := plugin.(map[string]interface{})
+					if !ok {
+						filtered = append(filtered, plugin)
+						continue
+					}
+					if pluginMap["type"] == pluginType {
+						if name, ok := pluginMap["name"].(string); ok {
+							removedNames[name] = true
+						}
+						continue
+					}
+					filtered = append(filtered, plugin)
+				}
+				u.Object["plugins"] = filtered
 			}
-			if pluginMap["type"] == pluginType {
-				continue
-			}
-			filtered = append(filtered, plugin)
 		}
-		u.Object["plugins"] = filtered
 
 		profiles, found, err := unstructured.NestedFieldNoCopy(u.Object, "schedulingProfiles")
-		if err != nil || !found {
+		if err != nil {
 			return err
+		}
+		if !found {
+			return nil
 		}
 		profileList, ok := profiles.([]interface{})
 		if !ok {
@@ -1124,7 +1131,10 @@ func WithRemovePlugin(pluginType string) mutateSchedulerConfigFunc {
 			if !ok {
 				continue
 			}
-			pluginRefs, found, _ := unstructured.NestedFieldNoCopy(profileMap, "plugins")
+			pluginRefs, found, err := unstructured.NestedFieldNoCopy(profileMap, "plugins")
+			if err != nil {
+				return err
+			}
 			if !found {
 				continue
 			}
@@ -1139,7 +1149,7 @@ func WithRemovePlugin(pluginType string) mutateSchedulerConfigFunc {
 					filteredRefs = append(filteredRefs, ref)
 					continue
 				}
-				if refMap["pluginRef"] == pluginType {
+				if name, _ := refMap["pluginRef"].(string); removedNames[name] {
 					continue
 				}
 				filteredRefs = append(filteredRefs, ref)

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -556,7 +556,6 @@ func schedulerConfigText(llmSvc *v1alpha2.LLMInferenceService) string {
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: disagg-headers-handler
 - type: prefill-filter
 - type: decode-filter
 - type: queue-scorer
@@ -1084,6 +1083,74 @@ func WithRenamePlugin(oldType, newType string) mutateSchedulerConfigFunc {
 	}
 }
 
+// WithRemovePlugin returns a mutateSchedulerConfigFunc that removes a plugin
+// by type from the plugins array and removes matching pluginRef entries from
+// schedulingProfiles.
+func WithRemovePlugin(pluginType string) mutateSchedulerConfigFunc {
+	return func(_ context.Context, u *unstructured.Unstructured) error {
+		val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+		if err != nil || !found {
+			return err
+		}
+		plugins, ok := val.([]interface{})
+		if !ok {
+			return nil
+		}
+
+		filtered := make([]interface{}, 0, len(plugins))
+		for _, plugin := range plugins {
+			pluginMap, ok := plugin.(map[string]interface{})
+			if !ok {
+				filtered = append(filtered, plugin)
+				continue
+			}
+			if pluginMap["type"] == pluginType {
+				continue
+			}
+			filtered = append(filtered, plugin)
+		}
+		u.Object["plugins"] = filtered
+
+		profiles, found, err := unstructured.NestedFieldNoCopy(u.Object, "schedulingProfiles")
+		if err != nil || !found {
+			return err
+		}
+		profileList, ok := profiles.([]interface{})
+		if !ok {
+			return nil
+		}
+		for _, profile := range profileList {
+			profileMap, ok := profile.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			pluginRefs, found, _ := unstructured.NestedFieldNoCopy(profileMap, "plugins")
+			if !found {
+				continue
+			}
+			refList, ok := pluginRefs.([]interface{})
+			if !ok {
+				continue
+			}
+			filteredRefs := make([]interface{}, 0, len(refList))
+			for _, ref := range refList {
+				refMap, ok := ref.(map[string]interface{})
+				if !ok {
+					filteredRefs = append(filteredRefs, ref)
+					continue
+				}
+				if refMap["pluginRef"] == pluginType {
+					continue
+				}
+				filteredRefs = append(filteredRefs, ref)
+			}
+			profileMap["plugins"] = filteredRefs
+		}
+
+		return nil
+	}
+}
+
 // WithMigrateDisaggProfileParams migrates the disagg-profile-handler (formerly
 // pd-profile-handler) from the old flat deciderPluginName/threshold parameters
 // to the new deciders map structure introduced in llm-d-router v0.7.0.
@@ -1371,6 +1438,9 @@ func hasDeprecatedMetricFlags(d *appsv1.Deployment) bool {
 //  7. withMetricsDataSourceParams – move --model-server-metrics-{scheme,path,
 //     https-insecure-skip-verify} into the metrics-data-source plugin parameters
 //     and strip --model-server-metrics-port (v0.10.0+, flags removed in llm-d-router)
+//  8. WithRemovePlugin – strip disagg-headers-handler, prefill-header-handler,
+//     and pd-profile-handler (v0.11.0+, disagg-headers-handler removed from
+//     llm-d-router; the other two are legacy names from prior renames)
 func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alpha2.LLMInferenceService, enableTLS bool) error {
 	version, ok := d.Spec.Template.Annotations["app.kubernetes.io/version"]
 	if !ok || version == "" {
@@ -1461,6 +1531,18 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alp
 				opts = append(opts, withMetricsDataSourceParams(parameters))
 			}
 		}
+	}
+
+	// llm-d-router v0.11.0 removes the disagg-headers-handler plugin entirely:
+	// - prefill-header-handler  (pre-v0.7.0 name, renamed to disagg-headers-handler) to support upgrade from pre-v0.7 to 0.11
+	// - pd-profile-handler      (pre-v0.7.0 name, renamed to disagg-headers-handler) to support upgrade from pre-v0.7 to 0.11
+	// - disagg-headers-handler  (v0.7.0 name, no longer recognised by router after 0.11.0)
+	if v.Compare(*semver.New("0.11.0")) >= 0 {
+		opts = append(opts,
+			WithRemovePlugin("prefill-header-handler"),
+			WithRemovePlugin("disagg-headers-handler"),
+			WithRemovePlugin("pd-profile-handler"),
+		)
 	}
 
 	if err := mutateSchedulerConfig(ctx, d, opts...); err != nil {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -755,6 +755,46 @@ schedulingProfiles:
 				g.Expect(profilePlugins[0].(map[string]interface{})["pluginRef"]).To(Equal("queue-scorer"))
 			},
 		},
+		{
+			name: "removes aliased pluginRef when plugin has a name",
+			configYAML: `
+plugins:
+- type: disagg-headers-handler
+  name: headers
+- type: queue-scorer
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: headers
+  - pluginRef: queue-scorer
+`,
+			pluginType: "disagg-headers-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+
+				profiles := obj["schedulingProfiles"].([]interface{})
+				profilePlugins := profiles[0].(map[string]interface{})["plugins"].([]interface{})
+				g.Expect(profilePlugins).To(HaveLen(1))
+				g.Expect(profilePlugins[0].(map[string]interface{})["pluginRef"]).To(Equal("queue-scorer"))
+			},
+		},
+		{
+			name: "no plugins field - still removes pluginRef from profiles",
+			configYAML: `
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: disagg-headers-handler
+`,
+			pluginType: "disagg-headers-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				profiles := obj["schedulingProfiles"].([]interface{})
+				profilePlugins := profiles[0].(map[string]interface{})["plugins"].([]interface{})
+				g.Expect(profilePlugins).To(BeEmpty())
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -764,7 +804,7 @@ schedulingProfiles:
 			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
 			u := unstructured.Unstructured{Object: obj}
 			fn := WithRemovePlugin(tt.pluginType)
-			g.Expect(fn(context.Background(), &u)).To(Succeed())
+			g.Expect(fn(t.Context(), &u)).To(Succeed())
 			tt.validate(g, u.Object)
 		})
 	}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -663,22 +663,22 @@ plugins:
 			name: "renames pluginRef in schedulingProfiles",
 			configYAML: `
 plugins:
-- type: pd-profile-handler
+- type: prefill-header-handler
 schedulingProfiles:
 - name: default
   plugins:
-  - pluginRef: pd-profile-handler
+  - pluginRef: prefill-header-handler
   - pluginRef: queue-scorer
 `,
-			oldType: "pd-profile-handler",
-			newType: "disagg-profile-handler",
+			oldType: "prefill-header-handler",
+			newType: "disagg-headers-handler",
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
-				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("disagg-profile-handler"))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("disagg-headers-handler"))
 
 				profiles := obj["schedulingProfiles"].([]interface{})
 				profilePlugins := profiles[0].(map[string]interface{})["plugins"].([]interface{})
-				g.Expect(profilePlugins[0].(map[string]interface{})["pluginRef"]).To(Equal("disagg-profile-handler"))
+				g.Expect(profilePlugins[0].(map[string]interface{})["pluginRef"]).To(Equal("disagg-headers-handler"))
 				g.Expect(profilePlugins[1].(map[string]interface{})["pluginRef"]).To(Equal("queue-scorer"))
 			},
 		},
@@ -691,6 +691,79 @@ schedulingProfiles:
 			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
 			u := unstructured.Unstructured{Object: obj}
 			fn := WithRenamePlugin(tt.oldType, tt.newType)
+			g.Expect(fn(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
+func TestWithRemovePlugin(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		pluginType string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "removes matching plugin",
+			configYAML: `
+plugins:
+- type: disagg-headers-handler
+- type: queue-scorer
+`,
+			pluginType: "disagg-headers-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+			},
+		},
+		{
+			name: "no match - no change",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			pluginType: "disagg-headers-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+			},
+		},
+		{
+			name: "removes plugin and matching pluginRef from schedulingProfiles",
+			configYAML: `
+plugins:
+- type: prefill-header-handler
+- type: queue-scorer
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: prefill-header-handler
+  - pluginRef: queue-scorer
+`,
+			pluginType: "prefill-header-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+
+				profiles := obj["schedulingProfiles"].([]interface{})
+				profilePlugins := profiles[0].(map[string]interface{})["plugins"].([]interface{})
+				g.Expect(profilePlugins).To(HaveLen(1))
+				g.Expect(profilePlugins[0].(map[string]interface{})["pluginRef"]).To(Equal("queue-scorer"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			fn := WithRemovePlugin(tt.pluginType)
 			g.Expect(fn(context.Background(), &u)).To(Succeed())
 			tt.validate(g, u.Object)
 		})
@@ -1457,6 +1530,18 @@ plugins:
 				g.Expect(configText).To(ContainSubstring("pd-profile-handler"))
 				g.Expect(configText).To(ContainSubstring("deciderPluginName"))
 				g.Expect(configText).To(ContainSubstring("hashBlockSize"))
+			},
+		},
+		{
+			name:    "v0.11.0 strips all legacy disagg plugin names",
+			version: "0.11.0",
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+				g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Prepares the llmisvc scheduler migration pipeline for llm-d-router v0.11.0 image, which will remove `disagg-headers-handler` plugin , the rename of  `--vllm-port` flag to `--model-server-port` has been done in 0.10.0 for deprecation 2 releases.

Changes:
- Remove `disagg-headers-handler` from the default EndpointPickerConfig template (fresh deployments no longer emit it)
- Rename` --vllm-port` to` --model-server-port` in all pd-sidecar llmisvcconfig 
- Add WithRemovePlugin migration helper and wire a v0.11.0 gated step that strips `disagg-headers-handler` `prefill-header-handler` and `pd-profile-handler `from existing user configs on upgrade

The version annotation in the scheduler template stays at 0.10.0 for now; when the router image is bumped to 0.11.0 in a later release, the annotation bump will activate the removal migration.

**Feature/Issue validation/testing**:

new test for TestWithRemovePlugin


**Special notes for your reviewer**:

**Release note**:
```release-note
Remove deprecated disagg-headers-handler plugin from default scheduler config and add v0.11.0-gated migration to strip legacy plugin names (prefill-header-handler, disagg-headers-handler, pd-profile-handler) from existing configs. Rename --vllm-port to --model-server-port in pd-sidecar configs.
```
