### PR TITLE
fix: set ObservedGeneration from own generation, not child object

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -452,9 +452,6 @@ func (ss *InferenceServiceStatus) PropagateRawStatus(
 
 	ss.SetCondition(readyCondition, componentReadyCondition)
 	ss.Components[component] = statusSpec
-	if len(deploymentList) > 0 {
-		ss.ObservedGeneration = deploymentList[0].Status.ObservedGeneration
-	}
 }
 
 func getDeploymentCondition(deploymentList []*appsv1.Deployment, conditionType appsv1.DeploymentConditionType) *apis.Condition {
@@ -632,7 +629,6 @@ func (ss *InferenceServiceStatus) PropagateStatus(component ComponentType, servi
 	ss.SetCondition(configurationConditionType, configurationCondition)
 
 	ss.Components[component] = statusSpec
-	ss.ObservedGeneration = serviceStatus.ObservedGeneration
 }
 
 func (ss *InferenceServiceStatus) SetCondition(conditionType apis.ConditionType, condition *apis.Condition) {

--- a/pkg/apis/serving/v1beta1/inference_service_status_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status_test.go
@@ -274,6 +274,75 @@ func TestPropagateRawStatus_EmptyDeploymentList(t *testing.T) {
 	g.Expect(status.ObservedGeneration).To(gomega.Equal(int64(0)))
 }
 
+// TestPropagateRawStatus_DoesNotSetObservedGeneration verifies that
+// PropagateRawStatus no longer copies the child Deployment's ObservedGeneration
+// onto the InferenceServiceStatus. The field is now set by updateStatus() in
+// the controller from the InferenceService's own metadata.Generation.
+func TestPropagateRawStatus_DoesNotSetObservedGeneration(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": "1",
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			// Simulate a child Deployment that has been updated 7 times.
+			ObservedGeneration: 7,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionTrue,
+					Reason: "MinimumReplicasAvailable",
+				},
+			},
+		},
+	}
+	status := &InferenceServiceStatus{}
+	parsedURL, _ := url.Parse("http://test-predictor-default.default.example.com")
+	serviceURL := (*apis.URL)(parsedURL)
+
+	status.PropagateRawStatus(PredictorComponent, []*appsv1.Deployment{deployment}, serviceURL)
+
+	// PropagateRawStatus must NOT copy the child's ObservedGeneration (7).
+	// The controller's updateStatus() is responsible for setting it from
+	// isvc.Generation instead.
+	g.Expect(status.ObservedGeneration).To(gomega.Equal(int64(0)),
+		"PropagateRawStatus must not copy the child Deployment's ObservedGeneration")
+}
+
+// TestPropagateStatus_DoesNotSetObservedGeneration verifies that PropagateStatus
+// no longer copies the child Knative Service's ObservedGeneration onto the
+// InferenceServiceStatus. Same contract as TestPropagateRawStatus_DoesNotSetObservedGeneration.
+func TestPropagateStatus_DoesNotSetObservedGeneration(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	parsedURL, _ := url.Parse("http://test-predictor-default.default.example.com")
+	serviceStatus := &knservingv1.ServiceStatus{
+		Status: duckv1.Status{
+			// Simulate a child Knative Service at its own generation 5.
+			ObservedGeneration: 5,
+			Conditions: duckv1.Conditions{
+				{Type: "RoutesReady", Status: corev1.ConditionTrue},
+				{Type: "ConfigurationsReady", Status: corev1.ConditionTrue},
+				{Type: knservingv1.ServiceConditionReady, Status: corev1.ConditionTrue},
+			},
+		},
+		RouteStatusFields: knservingv1.RouteStatusFields{
+			URL:     (*apis.URL)(parsedURL),
+			Address: &duckv1.Addressable{},
+		},
+	}
+	status := &InferenceServiceStatus{}
+
+	status.PropagateStatus(PredictorComponent, serviceStatus)
+
+	// PropagateStatus must NOT copy the child Knative Service's ObservedGeneration (5).
+	g.Expect(status.ObservedGeneration).To(gomega.Equal(int64(0)),
+		"PropagateStatus must not copy the child Knative Service's ObservedGeneration")
+}
+
 func TestPropagateRawStatusWithMessages(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -323,6 +323,9 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func (r *InferenceGraphReconciler) updateStatus(ctx context.Context, desiredGraph *v1alpha1.InferenceGraph) error {
+	// Record the generation the controller has observed. This must use the
+	// InferenceGraph's own metadata.Generation, not a child object's counter.
+	desiredGraph.Status.ObservedGeneration = desiredGraph.Generation
 	graph := &v1alpha1.InferenceGraph{}
 	namespacedName := types.NamespacedName{Name: desiredGraph.Name, Namespace: desiredGraph.Namespace}
 	if err := r.Get(ctx, namespacedName, graph); err != nil {

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -192,5 +192,4 @@ func PropagateRawStatus(graphStatus *v1alpha1.InferenceGraphStatus, deployment *
 			break
 		}
 	}
-	graphStatus.ObservedGeneration = deployment.Status.ObservedGeneration
 }

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
@@ -643,3 +643,31 @@ func TestPropagateRawStatus(t *testing.T) {
 		})
 	}
 }
