### PR TITLE
fix: don't assume LoRA served names are valid object names

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/workload_lora.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora.go
@@ -47,10 +47,6 @@ const (
 // Replaces anything that is not alphanumeric, dash, underscore, or dot.
 var loraPathInvalidCharsRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
 
-// loraVolumeNameInvalidCharsRe matches characters that are invalid in Kubernetes volume names
-// (which must be DNS labels: lowercase alphanumeric and hyphens only).
-var loraVolumeNameInvalidCharsRe = regexp.MustCompile(`[^a-z0-9-]`)
-
 // resolvedLoRAAdapter is one adapter after URI validation (hf/s3 downloads are handled in attachModelArtifacts).
 type resolvedLoRAAdapter struct {
 	name      string
@@ -153,7 +149,7 @@ func (r *LLMISVCReconciler) attachLoRAAdapters(
 	for _, a := range adapters {
 		switch a.scheme {
 		case constants.PvcURIPrefix:
-			volName := kmeta.ChildName("lora-pvc-", a.name)
+			volName := utils.SafeObjectName(kmeta.ChildName("lora-pvc-", a.name))
 			if err := attachLoraPVCAdapter(a.uri, podSpec, containerName, a.mountPath, volName); err != nil {
 				return fmt.Errorf("LoRA adapter %q: %w", a.name, err)
 			}

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -20,7 +20,12 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 func TestSanitizeLoRAPathSegment(t *testing.T) {
@@ -36,6 +41,55 @@ func TestSanitizeLoRAPathSegment(t *testing.T) {
 	}
 	if got, want := sanitizeLoRAPathSegment(""), "adapter"; got != want {
 		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+// TestAttachLoRAAdaptersVolumeNames covers PVC adapter volume naming. Volume
+// names are part of the Deployment pod template, so deriving a different name
+// for an unchanged adapter rolls every pod on controller upgrade - the
+// hardcoded name below is what the controller produced before the sanitizer
+// existed and must never change. The HF-style adapter name used to yield a
+// volume name the API server rejected; it only has to yield a valid one now,
+// as the exact rewrite is pkg/utils's contract, tested there.
+func TestAttachLoRAAdaptersVolumeNames(t *testing.T) {
+	t.Parallel()
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns"},
+	}
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "main"}},
+	}
+	adapters := []resolvedLoRAAdapter{
+		{name: "billing-en-v1", mountPath: "/mnt/lora/billing-en-v1", uri: "pvc://claim/adapters/billing", scheme: constants.PvcURIPrefix},
+		{name: "acme/x.r16", mountPath: "/mnt/lora/acme-x.r16", uri: "pvc://claim/adapters/x", scheme: constants.PvcURIPrefix},
+	}
+
+	r := &LLMISVCReconciler{}
+	if err := r.attachLoRAAdapters(t.Context(), llmSvc, podSpec, adapters); err != nil {
+		t.Fatal(err)
+	}
+	if len(podSpec.Volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %v", podSpec.Volumes)
+	}
+
+	// The exact name running Deployments already use; a change rolls pods.
+	if got, want := podSpec.Volumes[0].Name, "lora-pvc-billing-en-v1"; got != want {
+		t.Fatalf("valid adapter name renamed: got %q want %q", got, want)
+	}
+
+	hfVol := podSpec.Volumes[1].Name
+	if errs := validation.IsDNS1123Label(hfVol); len(errs) > 0 {
+		t.Fatalf("volume name %q for HF-style adapter is not a valid DNS-1123 label: %v", hfVol, errs)
+	}
+	if hfVol == podSpec.Volumes[0].Name {
+		t.Fatalf("adapters must not share volume name %q", hfVol)
+	}
+
+	for i, m := range podSpec.Containers[0].VolumeMounts {
+		if m.Name != podSpec.Volumes[i].Name {
+			t.Fatalf("mounts[%d]=%q does not match volume %q", i, m.Name, podSpec.Volumes[i].Name)
+		}
 	}
 }
 

--- a/pkg/utils/names.go
+++ b/pkg/utils/names.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// dns1123InvalidCharsRe matches characters invalid in DNS-1123 labels
+// (Kubernetes volume and object names): anything but lowercase alphanumerics
+// and hyphens.
+var dns1123InvalidCharsRe = regexp.MustCompile(`[^a-z0-9-]`)
+
+// sanitizeDNS1123Label transforms an arbitrary identifier into the DNS-1123
+// label character set: lowercased, invalid characters replaced with hyphens,
+// leading and trailing hyphens trimmed. The result may be empty and is not
+// length-bounded; use SafeObjectName for a complete object name.
+func sanitizeDNS1123Label(name string) string {
+	sanitized := dns1123InvalidCharsRe.ReplaceAllString(strings.ToLower(name), "-")
+	return strings.Trim(sanitized, "-")
+}
+
+// SafeObjectName makes a candidate string a valid Kubernetes object name:
+// DNS-1123 label character set, at most 63 characters. Valid candidates pass
+// through unchanged, so adopting this helper does not rename existing
+// resources. Sanitized candidates carry a short hash of the original, keeping
+// distinct candidates distinct ("a/b" and "a.b" both reduce to "a-b");
+// over-long results are truncated in favor of the hash. Typically composed
+// with kmeta.ChildName, e.g. SafeObjectName(kmeta.ChildName(prefix, name)).
+func SafeObjectName(candidate string) string {
+	sanitized := sanitizeDNS1123Label(candidate)
+	if sanitized == candidate && len(candidate) <= validation.DNS1123LabelMaxLength {
+		return candidate
+	}
+
+	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(candidate)))[:8]
+	budget := validation.DNS1123LabelMaxLength - len(digest) - 1
+	if len(sanitized) > budget {
+		sanitized = strings.TrimRight(sanitized[:budget], "-")
+	}
+	if sanitized == "" {
+		return digest
+	}
+	return sanitized + "-" + digest
+}

--- a/pkg/utils/names_test.go
+++ b/pkg/utils/names_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeObjectName(t *testing.T) {
+	valid := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{name: "plain name", in: "lora-pvc-billing-summarize-en-v1"},
+		{name: "hf org prefix", in: "lora-pvc-acme/billing-summarize-en-v1.r16"},
+		{name: "dots", in: "lora-pvc-adapter.v1.2"},
+		{name: "uppercase", in: "lora-pvc-Qwen/Qwen2.5-7B-Instruct"},
+		{name: "trailing invalid", in: "lora-pvc-adapter."},
+		{name: "only invalid chars", in: "///"},
+		{name: "longer than a label", in: strings.Repeat("x", 80)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SafeObjectName(tt.in)
+			assert.True(t, valid.MatchString(got), "name %q must be a DNS-1123 label", got)
+			assert.LessOrEqual(t, len(got), 63)
+		})
+	}
+
+	// Valid candidates pass through unchanged; adopting the helper must not
+	// rename existing resources.
+	assert.Equal(t, "lora-pvc-my-adapter", SafeObjectName("lora-pvc-my-adapter"))
+
+	// "p-a/b" and "p-a.b" both sanitize to "p-a-b"; the hash of the original
+	// keeps the two names distinct instead of silently sharing one volume.
+	assert.Equal(t, "p-a-b-734c5699", SafeObjectName("p-a/b"))
+	assert.Equal(t, "p-a-b-87e580e9", SafeObjectName("p-a.b"))
+
+	// Results name live volumes, so the mapping must not change between
+	// releases - a new result would rename volumes and restart pods on upgrade.
+	assert.Equal(t, "p-acme-x-y-7c26bdb9", SafeObjectName("p-acme/x.y"))
+}
+
+func TestSanitizeDNS1123Label(t *testing.T) {
+	assert.Equal(t, "qwen-qwen2-5-7b-instruct", sanitizeDNS1123Label("Qwen/Qwen2.5-7B-Instruct"))
+	assert.Equal(t, "my-adapter", sanitizeDNS1123Label("my-adapter"))
+	assert.Equal(t, "", sanitizeDNS1123Label("///"))
+}

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -232,10 +232,16 @@ func FindCommonParentPath(paths []string) string {
 	return "/" + strings.Join(commonComponents, "/")
 }
 
