### PR TITLE
fix(llmisvc): validate LoRA adapters declared in a config

### DIFF
--- a/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -134,6 +135,18 @@ func (l *LLMInferenceServiceConfigValidator) validate(ctx context.Context, confi
 	}
 
 	allErrs = append(allErrs, l.validateScheduler(config)...)
+
+	// A config's adapters are merged into the LLMInferenceService spec and reach the
+	// controller unchanged, but LLMInferenceServiceValidator only sees the unmerged
+	// service, so without this they would be validated by nothing. The base model name
+	// stays empty when the config does not set one: it is supplied by the service at
+	// merge time, and config.Name is a different identifier that would reject legitimate
+	// adapter names.
+	allErrs = append(allErrs, ValidateLoRAAdapters(
+		config.Spec.Model.LoRA,
+		ptr.Deref(config.Spec.Model.Name, ""),
+		field.NewPath("spec", "model", "lora"),
+	)...)
 
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation_test.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
+)
+
+// Adapters declared in an LLMInferenceServiceConfig are merged into the service spec
+// and reach the controller unchanged. LLMInferenceServiceValidator only ever sees the
+// unmerged service, so the config validator is the only place they can be caught.
+func TestValidateLoRAAdaptersFromConfig(t *testing.T) {
+	t.Parallel()
+
+	validator := &LLMInferenceServiceConfigValidator{}
+
+	makeConfig := func(modelName *string, adapters ...LLMModelSpec) *LLMInferenceServiceConfig {
+		return &LLMInferenceServiceConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "preset", Namespace: "default"},
+			Spec: LLMInferenceServiceSpec{
+				Model: LLMModelSpec{
+					URI:  apis.URL{Scheme: "hf", Host: "base-model"},
+					Name: modelName,
+					LoRA: &LoRASpec{Adapters: adapters},
+				},
+			},
+		}
+	}
+	adapter := func(name, host string) LLMModelSpec {
+		return LLMModelSpec{URI: apis.URL{Scheme: "hf", Host: host}, Name: ptr.To(name)}
+	}
+
+	t.Run("no lora", func(t *testing.T) {
+		t.Parallel()
+		config := makeConfig(nil)
+		config.Spec.Model.LoRA = nil
+		require.NoError(t, validator.validate(t.Context(), config))
+	})
+
+	t.Run("valid adapters", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validator.validate(t.Context(),
+			makeConfig(nil, adapter("adapter-1", "a1"), adapter("adapter-2", "a2"))))
+	})
+
+	t.Run("duplicate adapter names", func(t *testing.T) {
+		t.Parallel()
+		err := validator.validate(t.Context(),
+			makeConfig(nil, adapter("dup", "a1"), adapter("dup", "a2")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.model.lora.adapters[1].name")
+	})
+
+	t.Run("adapter name missing", func(t *testing.T) {
+		t.Parallel()
+		err := validator.validate(t.Context(),
+			makeConfig(nil, LLMModelSpec{URI: apis.URL{Scheme: "hf", Host: "a1"}}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.model.lora.adapters[0].name")
+	})
+
+	t.Run("adapter name is path traversal", func(t *testing.T) {
+		t.Parallel()
+		err := validator.validate(t.Context(), makeConfig(nil, adapter("..", "a1")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.model.lora.adapters[0].name")
+	})
+
+	t.Run("maxRank bound", func(t *testing.T) {
+		t.Parallel()
+		config := makeConfig(nil, adapter("adapter-1", "a1"))
+		config.Spec.Model.LoRA.MaxRank = ptr.To(int32(0))
+		err := validator.validate(t.Context(), config)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.model.lora.maxRank")
+	})
+
+	// The base model name is supplied by the LLMInferenceService at merge time. A config
+	// that does not set one must not have its own object name stand in, or an adapter
+	// legitimately named after the preset would be rejected.
+	t.Run("adapter named after the config object is allowed", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validator.validate(t.Context(), makeConfig(nil, adapter("preset", "a1"))))
+	})
+
+	t.Run("adapter colliding with an explicit base model name is rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validator.validate(t.Context(), makeConfig(ptr.To("base"), adapter("base", "a1")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spec.model.lora.adapters[0].name")
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes a validation gap for LoRA adapters declared in an `LLMInferenceServiceConfig`.

The config webhook never ran the LoRA checks, and the service webhook only sees the unmerged `LLMInferenceService` spec. Adapters contributed by a config preset therefore reached the controller validated by nothing - duplicate names, missing names, path traversal in a name, or an adapter shadowing the base model all went through. The CRD cannot catch these either, since the adapters array is schemaless.

Now a broken preset is rejected at admission time with a clear field error, instead of surfacing later as a confusing runtime failure in every service that references it.

Adapter names are still allowed to match the config object's own name - only a base model name explicitly set by the config is treated as a collision, since the real base model is supplied by the service at merge time.

**Feature/Issue validation/testing**:

- [x] Unit tests covering configs with no LoRA section, valid adapters, duplicate names, missing names, path traversal, rank bounds, an adapter named after the config, and an adapter colliding with an explicit base model name.

```
go test ./pkg/apis/serving/v1alpha2/... -run TestValidateLoRAAdaptersFromConfig
```

**Special notes for your reviewer**:

None.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
