### PR TITLE
feat(kernelcache): add signing contract

### DIFF
--- a/pkg/kernelcache/security/factory.go
+++ b/pkg/kernelcache/security/factory.go
@@ -48,6 +48,36 @@ func NewVerifier(ctx context.Context, cfg SecurityConfig, src SecretSource) (Ver
 	}
 }
 
+// NewSigner builds the Signer for the configured mode, mirroring NewVerifier.
+// The config is defaulted and validated first; ctx bounds any construction-time
+// I/O and src provides key material to the signing modes. Only the disabled
+// mode is wired here -- the signing modes (cert, keyless) add their own cases.
+func NewSigner(ctx context.Context, cfg SecurityConfig, src SecretSource) (Signer, error) {
+	cfg.Default()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	switch cfg.Mode {
+	case ModeDisabled:
+		return noopSigner{}, nil
+	default:
+		// Validate accepts every known mode, so a mode reaching here is valid
+		// but has no signer wired yet (cert, keyless) or never signs (kyverno).
+		return nil, fmt.Errorf("signing not implemented for mode %q", cfg.Mode)
+	}
+}
+
+// noopSigner signs nothing. It backs the disabled mode.
+type noopSigner struct{}
+
+var _ Signer = noopSigner{}
+
+// Sign is a no-op that reports the disabled mode without contacting a registry.
+func (noopSigner) Sign(_ context.Context, _ SignRequest) (SignResult, error) {
+	return SignResult{Mode: ModeDisabled}, nil
+}
+
 // noopVerifier performs no signature check. It backs the disabled mode.
 type noopVerifier struct{}
 

--- a/pkg/kernelcache/security/sign.go
+++ b/pkg/kernelcache/security/sign.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import "context"
+
+// SignRequest describes the image to sign.
+type SignRequest struct {
+	// ImageRef is the image to sign, by tag or digest.
+	ImageRef string
+}
+
+// SignResult reports the outcome of a signing operation.
+type SignResult struct {
+	// Digest is the resolved image digest the signature was bound to.
+	Digest string
+
+	// Mode is the signing mode that produced the result.
+	Mode Mode
+}
+
+// Signer attaches a signature to a container image so a matching Verifier can
+// later confirm it. Implementations sign by digest, never by mutable tag.
+type Signer interface {
+	Sign(ctx context.Context, req SignRequest) (SignResult, error)
+}

--- a/pkg/kernelcache/security/sign_test.go
+++ b/pkg/kernelcache/security/sign_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSigner(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("disabled returns a working no-op", func(t *testing.T) {
+		s, err := NewSigner(ctx, SecurityConfig{Mode: ModeDisabled}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, s)
+
+		res, err := s.Sign(ctx, SignRequest{ImageRef: "registry/img:tag"})
+		require.NoError(t, err)
+		assert.Equal(t, ModeDisabled, res.Mode)
+		assert.Empty(t, res.Digest)
+	})
+
+	t.Run("empty mode defaults to disabled", func(t *testing.T) {
+		s, err := NewSigner(ctx, SecurityConfig{}, nil)
+		require.NoError(t, err)
+		assert.IsType(t, noopSigner{}, s)
+	})
+
+	t.Run("unknown mode errors", func(t *testing.T) {
+		s, err := NewSigner(ctx, SecurityConfig{Mode: "bogus"}, nil)
+		assert.Nil(t, s)
+		assert.ErrorIs(t, err, ErrUnknownMode)
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the Signer contract (interface + factory) for kernel cache image signing, mirroring the verification framework. Full description in #6117.

Unit tests only -- `go test ./pkg/kernelcache/security/...`.

**Which issue(s) this PR fixes**:
Fixes #6117

**Release note**:
```release-note
NONE
```
