### PR TITLE
feat: added power support for pmmlserver component

### DIFF
--- a/.github/workflows/pmml-ppc64le-docker-publish.yml
+++ b/.github/workflows/pmml-ppc64le-docker-publish.yml
@@ -1,0 +1,129 @@
+name: PMMLServer ppc64le Docker Publisher
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+    paths:
+      - "python/**"
+      - "!.github/**"
+      - "!docs/**"
+      - "!**.md"
+      - ".github/workflows/pmml-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
+
+env:
+  IMAGE_NAME: pmmlserver
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Merge target branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --unshallow origin
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
+      - name: Run tests
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/ppc64le
+          context: python
+          file: python/pmml.Dockerfile
+          push: false
+          # https://github.com/docker/buildx/issues/1533
+          provenance: false
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Export version variable
+        run: |
+          IMAGE_ID=kserve/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: ppc64le
+          context: python
+          file: python/pmml.Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
+          # https://github.com/docker/buildx/issues/1533
+          provenance: false
+          sbom: true

--- a/python/pmml.Dockerfile
+++ b/python/pmml.Dockerfile
@@ -7,7 +7,32 @@ FROM ${BASE_IMAGE} AS builder
 
 ARG PYTHON_VERSION
 # Install python
-RUN apt-get update && \
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    "python${PYTHON_VERSION}" \
+    "python${PYTHON_VERSION}-dev" \
+    "python${PYTHON_VERSION}-venv" \
+    python3-pip \
+    curl \
+    wget \
+    libssl-dev \
+    pkg-config \
+    libopenblas-dev \
+    apt-transport-https \
+    gpg \
+    gcc build-essential \
+    libjpeg-dev \
+    zlib1g-dev \
+    libtiff-dev \
+    libfreetype6-dev \
+    liblcms2-dev \
+    libwebp-dev \
+    libopenjp2-7-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*; \
+    else \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     "python${PYTHON_VERSION}" \
     "python${PYTHON_VERSION}-dev" \
@@ -16,7 +41,8 @@ RUN apt-get update && \
     curl \
     gcc build-essential && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    fi
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
@@ -33,27 +59,146 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+
+# On ppc64le: patch pyproject.toml to add the ppc64le package index and sources,
+# then regenerate uv.lock before syncing.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^index-strategy\s*=.*/a \\' \
+            -e '/^index-strategy\s*=.*/a [[tool.uv.index]]' \
+            -e '/^index-strategy\s*=.*/a name = "ppc64le-wheels"' \
+            -e '/^index-strategy\s*=.*/a url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            -e '/^index-strategy\s*=.*/a explicit = true' \
+            -e '/^\s*"pyasn1>=[^,]*"$/s/"$/",/' \
+            -e '/^\s*"pyasn1>=/a\    "httptools==0.6.4",' \
+            -e '/^\s*"pyasn1>=/a\    "uvloop==0.21.0",' \
+            -e '/^kserve-storage\s*=.*/a grpcio = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a grpcio-tools = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a numpy = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pandas = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a psutil = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pyyaml = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a httptools = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a uvloop = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a scikit-learn = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pillow = { index = "ppc64le-wheels" }' \
+            kserve/pyproject.toml && \
+        cd kserve && uv lock && \
+        cp uv.lock /tmp/kserve_ppc64le_uv.lock && \
+        cp pyproject.toml /tmp/kserve_ppc64le_pyproject.toml; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+
+# On ppc64le: restore the patched pyproject.toml + uv.lock after COPY overwrites them
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        rm -f kserve/pyproject.toml kserve/uv.lock && \
+        cp /tmp/kserve_ppc64le_pyproject.toml kserve/pyproject.toml && \
+        cp /tmp/kserve_ppc64le_uv.lock kserve/uv.lock && \
+        rm -f /tmp/kserve_ppc64le_pyproject.toml /tmp/kserve_ppc64le_uv.lock; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd kserve && uv sync --active
 
 # Install kserve-storage
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
+
+# On ppc64le: append ppc64le index + sources to storage/pyproject.toml,
+# regenerate uv.lock, then sync (same pattern as kserve/lgbserver).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^    "pyasn1>=[^,]*"$/s/"$/",/' \
+            -e '/^    "pyasn1>=/a\    "google-crc32c==1.7.1",' \
+            -e '/^    "pyasn1>=/a\    "pyyaml==6.0.2",' \
+            storage/pyproject.toml && \
+        printf '%s\n' \
+            '' \
+            '[tool.uv]' \
+            'index-strategy = "unsafe-best-match"' \
+            'package = true' \
+            '' \
+            '[build-system]' \
+            'requires = ["setuptools>=61.0"]' \
+            'build-backend = "setuptools.build_meta"' \
+            '' \
+            '[[tool.uv.index]]' \
+            'name = "ppc64le-wheels"' \
+            'url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            'explicit = true' \
+            '' \
+            '[tool.uv.sources]' \
+            'google-crc32c = { index = "ppc64le-wheels" }' \
+            'hf-xet = { index = "ppc64le-wheels" }' \
+            'pyyaml = { index = "ppc64le-wheels" }' \
+            >> storage/pyproject.toml && \
+        cd storage && uv lock && \
+        uv sync --active; \
+    else \
+        cd storage && uv pip install .; \
+    fi
 
 # Install dependencies for pmmlserver using uv
 COPY pmmlserver/pyproject.toml pmmlserver/uv.lock pmmlserver/
