### PR TITLE
feat: reload rotated TLS certificates

### DIFF
--- a/python/aiffairness/uv.lock
+++ b/python/aiffairness/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1156,6 +1156,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -1193,6 +1194,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/artexplainer/uv.lock
+++ b/python/artexplainer/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1030,6 +1030,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -1067,6 +1068,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/autogluonserver/uv.lock
+++ b/python/autogluonserver/uv.lock
@@ -2215,6 +2215,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -2252,6 +2253,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/custom_model/uv.lock
+++ b/python/custom_model/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -525,7 +525,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -973,6 +973,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.optional-dependencies]
@@ -1015,6 +1016,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/custom_tokenizer/uv.lock
+++ b/python/custom_tokenizer/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -852,6 +852,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -889,6 +890,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/custom_transformer/uv.lock
+++ b/python/custom_transformer/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -499,7 +499,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -896,6 +896,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -933,6 +934,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/huggingfaceserver/uv.lock
+++ b/python/huggingfaceserver/uv.lock
@@ -2152,6 +2152,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.optional-dependencies]
@@ -2194,6 +2195,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -24,30 +24,29 @@ from typing import Any, Callable, Dict, List, Optional
 from fastapi import FastAPI
 from fastapi.responses import ORJSONResponse
 
-from . import logging
 from . import context as kserve_context
+from . import logging
 from .constants.constants import (
+    DEFAULT_GRPC_PORT,
     DEFAULT_HTTP_PORT,
     DEFAULT_HTTPS_PORT,
-    DEFAULT_GRPC_PORT,
+    FASTAPI_APP_IMPORT_STRING,
     KSERVE_TLS_CERT_FILE_ENV,
     KSERVE_TLS_KEY_FILE_ENV,
     MAX_GRPC_MESSAGE_LENGTH,
-    FASTAPI_APP_IMPORT_STRING,
 )
 from .errors import NoModelReady
 from .logging import logger
 from .model import BaseKServeModel
-from .predictor_config import PredictorConfig
 from .model_repository import ModelRepository
+from .predictor_config import PredictorConfig
 from .protocol.dataplane import DataPlane
 from .protocol.grpc.server import GRPCServer
 from .protocol.model_repository_extension import ModelRepositoryExtension
-from .protocol.rest.server import RESTServer
 from .protocol.rest.multiprocess.server import RESTServerMultiProcess
+from .protocol.rest.server import RESTServer
 from .utils import utils
 from .utils.inference_client_factory import InferenceClientFactory
-
 
 parser = argparse.ArgumentParser(
     add_help=False, formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -378,6 +377,8 @@ class ModelServer:
                 log_config_file=args.log_config_file,
                 event_loop=self.event_loop,
                 timeout_keep_alive=self.timeout_keep_alive,
+                ssl_certfile=self.ssl_certfile,
+                ssl_keyfile=self.ssl_keyfile,
             )
             self.servers.append(self._rest_multiprocess_server.start())
         else:

--- a/python/kserve/kserve/protocol/rest/multiprocess/server.py
+++ b/python/kserve/kserve/protocol/rest/multiprocess/server.py
@@ -16,8 +16,8 @@ import asyncio
 import multiprocessing as mp
 import os
 import signal
-from socket import socket
 import threading
+from socket import socket
 from typing import Any, Callable, List, Optional, Union
 
 from kserve import logging
@@ -134,6 +134,8 @@ class RESTServerMultiProcess:
         log_config_file: Optional[str] = None,
         event_loop: str = "auto",
         timeout_keep_alive: int = 65,
+        ssl_certfile: Optional[str] = None,
+        ssl_keyfile: Optional[str] = None,
     ) -> None:
         self.log_config_file = log_config_file
         self._rest_server = RESTServer(
@@ -146,6 +148,8 @@ class RESTServerMultiProcess:
             grace_period,
             event_loop,
             timeout_keep_alive,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile,
         )
         self._processes: List[RESTServerProcess] = []
         self.should_exit = asyncio.Event()

