### PR TITLE
feat: add hook files for TLS resolution and manager startup

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -168,7 +168,7 @@ func main() {
 	switch {
 	case options.tlsMinVersion != "" || options.tlsCipherSuites != "":
 		var err error
-		tlsOpts, err = kservetls.Resolve(ctx, cfg, options.tlsMinVersion, options.tlsCipherSuites)
+		tlsOpts, err = resolveTLS(ctx, options.tlsMinVersion, options.tlsCipherSuites)
 		if err != nil {
 			setupLog.Error(err, "unable to resolve TLS configuration")
 			os.Exit(1)
@@ -181,7 +181,7 @@ func main() {
 		}
 	default:
 		var err error
-		tlsOpts, err = kservetls.Resolve(ctx, cfg, "", "")
+		tlsOpts, err = resolveTLS(ctx, "", "")
 		if err != nil {
 			setupLog.Error(err, "unable to resolve TLS configuration")
 			os.Exit(1)
@@ -393,7 +393,11 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctx); err != nil {
+	startCtx, err := setupDistroStartup(ctx, mgr)
+	if err != nil {
+		setupLog.Error(err, "Failed to set up distro startup; profile changes will not trigger a restart")
+	}
+	if err := mgr.Start(startCtx); err != nil {
 		setupLog.Error(err, "unable to run the manager")
 		os.Exit(1)
 	}

--- a/cmd/llmisvc/main_start_default.go
+++ b/cmd/llmisvc/main_start_default.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kservetls "github.com/kserve/kserve/pkg/tls"
+)
+
+// resolveTLS and setupDistroStartup are distro hooks (see main.go). This is
+// the upstream no-op default; distributions overlay their own version to add
+// platform-specific TLS handling without touching main.go.
+func resolveTLS(_ context.Context, minVer, ciphers string) ([]func(*tls.Config), error) {
+	return kservetls.Resolve(minVer, ciphers)
+}
+
+func setupDistroStartup(ctx context.Context, _ ctrl.Manager) (context.Context, error) {
+	return ctx, nil
+}

--- a/cmd/localmodel/main.go
+++ b/cmd/localmodel/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	localmodelcontroller "github.com/kserve/kserve/pkg/controller/v1alpha1/localmodel"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
-	kservetls "github.com/kserve/kserve/pkg/tls"
 	localmodelwebhook "github.com/kserve/kserve/pkg/webhook/admission/localmodelcache"
 	localmodelnamespacecachewebhook "github.com/kserve/kserve/pkg/webhook/admission/localmodelnamespacecache"
 )
@@ -105,7 +104,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	tlsResult, err := kservetls.Resolve(context.Background(), cfg, options.tlsMinVersion, options.tlsCipherSuites)
+	tlsOpts, err := resolveTLS(context.Background(), options.tlsMinVersion, options.tlsCipherSuites)
 	if err != nil {
 		setupLog.Error(err, "unable to resolve TLS configuration")
 		os.Exit(1)
@@ -116,11 +115,11 @@ func main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
-			TLSOpts:     tlsResult,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    options.webhookPort,
-			TLSOpts: tlsResult,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,
@@ -194,7 +193,11 @@ func main() {
 
 	// Start the Cmd
 	setupLog.Info("Starting the Cmd.")
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+	startCtx, err := setupDistroStartup(signals.SetupSignalHandler(), mgr)
+	if err != nil {
+		setupLog.Error(err, "Failed to set up distro startup; profile changes will not trigger a restart")
+	}
+	if err := mgr.Start(startCtx); err != nil {
 		setupLog.Error(err, "unable to run the manager")
 		os.Exit(1)
 	}

--- a/cmd/localmodel/main_start_default.go
+++ b/cmd/localmodel/main_start_default.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kservetls "github.com/kserve/kserve/pkg/tls"
+)
+
+// resolveTLS and setupDistroStartup are distro hooks (see main.go). This is
+// the upstream no-op default; distributions overlay their own version to add
+// platform-specific TLS handling without touching main.go.
+func resolveTLS(_ context.Context, minVer, ciphers string) ([]func(*tls.Config), error) {
+	return kservetls.Resolve(minVer, ciphers)
+}
+
+func setupDistroStartup(ctx context.Context, _ ctrl.Manager) (context.Context, error) {
+	return ctx, nil
+}

--- a/cmd/localmodelnode/main.go
+++ b/cmd/localmodelnode/main.go
@@ -35,7 +35,6 @@ import (
 
 	localmodelnodecontroller "github.com/kserve/kserve/pkg/controller/v1alpha1/localmodelnode"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
-	kservetls "github.com/kserve/kserve/pkg/tls"
 )
 
 var setupLog = ctrl.Log.WithName("setup")
@@ -98,7 +97,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	tlsResult, err := kservetls.Resolve(context.Background(), cfg, options.tlsMinVersion, options.tlsCipherSuites)
+	tlsOpts, err := resolveTLS(context.Background(), options.tlsMinVersion, options.tlsCipherSuites)
 	if err != nil {
 		setupLog.Error(err, "unable to resolve TLS configuration")
 		os.Exit(1)
@@ -109,11 +108,11 @@ func main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
-			TLSOpts:     tlsResult,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    options.webhookPort,
-			TLSOpts: tlsResult,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,
@@ -150,7 +149,11 @@ func main() {
 
 	// Start the Cmd
 	setupLog.Info("Starting the Cmd.")
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+	startCtx, err := setupDistroStartup(signals.SetupSignalHandler(), mgr)
+	if err != nil {
+		setupLog.Error(err, "Failed to set up distro startup; profile changes will not trigger a restart")
+	}
+	if err := mgr.Start(startCtx); err != nil {
 		setupLog.Error(err, "unable to run the manager")
 		os.Exit(1)
 	}

--- a/cmd/localmodelnode/main_start_default.go
+++ b/cmd/localmodelnode/main_start_default.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kservetls "github.com/kserve/kserve/pkg/tls"
+)
+
+// resolveTLS and setupDistroStartup are distro hooks (see main.go). This is
+// the upstream no-op default; distributions overlay their own version to add
+// platform-specific TLS handling without touching main.go.
+func resolveTLS(_ context.Context, minVer, ciphers string) ([]func(*tls.Config), error) {
+	return kservetls.Resolve(minVer, ciphers)
+}
+
+func setupDistroStartup(ctx context.Context, _ ctrl.Manager) (context.Context, error) {
+	return ctx, nil
+}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -45,7 +45,6 @@ import (
 	"github.com/kserve/kserve/pkg/controller/v1alpha1/trainedmodel/reconcilers/modelconfig"
 	v1beta1controller "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice"
 	kservescheme "github.com/kserve/kserve/pkg/scheme"
-	kservetls "github.com/kserve/kserve/pkg/tls"
 	kserveutils "github.com/kserve/kserve/pkg/utils"
 	"github.com/kserve/kserve/pkg/webhook/admission/pod"
 	"github.com/kserve/kserve/pkg/webhook/admission/servingruntime"
@@ -120,7 +119,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	tlsResult, err := kservetls.Resolve(context.Background(), cfg, options.tlsMinVersion, options.tlsCipherSuites)
+	tlsOpts, err := resolveTLS(context.Background(), options.tlsMinVersion, options.tlsCipherSuites)
 	if err != nil {
 		setupLog.Error(err, "unable to resolve TLS configuration")
 		os.Exit(1)
@@ -138,11 +137,11 @@ func main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Metrics: metricsserver.Options{
 			BindAddress: options.metricsAddr,
-			TLSOpts:     tlsResult,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    options.webhookPort,
-			TLSOpts: tlsResult,
+			TLSOpts: tlsOpts,
 		}),
 		LeaderElection:         options.enableLeaderElection,
 		LeaderElectionID:       LeaderLockName,
@@ -296,7 +295,11 @@ func main() {
 
 	// Start the Cmd
 	setupLog.Info("Starting the Cmd.")
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+	startCtx, err := setupDistroStartup(signals.SetupSignalHandler(), mgr)
+	if err != nil {
+		setupLog.Error(err, "Failed to set up distro startup; profile changes will not trigger a restart")
+	}
+	if err := mgr.Start(startCtx); err != nil {
 		setupLog.Error(err, "unable to run the manager")
 		os.Exit(1)
 	}

--- a/cmd/manager/main_start_default.go
+++ b/cmd/manager/main_start_default.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kservetls "github.com/kserve/kserve/pkg/tls"
+)
+
+// resolveTLS and setupDistroStartup are distro hooks (see main.go). This is
+// the upstream no-op default; distributions overlay their own version to add
+// platform-specific TLS handling without touching main.go.
+func resolveTLS(_ context.Context, minVer, ciphers string) ([]func(*tls.Config), error) {
+	return kservetls.Resolve(minVer, ciphers)
+}
+
+func setupDistroStartup(ctx context.Context, _ ctrl.Manager) (context.Context, error) {
+	return ctx, nil
+}

--- a/pkg/tls/resolve.go
+++ b/pkg/tls/resolve.go
@@ -1,5 +1,3 @@
-//go:build !distro
-
 /*
 Copyright 2026 The KServe Authors.
 
@@ -19,18 +17,14 @@ limitations under the License.
 package tls
 
 import (
-	"context"
 	"crypto/tls"
 	"errors"
-
-	"k8s.io/client-go/rest"
 )
 
 // Resolve builds TLS option functions from the provided min version and cipher
 // suites strings. When both are empty, it returns hardened Intermediate defaults
 // (TLS 1.2, ECDHE AEAD ciphers, ALPN h2/http1.1).
-// In the default (upstream) build, ctx and cfg are unused.
-func Resolve(_ context.Context, _ *rest.Config, tlsMinVersion, tlsCipherSuites string) ([]func(*tls.Config), error) {
+func Resolve(tlsMinVersion, tlsCipherSuites string) ([]func(*tls.Config), error) {
 	minVersion, err := parseMinVersion(tlsMinVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tls
 
 import (
-	"context"
 	"crypto/tls"
 	"strings"
 	"testing"
@@ -156,7 +155,7 @@ func TestResolve(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := Resolve(context.Background(), nil, tt.minVersion, tt.cipherSuites)
+			result, err := Resolve(tt.minVersion, tt.cipherSuites)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("Resolve() expected error containing %q, got nil", tt.errContains)


### PR DESCRIPTION
## Summary

- Introduce `main_start_default.go` in each binary (`manager`, `llmisvc`, `localmodel`, `localmodelnode`) with `resolveTLS` and `setupDistroStartup` hooks.
- Rename `pkg/tls/tls_default.go` → `pkg/tls/resolve.go`, removing the `!distro` build tag and simplifying `Resolve()` to accept only the TLS min-version and cipher-suite strings.
- Update all `cmd/*/main.go` to call the hook functions instead of directly calling `kservetls.Resolve`.

## Motivation

The TLS resolution and manager startup logic is currently inlined in each binary's `main.go`. Extracting these into dedicated hook files (`main_start_default.go`) makes it easier to customize TLS behavior (e.g. platform-specific TLS profile watchers) without modifying shared `main.go` files. The default hooks are pass-through no-ops — upstream behavior is unchanged.

## Test plan

- [x] All 4 binaries compile (`go build ./cmd/...`)
- [x] `go test ./pkg/tls/...` — 26 tests pass
- [x] `go vet ./cmd/... ./pkg/tls/...` — clean
- [ ] CI e2e tests