### PR TITLE
feat: added power support for paddleserver component

### DIFF
--- a/.github/workflows/paddle-ppc64le-docker-publish.yml
+++ b/.github/workflows/paddle-ppc64le-docker-publish.yml
@@ -1,0 +1,138 @@
+name: PaddleServer ppc64le Docker Publisher
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+    paths:
+      - "python/*paddleserver*"
+      - "python/storage/**"
+      - "python/paddle.Dockerfile"
+      - "!.github/**"
+      - "!docs/**"
+      - "!**.md"
+      - ".github/workflows/paddle-ppc64le-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
+
+env:
+  IMAGE_NAME: paddleserver
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Merge target branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --unshallow origin
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
+      - name: Run tests
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/ppc64le
+          context: python
+          file: python/paddle.Dockerfile
+          push: false
+          # https://github.com/docker/buildx/issues/1533
+          provenance: false
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Export version variable
+        run: |
+          IMAGE_ID=kserve/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/ppc64le
+          context: python
+          file: python/paddle.Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
+          # https://github.com/docker/buildx/issues/1533
+          provenance: false
+          sbom: true

--- a/python/paddle.Dockerfile
+++ b/python/paddle.Dockerfile
@@ -7,7 +7,11 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
+RUN apt-get update && apt-get install -y --no-install-recommends curl python3-dev build-essential && \
+    if [ "$(uname -m)" = "ppc64le" ]; then apt-get install -y libtiff5-dev libjpeg-dev libopenjp2-7-dev zlib1g-dev \
+    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
+    libharfbuzz-dev libfribidi-dev libxcb1-dev; fi && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv and ensure it's in PATH
@@ -25,21 +29,130 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Install kserve dependencies using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
-RUN cd kserve && uv sync --active --no-cache
+
+# On ppc64le: patch pyproject.toml to add the ppc64le package index and sources,
+# then regenerate uv.lock before syncing.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^index-strategy\s*=.*/a \\' \
+            -e '/^index-strategy\s*=.*/a [[tool.uv.index]]' \
+            -e '/^index-strategy\s*=.*/a name = "ppc64le-wheels"' \
+            -e '/^index-strategy\s*=.*/a url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            -e '/^index-strategy\s*=.*/a explicit = true' \
+            -e '/^\s*"pyasn1>=[^,]*"$/s/"$/",/' \
+            -e '/^\s*"pyasn1>=/a\    "httptools==0.6.4",' \
+            -e '/^\s*"pyasn1>=/a\    "uvloop==0.21.0",' \
+            -e '/^kserve-storage\s*=.*/a grpcio = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a grpcio-tools = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a numpy = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pandas = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a psutil = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pyyaml = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a httptools = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a uvloop = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pillow = { index = "ppc64le-wheels" }' \
+            kserve/pyproject.toml && \
+        cd kserve && uv lock && \
+        cp uv.lock /tmp/kserve_ppc64le_uv.lock && \
+        cp pyproject.toml /tmp/kserve_ppc64le_pyproject.toml; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd kserve && uv sync --active
 
 COPY kserve kserve
-RUN cd kserve && uv sync --active --no-cache
+
+# On ppc64le: restore the patched pyproject.toml + uv.lock after COPY overwrites them
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        rm -f kserve/pyproject.toml kserve/uv.lock && \
+        cp /tmp/kserve_ppc64le_pyproject.toml kserve/pyproject.toml && \
+        cp /tmp/kserve_ppc64le_uv.lock kserve/uv.lock && \
+        rm -f /tmp/kserve_ppc64le_pyproject.toml /tmp/kserve_ppc64le_uv.lock; \
+    fi
+    
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd kserve && uv sync --active
 
 # Install kserve-storage
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
+
+
+# On ppc64le: append ppc64le index + sources to storage/pyproject.toml,
+# regenerate uv.lock, then sync (same pattern as kserve/lgbserver).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^    "pyasn1>=[^,]*"$/s/"$/",/' \
+            -e '/^    "pyasn1>=/a\    "google-crc32c==1.8.0",' \
+            -e '/^    "pyasn1>=/a\    "pyyaml==6.0.2",' \
+            storage/pyproject.toml && \
+        printf '%s\n' \
+            '' \
+            '[tool.uv]' \
+            'index-strategy = "unsafe-best-match"' \
+            'package = true' \
+            '' \
+            '[build-system]' \
+            'requires = ["setuptools>=61.0"]' \
+            'build-backend = "setuptools.build_meta"' \
+            '' \
+            '[[tool.uv.index]]' \
+            'name = "ppc64le-wheels"' \
+            'url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            'explicit = true' \
+            '' \
+            '[tool.uv.sources]' \
+            'google-crc32c = { index = "ppc64le-wheels" }' \
+            'hf-xet = { index = "ppc64le-wheels" }' \
+            'pyyaml = { index = "ppc64le-wheels" }' \
+            >> storage/pyproject.toml && \
+        cd storage && uv lock && \
+        uv sync --active; \
+    else \
+        cd storage && uv pip install .; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd storage && uv pip install .
 
 # Install paddleserver dependencies using uv
 COPY paddleserver/pyproject.toml paddleserver/uv.lock paddleserver/