--- a/python/kserve/kserve/protocol/rest/server.py
+++ b/python/kserve/kserve/protocol/rest/server.py
@@ -50,6 +50,7 @@ from kserve.protocol.rest.timeseries.config import maybe_register_time_series_en
 
 from .v1_endpoints import register_v1_endpoints
 from .v2_endpoints import register_v2_endpoints
+from .ssl_cert_refresher import SSLCertRefresher
 from ..model_repository_extension import ModelRepositoryExtension
 
 
@@ -64,6 +65,36 @@ class PrintTimings(TimingClient):
 
 
 VALID_UVICORN_LOOPS = {"auto", "asyncio", "uvloop"}
+
+
+class _RefreshingServer(uvicorn.Server):
+    """Uvicorn server that refreshes its SSL context when certificates change."""
+
+    def __init__(self, config: uvicorn.Config):
+        super().__init__(config)
+        self._ssl_cert_refresher: Optional[SSLCertRefresher] = None
+
+    async def serve(self, sockets: Optional[List[socket]] = None) -> None:
+        if not self.config.loaded:
+            self.config.load()
+
+        if (
+            self.config.ssl is not None
+            and self.config.ssl_keyfile is not None
+            and self.config.ssl_certfile is not None
+        ):
+            self._ssl_cert_refresher = SSLCertRefresher(
+                ssl_context=self.config.ssl,
+                key_path=str(self.config.ssl_keyfile),
+                cert_path=str(self.config.ssl_certfile),
+            )
+
+        try:
+            await super().serve(sockets=sockets)
+        finally:
+            if self._ssl_cert_refresher is not None:
+                self._ssl_cert_refresher.stop()
+                self._ssl_cert_refresher = None
 
 
 class RESTServer:
@@ -105,7 +136,7 @@ class RESTServer:
             ssl_certfile=ssl_certfile,
             ssl_keyfile=ssl_keyfile,
         )
-        self._server = uvicorn.Server(self.config)
+        self._server = _RefreshingServer(self.config)
 
     def _register_endpoints(self, app: fastapi.FastAPI):
         root_router = APIRouter()

--- a/python/kserve/kserve/protocol/rest/ssl_cert_refresher.py
+++ b/python/kserve/kserve/protocol/rest/ssl_cert_refresher.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from collections.abc import Callable
+from ssl import SSLContext
+from typing import Optional
+
+from watchfiles import Change, awatch
+
+from kserve.logging import logger
+
+
+class SSLCertRefresher:
+    """Monitor TLS certificate files and reload the active SSL context."""
+
+    def __init__(
+        self,
+        ssl_context: SSLContext,
+        key_path: str,
+        cert_path: str,
+    ) -> None:
+        self.ssl_context = ssl_context
+        self.key_path = key_path
+        self.cert_path = cert_path
+        self._watch_task: Optional[asyncio.Task] = asyncio.create_task(
+            self._watch_files([self.key_path, self.cert_path], self._reload_cert_chain)
+        )
+
+    def _reload_cert_chain(self, _change: Change, _file_path: str) -> None:
+        logger.info("Reloading SSL certificate chain")
+        self.ssl_context.load_cert_chain(self.cert_path, self.key_path)
+
+    async def _watch_files(
+        self,
+        paths: list[str],
+        callback: Callable[[Change, str], None],
+    ) -> None:
+        logger.info("Monitoring SSL certificate files: %s", paths)
+        async for changes in awatch(*paths):
+            try:
+                for change, file_path in changes:
+                    logger.info(
+                        "SSL certificate file change detected: %s - %s",
+                        change.name,
+                        file_path,
+                    )
+                    callback(change, file_path)
+            except Exception:
+                logger.exception("Failed to reload SSL certificate chain")
+
+    def stop(self) -> None:
+        """Stop monitoring certificate files."""
+        if self._watch_task is not None:
+            self._watch_task.cancel()
+            self._watch_task = None

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -8,6 +8,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "uvicorn[standard]<1.0.0,>=0.30.6",
+    "watchfiles<2.0.0,>=1.0.4",
     "fastapi>=0.115.3,<1.0.0",
     "starlette>=1.0.1", # CVE-2026-48710 Starlette: Security restriction bypass via malformed HTTP Host header
     "cloudevents<2.0.0,>=1.6.2",

