### PR TITLE
fix(llmisvc): detect InferencePool targetPorts shrink

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -2109,7 +2109,8 @@ func semanticServiceIsEqual(expected *corev1.Service, current *corev1.Service) b
 }
 
 func semanticInferencePoolIsEqual(expected *igwapi.InferencePool, curr *igwapi.InferencePool) bool {
-	return equality.Semantic.DeepDerivative(expected.Spec, curr.Spec) &&
+	return slices.Equal(expected.Spec.TargetPorts, curr.Spec.TargetPorts) &&
+		equality.Semantic.DeepDerivative(expected.Spec, curr.Spec) &&
 		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
 		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations)
 }

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -28,10 +28,59 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
+
+func TestSemanticInferencePoolIsEqualTargetPortsShrink(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	multi := []igwapi.Port{{Number: 8000}, {Number: 8001}, {Number: 8002}, {Number: 8003}, {Number: 8004}, {Number: 8005}, {Number: 8006}, {Number: 8007}}
+	single := []igwapi.Port{{Number: 8000}}
+
+	tests := []struct {
+		name     string
+		expected []igwapi.Port
+		curr     []igwapi.Port
+		want     bool
+	}{
+		{
+			name:     "identical single port is equal",
+			expected: single,
+			curr:     slices.Clone(single),
+			want:     true,
+		},
+		{
+			name:     "identical multi-port is equal",
+			expected: multi,
+			curr:     slices.Clone(multi),
+			want:     true,
+		},
+		{
+			name:     "shrinking from 8 ports to 1 (data-parallel-size 8 -> 1) must be detected as a change",
+			expected: single,
+			curr:     multi,
+			want:     false,
+		},
+		{
+			name:     "growing from 1 port to 8 (data-parallel-size 1 -> 8) must be detected as a change",
+			expected: multi,
+			curr:     single,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := &igwapi.InferencePool{Spec: igwapi.InferencePoolSpec{TargetPorts: tt.expected}}
+			curr := &igwapi.InferencePool{Spec: igwapi.InferencePoolSpec{TargetPorts: tt.curr}}
+
+			g.Expect(semanticInferencePoolIsEqual(expected, curr)).To(Equal(tt.want))
+		})
+	}
+}
 
 func TestSchedulerConfigTextLoRA(t *testing.T) {
 	loraAdapters := []v1alpha2.LLMModelSpec{{}}


### PR DESCRIPTION
**What this PR does / why we need it**:

`semanticInferencePoolIsEqual()` uses `DeepDerivative`, which considers a shorter expected slice equal when it matches the prefix of the current slice.

As a result, shrinking `InferencePool.spec.targetPorts` (for example, `[8000..8007]` to `[8000]`) was treated as unchanged and the controller skipped the update.

This PR compares `TargetPorts` exactly with `slices.Equal` and adds regression tests for equal, shrinking, and growing port lists.

**Which issue(s) this PR fixes**:

Fixes #6090

**Feature/Issue validation/testing**:

- [x] Added unit tests covering equal, shrink, and grow cases
- [x] `go test ./pkg/controller/v1alpha2/llmisvc/... -run TestSemanticInferencePoolIsEqualTargetPortsShrink -count=1`
- [x] `go vet ./pkg/controller/v1alpha2/llmisvc/...`

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation? (Not applicable; no API change)

**Release note**:

```release-note
Fixed an issue where the LLMInferenceService controller did not update an `InferencePool` when entries were removed from `spec.targetPorts`, leaving stale target ports.
```