### PR TITLE
fix: preserve InferResponse model_version from bytes

### DIFF
--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -1291,6 +1291,7 @@ class InferResponse:
         except orjson.JSONDecodeError as e:
             raise InvalidInput(f"Unrecognized request format: {e}")
         model_name = infer_res_dict["model_name"]
+        model_version = infer_res_dict.get("model_version", None)
         infer_outputs = []
         # Read the raw binary outputs appended after json
         start_index = json_length
@@ -1320,6 +1321,7 @@ class InferResponse:
             infer_outputs.append(infer_output)
         return cls(
             model_name=model_name,
+            model_version=model_version,
             response_id=infer_res_dict.get("id", None),
             parameters=infer_res_dict.get("parameters", None),
             infer_outputs=infer_outputs,

--- a/python/kserve/test/test_infer_type.py
+++ b/python/kserve/test/test_infer_type.py
@@ -997,7 +997,8 @@ class TestInferResponse:
 
     def test_infer_response_from_bytes_happy_path(self):
         model_name = "test_model"
-        response_bytes = b'{"id": "1", "model_name": "test_model", "outputs": [{"name": "output1", "shape": [1], "datatype": "INT32", "data": [1]}]}'
+        model_version = "v1"
+        response_bytes = b'{"id": "1", "model_name": "test_model", "model_version": "v1", "outputs": [{"name": "output1", "shape": [1], "datatype": "INT32", "data": [1]}]}'
         json_length = len(response_bytes)
 
         infer_response = InferResponse.from_bytes(
@@ -1007,6 +1008,7 @@ class TestInferResponse:
 
         assert infer_response.id == "1"
         assert infer_response.model_name == model_name
+        assert infer_response.model_version == model_version
         assert len(infer_response.outputs) == 1
         assert infer_response.outputs[0].name == "output1"
         assert infer_response.outputs[0].shape == [1]


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where `InferResponse.from_bytes()` does not preserve the `model_version` field from a REST inference response.

When a REST response contains a `model_version`, the value is correctly handled by `InferResponse.from_rest()`, but it was being dropped when the response was deserialized through `InferResponse.from_bytes()`.

For example, for a response containing:

```json
{
  "id": "1",
  "model_name": "test_model",
  "model_version": "v1",
  "outputs": [...]
}
```

`InferResponse.from_bytes()` previously returned an `InferResponse` where:

```python
infer_response.model_version is None
```

even though `"model_version": "v1"` was present in the response.

The issue was that `from_bytes()` extracted `model_name` from the decoded response but did not extract or pass `model_version` to the `InferResponse` constructor.

This PR updates `from_bytes()` to preserve the optional `model_version` field, consistent with the existing behavior of `from_rest()`.

A regression check was also added to the existing `test_infer_response_from_bytes_happy_path` test to ensure that `model_version` is preserved during deserialization.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #6111

**Feature/Issue validation/testing**:

The following test was run locally:

`pytest python\kserve\test\test_infer_type.py`

Result:

`33 passed, 1 warning`

The warning is the existing Windows-specific `timing_asgi` warning:

`UserWarning: resource module not available for Windows, cpu time will be set to 0`

This warning does not cause any test failures.

The diff was also checked with:

`git diff --check`

with no whitespace errors reported.

The regression test verifies that a response containing `"model_version": "v1"` produces an `InferResponse` whose `model_version` is `"v1"`.

* [x] `pytest python\kserve\test\test_infer_type.py`

* [x] `git diff --check`

* Logs

```text
========================= 33 passed, 1 warning in 1.10s =========================
```

**Special notes for your reviewer**:

The change is limited to the `InferResponse.from_bytes()` deserialization path and its corresponding regression test.

The behavior now matches `InferResponse.from_rest()`, which already preserves `model_version`.

No other response fields or binary-output handling were changed.

**Checklist**:

* [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
* [ ] Has code been commented, particularly in hard-to-understand areas?
* [ ] Have you made corresponding changes to the [[documentation](https://github.com/kserve/website)](https://github.com/kserve/website)?

**Release note**:

```release-note
NONE
```