### PR TITLE
feat(kernelcache): add security verification framework

### DIFF
--- a/pkg/kernelcache/security/config.go
+++ b/pkg/kernelcache/security/config.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package security defines the contracts for verifying kernel cache OCI images.
+// It exposes a mode-agnostic Verifier interface plus the configuration that
+// selects a verification mode. Only the disabled mode exists here; each real
+// mode (and any config it needs) is added together with its implementation.
+package security
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Mode selects how kernel cache images are verified.
+type Mode string
+
+const (
+	// ModeDisabled performs no signature verification.
+	ModeDisabled Mode = "disabled"
+)
+
+// FailurePolicy decides what a consumer does when verification fails. The
+// policy is applied by the caller (via VerifyResult.ShouldBlock), not by the
+// Verifier, so the same result can be handled uniformly across modes.
+type FailurePolicy string
+
+const (
+	// FailurePolicyReject blocks use of an image that fails verification.
+	FailurePolicyReject FailurePolicy = "reject"
+
+	// FailurePolicyWarn allows use after logging a warning. Intended for
+	// migration or development, not production.
+	FailurePolicyWarn FailurePolicy = "warn"
+)
+
+// SecurityConfig is the cluster-level security configuration. It mirrors the
+// "security" block of the "kernelcache" section in the inferenceservice-config
+// ConfigMap; the json tags are the wire contract and must match that schema.
+// Mode-specific sub-configuration is added with each mode.
+type SecurityConfig struct {
+	// Mode selects the verification mechanism.
+	Mode Mode `json:"mode,omitempty"`
+
+	// FailurePolicy controls consumer behaviour on verification failure.
+	FailurePolicy FailurePolicy `json:"failurePolicy,omitempty"`
+}
+
+// ErrUnknownMode is returned when the configured mode is not recognised.
+var ErrUnknownMode = errors.New("unknown verification mode")
+
+// Default fills empty fields with safe defaults. An unset mode defaults to
+// disabled so an unconfigured feature performs no verification rather than
+// failing; an unset failure policy defaults to reject.
+func (c *SecurityConfig) Default() {
+	if c.Mode == "" {
+		c.Mode = ModeDisabled
+	}
+	if c.FailurePolicy == "" {
+		c.FailurePolicy = FailurePolicyReject
+	}
+}
+
+// Validate checks that enum-valued fields hold known values. Each mode adds its
+// own case here (and any mode-specific field checks in its constructor).
+func (c *SecurityConfig) Validate() error {
+	switch c.Mode {
+	case ModeDisabled:
+	default:
+		return fmt.Errorf("%w: %q", ErrUnknownMode, c.Mode)
+	}
+
+	switch c.FailurePolicy {
+	case FailurePolicyReject, FailurePolicyWarn:
+	default:
+		return fmt.Errorf("invalid failurePolicy: %q", c.FailurePolicy)
+	}
+
+	return nil
+}