--- a/python/kserve/test/test_rest_server.py
+++ b/python/kserve/test/test_rest_server.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -81,3 +81,37 @@ def test_config_timeout_keep_alive_default(monkeypatch):
     )
 
     assert rs.config.timeout_keep_alive == 65
+
+
+@pytest.mark.asyncio
+async def test_ssl_cert_refresher_lifecycle(monkeypatch):
+    monkeypatch.setattr(rest_mod.RESTServer, "create_application", lambda self: None)
+    monkeypatch.setattr(rest_mod.uvicorn.Server, "serve", AsyncMock())
+    refresher = Mock()
+    refresher_class = Mock(return_value=refresher)
+    monkeypatch.setattr(rest_mod, "SSLCertRefresher", refresher_class)
+    ssl_context = Mock()
+
+    rs = rest_mod.RESTServer(
+        app="dummy:app",
+        data_plane=Mock(),
+        model_repository_extension=Mock(),
+        http_port=8443,
+        ssl_certfile="/etc/tls/tls.crt",
+        ssl_keyfile="/etc/tls/tls.key",
+    )
+
+    def load_config():
+        rs.config.loaded = True
+        rs.config.ssl = ssl_context
+
+    monkeypatch.setattr(rs.config, "load", load_config)
+
+    await rs.start()
+
+    refresher_class.assert_called_once_with(
+        ssl_context=ssl_context,
+        key_path="/etc/tls/tls.key",
+        cert_path="/etc/tls/tls.crt",
+    )
+    refresher.stop.assert_called_once_with()

--- a/python/kserve/test/test_ssl_cert_refresher.py
+++ b/python/kserve/test/test_ssl_cert_refresher.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+from watchfiles import Change
+
+from kserve.protocol.rest import ssl_cert_refresher
+
+
+@pytest.mark.asyncio
+async def test_ssl_cert_refresher_reloads_changed_certificate(monkeypatch):
+    cert_path = "/etc/tls/tls.crt"
+    key_path = "/etc/tls/tls.key"
+
+    async def changes(*paths):
+        assert paths == (key_path, cert_path)
+        yield {(Change.modified, cert_path)}
+
+    monkeypatch.setattr(ssl_cert_refresher, "awatch", changes)
+    ssl_context = Mock()
+
+    refresher = ssl_cert_refresher.SSLCertRefresher(
+        ssl_context=ssl_context,
+        key_path=key_path,
+        cert_path=cert_path,
+    )
+    await refresher._watch_task
+
+    ssl_context.load_cert_chain.assert_called_once_with(cert_path, key_path)
+
+
+@pytest.mark.asyncio
+async def test_ssl_cert_refresher_keeps_watching_after_reload_error(
+    monkeypatch, caplog
+):
+    cert_path = "/etc/tls/tls.crt"
+    key_path = "/etc/tls/tls.key"
+
+    async def changes(*_paths):
+        yield {(Change.modified, cert_path)}
+        yield {(Change.modified, key_path)}
+
+    monkeypatch.setattr(ssl_cert_refresher, "awatch", changes)
+    ssl_context = Mock()
+    ssl_context.load_cert_chain.side_effect = [ValueError("invalid certificate"), None]
+
+    refresher = ssl_cert_refresher.SSLCertRefresher(
+        ssl_context=ssl_context,
+        key_path=key_path,
+        cert_path=cert_path,
+    )
+    await refresher._watch_task
+
+    assert ssl_context.load_cert_chain.call_count == 2
+    assert "Failed to reload SSL certificate chain" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_ssl_cert_refresher_stop_cancels_watcher(monkeypatch):
+    watcher_started = asyncio.Event()
+
+    async def changes(*_paths):
+        watcher_started.set()
+        await asyncio.Event().wait()
+        yield
+
+    monkeypatch.setattr(ssl_cert_refresher, "awatch", changes)
+    refresher = ssl_cert_refresher.SSLCertRefresher(
+        ssl_context=Mock(),
+        key_path="/etc/tls/tls.key",
+        cert_path="/etc/tls/tls.crt",
+    )
+    await watcher_started.wait()
+    watch_task = refresher._watch_task
+
+    refresher.stop()
+
+    assert refresher._watch_task is None
+    assert watch_task.cancelling()