+
+// TestPropagateRawStatus_DoesNotSetObservedGeneration verifies that the
+// InferenceGraph PropagateRawStatus helper no longer copies the child
+// Deployment's ObservedGeneration onto the graph status. The field is set
+// by updateStatus() from the InferenceGraph's own metadata.Generation.
+func TestPropagateRawStatus_DoesNotSetObservedGeneration(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ig"},
+		Status: appsv1.DeploymentStatus{
+			// Simulate a child Deployment at its own generation 9.
+			ObservedGeneration: 9,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	graphStatus := &InferenceGraphStatus{}
+
+	PropagateRawStatus(graphStatus, deployment, nil)
+
+	if graphStatus.ObservedGeneration != 0 {
+		t.Errorf("PropagateRawStatus must not copy the child Deployment's ObservedGeneration: got %d, want 0",
+			graphStatus.ObservedGeneration)
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -422,6 +422,9 @@ func (r *InferenceServiceReconciler) updateStatus(ctx context.Context, desiredSe
 ) error {
 	// set the DeploymentMode used for the InferenceService in the status
 	desiredService.Status.DeploymentMode = string(deploymentMode)
+	// Record the generation the controller has observed. This must use the
+	// InferenceService's own metadata.Generation, not a child object's counter.
+	desiredService.Status.ObservedGeneration = desiredService.Generation
 
 	existingService := &v1beta1.InferenceService{}
 	namespacedName := types.NamespacedName{Name: desiredService.Name, Namespace: desiredService.Namespace}


### PR DESCRIPTION
Fixes #6081

## Root cause

`InferenceService.Status.ObservedGeneration` was being copied from the
child Deployment's or Knative Service's `ObservedGeneration` counter
instead of the InferenceService's own `metadata.Generation`.

For a multi-component InferenceService the value became the counter of
whichever child reconciled last — uninterpretable and inconsistent with
the Kubernetes API convention that `observedGeneration` mirrors the same
object's `metadata.generation`. `InferenceGraph` had the same defect via
its child Deployment's counter.

## Fix

Set `ObservedGeneration` from the object's own `Generation` in
`updateStatus()` (both controllers), and remove the child-copy
assignments from `PropagateRawStatus` / `PropagateStatus` / `raw_ig.go`.
The field is now written in a single place per controller, on every code
path that calls `updateStatus()` — both success and early-return error
paths — consistent with the standard Kubernetes convention that
observedGeneration means "the controller has observed this spec version."

No in-tree code reads `InferenceService.Status.ObservedGeneration` or
`InferenceGraph.Status.ObservedGeneration`, so blast radius is zero.

## Tests

- `TestPropagateRawStatus_DoesNotSetObservedGeneration` (ISVC) — asserts
  `PropagateRawStatus` no longer touches the field
- `TestPropagateStatus_DoesNotSetObservedGeneration` (ISVC) — asserts
  `PropagateStatus` no longer touches the field
- `TestPropagateRawStatus_DoesNotSetObservedGeneration` (InferenceGraph)
  — same assertion for the graph propagate function