-// Helper function to generate volume name from path
+// GetVolumeNameFromPath generates a volume name from a mount path. Path
+// segments may carry characters that are valid in paths but not in volume
+// names (dots, uppercase), and distinct paths must not collapse into the same
+// name, so the joined segments go through SafeObjectName. Joining slashes here
+// rather than delegating to SafeObjectName is deliberate: it reproduces the
+// historical name, which SafeObjectName then keeps when valid, so existing
+// pods are not restarted by a rename. An empty path yields an empty name;
+// callers keep their own fallbacks.
 func GetVolumeNameFromPath(path string) string {
-	// Convert path to valid volume name (remove slashes, etc.)
-	return strings.ReplaceAll(strings.Trim(path, "/"), "/", "-")
+	return SafeObjectName(strings.ReplaceAll(strings.Trim(path, "/"), "/", "-"))
 }
 
 // AddDefaultHuggingFaceEnvVars adds default HuggingFace optimization environment variables

--- a/pkg/utils/storage_test.go
+++ b/pkg/utils/storage_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -213,6 +214,15 @@ func TestGetVolumeNameFromPath(t *testing.T) {
 			g.Expect(result).To(gomega.Equal(scenario.expected))
 		})
 	}
+
+	// Path segments may carry characters that are valid in paths but not in
+	// volume names; the result must still be a valid name and distinct paths
+	// must not collapse into the same one.
+	validLabel := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+	for _, path := range []string{"/mnt/lora/Qwen2.5-SQL", "/mnt/lora/adapter.v1"} {
+		g.Expect(GetVolumeNameFromPath(path)).To(gomega.MatchRegexp(validLabel.String()), "path %s", path)
+	}
+	g.Expect(GetVolumeNameFromPath("/mnt/a/b")).ToNot(gomega.Equal(GetVolumeNameFromPath("/mnt/a.b")))
 }
 
 func TestAddDefaultHuggingFaceEnvVars(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

A LoRA adapter's served name is the value clients send in the OpenAI `model` parameter, where org-prefixed identifiers are the norm  (e.g. in our samples `Qwen/Qwen2.5-7B-Instruct`). A PVC created for such adapter assumes the valid object name but Kubernetes rejects slashes, dots etc. This results in breaking the workload.

Volume names are now derived through a shared helper that keeps already-valid names unchanged and makes distinct names stay distinct. Volume names built from mount paths get the same guarantee, closing the identical gap for future callers there.

**Feature/Issue validation/testing**:

- [x] Unit tests for the naming helper: valid names pass through untouched, invalid ones become valid, colliding inputs stay distinct, deterministic output, length bounds
- [x] Existing volume-name-from-path tests unchanged and passing, proving no rename of currently working volumes

**Special notes for your reviewer**:

Upgrade-safe by construction: a name this change alters belonged to a pod the API server was already rejecting, so no running workload gets renamed or restarted.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
