### PR TITLE
fix(llmisvc): disambiguate colliding LoRA adapter mount paths

### DIFF
--- a/pkg/apis/serving/v1alpha2/llm_inference_service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_lifecycle.go
@@ -26,9 +26,10 @@ import (
 const (
 	// PresetsCombined is True when all referenced LLMInferenceServiceConfig resources
 	// have been found, merged and checked. False with reason ConfigNotFound when a
-	// referenced config does not exist, CombineBaseError on merge failure, or
-	// InvalidRenderedConfig when the API server rejects the merged spec. Unknown with
-	// reason ValidationUnavailable when the merged spec could not be checked at all.
+	// referenced config does not exist, LoRAMountPathCollision when two adapters resolve
+	// to the same mount path, CombineBaseError on merge failure, or InvalidRenderedConfig
+	// when the API server rejects the merged spec. Unknown with reason
+	// ValidationUnavailable when the merged spec could not be checked at all.
 	// Set by the config reconciler (config_merge.go). Always present.
 	//
 	// Counts towards Ready: when this is not True the controller stops before creating

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -135,9 +135,11 @@ type CombinedConfig struct {
 // reconcileBaseRefs resolves and merges the referenced configs, then checks the
 // merged spec by dry-running it against the API server.
 //
-// A missing config or a rejected spec returns reconcile.TerminalError: retrying
-// fixes neither, so the controller waits for a watch event instead. Any other
-// error is returned as-is and requeued with backoff.
+// A missing config, an unservable merged spec, or a spec the API server rejects
+// returns reconcile.TerminalError: each is a pure function of the spec and its
+// referenced configs, so retrying fixes none of them and the controller waits for a
+// watch event on either instead. Any other error is returned as-is and requeued with
+// backoff.
 func (r *LLMISVCReconciler) reconcileBaseRefs(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) (*v1alpha2.LLMInferenceServiceConfig, error) {
 	// Combine base configurations with service-specific overrides
 	// This includes default configs based on deployment pattern (single node, multi-node, etc.)
@@ -153,10 +155,21 @@ func (r *LLMISVCReconciler) reconcileBaseRefs(ctx context.Context, llmSvc *v1alp
 
 		llmSvc.Status.AppliedConfigRefs = nil
 
+		// Both are raised inside combineBaseRefsConfig but classified here, because that
+		// function also runs in the watch mapping handlers: an unrelated Gateway or
+		// ConfigMap change would otherwise mark the condition and fire the event for a
+		// service nothing is reconciling.
 		var cfgNotFound *configNotFoundError
 		if errors.As(err, &cfgNotFound) {
 			llmSvc.MarkPresetsCombinedNotReady("ConfigNotFound", "%s", cfgNotFound.Error())
 			return nil, reconcile.TerminalError(cfgNotFound)
+		}
+
+		var collision *loRAMountPathCollisionError
+		if errors.As(err, &collision) {
+			r.Eventf(llmSvc, corev1.EventTypeWarning, "LoRAMountPathCollision", "%s", collision.Error())
+			llmSvc.MarkPresetsCombinedNotReady("LoRAMountPathCollision", "%s", collision.Error())
+			return nil, reconcile.TerminalError(collision)
 		}
 
 		llmSvc.MarkPresetsCombinedNotReady("CombineBaseError", "%s", err.Error())

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora.go
@@ -47,6 +47,29 @@ const (
 	loraAdapterDocsURL = "https://github.com/kserve/kserve/blob/master/docs/samples/llmisvc/lora-adapters/README.md"
 )
 
+// loRAMountPathCollisionError is returned by loraMountSegments when two adapters cannot be
+// given distinct directories under the LoRA mount root. Adapter names come from the service
+// spec and from any merged config, so it is the user's to resolve from either side.
+type loRAMountPathCollisionError struct {
+	// Adapters names the colliding adapters: empty when two or more are unnamed, one entry
+	// when two share that exact name, two when distinct names reduce to the same segment.
+	Adapters []string
+	// MountPath is the directory they contend for, set only when the names differ.
+	MountPath string
+}
+
+func (e *loRAMountPathCollisionError) Error() string {
+	switch len(e.Adapters) {
+	case 0:
+		return fmt.Sprintf("two or more LoRA adapters have no name (see %s)", loraAdapterDocsURL)
+	case 1:
+		return fmt.Sprintf("duplicate LoRA adapter name %q (see %s)", e.Adapters[0], loraAdapterDocsURL)
+	default:
+		return fmt.Sprintf("LoRA adapters %q and %q both resolve to mount path %q; rename one of them (see %s)",
+			e.Adapters[0], e.Adapters[1], e.MountPath, loraAdapterDocsURL)
+	}
+}
+
 // loraPathInvalidCharsRe matches characters that are invalid in filesystem paths.
 // Replaces anything that is not alphanumeric, dash, underscore, or dot.
 var loraPathInvalidCharsRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
@@ -92,16 +115,15 @@ func enumerateLoRAAdapters(spec v1alpha2.LLMInferenceServiceSpec) ([]resolvedLoR
 			return nil, fmt.Errorf("LoRA adapter %q: invalid URI %q", adapterName, uri)
 		}
 		scheme := schema + "://"
-		mountPath := filepath.Join(loraAdaptersMountRoot, sanitizeLoRAPathSegment(adapterName))
 
 		switch scheme {
 		case constants.HfURIPrefix, constants.S3URIPrefix:
 			if storageInitializerDisabled {
-				return nil, fmt.Errorf("LoRA adapter %q: hf:// and s3:// require the storage initializer — set storageInitializer.enabled to true (see %s)", adapterName, loraAdapterDocsURL)
+				return nil, fmt.Errorf("LoRA adapter %q: hf:// and s3:// require the storage initializer - set storageInitializer.enabled to true (see %s)", adapterName, loraAdapterDocsURL)
 			}
 		case constants.PvcURIPrefix:
 			if storageInitializerDisabled {
-				return nil, fmt.Errorf("LoRA adapter %q: pvc:// requires a mounted volume — do not set storageInitializer.enabled to false (see %s)", adapterName, loraAdapterDocsURL)
+				return nil, fmt.Errorf("LoRA adapter %q: pvc:// requires a mounted volume - do not set storageInitializer.enabled to false (see %s)", adapterName, loraAdapterDocsURL)
 			}
 		case constants.OciURIPrefix:
 			// oci:// is intentionally not supported for LoRA adapters. OCI models run as sidecar
@@ -113,11 +135,20 @@ func enumerateLoRAAdapters(spec v1alpha2.LLMInferenceServiceSpec) ([]resolvedLoR
 		}
 
 		out = append(out, resolvedLoRAAdapter{
-			name:      adapterName,
-			mountPath: mountPath,
-			uri:       uri,
-			scheme:    scheme,
+			name:   adapterName,
+			uri:    uri,
+			scheme: scheme,
 		})
+	}
+
+	// After the per-adapter checks: a spec carrying both an unsupported scheme and a
+	// collision should report the scheme, which is the more specific problem.
+	segments, err := loraMountSegments(adapters)
+	if err != nil {
+		return nil, err
+	}
+	for i := range out {
+		out[i].mountPath = filepath.Join(loraAdaptersMountRoot, segments[i])
 	}
 	return out, nil
 }
@@ -199,6 +230,62 @@ func resolveLoRACachePVC(
 	return cache.Spec.SourceModelUri, pvc, nil
 }
 
+// loraMountSegments returns the mount path segment for each adapter, positionally.
+// sanitizeLoRAPathSegment can map distinct names to the same segment ("sql/v2" and
+// "sql-v2" both become "sql-v2"), which would mount two adapters on one path. Every
+// name in such a collision group takes a short hash of the raw name as a suffix;
+// a name without a collision keeps its segment byte-for-byte, so adapters that
+// mount cleanly today stay on the paths their running pods already use.
+//
+// The whole group is suffixed, rather than letting the first adapter keep the bare
+// segment, so that the result does not depend on list order: reordering
+// spec.model.lora.adapters is a semantic no-op and must not move mounts. Returns an
+// error when suffixing still cannot separate two adapters (duplicate or missing names).
+func loraMountSegments(adapters []v1alpha2.LLMModelSpec) ([]string, error) {
+	names := make([]string, len(adapters))
+	segments := make([]string, len(adapters))
+	occurrences := make(map[string]int, len(adapters))
+	for i := range adapters {
+		names[i] = ptr.Deref(adapters[i].Name, "")
+		segments[i] = sanitizeLoRAPathSegment(names[i])
+		occurrences[segments[i]]++
+	}
+
+	claimedBy := make(map[string]string, len(adapters))
+	for i := range adapters {
+		if occurrences[segments[i]] > 1 {
+			segments[i] += "-" + utils.ShortHash(names[i])
+		}
+		// A literal adapter name can equal another adapter's suffixed form, which the
+		// occurrence count cannot see. Refuse rather than mount both on one path.
+		prev, taken := claimedBy[segments[i]]
+		if !taken {
+			claimedBy[segments[i]] = names[i]
+			continue
+		}
+		// Reached with input that admission did not screen. ValidateLoRAAdapters runs on the
+		// unmerged LLMInferenceService spec, so adapters contributed by an
+		// LLMInferenceServiceConfig depend on the config validator catching them, and a
+		// validating webhook covers neither objects already stored nor writes admitted
+		// while it was unavailable. Name the problem rather than mounting two adapters
+		// on one path.
+		// No index is reported: adapters are sorted by now, so i does not locate anything
+		// in spec.model.lora.adapters.
+		switch {
+		case names[i] == "":
+			return nil, &loRAMountPathCollisionError{}
+		case prev == names[i]:
+			return nil, &loRAMountPathCollisionError{Adapters: []string{names[i]}}
+		default:
+			return nil, &loRAMountPathCollisionError{
+				Adapters:  []string{prev, names[i]},
+				MountPath: filepath.Join(loraAdaptersMountRoot, segments[i]),
+			}
+		}
+	}
+	return segments, nil
+}
+
 // collectLoRADownloadPairs filters pre-resolved adapters to hf:// and s3:// uri/path pairs
 // for a single storage-initializer run.
 func collectLoRADownloadPairs(adapters []resolvedLoRAAdapter) []storageDownloadPair {
@@ -264,7 +351,7 @@ func (r *LLMISVCReconciler) attachLoRAAdapters(
 	main := &podSpec.Containers[mainIdx]
 
 	if hasValueFromLoRAConfig(main) {
-		log.FromContext(ctx).Info("VLLM_ADDITIONAL_ARGS is set via valueFrom; cannot inspect value at reconcile time — "+
+		log.FromContext(ctx).Info("VLLM_ADDITIONAL_ARGS is set via valueFrom; cannot inspect value at reconcile time - "+
 			"injecting --lora-modules as usual; if the referenced value already contains --lora-modules, duplicate flags may result",
 			"llmService", llmSvc.Name, "namespace", llmSvc.Namespace)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -327,4 +328,117 @@ func TestBuildCachedPVCURI_MatchesLocalModelCacheHelper(t *testing.T) {
 	got := localmodelcache.BuildCachedPVCURI("hf://org/model", "cache-gpu1", "hf://org/model/extra")
 	assert.True(t, strings.HasPrefix(got, "pvc://cache-gpu1/models/"))
 	assert.True(t, strings.HasSuffix(got, "/extra"))
+}
+
+func loRASpec(t *testing.T, nameToURI ...string) v1alpha2.LLMInferenceServiceSpec {
+	t.Helper()
+	if len(nameToURI)%2 != 0 {
+		t.Fatal("loRASpec takes name/uri pairs")
+	}
+	base, err := apis.ParseURL("hf://org/base")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapters := make([]v1alpha2.LLMModelSpec, 0, len(nameToURI)/2)
+	for i := 0; i < len(nameToURI); i += 2 {
+		uri, err := apis.ParseURL(nameToURI[i+1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		adapters = append(adapters, v1alpha2.LLMModelSpec{Name: ptr.To(nameToURI[i]), URI: *uri})
+	}
+	return v1alpha2.LLMInferenceServiceSpec{
+		Model: v1alpha2.LLMModelSpec{URI: *base, LoRA: &v1alpha2.LoRASpec{Adapters: adapters}},
+	}
+}
+
+// sanitizeLoRAPathSegment is lossy, so distinct adapter names can reduce to the
+// same segment. Admission does not catch this: the duplicate check in ValidateLoRA
+// compares raw names, not sanitized path segments.
+func TestEnumerateLoRAAdaptersDistinctMountPaths(t *testing.T) {
+	t.Parallel()
+
+	adapters, err := enumerateLoRAAdapters(loRASpec(t,
+		"sql/v2", "pvc://adapters/sql-slash-v2",
+		"sql-v2", "pvc://adapters/sql-dash-v2",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(adapters) != 2 {
+		t.Fatalf("got %d adapters, want 2", len(adapters))
+	}
+	if adapters[0].mountPath == adapters[1].mountPath {
+		t.Errorf("adapters %q and %q share mount path %q",
+			adapters[0].name, adapters[1].name, adapters[0].mountPath)
+	}
+}
+
+// Adapters whose sanitized name is already unique must keep the path they have
+// today, otherwise an upgrade moves the mount and restarts a healthy pod.
+func TestEnumerateLoRAAdaptersMountPathStableWithoutCollision(t *testing.T) {
+	t.Parallel()
+
+	adapters, err := enumerateLoRAAdapters(loRASpec(t, "sql/v2", "pvc://adapters/sql-v2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := adapters[0].mountPath, "/mnt/lora/sql-v2"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// Colliding hf:// adapters share a storage-initializer target, so one silently
+// overwrites the other and both names serve whichever landed last.
+func TestEnumerateLoRAAdaptersDistinctDownloadTargets(t *testing.T) {
+	t.Parallel()
+
+	adapters, err := enumerateLoRAAdapters(loRASpec(t,
+		"sql/v2", "hf://org/sql-slash-v2",
+		"sql-v2", "hf://org/sql-dash-v2",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pairs := collectLoRADownloadPairs(adapters)
+	if len(pairs) != 2 {
+		t.Fatalf("got %d download pairs, want 2", len(pairs))
+	}
+	if pairs[0].path == pairs[1].path {
+		t.Errorf("%q and %q both download to %q", pairs[0].uri, pairs[1].uri, pairs[0].path)
+	}
+}
+
+// Two volume mounts on the same mountPath in one container are rejected by the API
+// server (volumeMounts[1].mountPath must be unique), so the workload never starts.
+func TestAttachLoRAAdaptersNoDuplicateMountPath(t *testing.T) {
+	t.Parallel()
+
+	spec := loRASpec(t,
+		"sql/v2", "pvc://adapters/sql-slash-v2",
+		"sql-v2", "pvc://adapters/sql-dash-v2",
+	)
+	adapters, err := enumerateLoRAAdapters(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       spec,
+	}
+	podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
+
+	r := &LLMISVCReconciler{}
+	if err := r.attachLoRAAdapters(t.Context(), llmSvc, podSpec, adapters); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := make(map[string]string, len(podSpec.Containers[0].VolumeMounts))
+	for _, m := range podSpec.Containers[0].VolumeMounts {
+		if prev, dup := seen[m.MountPath]; dup {
+			t.Errorf("volumes %q and %q both mount at %q", prev, m.Name, m.MountPath)
+		}
+		seen[m.MountPath] = m.Name
+	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_lora_internal_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package llmisvc
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -35,6 +36,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/localmodelcache"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 func TestSanitizeLoRAPathSegment(t *testing.T) {
@@ -440,5 +442,220 @@ func TestAttachLoRAAdaptersNoDuplicateMountPath(t *testing.T) {
 			t.Errorf("volumes %q and %q both mount at %q", prev, m.Name, m.MountPath)
 		}
 		seen[m.MountPath] = m.Name
+	}
+}
+
+// Both members of a colliding pair are suffixed, so the outcome does not depend
+// on which one the sort happens to put first.
+func TestEnumerateLoRAAdaptersCollisionSuffix(t *testing.T) {
+	t.Parallel()
+
+	adapters, err := enumerateLoRAAdapters(loRASpec(t,
+		"sql/v2", "pvc://adapters/sql-slash-v2",
+		"sql-v2", "pvc://adapters/sql-dash-v2",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"sql-v2": "/mnt/lora/sql-v2-" + utils.ShortHash("sql-v2"),
+		"sql/v2": "/mnt/lora/sql-v2-" + utils.ShortHash("sql/v2"),
+	}
+	if len(adapters) != len(want) {
+		t.Fatalf("got %d adapters, want %d", len(adapters), len(want))
+	}
+	for _, a := range adapters {
+		if got := a.mountPath; got != want[a.name] {
+			t.Errorf("adapter %q: got %q want %q", a.name, got, want[a.name])
+		}
+	}
+}
+
+// Admission rejects duplicate names, so this only reaches specs that bypassed the
+// webhook. The message must name the duplicate rather than report a self-collision.
+func TestEnumerateLoRAAdaptersDuplicateName(t *testing.T) {
+	t.Parallel()
+
+	_, err := enumerateLoRAAdapters(loRASpec(t,
+		"dup", "pvc://adapters/one",
+		"dup", "pvc://adapters/two",
+	))
+	if err == nil {
+		t.Fatal("expected an error for duplicate adapter names")
+	}
+	if want := `duplicate LoRA adapter name "dup"`; !strings.Contains(err.Error(), want) {
+		t.Errorf("got %q, want it to contain %q", err.Error(), want)
+	}
+}
+
+// A literal adapter name can equal the suffixed form another adapter resolves to.
+// The occurrence count cannot see that, so the uniqueness check has to catch it.
+func TestEnumerateLoRAAdaptersSuffixCollidesWithLiteralName(t *testing.T) {
+	t.Parallel()
+
+	shadow := "sql-v2-" + utils.ShortHash("sql/v2")
+	_, err := enumerateLoRAAdapters(loRASpec(t,
+		"sql/v2", "pvc://adapters/sql-slash-v2",
+		"sql-v2", "pvc://adapters/sql-dash-v2",
+		shadow, "pvc://adapters/shadow",
+	))
+	if err == nil {
+		t.Fatal("expected an error when a suffixed segment collides with a literal name")
+	}
+	if want := "/mnt/lora/" + shadow; !strings.Contains(err.Error(), want) {
+		t.Errorf("got %q, want it to contain %q", err.Error(), want)
+	}
+}
+
+// Adapters merged in from an LLMInferenceServiceConfig are never LoRA-validated, so
+// unnamed adapters reach enumerateLoRAAdapters through a fully admitted spec. Two of
+// them collide on the sanitize fallback, and the error must name that, not a duplicate "".
+func TestEnumerateLoRAAdaptersUnnamedCollision(t *testing.T) {
+	t.Parallel()
+
+	spec := loRASpec(t, "placeholder", "pvc://adapters/one", "other", "pvc://adapters/two")
+	spec.Model.LoRA.Adapters[0].Name = nil
+	spec.Model.LoRA.Adapters[1].Name = nil
+
+	_, err := enumerateLoRAAdapters(spec)
+	if err == nil {
+		t.Fatal("expected an error for two unnamed adapters")
+	}
+	if want := "two or more LoRA adapters have no name"; !strings.Contains(err.Error(), want) {
+		t.Errorf("got %q, want it to contain %q", err.Error(), want)
+	}
+	// Adapters are sorted by name before segments are computed, so any index reported
+	// here would point into the sorted slice rather than spec.model.lora.adapters.
+	if strings.Contains(err.Error(), "index") {
+		t.Errorf("message names an index that does not locate the adapter in the spec: %q", err.Error())
+	}
+}
+
+// The reconciler dispatches the LoRAMountPathCollision event on errors.Is against this
+// sentinel, so rewording a message must not quietly cost the event its reason.
+func TestLoRAAdapterCollisionErrorsAreMarked(t *testing.T) {
+	t.Parallel()
+
+	shadow := "sql-v2-" + utils.ShortHash("sql/v2")
+	unnamed := loRASpec(t, "a", "pvc://adapters/a", "b", "pvc://adapters/b")
+	unnamed.Model.LoRA.Adapters[0].Name = nil
+	unnamed.Model.LoRA.Adapters[1].Name = nil
+
+	for name, spec := range map[string]v1alpha2.LLMInferenceServiceSpec{
+		"duplicate name": loRASpec(t, "dup", "pvc://adapters/one", "dup", "pvc://adapters/two"),
+		"shadowed suffix": loRASpec(t,
+			"sql/v2", "pvc://adapters/one", "sql-v2", "pvc://adapters/two", shadow, "pvc://adapters/three"),
+		"both unnamed": unnamed,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := enumerateLoRAAdapters(spec)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			var collision *loRAMountPathCollisionError
+			if !errors.As(err, &collision) {
+				t.Errorf("error is not a collision: %v", err)
+			}
+		})
+	}
+
+	// Other enumerate failures must not claim the collision reason.
+	_, err := enumerateLoRAAdapters(loRASpec(t, "a", "oci://registry/adapter"))
+	if err == nil {
+		t.Fatal("expected an error for oci://")
+	}
+	var collision *loRAMountPathCollisionError
+	if errors.As(err, &collision) {
+		t.Error("unsupported-scheme error must not be classified as a collision")
+	}
+}
+
+// The upgrade-safety property that matters is not "a lone adapter keeps its path" but
+// "a clean adapter keeps its path even when others in the same spec collide". Only the
+// colliding group may move.
+func TestEnumerateLoRAAdaptersCollisionDoesNotMoveBystanders(t *testing.T) {
+	t.Parallel()
+
+	adapters, err := enumerateLoRAAdapters(loRASpec(t,
+		"sql/v2", "pvc://adapters/one",
+		"sql-v2", "pvc://adapters/two",
+		"lonely", "pvc://adapters/three",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"lonely": "/mnt/lora/lonely",
+		"sql-v2": "/mnt/lora/sql-v2-" + utils.ShortHash("sql-v2"),
+		"sql/v2": "/mnt/lora/sql-v2-" + utils.ShortHash("sql/v2"),
+	}
+	if len(adapters) != len(want) {
+		t.Fatalf("got %d adapters, want %d", len(adapters), len(want))
+	}
+	for _, a := range adapters {
+		if a.mountPath != want[a.name] {
+			t.Errorf("adapter %q moved: got %q want %q", a.name, a.mountPath, want[a.name])
+		}
+	}
+}
+
+// Reordering spec.model.lora.adapters is a semantic no-op, so it must not move a mount.
+// The doc comment on loraMountSegments claims this; without a test nothing enforces it.
+func TestEnumerateLoRAAdaptersMountPathsAreOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{
+		{"sql/v2", "pvc://adapters/one"},
+		{"sql-v2", "pvc://adapters/two"},
+		{"lonely", "pvc://adapters/three"},
+	}
+	paths := func(order []int) map[string]string {
+		t.Helper()
+		flat := make([]string, 0, len(order)*2)
+		for _, i := range order {
+			flat = append(flat, pairs[i][0], pairs[i][1])
+		}
+		adapters, err := enumerateLoRAAdapters(loRASpec(t, flat...))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := make(map[string]string, len(adapters))
+		for _, a := range adapters {
+			got[a.name] = a.mountPath
+		}
+		return got
+	}
+
+	base := paths([]int{0, 1, 2})
+	for _, order := range [][]int{{2, 1, 0}, {1, 0, 2}, {0, 2, 1}, {2, 0, 1}, {1, 2, 0}} {
+		got := paths(order)
+		for name, path := range base {
+			if got[name] != path {
+				t.Errorf("order %v moved adapter %q: got %q want %q", order, name, got[name], path)
+			}
+		}
+	}
+}
+
+// An unsupported scheme is the more specific problem, so it must not be masked by a
+// collision that happens to share the spec - the event reason is chosen from the error.
+func TestEnumerateLoRAAdaptersSchemeErrorBeatsCollision(t *testing.T) {
+	t.Parallel()
+
+	_, err := enumerateLoRAAdapters(loRASpec(t,
+		"sql/v2", "pvc://adapters/one",
+		"sql-v2", "pvc://adapters/two",
+		"oci-adapter", "oci://registry/adapter",
+	))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "oci://") {
+		t.Errorf("got %q, want the unsupported scheme reported", err.Error())
+	}
+	var collision *loRAMountPathCollisionError
+	if errors.As(err, &collision) {
+		t.Error("scheme error must not carry the collision reason")
 	}
 }

--- a/pkg/utils/names.go
+++ b/pkg/utils/names.go
@@ -52,7 +52,7 @@ func SafeObjectName(candidate string) string {
 		return candidate
 	}
 
-	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(candidate)))[:8]
+	digest := ShortHash(candidate)
 	budget := validation.DNS1123LabelMaxLength - len(digest) - 1
 	if len(sanitized) > budget {
 		sanitized = strings.TrimRight(sanitized[:budget], "-")
@@ -61,4 +61,18 @@ func SafeObjectName(candidate string) string {
 		return digest
 	}
 	return sanitized + "-" + digest
+}
+
+// ShortHash returns exactly 8 lowercase hex characters derived from s. It disambiguates
+// names that a lossy sanitizer would otherwise collapse together; the digest is taken
+// over the raw input, before any sanitizer runs, so callers sanitizing for different
+// character sets derive the same suffix for the same name.
+//
+// The 8-character width is a compatibility contract, not an implementation detail.
+// SafeObjectName derives its truncation budget from it, so widening it renames every
+// sanitized object and restarts the pods holding them, and loraMountSegments relies on
+// a fixed width for two suffixed segments to be unable to collide. Not for security
+// use: 32 bits.
+func ShortHash(s string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(s)))[:8]
 }

--- a/pkg/utils/names_test.go
+++ b/pkg/utils/names_test.go
@@ -66,3 +66,27 @@ func TestSanitizeDNS1123Label(t *testing.T) {
 	assert.Equal(t, "my-adapter", sanitizeDNS1123Label("my-adapter"))
 	assert.Equal(t, "", sanitizeDNS1123Label("///"))
 }
+
+// The 8-character width is a compatibility contract: SafeObjectName derives its
+// truncation budget from it, and loraMountSegments relies on a fixed width for two
+// suffixed segments to be unable to collide. Widening it renames live objects.
+func TestShortHash(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{"", "sql/v2", "sql-v2", strings.Repeat("x", 512)} {
+		got := ShortHash(in)
+		if len(got) != 8 {
+			t.Errorf("ShortHash(%q) = %q, want 8 characters", in, got)
+		}
+		if got != ShortHash(in) {
+			t.Errorf("ShortHash(%q) is not stable", in)
+		}
+		if strings.Trim(got, "0123456789abcdef") != "" {
+			t.Errorf("ShortHash(%q) = %q, want lowercase hex", in, got)
+		}
+	}
+
+	if a, b := ShortHash("sql/v2"), ShortHash("sql-v2"); a == b {
+		t.Errorf("distinct inputs share a digest: %q", a)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adapter names become directory names under `/mnt/lora`, and the sanitizer that makes them filesystem-safe is lossy - every character outside `[a-zA-Z0-9._-]` becomes a hyphen. Distinct names can therefore land on the same path. Admission does not catch it, because the duplicate check compares raw names.

Colliding names now carry a short hash of the raw name, which keeps them distinct while leaving every other adapter on the path it already has. Adapters that mount cleanly today are untouched, so upgrading hopefully moves no mounts and restarts no healthy pods. Where names still cannot be separated the service is parked with a named condition and event rather than retried forever, since it requires fixes a spec.

**Feature/Issue validation/testing**:

- [x] Unit tests, added as a failing commit first: distinct paths for colliding
      names, distinct storage-initializer targets, no duplicate `mountPath` on the
      workload container, and the exact suffixed form
- [x] Upgrade safety pinned by tests that pass both before and after the fix: a
      non-colliding adapter keeps its exact path, including when other adapters in
      the same spec do collide
- [x] Order independence across permutations of `spec.model.lora.adapters`
- [x] Error classification: the collision sentinel is asserted on every refusal and
      asserted absent on unrelated failures, so rewording a message cannot silently
      cost the event its reason
- [x] Verified end to end on kind: a service with `sql/v2` and `sql-v2` adapters
      previously had its Deployment refused by the API server, and now comes up with
      two distinct mounts and correct per-adapter `--lora-modules` entries

**Special notes for your reviewer**:

Which way it breaks depends on the URI scheme: 
- `pvc://` adapters produce two volumes contending for one `mountPath` and the API server refuses the Deployment
- `hf://` and `s3://` adapters share a single download directory, so the workload starts and one adapter's weights handles to both names.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
LoRA adapter names that differ only in characters KServe rewrites for filesystem safety (for example `sql/v2` and `sql-v2`) no longer share a mount path. Previously such a pair either prevented the workload from starting or served one adapter's weights under both names. Adapters whose names do not collide keep their existing mount paths, so upgrading does not restart running pods. Adapters sharing an exact name are now rejected instead of silently dropped.
```