-RUN cd paddleserver && uv sync --active --no-cache
+
+# On ppc64le: paddlepaddle has no PyPI wheel; install it from the ppc64le index.
+# Patch pyproject.toml to add the index + source, regenerate uv.lock, then sync.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$(uname -m)" = "ppc64le" ]; then \
+        printf '%s\n' \
+            '' \
+            '[[tool.uv.index]]' \
+            'name = "ppc64le-wheels"' \
+            'url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            'explicit = true' \
+            '' \
+            '[tool.uv.sources]' \
+            'paddlepaddle = { index = "ppc64le-wheels" }' \
+            'pillow = { index = "ppc64le-wheels" }' \
+            >> paddleserver/pyproject.toml && \
+        cd paddleserver && uv lock && \
+        cp uv.lock /tmp/paddleserver_ppc64le_uv.lock && \
+        cp pyproject.toml /tmp/paddleserver_ppc64le_pyproject.toml; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd paddleserver && uv sync --active
 
 COPY paddleserver paddleserver
-RUN cd paddleserver && uv sync --active --no-cache
+
+# On ppc64le: restore patched files after COPY overwrites them
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        cp /tmp/paddleserver_ppc64le_pyproject.toml paddleserver/pyproject.toml && \
+        cp /tmp/paddleserver_ppc64le_uv.lock paddleserver/uv.lock && \
+        rm -f /tmp/paddleserver_ppc64le_pyproject.toml /tmp/paddleserver_ppc64le_uv.lock; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    cd paddleserver && uv sync --active
 
 # Generate third-party licenses
 COPY pyproject.toml pyproject.toml


### PR DESCRIPTION
**What this PR does / why we need it**: We have updated the existing Dockerfile and added a new workflow for PaddleServer to add Power support.

**Feature/Issue validation/testing**:

```
ubuntu@pytorch-5:~$ docker run --rm -p 9090:8080 \
  -v ~/kserve/paddle/kserve/python/paddleserver/paddleserver/inference_model:/mnt/models \
  paddleserver-ppc64le:latest \
  --model_name=paddle-test \
  --model_dir=/mnt/models
/prod_venv/lib/python3.11/site-packages/paddle/utils/cpp_extension/extension_utils.py:711: UserWarning: No ccache found. Please be aware that recompiling all source files may be required. You can download and install ccache from: https://github.com/ccache/ccache/blob/master/doc/INSTALL.md
  warnings.warn(warning_message)
--- Running PIR pass [add_shadow_output_after_dead_parameter_pass]
--- Running PIR pass [delete_quant_dequant_linear_op_pass]
--- Running PIR pass [delete_weight_dequant_linear_op_pass]
--- Running PIR pass [transfer_layout_pass]
--- Running PIR pass [common_subexpression_elimination_pass]
I0825 08:40:37.121795     1 print_statistics.cc:50] --- detected [6] subgraphs!
--- Running PIR pass [constant_folding_pass]
I0825 08:40:37.122452     1 pir_interpreter.cc:1619] New Executor is Running ...
I0825 08:40:37.122730     1 pir_interpreter.cc:1643] pir interpreter is running by multi-thread mode ...
I0825 08:40:37.135219     1 print_statistics.cc:44] --- detected [8, 66] subgraphs!
--- Running PIR pass [dead_code_elimination_pass]
I0825 08:40:37.135450     1 print_statistics.cc:50] --- detected [5] subgraphs!
--- Running PIR pass [replace_fetch_with_shadow_output_pass]
I0825 08:40:37.135536     1 print_statistics.cc:50] --- detected [1] subgraphs!
--- Running PIR pass [remove_shadow_feed_pass]
--- Running PIR pass [inplace_pass]
I0825 08:40:37.139017     1 print_statistics.cc:50] --- detected [12] subgraphs!
I0825 08:40:37.139073     1 analysis_predictor.cc:1186] ======= pir optimization completed =======
```

```
ubuntu@pytorch-5:~$ curl -s http://localhost:9090/v1/models/paddle-test
{"name":"paddle-test","ready":true}ubuntu@pytorch-5:~$
```

**Special notes for your reviewer**:

- This PR only introduces Power (ppc64le) image build support for PaddleServer.
- A separate workflow file has been created specifically for ppc64le to trigger the Power build workflow.
- For the packages that do not have power support, we are fetching wheels from   https://wheels.developerfirst.ibm.com/ppc64le/linux. We have added this index to pyproject.toml file of kserve , paddleserver and storage.
- The build time taken for Power is below 9 mins, which is comparable to linux/arm64/v8 when built separately.

**Release note**:
```
 Added ppc64le support to PaddleServer
```