### PR TITLE
feat: added power support for xgbserver component

### DIFF
--- a/.github/workflows/xgbserver-ppc64le-docker-publisher.yml
+++ b/.github/workflows/xgbserver-ppc64le-docker-publisher.yml
@@ -1,0 +1,138 @@
+name: XgbServer ppc64le Docker Publisher
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+    paths:
+      - "python/*xgbserver*"
+      - "python/storage/**"
+      - "python/xgb.Dockerfile"
+      - "!.github/**"
+      - "!docs/**"
+      - "!**.md"
+      - ".github/workflows/xgbserver-ppc64le-docker-publish.yml"
+      - ".github/actions/free-up-disk-space/**"
+  # To save some compute time, rely on PR check and don't run for merge queues
+  # merge_group:
+  #   types: [ checks_requested ]
+
+env:
+  IMAGE_NAME: xgbserver
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Merge target branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --unshallow origin
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
+      - name: Run tests
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/ppc64le
+          context: python
+          file: python/xgb.Dockerfile
+          push: false
+          # https://github.com/docker/buildx/issues/1533
+          provenance: false
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          cache-image: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Export version variable
+        run: |
+          IMAGE_ID=kserve/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/ppc64le
+          context: python
+          file: python/xgb.Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
+          # https://github.com/docker/buildx/issues/1533
+          provenance: false
+          sbom: true

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -5,7 +5,9 @@ ARG VENV_PATH=/prod_venv
 FROM ${BASE_IMAGE} AS builder
 
 # Install necessary dependencies for building Python packages
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
+RUN apt-get update && apt-get install -y --no-install-recommends curl python3-dev build-essential && \
+    if [ "$(uname -m)" = "ppc64le" ]; then apt-get install pkg-config libssl-dev gcc gfortran cmake pkg-config libssl-dev libopenblas-dev libjpeg-dev libhdf5-dev wget -y; fi && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv
@@ -23,18 +25,129 @@ COPY storage/pyproject.toml storage/uv.lock storage/
 
 # Copy and install dependencies for kserve using uv
 COPY kserve/pyproject.toml kserve/uv.lock kserve/
+
+# On ppc64le: patch pyproject.toml to add the ppc64le package index and sources,
+# then regenerate uv.lock before syncing.
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^index-strategy\s*=.*/a \\' \
+            -e '/^index-strategy\s*=.*/a [[tool.uv.index]]' \
+            -e '/^index-strategy\s*=.*/a name = "ppc64le-wheels"' \
+            -e '/^index-strategy\s*=.*/a url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            -e '/^index-strategy\s*=.*/a explicit = true' \
+            -e '/^\s*"pyasn1>=[^,]*"$/s/"$/",/' \
+            -e '/^\s*"pyasn1>=/a\    "httptools==0.6.4",' \
+            -e '/^\s*"pyasn1>=/a\    "uvloop==0.21.0",' \
+            -e '/^kserve-storage\s*=.*/a grpcio = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a grpcio-tools = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a numpy = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pandas = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a psutil = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pyyaml = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a httptools = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a uvloop = { index = "ppc64le-wheels" }' \
+            -e '/^kserve-storage\s*=.*/a pillow = { index = "ppc64le-wheels" }' \
+            kserve/pyproject.toml && \
+        cd kserve && uv lock && \
+        cp uv.lock /tmp/kserve_ppc64le_uv.lock && \
+        cp pyproject.toml /tmp/kserve_ppc64le_pyproject.toml; \
+    fi
+
 RUN cd kserve && uv sync --active --no-cache
+
 COPY kserve kserve
+
+# On ppc64le: restore the patched pyproject.toml + uv.lock after COPY overwrites them
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        rm -f kserve/pyproject.toml kserve/uv.lock && \
+        cp /tmp/kserve_ppc64le_pyproject.toml kserve/pyproject.toml && \
+        cp /tmp/kserve_ppc64le_uv.lock kserve/uv.lock && \
+        rm -f /tmp/kserve_ppc64le_pyproject.toml /tmp/kserve_ppc64le_uv.lock; \
+    fi
+
 RUN cd kserve && uv sync --active --no-cache
 
 # Install kserve-storage
 COPY storage storage
-RUN cd storage && uv pip install . --no-cache
 
-# Copy and install dependencies for xgbserver using uv
+# On ppc64le: append ppc64le index + sources to storage/pyproject.toml,
+# regenerate uv.lock, then sync (same pattern as kserve/lgbserver).
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e '/^    "pyasn1>=[^,]*"$/s/"$/",/' \
+            -e '/^    "pyasn1>=/a\    "google-crc32c==1.8.0",' \
+            -e '/^    "pyasn1>=/a\    "pyyaml==6.0.2",' \
+            storage/pyproject.toml && \
+        printf '%s\n' \
+            '' \
+            '[tool.uv]' \
+            'index-strategy = "unsafe-best-match"' \
+            'package = true' \
+            '' \
+            '[build-system]' \
+            'requires = ["setuptools>=61.0"]' \
+            'build-backend = "setuptools.build_meta"' \
+            '' \
+            '[[tool.uv.index]]' \
+            'name = "ppc64le-wheels"' \
+            'url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            'explicit = true' \
+            '' \
+            '[tool.uv.sources]' \
+            'google-crc32c = { index = "ppc64le-wheels" }' \
+            'hf-xet = { index = "ppc64le-wheels" }' \
+            'pyyaml = { index = "ppc64le-wheels" }' \
+            >> storage/pyproject.toml && \
+        cd storage && uv lock && \
+        uv sync --active --no-cache; \
+    else \
+        cd storage && uv pip install . --no-cache; \
+    fi
+
+# On ppc64le: patch pyproject.toml for xgbserver, then regenerate uv.lock before syncing.
 COPY xgbserver/pyproject.toml xgbserver/uv.lock xgbserver/