--- a/pkg/kernelcache/security/config_test.go
+++ b/pkg/kernelcache/security/config_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSecurityConfigSchema locks the json tags to the ConfigMap schema. A typo
+// or renamed tag would silently drop config in production; this test fails
+// instead.
+func TestSecurityConfigSchema(t *testing.T) {
+	const raw = `{ "mode": "disabled", "failurePolicy": "reject" }`
+
+	var got SecurityConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &got))
+
+	want := SecurityConfig{
+		Mode:          ModeDisabled,
+		FailurePolicy: FailurePolicyReject,
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestSecurityConfigDefault(t *testing.T) {
+	t.Run("empty defaults to disabled + reject", func(t *testing.T) {
+		c := SecurityConfig{}
+		c.Default()
+		assert.Equal(t, ModeDisabled, c.Mode)
+		assert.Equal(t, FailurePolicyReject, c.FailurePolicy)
+	})
+
+	t.Run("set values are preserved", func(t *testing.T) {
+		c := SecurityConfig{Mode: ModeDisabled, FailurePolicy: FailurePolicyWarn}
+		c.Default()
+		assert.Equal(t, ModeDisabled, c.Mode)
+		assert.Equal(t, FailurePolicyWarn, c.FailurePolicy)
+	})
+}
+
+func TestSecurityConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     SecurityConfig
+		wantErr bool
+	}{
+		{"disabled reject", SecurityConfig{Mode: ModeDisabled, FailurePolicy: FailurePolicyReject}, false},
+		{"disabled warn", SecurityConfig{Mode: ModeDisabled, FailurePolicy: FailurePolicyWarn}, false},
+		{"unknown mode", SecurityConfig{Mode: "cert", FailurePolicy: FailurePolicyReject}, true},
+		{"empty mode", SecurityConfig{Mode: "", FailurePolicy: FailurePolicyReject}, true},
+		{"bad failure policy", SecurityConfig{Mode: ModeDisabled, FailurePolicy: "explode"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/kernelcache/security/factory.go
+++ b/pkg/kernelcache/security/factory.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"context"
+	"fmt"
+)
+
+// NewVerifier builds the Verifier for the configured mode. The config is
+// defaulted and validated first. Only the disabled mode is wired here; each
+// real mode adds its own case (and any dependencies its constructor needs)
+// when it lands.
+func NewVerifier(cfg SecurityConfig) (Verifier, error) {
+	cfg.Default()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	switch cfg.Mode {
+	case ModeDisabled:
+		return noopVerifier{}, nil
+	default:
+		// Unreachable after Validate, kept as a defensive guard.
+		return nil, fmt.Errorf("%w: %q", ErrUnknownMode, cfg.Mode)
+	}
+}
+
+// noopVerifier performs no signature check. It backs the disabled mode.
+type noopVerifier struct{}
+
+var _ Verifier = noopVerifier{}
+
+// Verify reports the image as not verified without contacting any registry.
+// Digest resolution for the disabled mode is added together with the shared
+// registry helper used by the real verifiers.
+func (noopVerifier) Verify(_ context.Context, _ VerifyRequest) (VerifyResult, error) {
+	return VerifyResult{
+		Mode:     ModeDisabled,
+		Verified: false,
+		Reason:   "verification disabled",
+	}, nil
+}

--- a/pkg/kernelcache/security/factory_test.go
+++ b/pkg/kernelcache/security/factory_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVerifier(t *testing.T) {
+	t.Run("disabled returns a working no-op", func(t *testing.T) {
+		v, err := NewVerifier(SecurityConfig{Mode: ModeDisabled})
+		require.NoError(t, err)
+		require.NotNil(t, v)
+
+		res, err := v.Verify(context.Background(), VerifyRequest{ImageRef: "registry/img:tag"})
+		require.NoError(t, err)
+		assert.False(t, res.Verified)
+		assert.Equal(t, ModeDisabled, res.Mode)
+	})
+
+	t.Run("empty mode defaults to disabled", func(t *testing.T) {
+		v, err := NewVerifier(SecurityConfig{})
+		require.NoError(t, err)
+		assert.IsType(t, noopVerifier{}, v)
+	})
+
+	t.Run("unknown mode errors", func(t *testing.T) {
+		v, err := NewVerifier(SecurityConfig{Mode: "bogus"})
+		assert.Nil(t, v)
+		assert.ErrorIs(t, err, ErrUnknownMode)
+	})
+}

--- a/pkg/kernelcache/security/verify.go
+++ b/pkg/kernelcache/security/verify.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import "context"
+
+// VerifyRequest carries the inputs for a verification. It is a struct rather
+// than a bare image reference so new inputs (for example, delegated-mode
+// annotations) can be added without changing the Verifier interface.
+type VerifyRequest struct {
+	// ImageRef is the image to verify (tag or digest reference).
+	ImageRef string
+
+	// Annotations carries out-of-band metadata a mode may need. The kyverno
+	// mode reads the policy-engine verification result from here; other modes
+	// ignore it.
+	Annotations map[string]string
+}
+
+// VerifyResult is the outcome of a completed verification attempt. Digest is
+// populated whenever the reference could be resolved, even when Verified is
+// false, so callers can still pin an immutable reference under a warn policy.
+type VerifyResult struct {
+	// Digest is the resolved sha256 digest of the image.
+	Digest string
+
+	// Verified reports whether the signature check passed.
+	Verified bool
+
+	// Mode is the mode that produced this result.
+	Mode Mode
+
+	// Reason is a human-readable explanation, used for status and logging.
+	Reason string
+}
+
+// ShouldBlock reports whether a consumer must block use of the image given a
+// failure policy. It centralises the allow/block decision so callers do not
+// reimplement the subtle cases (in particular, disabled mode is a deliberate
+// skip, not a failure, and must never block).
+//
+// Rules:
+//   - disabled mode: never blocks (verification was intentionally skipped).
+//   - verified: never blocks.
+//   - not verified: blocks only under FailurePolicyReject.
+//
+// Operational errors (a nil, non-completed result) are handled by the caller
+// separately and are outside this decision.
+func (r VerifyResult) ShouldBlock(policy FailurePolicy) bool {
+	if r.Mode == ModeDisabled || r.Verified {
+		return false
+	}
+	return policy == FailurePolicyReject
+}
+
+// Verifier verifies a kernel cache image according to a configured mode.
+//
+// The returned error is reserved for operational failures (network, registry,
+// misconfiguration) that a caller may retry. A completed check that fails is
+// reported as VerifyResult{Verified: false} with a nil error, so the caller can
+// apply its FailurePolicy uniformly.
+type Verifier interface {
+	Verify(ctx context.Context, req VerifyRequest) (VerifyResult, error)
+}

--- a/pkg/kernelcache/security/verify_test.go
+++ b/pkg/kernelcache/security/verify_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// otherMode stands in for a real (fallible) verification mode. ShouldBlock only
+// special-cases ModeDisabled, so any non-disabled mode exercises the same path.
+const otherMode Mode = "othermode"
+
+func TestVerifyResultShouldBlock(t *testing.T) {
+	tests := []struct {
+		name   string
+		result VerifyResult
+		policy FailurePolicy
+		want   bool
+	}{
+		{"disabled never blocks even under reject", VerifyResult{Mode: ModeDisabled, Verified: false}, FailurePolicyReject, false},
+		{"verified never blocks", VerifyResult{Mode: otherMode, Verified: true}, FailurePolicyReject, false},
+		{"unverified blocks under reject", VerifyResult{Mode: otherMode, Verified: false}, FailurePolicyReject, true},
+		{"unverified warns (no block) under warn", VerifyResult{Mode: otherMode, Verified: false}, FailurePolicyWarn, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.result.ShouldBlock(tt.policy))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

First slice of the kernel cache signing/verification work (#6097): the framework structure, no crypto and no consumers yet. It sets up the seam every mode plugs into so the follow-up PRs stay small.

Adds pkg/kernelcache/security:

- Verifier interface with VerifyRequest/VerifyResult. The request is a struct so a mode can take extra inputs later without changing the interface; operational errors come back as an error, a failed check as VerifyResult{Verified:false}.
- SecurityConfig (mode + failurePolicy) with Default/Validate; the json tags mirror the kernelcache.security block of inferenceservice-config. Only the disabled mode exists - each real mode adds its own config and factory case alongside its implementation.
- NewVerifier factory that wires disabled to a no-op verifier and errors on unknown modes.
- VerifyResult.ShouldBlock, so callers apply the failure policy the same way everywhere (disabled never blocks, otherwise the policy decides).

Leaf package, no dependencies and no consumers yet, so nothing changes at runtime.

**Which issue(s) this PR fixes**:
Fixes #6098

**Feature/Issue validation/testing**:

Pure unit tests, no external dependencies:

`go test ./pkg/kernelcache/security/...`

**Special notes for your reviewer**:

First of several small PRs under #6097, scoped to just the framework so the mode PRs stay reviewable. Real modes (cert, keyless, kyverno) come next, each with its own config, tests, and dependency-setup docs under docs/kernelcache/.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
NONE
```
