### PR TITLE
feat(storage): acquire CNCF ModelPack artifacts via llmman serve

### DIFF
--- a/python/storage/kserve_storage/kserve_storage.py
+++ b/python/storage/kserve_storage/kserve_storage.py
@@ -123,6 +123,12 @@ _LAYER_MEDIA_TYPE_MODES = {
     "application/vnd.oci.image.layer.v1.tar": "r|",
 }
 
+# CNCF ModelPack (https://github.com/modelpack/model-spec) discriminators. A
+# manifest declaring either carries model files directly, with no modelcar
+# /models/ subtree, so it cannot be read as a container image.
+_MODELPACK_ARTIFACT_TYPE = "application/vnd.cncf.model.manifest.v1+json"
+_MODELPACK_CONFIG_MEDIA_TYPE = "application/vnd.cncf.model.config.v1+json"
+
 _HDFS_SECRET_DIRECTORY = "/var/secrets/kserve-hdfscreds"
 _HDFS_FILE_SECRETS = ["KERBEROS_KEYTAB", "TLS_CERT", "TLS_KEY", "TLS_CA"]
 
@@ -1482,6 +1488,11 @@ class Storage(object):
             manifest = client.get_manifest(target)
 
         os.makedirs(out_dir, exist_ok=True)
+
+        if Storage._is_modelpack_manifest(manifest):
+            logger.info("Detected CNCF ModelPack artifact at %s", uri)
+            return Storage._download_modelpack_via_llmman(target, out_dir)
+
         extracted_any = False
         seen_top_level: set = set()
         for layer in manifest.get("layers", []):
@@ -1526,6 +1537,75 @@ class Storage(object):
                 % (uri, sorted(seen_top_level)[:10])
             )
         return out_dir
+
+    @staticmethod
+    def _is_modelpack_manifest(manifest: dict) -> bool:
+        """True if the manifest describes a CNCF ModelPack artifact.
+
+        artifactType is the spec's own discriminator. The config mediaType is checked as
+        well because registries and clients that predate artifactType (or strip it) still
+        carry the ModelPack config descriptor.
+        """
+        if manifest.get("artifactType") == _MODELPACK_ARTIFACT_TYPE:
+            return True
+        return (
+            manifest.get("config", {}).get("mediaType") == _MODELPACK_CONFIG_MEDIA_TYPE
+        )
+
+    @staticmethod
+    def _download_modelpack_via_llmman(reference: str, out_dir: str) -> str:
+        """Acquire a ModelPack artifact through a running `llmman serve`.
+
+        The daemon does the pull (POST /api/pull, streamed so a multi-gigabyte
+        fetch is not silent) but deliberately exposes no local path, so
+        `llmman resolve --no-pull` reports where the bytes landed. Both the
+        daemon and the binary are therefore required, and each missing piece
+        has its own actionable error.
+        """
+        from kserve_storage import llmman
+
+        def _progress(status, completed, total):
+            if total:
+                logger.info("llmman: %s (%s/%s bytes)", status, completed, total)
+            else:
+                logger.info("llmman: %s", status)
+
+        resolved = llmman.pull_and_resolve(reference, progress=_progress)
+        Storage._materialize_resolved_model(resolved, out_dir)
+        logger.info("Fetched ModelPack artifact %s into %s", reference, out_dir)
+        return out_dir
+
+    @staticmethod
+    def _materialize_resolved_model(src: str, out_dir: str) -> None:
+        """Place llmman's extracted model at out_dir.
+
+        Files are hard-linked where possible so a model shared with llmman's
+        store costs its bytes once, falling back to a copy across filesystems.
+        """
+        os.makedirs(out_dir, exist_ok=True)
+
+        if not os.path.isdir(src):
+            Storage._link_or_copy(src, os.path.join(out_dir, os.path.basename(src)))
+            return
+
+        for root, _, files in os.walk(src):
+            rel_root = os.path.relpath(root, src)
+            dest_root = out_dir if rel_root == "." else os.path.join(out_dir, rel_root)
+            os.makedirs(dest_root, exist_ok=True)
+            for name in files:
+                Storage._link_or_copy(
+                    os.path.join(root, name), os.path.join(dest_root, name)
+                )
+
+    @staticmethod
+    def _link_or_copy(src: str, dest: str) -> None:
+        if os.path.lexists(dest):
+            os.remove(dest)
+        try:
+            os.link(src, dest)
+        except OSError:
+            # Different filesystem, or a filesystem without hard links.
+            shutil.copy2(src, dest)
 
     @staticmethod
     def _download_git_repo(uri: str, out_dir: str) -> str:

--- a/python/storage/kserve_storage/llmman.py
+++ b/python/storage/kserve_storage/llmman.py
@@ -1,0 +1,246 @@
+# Copyright 2024 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Client for a running ``llmman serve`` daemon.
+
+Used to acquire models published as CNCF ModelPack
+(https://github.com/modelpack/model-spec) OCI artifacts. The daemon owns the
+registry work -- ModelPack media types, registry auth, resumable blob download
+and a content-addressed store -- so it is not reimplemented here.
+
+Contract (from llmman's src/cmd/serve.rs and src/daemon.rs):
+  - LLMMAN_HOST is ``[scheme://]host[:port][/path]``, default 127.0.0.1:17434.
+    A wildcard bind host (0.0.0.0, ::) is rewritten to loopback, since a client
+    cannot connect to "every interface".
+  - ``GET /api/version`` -> ``{"version":..., "exe":..., "pid":...}``.
+  - ``POST /api/pull`` ``{"model": ref}`` -> NDJSON stream of ``{"status":...}``
+    objects, terminated by ``{"status":"success"}`` or ``{"error":"..."}``.
+    An error can arrive in-band at HTTP 200.
+  - ``llmman resolve --no-pull <ref>`` -> one line of JSON carrying ``path``.
+"""
+
+import ipaddress
+import json
+import os
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+
+from kserve_storage.logging import logger
+
+HOST_ENV = "LLMMAN_HOST"
+BIN_ENV = "KSERVE_LLMMAN_BIN"
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 17434
+
+PROBE_TIMEOUT_SECONDS = 5
+
+
+def _connectable_host(host: str) -> str:
+    """Rewrite a wildcard bind host to its loopback equivalent."""
+    try:
+        ip = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return host
+    if not ip.is_unspecified:
+        return host
+    return "127.0.0.1" if ip.version == 4 else "::1"
+
+
+def endpoint() -> str:
+    """The http origin of the llmman daemon, honouring LLMMAN_HOST."""
+    raw = os.getenv(HOST_ENV, "").strip().strip("\"'")
+    if not raw:
+        return f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
+
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    raw = raw.split("/", 1)[0]
+
+    host, port = raw, DEFAULT_PORT
+    if raw.startswith("["):  # bracketed IPv6, optionally with :port
+        close = raw.find("]")
+        if close != -1:
+            host = raw[: close + 1]
+            rest = raw[close + 1 :]
+            if rest.startswith(":") and rest[1:].isdigit():
+                port = int(rest[1:])
+    elif raw.count(":") == 1:
+        maybe_host, maybe_port = raw.rsplit(":", 1)
+        if maybe_port.isdigit():
+            host, port = maybe_host, int(maybe_port)
+
+    host = host or DEFAULT_HOST
+    resolved = _connectable_host(host)
+    if ":" in resolved and not resolved.startswith("["):
+        resolved = f"[{resolved}]"
+    return f"http://{resolved}:{port}"
+
+
+def llmman_bin() -> str:
+    """The llmman executable name, overridable per project."""
+    return os.getenv(BIN_ENV, "").strip() or "llmman"
+
+
+def check_daemon(base: str) -> None:
+    """Confirm an llmman daemon is listening and is actually llmman."""
+    url = base + "/api/version"
+    try:
+        with urllib.request.urlopen(url, timeout=PROBE_TIMEOUT_SECONDS) as resp:
+            if resp.status != 200:
+                raise RuntimeError(
+                    f"llmman daemon at {base} answered /api/version with HTTP {resp.status}"
+                )
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"no llmman daemon reachable at {base} ({exc.reason}). Start one with "
+            f"`llmman serve`, or point {HOST_ENV} at an existing daemon."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"the server at {base} is not an llmman daemon (unparseable /api/version)"
+        ) from exc
+
+    if not isinstance(payload, dict) or not payload.get("version"):
+        raise RuntimeError(
+            f"the server at {base} is not an llmman daemon (no version in /api/version)"
+        )
+
+
+def pull(base: str, reference: str, progress=None) -> None:
+    """Stream POST /api/pull until the daemon reports success.
+
+    ``progress`` receives ``(status, completed, total)``. An error can arrive
+    in-band at HTTP 200, and a stream that ends without ``success`` is also a
+    failure -- neither is treated as a completed pull.
+    """
+    body = json.dumps({"model": reference}).encode("utf-8")
+    req = urllib.request.Request(
+        base + "/api/pull",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    succeeded = False
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status != 200:
+                raise RuntimeError(
+                    f"llmman pull of {reference!r} failed: HTTP {resp.status}"
+                )
+            for raw_line in resp:
+                line = raw_line.decode("utf-8").strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    # Tolerate a non-JSON diagnostic rather than aborting a
+                    # pull that may still be progressing.
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("error"):
+                    raise RuntimeError(
+                        f"llmman pull of {reference!r} failed: {obj['error']}"
+                    )
+                status = obj.get("status")
+                if status == "success":
+                    succeeded = True
+                    continue
+                if progress is not None and status:
+                    progress(status, obj.get("completed", 0), obj.get("total", 0))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} failed: HTTP {exc.code}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} failed: {exc.reason}"
+        ) from exc
+
+    if not succeeded:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} ended without reporting success"
+        )
+
+
+def parse_resolve_output(stdout: str, reference: str) -> str:
+    """Parse ``llmman resolve`` stdout into the resolved local path."""
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError(f"llmman resolve {reference!r}: no output on stdout")
+
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: could not parse output as JSON: {lines[-1]}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: expected a JSON object, got {lines[-1]}"
+        )
+
+    path = payload.get("path")
+    if not isinstance(path, str) or not path.strip():
+        raise RuntimeError(f"llmman resolve {reference!r}: returned an empty path")
+    if not os.path.exists(path):
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: reported path {path!r} does not exist"
+        )
+    return path
+
+
+def resolve(reference: str) -> str:
+    """Ask the CLI where the daemon's pull left the model on disk.
+
+    ``--no-pull`` guarantees this only reports on bytes ``/api/pull`` already
+    fetched, so the daemon stays the only thing that touches the network.
+    """
+    binary = llmman_bin()
+    if shutil.which(binary) is None and not os.path.isfile(binary):
+        raise RuntimeError(
+            f"{binary!r} not found. Install llmman "
+            "(https://github.com/llmmanorg/llmman) and put it on PATH, or set "
+            f"{BIN_ENV} to its location."
+        )
+
+    completed = subprocess.run(
+        [binary, "resolve", "--no-pull", reference],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"`{binary} resolve --no-pull {reference}` failed with exit code "
+            f"{completed.returncode}: {completed.stderr.strip()}"
+        )
+    return parse_resolve_output(completed.stdout, reference)
+
+
+def pull_and_resolve(reference: str, progress=None) -> str:
+    """Full acquisition: probe the daemon, pull through it, report the path."""
+    base = endpoint()
+    check_daemon(base)
+    logger.info("Pulling %s via llmman daemon at %s", reference, base)
+    pull(base, reference, progress)
+    return resolve(reference)

--- a/python/storage/test/test_llmman.py
+++ b/python/storage/test/test_llmman.py
@@ -1,0 +1,205 @@
+# Copyright 2024 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The `llmman serve` client: endpoint resolution and the daemon protocol.
+
+Exercised against a real HTTP server on a loopback port rather than mocks, so
+the NDJSON streaming contract is genuinely tested.
+"""
+
+import http.server
+import json
+import socketserver
+import tempfile
+import threading
+
+import pytest
+
+from kserve_storage import llmman
+
+
+@pytest.mark.parametrize(
+    "host,want",
+    [
+        ("", "http://127.0.0.1:17434"),
+        ("1.2.3.4:9999", "http://1.2.3.4:9999"),
+        ("1.2.3.4", "http://1.2.3.4:17434"),
+        ("http://1.2.3.4:9999", "http://1.2.3.4:9999"),
+        ("http://1.2.3.4:9999/ignored", "http://1.2.3.4:9999"),
+        ('"1.2.3.4:9999"', "http://1.2.3.4:9999"),
+        # A wildcard bind is meaningful to the server but not to a client,
+        # which cannot connect to "every interface".
+        ("0.0.0.0:9999", "http://127.0.0.1:9999"),
+        ("[::]:9999", "http://[::1]:9999"),
+    ],
+)
+def test_endpoint_parsing(monkeypatch, host, want):
+    monkeypatch.setenv(llmman.HOST_ENV, host)
+    assert llmman.endpoint() == want
+
+
+def test_binary_default_and_override(monkeypatch):
+    monkeypatch.delenv(llmman.BIN_ENV, raising=False)
+    assert llmman.llmman_bin() == "llmman"
+    monkeypatch.setenv(llmman.BIN_ENV, "/opt/bin/llmman")
+    assert llmman.llmman_bin() == "/opt/bin/llmman"
+    # An empty override is a mistake, not a request to run the empty string.
+    monkeypatch.setenv(llmman.BIN_ENV, "   ")
+    assert llmman.llmman_bin() == "llmman"
+
+
+def _ndjson(*objs):
+    return "".join(json.dumps(o) + "\n" for o in objs)
+
+
+class _FakeDaemon:
+    """A minimal stand-in for `llmman serve`, on a real loopback port."""
+
+    def __init__(self):
+        self.version = {"version": "0.1.0", "pid": 1}
+        self.pull_body = _ndjson({"status": "success"})
+        self.pull_status = 200
+        self.last_request = None
+        daemon = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def _send(self, status, body, ctype):
+                raw = body.encode()
+                self.send_response(status)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def do_GET(self):
+                assert self.path == "/api/version"
+                self._send(200, json.dumps(daemon.version), "application/json")
+
+            def do_POST(self):
+                assert self.path == "/api/pull"
+                length = int(self.headers.get("Content-Length", 0))
+                daemon.last_request = json.loads(self.rfile.read(length))
+                self._send(daemon.pull_status, daemon.pull_body, "application/x-ndjson")
+
+        self._server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+@pytest.fixture
+def daemon():
+    d = _FakeDaemon()
+    yield d
+    d.close()
+
+
+def test_check_daemon_accepts_a_llmman_daemon(daemon):
+    llmman.check_daemon(daemon.url)
+
+
+def test_check_daemon_rejects_a_non_llmman_server(daemon):
+    daemon.version = {"hello": "world"}
+    with pytest.raises(RuntimeError, match="not an llmman daemon"):
+        llmman.check_daemon(daemon.url)
+
+
+def test_check_daemon_reports_nothing_listening():
+    with pytest.raises(RuntimeError, match="llmman serve"):
+        llmman.check_daemon("http://127.0.0.1:1")
+
+
+def test_pull_succeeds_and_forwards_progress(daemon):
+    daemon.pull_body = _ndjson(
+        {"status": "pulling manifest"},
+        {"status": "pulling blobs", "completed": 50, "total": 100},
+        {"status": "success"},
+    )
+    seen = []
+    llmman.pull(daemon.url, "ghcr.io/org/model:tag", lambda *a: seen.append(a))
+
+    assert daemon.last_request == {"model": "ghcr.io/org/model:tag"}
+    assert seen == [("pulling manifest", 0, 0), ("pulling blobs", 50, 100)]
+
+
+def test_pull_reports_in_band_error_at_http_200(daemon):
+    # The daemon streams errors in-band, so a 200 does not mean success.
+    daemon.pull_body = _ndjson({"status": "pulling"}, {"error": "unauthorized"})
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_pull_rejects_a_stream_that_ends_without_success(daemon):
+    daemon.pull_body = _ndjson({"status": "pulling blobs"})
+    with pytest.raises(RuntimeError, match="without reporting success"):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_pull_tolerates_a_non_json_diagnostic_line(daemon):
+    daemon.pull_body = "not json\n" + _ndjson({"status": "success"})
+    llmman.pull(daemon.url, "ref")
+
+
+def test_pull_reports_non_ok_status(daemon):
+    daemon.pull_status = 400
+    daemon.pull_body = '{"error":"bad request"}'
+    with pytest.raises(RuntimeError):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_parse_resolve_output_accepts_the_documented_contract():
+    with tempfile.TemporaryDirectory() as path:
+        line = json.dumps({"reference": "r", "path": path, "format": "safetensors"})
+        assert llmman.parse_resolve_output(line, "r") == path
+
+
+def test_parse_resolve_output_tolerates_leaked_diagnostics():
+    with tempfile.TemporaryDirectory() as path:
+        out = "pulling...\n" + json.dumps({"path": path}) + "\n"
+        assert llmman.parse_resolve_output(out, "r") == path
+
+
+def test_parse_resolve_output_ignores_unknown_fields():
+    with tempfile.TemporaryDirectory() as path:
+        line = json.dumps({"path": path, "format": "gguf", "mmproj": "/x", "new": 1})
+        assert llmman.parse_resolve_output(line, "r") == path
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "   \n\n",
+        "not json",
+        '["a", "list"]',
+        '{"no_path": 1}',
+        '{"path": ""}',
+        '{"path": 3}',
+        '{"path": "/nonexistent/xyzzy"}',
+    ],
+)
+def test_parse_resolve_output_rejects_malformed_output(bad):
+    with pytest.raises(RuntimeError):
+        llmman.parse_resolve_output(bad, "r")
+
+
+def test_resolve_reports_a_missing_binary(monkeypatch):
+    monkeypatch.setenv(llmman.BIN_ENV, "/definitely/not/here/llmman")
+    with pytest.raises(RuntimeError, match="not found"):
+        llmman.resolve("ref")

--- a/python/storage/test/test_oci_storage.py
+++ b/python/storage/test/test_oci_storage.py
@@ -149,8 +149,8 @@ def _make_client(
         extra_dirs=extra_dirs,
         compress=compress,
     )
-    client.get_blob.side_effect = lambda target, digest, stream=True: (
-        _FakeBlobResponse(layer_bytes)
+    client.get_blob.side_effect = lambda target, digest, stream=True: _FakeBlobResponse(
+        layer_bytes
     )
     return client
 
@@ -299,8 +299,8 @@ def test_oci_multi_arch_index_resolves_to_platform(tmp_path):
     # the per-platform manifest whose layers are actually streamed.
     client.get_manifest.side_effect = [_INDEX, per_platform_manifest]
     layer_bytes = _build_layer_tar_bytes()
-    client.get_blob.side_effect = lambda target, digest, stream=True: (
-        _FakeBlobResponse(layer_bytes)
+    client.get_blob.side_effect = lambda target, digest, stream=True: _FakeBlobResponse(
+        layer_bytes
     )
     with (
         mock.patch("oras.client.OrasClient", return_value=client),
@@ -571,4 +571,138 @@ def test_oras_get_blob_signature_drift():
         assert kw in sig.parameters, (
             f"oras.provider.Registry.get_blob missing parameter '{kw}' — "
             f"API drift; update _download_oci call site."
+        )
+
+
+# ---------------------------------------------------------------------------
+# CNCF ModelPack artifacts (https://github.com/modelpack/model-spec)
+#
+# A ModelPack manifest carries model files directly rather than a modelcar
+# /models/ subtree, so acquisition is delegated to a running `llmman serve`.
+# These pin detection, the daemon protocol, and that a plain container image
+# still takes the modelcar path unchanged.
+# ---------------------------------------------------------------------------
+
+_MP_ARTIFACT_TYPE = "application/vnd.cncf.model.manifest.v1+json"
+_MP_CONFIG_TYPE = "application/vnd.cncf.model.config.v1+json"
+
+
+def _mp_manifest(by_config=False):
+    manifest = {"mediaType": "application/vnd.oci.image.manifest.v1+json", "layers": []}
+    if by_config:
+        manifest["config"] = {"mediaType": _MP_CONFIG_TYPE}
+    else:
+        manifest["artifactType"] = _MP_ARTIFACT_TYPE
+    return manifest
+
+
+class TestModelPackDetection:
+    def test_detected_by_artifact_type(self):
+        assert Storage._is_modelpack_manifest(_mp_manifest())
+
+    def test_detected_by_config_media_type(self):
+        # Some registries and older clients drop artifactType.
+        assert Storage._is_modelpack_manifest(_mp_manifest(by_config=True))
+
+    def test_plain_container_image_not_claimed(self):
+        assert not Storage._is_modelpack_manifest(
+            {"config": {"mediaType": "application/vnd.oci.image.config.v1+json"}}
+        )
+        assert not Storage._is_modelpack_manifest({})
+
+
+def test_modelpack_manifest_delegates_to_llmman(tmp_path):
+    out = str(tmp_path / "out")
+    client = mock.MagicMock()
+    client.get_manifest.return_value = _mp_manifest()
+
+    with (
+        mock.patch("oras.client.OrasClient", return_value=client),
+        mock.patch(
+            "kserve_storage.kserve_storage.os.path.exists",
+            side_effect=_fake_config_exists(False),
+        ),
+        mock.patch("kserve_storage.kserve_storage._login_from_docker_config"),
+        mock.patch(
+            "kserve_storage.kserve_storage.Storage._download_modelpack_via_llmman",
+            return_value=out,
+        ) as delegate,
+    ):
+        assert Storage._download_oci("oci://registry.io/mymodel:v1", out) == out
+
+    # The daemon receives the scheme-less reference, and no blob is fetched
+    # through oras: llmman owns the download.
+    delegate.assert_called_once_with("registry.io/mymodel:v1", out)
+    client.get_blob.assert_not_called()
+
+
+def test_modelcar_image_still_uses_the_models_subtree(tmp_path):
+    """A plain container image must not take the ModelPack path."""
+    out = str(tmp_path / "out")
+    client = _make_client(_IMAGE_MANIFEST)
+    with (
+        mock.patch("oras.client.OrasClient", return_value=client),
+        mock.patch(
+            "kserve_storage.kserve_storage.os.path.exists",
+            side_effect=_fake_config_exists(False),
+        ),
+        mock.patch("kserve_storage.kserve_storage._login_from_docker_config"),
+    ):
+        Storage._download_oci("oci://registry.io/mymodel:v1", out)
+    assert os.path.isfile(os.path.join(out, "model.joblib"))
+
+
+class TestMaterializeResolvedModel:
+    def test_hard_links_a_directory(self, tmp_path):
+        src = tmp_path / "store"
+        (src / "sub").mkdir(parents=True)
+        (src / "config.json").write_text("{}")
+        (src / "sub" / "model.safetensors").write_text("w")
+        out = str(tmp_path / "out")
+
+        Storage._materialize_resolved_model(str(src), out)
+
+        assert open(os.path.join(out, "sub", "model.safetensors")).read() == "w"
+        # A model shared with llmman's store should cost its bytes once.
+        assert (
+            os.stat(os.path.join(out, "config.json")).st_ino
+            == os.stat(str(src / "config.json")).st_ino
+        )
+
+    def test_handles_a_single_file_payload(self, tmp_path):
+        src = tmp_path / "model.gguf"
+        src.write_text("gguf")
+        out = str(tmp_path / "out")
+
+        Storage._materialize_resolved_model(str(src), out)
+
+        assert open(os.path.join(out, "model.gguf")).read() == "gguf"
+
+    def test_overwrites_a_stale_destination(self, tmp_path):
+        src = tmp_path / "store"
+        src.mkdir()
+        (src / "config.json").write_text("new")
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "config.json").write_text("stale")
+
+        Storage._materialize_resolved_model(str(src), str(out))
+
+        assert (out / "config.json").read_text() == "new"
+
+    def test_falls_back_to_copy_when_linking_fails(self, tmp_path):
+        src = tmp_path / "store"
+        src.mkdir()
+        (src / "config.json").write_text("{}")
+        out = str(tmp_path / "out")
+
+        with mock.patch(
+            "kserve_storage.kserve_storage.os.link", side_effect=OSError("EXDEV")
+        ):
+            Storage._materialize_resolved_model(str(src), out)
+
+        assert open(os.path.join(out, "config.json")).read() == "{}"
+        assert (
+            os.stat(os.path.join(out, "config.json")).st_ino
+            != os.stat(str(src / "config.json")).st_ino
         )


### PR DESCRIPTION
## What this PR does / why we need it

The `oci://` storage handler assumes a **modelcar** layout: `_download_oci` walks tar layers and extracts only members under a `models/` prefix. A [CNCF ModelPack](https://github.com/modelpack/model-spec) artifact has no such subtree.

ModelPack layers are typed `application/vnd.cncf.model.{weight,weight.config,doc,code,dataset}.v1.{raw,tar,tar+gzip,tar+zstd}` and are already rooted at the model directory. Today every one of those layers misses `_LAYER_MEDIA_TYPE_MODES`, gets skipped as a "non-tar layer", and the pull ends with:

```
OCI image at oci://... has no /models/ directory; this handler expects a modelcar layout.
```

So `storageUri: oci://...` works for a *runnable container image with weights baked in*, but not for a *model artifact*.

## Implementation

**Detection stays here**: `artifactType == application/vnd.cncf.model.manifest.v1+json`, falling back to the config descriptor's mediaType for registries and clients that predate or strip `artifactType`.

**Acquisition is delegated to a running [`llmman serve`](https://github.com/llmmanorg/llmman)** rather than hand-rolled. llmman already implements the ModelPack media types, registry auth, resumable blob download and a content-addressed store -- that is registry protocol code the storage initializer has no particular interest in owning, and it sidesteps the layout matrix (`.raw` vs `.tar` vs `.tar+gzip` vs `.tar+zstd`, filepath annotations, image indexes) as well as the zstd gap the container path already documents (stdlib `tarfile` gained zstd only in 3.14; the initializer runs 3.11).

New `kserve_storage/llmman.py` is the client, stdlib-only (`urllib`), **no new dependency**:

- `GET /api/version` probes reachability *and* identity -- a server answering without a `version` field is reported as "not an llmman daemon", worth distinguishing from nothing listening.
- `POST /api/pull` streams NDJSON so a multi-gigabyte fetch is not silent. An error arrives **in-band at HTTP 200**, and a stream that ends without `success` is also a failure -- both are errors, not a completed pull.
- `llmman resolve --no-pull` reports where the bytes landed. The daemon deliberately exposes no local path (`/api/show` returns only a digest and size), so the CLI is the documented interface; `--no-pull` guarantees it only reports on what `/api/pull` already fetched, keeping the daemon the only thing that touches the network.

A pull therefore needs **both** the daemon reachable and the binary on `PATH` (or `KSERVE_LLMMAN_BIN`); each missing piece has its own actionable error. `LLMMAN_HOST` is honoured with llmman's own parsing, including rewriting a wildcard bind (`0.0.0.0`, `[::]`) to loopback.

Files are **hard-linked** out of llmman's store where possible, falling back to a copy across filesystems, so a model shared with llmman costs its bytes once.

**The modelcar path is untouched** -- a manifest that is not ModelPack takes exactly the branch it did before, pinned by `test_modelcar_image_still_uses_the_models_subtree`.

## Testing

Verified, actually executed:

```
$ pytest test/test_llmman.py test/test_oci_storage.py
65 passed
```

Regression check against a clean tree, same environment:

| | passed | failed |
|---|---|---|
| `master` | 105 | 45 |
| this branch | 143 | 45 |

+38, and the **same** 45 failures before and after -- all collection errors from optional deps absent here (`azure`, `google`, `dulwich`, `huggingface_hub`, `botocore`), none related to this change.

New `test/test_llmman.py` (22 cases) runs against a **real HTTP server on a loopback port**, not mocks, so the NDJSON streaming contract is genuinely exercised: every `LLMMAN_HOST` form incl. wildcard-to-loopback; `/api/version` accepted, a non-llmman server rejected, nothing-listening reported actionably; pull success with forwarded byte progress and the exact request body asserted; in-band error at HTTP 200; a stream ending without `success`; non-OK status; a non-JSON diagnostic tolerated; the full resolve contract plus eight malformed-output cases; binary default/override/empty-override; missing-binary error.

New cases in `test_oci_storage.py` (16) cover detection both ways, a plain container image not claimed, that a ModelPack manifest delegates to llmman with the scheme-less reference **and fetches no blob through oras**, the modelcar path unchanged, and `_materialize_resolved_model`: hard-linking asserted via **`st_ino` equality**, a single-file (GGUF) payload, a stale destination overwritten, and the copy fallback when `os.link` raises `EXDEV` (asserting the inodes then differ).

- [x] `ruff format` and `ruff check --config ruff.toml` clean

Not verified here, flagged rather than implied: no end-to-end `InferenceService` run, and no pull against a live `llmman serve` backed by a real registry. Coverage is at the client/protocol level with a stub daemon.

## Does this PR introduce a user-facing change?

```release-note
The `oci://` storage URI now supports CNCF ModelPack artifacts in addition to modelcar container images, by delegating acquisition to a running `llmman serve` daemon.
```
