### PR TITLE
fix: keep model status UpToDate for scaled-to-zero serverless services

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -737,6 +737,15 @@ func (ss *InferenceServiceStatus) PropagateModelStatus(statusSpec ComponentStatu
 					return true
 				}
 			}
+
+			// If the latest revision is ready and all Knative conditions are healthy,
+			// the service is intentionally scaled to zero. Preserve UpToDate rather
+			// than reporting an ongoing transition.
+			if statusSpec.LatestCreatedRevision != "" &&
+				statusSpec.LatestCreatedRevision == statusSpec.LatestReadyRevision {
+				ss.UpdateModelRevisionStates(Loaded, nil)
+				return true
+			}
 		}
 
 		// If we made it here then hopefully there are 0 pods because we're just getting started and therefore Pending seems appropriate

--- a/pkg/apis/serving/v1beta1/inference_service_status_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status_test.go
@@ -527,6 +527,59 @@ func TestInferenceServiceStatus_PropagateModelStatus(t *testing.T) {
 			expectedFailureInfo:      nil,
 			expectedReturnValue:      true,
 		},
+		"pod list is empty but latest revision is ready": {
+			isvcStatus: &InferenceServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+				Address: &duckv1.Addressable{},
+				URL:     &apis.URL{},
+				Components: map[ComponentType]ComponentStatusSpec{
+					PredictorComponent: {
+						LatestRolledoutRevision: "test-predictor-default-0001",
+					},
+				},
+				ModelStatus: ModelStatus{
+					ModelRevisionStates: &ModelRevisionStates{
+						ActiveModelState: Loaded,
+						TargetModelState: Loaded,
+					},
+					TransitionStatus: UpToDate,
+				},
+			},
+			statusSpec: ComponentStatusSpec{
+				LatestReadyRevision:       "test-predictor-default-0002",
+				LatestCreatedRevision:     "test-predictor-default-0002",
+				PreviousRolledoutRevision: "test-predictor-default-0001",
+				LatestRolledoutRevision:   "test-predictor-default-0001",
+			},
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{},
+			},
+			rawDeployment: false,
+			serviceStatus: &knservingv1.ServiceStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{
+						{
+							Type:   "Ready",
+							Status: "True",
+						},
+					},
+				},
+			},
+			expectedRevisionStates: &ModelRevisionStates{
+				ActiveModelState: Loaded,
+				TargetModelState: Loaded,
+			},
+			expectedTransitionStatus: UpToDate,
+			expectedFailureInfo:      nil,
+			expectedReturnValue:      true,
+		},
 		"pod list is empty but knative has an error": {
 			isvcStatus: &InferenceServiceStatus{
 				Status: duckv1.Status{


### PR DESCRIPTION
**What this PR does / why we need it**:

For a Serverless `InferenceService` with `minReplicas: 0`, scaling to zero leaves `status.modelStatus` stuck at:

```yaml
transitionStatus: InProgress
targetModelState: Pending
```

even though all Knative conditions are `True`, the latest revision is ready, and no transition is actually happening. This breaks external consumers (e.g. Argo CD's built-in health check) that map `InProgress` to `Progressing` forever.

**Which issue(s) this PR fixes**:

Fixes #6079

**Special notes for your reviewer**:

- The fix is intentionally narrow: only the serverless (`!rawDeployment`) zero-pod branch is changed, and only when `LatestCreatedRevision == LatestReadyRevision` and non-empty.
- In that case we call `UpdateModelRevisionStates(Loaded)` so the resulting status is `transitionStatus: UpToDate` with both active and target model states `Loaded`, matching a fully rolled-out revision.
- Added a table-driven test case covering the scaled-to-zero-but-ready scenario; the existing "pod list is empty" case (empty revisions) still expects `Pending`/`InProgress`.

**Release note**:

```release-note
Fixed InferenceService modelStatus incorrectly reporting InProgress for healthy scale-to-zero Serverless services.
```

### Agent review
- No independent agent review pass was run.
- This PR was authored with the assistance of an AI coding agent (OpenCode / Kimi-K2.7-Code).