--- a/python/kserve/test/test_ssl_cert_refresher.py
+++ b/python/kserve/test/test_ssl_cert_refresher.py
@@ -44,9 +44,7 @@ async def test_ssl_cert_refresher_reloads_changed_certificate(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ssl_cert_refresher_keeps_watching_after_reload_error(
-    monkeypatch, caplog
-):
+async def test_ssl_cert_refresher_keeps_watching_after_reload_error(monkeypatch):
     cert_path = "/etc/tls/tls.crt"
     key_path = "/etc/tls/tls.key"
 
@@ -55,6 +53,8 @@ async def test_ssl_cert_refresher_keeps_watching_after_reload_error(
         yield {(Change.modified, key_path)}
 
     monkeypatch.setattr(ssl_cert_refresher, "awatch", changes)
+    exception_logger = Mock()
+    monkeypatch.setattr(ssl_cert_refresher.logger, "exception", exception_logger)
     ssl_context = Mock()
     ssl_context.load_cert_chain.side_effect = [ValueError("invalid certificate"), None]
 
@@ -66,7 +66,7 @@ async def test_ssl_cert_refresher_keeps_watching_after_reload_error(
     await refresher._watch_task
 
     assert ssl_context.load_cert_chain.call_count == 2
-    assert "Failed to reload SSL certificate chain" in caplog.text
+    exception_logger.assert_called_once_with("Failed to reload SSL certificate chain")
 
 
 @pytest.mark.asyncio
@@ -90,4 +90,6 @@ async def test_ssl_cert_refresher_stop_cancels_watcher(monkeypatch):
     refresher.stop()
 
     assert refresher._watch_task is None
-    assert watch_task.cancelling()
+    with pytest.raises(asyncio.CancelledError):
+        await watch_task
+    assert watch_task.cancelled()

--- a/python/kserve/uv.lock
+++ b/python/kserve/uv.lock
@@ -2163,6 +2163,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.optional-dependencies]
@@ -2236,6 +2237,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/lgbserver/uv.lock
+++ b/python/lgbserver/uv.lock
@@ -1278,6 +1278,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -1315,6 +1316,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/paddleserver/uv.lock
+++ b/python/paddleserver/uv.lock
@@ -1295,6 +1295,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -1332,6 +1333,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/pmmlserver/uv.lock
+++ b/python/pmmlserver/uv.lock
@@ -1315,6 +1315,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -1352,6 +1353,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/predictiveserver/uv.lock
+++ b/python/predictiveserver/uv.lock
@@ -1253,6 +1253,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -1290,6 +1291,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/sklearnserver/uv.lock
+++ b/python/sklearnserver/uv.lock
@@ -1253,6 +1253,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -1290,6 +1291,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/test_resources/graph/error_404_isvc/uv.lock
+++ b/python/test_resources/graph/error_404_isvc/uv.lock
@@ -724,6 +724,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -761,6 +762,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/test_resources/graph/success_200_isvc/uv.lock
+++ b/python/test_resources/graph/success_200_isvc/uv.lock
@@ -705,6 +705,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -742,6 +743,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 

--- a/python/xgbserver/uv.lock
+++ b/python/xgbserver/uv.lock
@@ -1278,6 +1278,7 @@ dependencies = [
     { name = "timing-asgi" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -1315,6 +1316,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6,<1.0.0" },
     { name = "vllm", marker = "extra == 'llm'", specifier = "==0.24.0" },
+    { name = "watchfiles", specifier = ">=1.0.4,<2.0.0" },
 ]
 provides-extras = ["storage", "logging", "ray", "llm"]
 


### PR DESCRIPTION
## What this PR does

- watches configured TLS certificate and key files for changes
- reloads the active Uvicorn SSL context without restarting the server
- keeps the existing certificate active when a reload fails
- stops the certificate watcher during server shutdown
- propagates TLS configuration to RESTServerMultiProcess workers
- declares watchfiles as a direct dependency

## Validation

- make precommit
- focused REST server and certificate refresher tests

Closes #6093

Testing:
# TLS Certificate Refresh Demo

This walkthrough demonstrates that KServe reloads rotated TLS certificates without restarting the model server.

## 1. Generate an initial certificate

```bash
openssl req -x509 -newkey rsa:2048 -nodes \
  -keyout ~/tls/key-v1.pem \
  -out ~/tls/cert-v1.pem \
  -days 30 \
  -subj "/CN=kserve-initial"
```

```bash
cp ~/tls/cert-v1.pem ~/tls/cert.pem
cp ~/tls/key-v1.pem ~/tls/key.pem
```

## 2. Start a KServe model server

From the repository root, start a lightweight model server on port `8443`:

```bash
bin/.venv/bin/python -c '
from kserve import Model, ModelServer

model = Model("demo")
model.ready = True

ModelServer(
    http_port=8443,
    enable_grpc=False,
    ssl_certfile="'"$HOME"'/tls/cert.pem",
    ssl_keyfile="'"$HOME"'/tls/key.pem",
).start([model])
'
```

The server log should include a message similar to:

```text
Monitoring SSL certificate files
```

Leave the server running and use a second terminal for the remaining steps.

## 3. Inspect the certificate being served

```bash
openssl s_client -connect localhost:8443 </dev/null 2>/dev/null \
  | openssl x509 -noout -subject -serial -fingerprint -sha256
```
and observe in the output:
```
subject=CN=kserve-initial
```

Confirm that the HTTPS server is healthy:

```bash
curl -sk https://localhost:8443/v2/health/live
```

## 4. Generate a replacement certificate

```bash
openssl req -x509 -newkey rsa:2048 -nodes \
  -keyout ~/tls/key-v2.pem \
  -out ~/tls/cert-v2.pem \
  -days 30 \
  -subj "/CN=kserve-refreshed"
```

## 5. Rotate the certificate and key

Replace each watched file using a temporary file and an atomic rename:

```bash
cp ~/tls/key-v2.pem ~/tls/key.pem.new
mv ~/tls/key.pem.new ~/tls/key.pem
```
observe in the server logs:
```
2026-08-31 15:41:06.831 82834 kserve ERROR [ssl_cert_refresher.py:_watch_files():61] Failed to reload SSL certificate chain
Traceback (most recent call last):
  File "/Users/mskarbek/projects/kserve/python/kserve/kserve/protocol/rest/ssl_cert_refresher.py", line 59, in _watch_files
    callback(change, file_path)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/mskarbek/projects/kserve/python/kserve/kserve/protocol/rest/ssl_cert_refresher.py", line 43, in _reload_cert_chain
    self.ssl_context.load_cert_chain(self.cert_path, self.key_path)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ssl.SSLError: [X509: KEY_VALUES_MISMATCH] key values mismatch (_ssl.c:4121)
```
If you examine the certificate being served, it should still show `CN=kserve-initial` in the output.

Then move the cert
```
cp ~/tls/cert-v2.pem ~/tls/cert.pem.new
mv ~/tls/cert.pem.new ~/tls/cert.pem
```

The running server should log messages similar to:

```text
SSL certificate file change detected
Reloading SSL certificate chain
```

## 6. Verify that the certificate changed

Run the inspection command again without restarting the server:

```bash
openssl s_client -connect localhost:8443 </dev/null 2>/dev/null \
  | openssl x509 -noout -subject -serial -fingerprint -sha256
```

The subject should now contain `CN=kserve-refreshed`. The server process should be the same process started in step 2.

Verify that it remains healthy:

```bash
curl -sk https://localhost:8443/v2/health/live
```

## 7. Restore the original certificate

```bash
cp ~/tls/key-v1.pem ~/tls/key.pem
cp ~/tls/cert-v1.pem ~/tls/cert.pem
```

The server should reload the original certificate as well. Press `Ctrl+C` in the first terminal when the demonstration is complete.
