### PR TITLE
fix(llmisvc): template base llmisvcconfig files in the correct namespace

### DIFF
--- a/charts/kserve-runtime-configs/templates/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/templates/llmisvcconfigs/resources.yaml
@@ -1,3 +1,3 @@
 {{- if .Values.kserve.llmisvcConfigs.enabled }}
-{{ .Files.Get "files/llmisvcconfigs/resources.yaml" }}
+{{ include "kserve-common.replaceNamespace" (list (.Files.Get "files/llmisvcconfigs/resources.yaml") .Release.Namespace) }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Renders the default LLMInferenceServiceConfig presets into the Helm release namespace instead of hardcoding kserve.
This lets the LLMInferenceService controller find the presets when KServe is installed in a custom namespace such as inf-kserve.

**Which issue(s) this PR fixes**:
Fixes #6087 

**Feature/Issue validation/testing**:

- [x] Rendered kserve-runtime-configs with --namespace inf-kserve
- [x] Confirmed all 11 default LLMInferenceServiceConfig presets render with namespace: inf-kserve
- [x] Ran helm lint charts/kserve-runtime-configs --set kserve.llmisvcConfigs.enabled=true

**Special notes for your reviewer**:

This follows the existing chart pattern of applying the shared replaceNamespace helper to generated resource files. The runtime configs chart already had this helper but did not apply it to the LLM preset manifest.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix LLMInferenceServiceConfig preset namespace rendering for Helm installs in custom namespaces.
```