+
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        sed -i \
+            -e 's/"xgboost~=2.1.1"/"xgboost-cpu~=2.1.1"/' \
+            -e '/^    "xgboost-cpu~=2.1.1",$/s/"$/",/' \
+            -e '/^    "xgboost-cpu~=2.1.1",$/a\    "scipy==1.15.2",' \
+            xgbserver/pyproject.toml && \
+        printf '%s\n' \
+            '' \
+            '[[tool.uv.index]]' \
+            'name = "ppc64le-wheels"' \
+            'url = "https://wheels.developerfirst.ibm.com/ppc64le/linux"' \
+            'explicit = true' \
+            '' \
+            '[tool.uv]' \
+            'override-dependencies = [' \
+            '  "nvidia-nccl-cu12; sys_platform == '\''linux'\'' and (platform_machine == '\''x86_64'\'' or platform_machine == '\''aarch64'\'')"' \
+            ']' \
+            'index-strategy = "unsafe-best-match"' \
+            '' \
+            '[tool.uv.sources]' \
+            'scipy = { index = "ppc64le-wheels" }' \
+            'pillow = { index = "ppc64le-wheels" }' \
+            'xgboost-cpu = { index = "ppc64le-wheels" }' \
+            >> xgbserver/pyproject.toml && \
+        cd xgbserver && uv lock && \
+        cp uv.lock /tmp/xgbserver_ppc64le_uv.lock && \
+        cp pyproject.toml /tmp/xgbserver_ppc64le_pyproject.toml; \
+    fi
+
 RUN cd xgbserver && uv sync --active --no-cache
+
 COPY xgbserver xgbserver
+
+# On ppc64le: restore the patched pyproject.toml + uv.lock after COPY overwrites them
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+        rm -f xgbserver/pyproject.toml xgbserver/uv.lock && \
+        cp /tmp/xgbserver_ppc64le_pyproject.toml xgbserver/pyproject.toml && \
+        cp /tmp/xgbserver_ppc64le_uv.lock xgbserver/uv.lock && \
+        rm -f /tmp/xgbserver_ppc64le_pyproject.toml /tmp/xgbserver_ppc64le_uv.lock; \
+    fi
+
 RUN cd xgbserver && uv sync --active --no-cache
 
 # Generate third-party licenses


### PR DESCRIPTION
**What this PR does / why we need it**: We have updated the existing Dockerfile and added a new workflow for xgbserver to add Power support.

**Feature/Issue validation/testing**:

```
ubuntu@pytorch-5:~/kserve-testing/xgb$ docker run -p 8080:8080 -v /home/ubuntu/kserve-testing/xgb:/mnt/models localhost/xgb-ppc64le:latest python -m xgbserver --model_dir /mnt/models --model_name xgboost-iris
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
2026-08-12 06:08:50.633 1 kserve INFO [model_server.py:register_model():439] Registering model: xgboost-iris
2026-08-12 06:08:50.635 1 kserve INFO [model_server.py:setup_event_loop():315] Setting max asyncio worker threads as 20
2026-08-12 06:08:50.763 1 kserve INFO [server.py:_register_endpoints():124] OpenAI endpoints not registered
2026-08-12 06:08:50.763 1 kserve INFO [server.py:_register_endpoints():132] Time series endpoints not registered
2026-08-12 06:08:50.763 1 kserve INFO [server.py:start():183] Starting uvicorn with 1 workers
2026-08-12 06:08:50.848 1 uvicorn.error INFO:     Started server process [1]
2026-08-12 06:08:50.848 1 uvicorn.error INFO:     Waiting for application startup.
2026-08-12 06:08:50.860 1 kserve INFO [server.py:start():70] Starting gRPC server with 4 workers
2026-08-12 06:08:50.861 1 kserve INFO [server.py:start():71] Starting gRPC server on [::]:8081
2026-08-12 06:08:50.861 1 uvicorn.error INFO:     Application startup complete.
2026-08-12 06:08:50.862 1 uvicorn.error INFO:     Uvicorn running on http://0.0.0.0:8080/ (Press CTRL+C to quit)
```
```
ubuntu@pytorch-5:~$ curl -X POST http://localhost:8080/v1/models/xgboost-iris:predict \
  -H "Content-Type: application/json" \
  -d '{"instances": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}'
{"predictions":[1.0,1.0]}
```

**Special notes for your reviewer**:

- This PR only introduces Power (ppc64le) image build support for xgbServer.
- A separate workflow file has been created specifically for ppc64le to trigger the Power build workflow.
- For the packages that do not have power support, we are fetching wheels from https://wheels.developerfirst.ibm.com/ppc64le/linux. We have added this index to pyproject.toml file of kserve , xgbserver and storage.
- The build time taken for Power is below 44 mins, which is comparable to linux/arm64/v8 when built separately.

**Release note**:
```
Added ppc64le support to xgbServer
```