-RUN cd pmmlserver && uv sync --active --no-cache
+
+# On ppc64le: add transitive deps that need wheel pinning, append the ppc64le
+# index + sources to pmmlserver/pyproject.toml, then regenerate uv.lock.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^\s*"setuptools<71\.0\.0,>=70\.0\.0",$/a\    "pyjnius==1.6.1",' \
+            -e '/^\s*"setuptools<71\.0\.0,>=70\.0\.0",$/a\    "jpype1==1.5.2",' \
+            -e '/^\s*"setuptools<71\.0\.0,>=70\.0\.0",$/a\    "hf-xet==1.5.1",' \
+            -e '/^\s*"setuptools<71\.0\.0,>=70\.0\.0",$/a\    "google-crc32c==1.7.1",' \
+            pmmlserver/pyproject.toml && \
+        printf '%s\n' \
+            '' \
+            '[tool.uv]' \
+            'index-strategy = "unsafe-best-match"' \
+            '' \
+            '[[tool.uv.index]]' \
+            'name = "ppc64le-wheels"' \
+            'url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            'explicit = true' \
+            '' \
+            '[tool.uv.sources]' \
+            'pyjnius = { index = "ppc64le-wheels" }' \
+            'hf-xet = { index = "ppc64le-wheels" }' \
+            'google-crc32c = { index = "ppc64le-wheels" }' \
+            'jpype1 = { index = "ppc64le-wheels" }' \
+            >> pmmlserver/pyproject.toml && \
+        cd pmmlserver && uv lock && \
+        cp uv.lock /tmp/pmmlserver_ppc64le_uv.lock && \
+        cp pyproject.toml /tmp/pmmlserver_ppc64le_pyproject.toml; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd pmmlserver && uv sync --active
 
 COPY pmmlserver pmmlserver
-RUN cd pmmlserver && uv sync --active --no-cache
+
+# On ppc64le: restore the patched pyproject.toml + uv.lock after COPY overwrites them, then clean up
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        rm -f pmmlserver/pyproject.toml pmmlserver/uv.lock && \
+        cp /tmp/pmmlserver_ppc64le_pyproject.toml pmmlserver/pyproject.toml && \
+        cp /tmp/pmmlserver_ppc64le_uv.lock pmmlserver/uv.lock && \
+        rm -f /tmp/pmmlserver_ppc64le_pyproject.toml /tmp/pmmlserver_ppc64le_uv.lock; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd pmmlserver && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml
 COPY third_party/pip-licenses.py pip-licenses.py
 # TODO: Remove this when upgrading to python 3.11+
-RUN uv pip install --no-cache-dir tomli
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ---------- Production image ----------


### PR DESCRIPTION
**What this PR does / why we need it**: We have updated the existing Dockerfile and added a new workflow for PmmlServer to add Power support.

**Feature/Issue validation/testing**:

```
ubuntu@pytorch-5:~/kserve-testing/pmml/model$ docker run --rm -p 8080:8080 \
  -v ~/kserve-testing/pmml/model:/mnt/models \
  pmmlserver-ppc64le:latest \
  --model_name=pmml-demo \
  --model_dir=/mnt/models
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
2026-08-13 05:02:31.175 1 kserve INFO [model_server.py:register_model():439] Registering model: pmml-demo
2026-08-13 05:02:31.176 1 kserve INFO [model_server.py:setup_event_loop():315] Setting max asyncio worker threads as 20
2026-08-13 05:02:31.302 1 kserve INFO [server.py:_register_endpoints():124] OpenAI endpoints not registered
2026-08-13 05:02:31.302 1 kserve INFO [server.py:_register_endpoints():132] Time series endpoints not registered
2026-08-13 05:02:31.302 1 kserve INFO [server.py:start():183] Starting uvicorn with 1 workers
2026-08-13 05:02:31.367 1 uvicorn.error INFO:     Started server process [1]
2026-08-13 05:02:31.368 1 uvicorn.error INFO:     Waiting for application startup.
2026-08-13 05:02:31.372 1 kserve INFO [server.py:start():70] Starting gRPC server with 4 workers
2026-08-13 05:02:31.372 1 kserve INFO [server.py:start():71] Starting gRPC server on [::]:8081
2026-08-13 05:02:31.372 1 uvicorn.error INFO:     Application startup complete.
2026-08-13 05:02:31.372 1 uvicorn.error INFO:     Uvicorn running on http://0.0.0.0:8080/ (Press CTRL+C to quit)
```
```
ubuntu@pytorch-5:~$ curl -X POST http://localhost:8080/v1/models/pmml-demo:predict \
  -H "Content-Type: application/json" \
  -d '{"instances": [[5.1, 3.5, 1.4, 0.2]]}'
{"predictions":[{"class":"Iris-setosa"}]}
```

**Special notes for your reviewer**:

- This PR only introduces Power (ppc64le) image build support for pmmlServer.
- A separate workflow file has been created specifically for ppc64le to trigger the Power build workflow.
- For the packages that do not have power support, we are fetching wheels from https://wheels.developerfirst.ibm.com/ppc64le/linux. We have added this index to pyproject.toml file of kserve , pmmlserver and storage.
- The build time taken for Power is below 6 mins, which is comparable to linux/arm64/v8 when built separately.

**Release note**:
```
Added ppc64le support to PmmlServer
```
