### PR TITLE
feat(llmisvc): implement encode disaggregation (E/PD and E/P/D topologies)

### DIFF
--- a/pkg/apis/serving/v1alpha2/llm_inference_service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_lifecycle.go
@@ -86,6 +86,22 @@ const (
 	// Only present when autoscaling is configured for the prefill workload in
 	// P/D disaggregated serving topologies; cleared (unset) otherwise.
 	PrefillScalingReady apis.ConditionType = "PrefillScalingReady"
+
+	// EncodeWorkloadReady is True when the encode-phase workload is ready.
+	// Set by the workload reconciler. Only present for encode-disaggregated
+	// serving topologies (E/PD or E/P/D).
+	EncodeWorkloadReady apis.ConditionType = "EncodeWorkloadReady"
+
+	// EncodeWorkerWorkloadReady is True when the multi-node worker pods for
+	// the encode workload are ready. Set by the workload reconciler.
+	// Only present for multi-node encode-disaggregated serving topologies.
+	EncodeWorkerWorkloadReady apis.ConditionType = "EncodeWorkerWorkloadReady"
+
+	// EncodeScalingReady is True when the autoscaler for the encode workload
+	// is configured and operational. Set by the scaling reconciler.
+	// Only present when autoscaling is configured for the encode workload in
+	// encode-disaggregated serving topologies; cleared (unset) otherwise.
+	EncodeScalingReady apis.ConditionType = "EncodeScalingReady"
 )
 
 // Router sub-conditions rolled up into RouterReady.
@@ -221,6 +237,42 @@ func (in *LLMInferenceService) MarkPrefillScalingUnset() {
 	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(PrefillScalingReady)
 }
 
+func (in *LLMInferenceService) MarkEncodeWorkloadReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(EncodeWorkloadReady)
+}
+
+func (in *LLMInferenceService) MarkEncodeWorkloadNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(EncodeWorkloadReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkEncodeWorkloadUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(EncodeWorkloadReady)
+}
+
+func (in *LLMInferenceService) MarkEncodeWorkerWorkloadReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(EncodeWorkerWorkloadReady)
+}
+
+func (in *LLMInferenceService) MarkEncodeWorkerWorkloadNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(EncodeWorkerWorkloadReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkEncodeWorkerWorkloadUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(EncodeWorkerWorkloadReady)
+}
+
+func (in *LLMInferenceService) MarkEncodeScalingReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(EncodeScalingReady)
+}
+
+func (in *LLMInferenceService) MarkEncodeScalingNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(EncodeScalingReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkEncodeScalingUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(EncodeScalingReady)
+}
+
 // DetermineWorkloadReadiness rolls up sub-conditions into the top-level WorkloadsReady
 // condition. Any sub-condition that is False blocks overall readiness.
 //
@@ -235,8 +287,11 @@ func (in *LLMInferenceService) DetermineWorkloadReadiness() {
 		in.GetStatus().GetCondition(WorkerWorkloadReady),
 		in.GetStatus().GetCondition(PrefillWorkloadReady),
 		in.GetStatus().GetCondition(PrefillWorkerWorkloadReady),
+		in.GetStatus().GetCondition(EncodeWorkloadReady),
+		in.GetStatus().GetCondition(EncodeWorkerWorkloadReady),
 		in.GetStatus().GetCondition(ScalingReady),
 		in.GetStatus().GetCondition(PrefillScalingReady),
+		in.GetStatus().GetCondition(EncodeScalingReady),
 	}
 
 	for _, cond := range subConditions {

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
@@ -110,6 +110,13 @@ type LLMInferenceServiceSpec struct {
 	// +optional
 	Prefill *WorkloadSpec `json:"prefill,omitempty"`
 
+	// Encode configuration for disaggregated serving.
+	// When this section is included, the controller creates a separate deployment for encoding multi modal input into embeddings (encode)
+	// in addition to the main 'decode' deployment, inspired by the llm-d architecture.
+	// This allows for independent scaling and hardware allocation for encode, prefill and decode steps.
+	// +optional
+	Encode *WorkloadSpec `json:"encode,omitempty"`
+
 	// Tracing configuration for distributed tracing across all managed components.
 	// When present (even as `{}`), distributed tracing is enabled with defaults.
 	// When omitted, no tracing instrumentation is injected.
@@ -890,6 +897,11 @@ type WorkloadStatus struct {
 	// Nil when disaggregated serving is not configured.
 	// +optional
 	Prefill *ObservedWorkloadStatus `json:"prefill,omitempty"`
+
+	// Encode is the encode workload in encode-disaggregated serving mode.
+	// Nil when encode disaggregation is not configured.
+	// +optional
+	Encode *ObservedWorkloadStatus `json:"encode,omitempty"`
 
 	// Service is the Kubernetes Service fronting the primary inference workload.
 	// +optional

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_validation.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_validation.go
@@ -259,6 +259,10 @@ func (l *LLMInferenceServiceValidator) validateParallelismConstraints(llmSvc *LL
 		allErrs = append(allErrs, l.validateWorkloadParallelism(field.NewPath("spec").Child("prefill"), llmSvc.Spec.Prefill)...)
 	}
 
+	if llmSvc.Spec.Encode != nil {
+		allErrs = append(allErrs, l.validateWorkloadParallelism(field.NewPath("spec").Child("encode"), llmSvc.Spec.Encode)...)
+	}
+
 	return allErrs
 }
 
@@ -353,6 +357,9 @@ func (l *LLMInferenceServiceValidator) validateImmutable(prev *LLMInferenceServi
 	allErrs = append(allErrs, l.validateImmutableParallelism(specPath, prev.Spec.Parallelism, curr.Spec.Parallelism)...)
 	if curr.Spec.Prefill != nil && prev.Spec.Prefill != nil {
 		allErrs = append(allErrs, l.validateImmutableParallelism(specPath.Child("prefill"), prev.Spec.Prefill.Parallelism, curr.Spec.Prefill.Parallelism)...)
+	}
+	if curr.Spec.Encode != nil && prev.Spec.Encode != nil {
+		allErrs = append(allErrs, l.validateImmutableParallelism(specPath.Child("encode"), prev.Spec.Encode.Parallelism, curr.Spec.Encode.Parallelism)...)
 	}
 
 	return allErrs
@@ -507,6 +514,11 @@ func (l *LLMInferenceServiceValidator) validateScaling(llmSvc *LLMInferenceServi
 	// Validate scaling on the prefill workload, if present
 	if llmSvc.Spec.Prefill != nil {
 		allErrs = append(allErrs, ValidateWorkloadScaling(field.NewPath("spec").Child("prefill"), llmSvc.Spec.Prefill)...)
+	}
+
+	// Validate scaling on the encode workload, if present
+	if llmSvc.Spec.Encode != nil {
+		allErrs = append(allErrs, ValidateWorkloadScaling(field.NewPath("spec").Child("encode"), llmSvc.Spec.Encode)...)
 	}
 
 	allErrs = append(allErrs, l.validateActuatorConsistency(llmSvc)...)
@@ -779,6 +791,9 @@ func (l *LLMInferenceServiceValidator) validateKVCacheOffloading(llmSvc *LLMInfe
 	if llmSvc.Spec.Prefill != nil {
 		allErrs = append(allErrs, validateKVCacheOffloadingSpec(llmSvc.Spec.Prefill.KVCacheOffloading, field.NewPath("spec", "prefill", "kvCacheOffloading"))...)
 	}
+	if llmSvc.Spec.Encode != nil {
+		allErrs = append(allErrs, validateKVCacheOffloadingSpec(llmSvc.Spec.Encode.KVCacheOffloading, field.NewPath("spec", "encode", "kvCacheOffloading"))...)
+	}
 	return allErrs
 }
 
@@ -926,6 +941,11 @@ func (l *LLMInferenceServiceValidator) validateRolloutStrategy(llmSvc *LLMInfere
 	if llmSvc.Spec.Prefill != nil {
 		prefillMultiNode := llmSvc.Spec.Prefill.Worker != nil
 		allErrs = append(allErrs, ValidateWorkloadRolloutFields(field.NewPath("spec", "prefill"), llmSvc.Spec.Prefill.RolloutStrategy, prefillMultiNode)...)
+	}
+
+	if llmSvc.Spec.Encode != nil {
+		encodeMultiNode := llmSvc.Spec.Encode.Worker != nil
+		allErrs = append(allErrs, ValidateWorkloadRolloutFields(field.NewPath("spec", "encode"), llmSvc.Spec.Encode.RolloutStrategy, encodeMultiNode)...)
 	}
 
 	return allErrs

--- a/pkg/apis/serving/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha2/zz_generated.deepcopy.go
@@ -588,6 +588,11 @@ func (in *LLMInferenceServiceSpec) DeepCopyInto(out *LLMInferenceServiceSpec) {
 		*out = new(WorkloadSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Encode != nil {
+		in, out := &in.Encode, &out.Encode
+		*out = new(WorkloadSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Tracing != nil {
 		in, out := &in.Tracing, &out.Tracing
 		*out = new(TracingSpec)
@@ -1322,6 +1327,11 @@ func (in *WorkloadStatus) DeepCopyInto(out *WorkloadStatus) {
 	}
 	if in.Prefill != nil {
 		in, out := &in.Prefill, &out.Prefill
+		*out = new(ObservedWorkloadStatus)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Encode != nil {
+		in, out := &in.Encode, &out.Encode
 		*out = new(ObservedWorkloadStatus)
 		(*in).DeepCopyInto(*out)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -434,6 +434,7 @@ const (
 	LLMDRoleLabelKey = "llm-d.ai/role"
 	LLMDRoleDecode   = "decode"
 	LLMDRolePrefill  = "prefill"
+	LLMDRoleEncode   = "encode"
 	LLMDRoleBoth     = "both"
 )
 
@@ -445,10 +446,13 @@ const (
 	LLMComponentRouterScheduler       = "llminferenceservice-router-scheduler"
 	LLMComponentWorkload              = "llminferenceservice-workload"
 	LLMComponentWorkloadPrefill       = "llminferenceservice-workload-prefill"
+	LLMComponentWorkloadEncode        = "llminferenceservice-workload-encode"
 	LLMComponentWorkloadWorker        = "llminferenceservice-workload-worker"
 	LLMComponentWorkloadLeader        = "llminferenceservice-workload-leader"
 	LLMComponentWorkloadWorkerPrefill = "llminferenceservice-workload-worker-prefill"
 	LLMComponentWorkloadLeaderPrefill = "llminferenceservice-workload-leader-prefill"
+	LLMComponentWorkloadWorkerEncode  = "llminferenceservice-workload-worker-encode"
+	LLMComponentWorkloadLeaderEncode  = "llminferenceservice-workload-leader-encode"
 	LLMComponentInference             = "inference" // used in sample/template resources
 	LLMComponentTokenizer             = "tokenizer" // standalone vLLM tokenizer deployment
 )

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -65,11 +65,17 @@ const (
 	configWorkerDataParallelNameSuffix        = "config-llm-worker-data-parallel"
 	configDecodeWorkerDataParallelNameSuffix  = "config-llm-decode-worker-data-parallel"
 	configPrefillWorkerDataParallelNameSuffix = "config-llm-prefill-worker-data-parallel"
+	// Encode disaggregation templates (E/PD and E/P/D topologies)
+	configEncodeTemplateNameSuffix      = "config-llm-encode-template"
+	configEncodeWorkerPipelineParallelNameSuffix = "config-llm-encode-worker-pipeline-parallel"
+	configEncodeWorkerDataParallelNameSuffix     = "config-llm-encode-worker-data-parallel"
 	// Router and scheduler configurations
-	configRouterSchedulerNameSuffix                   = "config-llm-scheduler"
-	configRouterSchedulerDefaultEPPConfigNameSuffix   = "config-llm-scheduler-eppconfig-default"    // default EPPConfig
-	configRouterSchedulerDefaultPDEPPConfigNameSuffix = "config-llm-scheduler-eppconfig-default-pd" // default EPPConfig for P/D
-	configRouterRouteNameSuffix                       = "config-llm-router-route"
+	configRouterSchedulerNameSuffix                    = "config-llm-scheduler"
+	configRouterSchedulerDefaultEPPConfigNameSuffix    = "config-llm-scheduler-eppconfig-default"     // default EPPConfig
+	configRouterSchedulerDefaultPDEPPConfigNameSuffix  = "config-llm-scheduler-eppconfig-default-pd"  // default EPPConfig for P/D
+	configRouterSchedulerDefaultEPDEPPConfigNameSuffix = "config-llm-scheduler-eppconfig-default-epd" // default EPPConfig for E/PD
+	configRouterSchedulerDefaultEPPDEPPConfigNameSuffix = "config-llm-scheduler-eppconfig-default-eppd" // default EPPConfig for E/P/D
+	configRouterRouteNameSuffix                        = "config-llm-router-route"
 	configSchedulerLatencyPredictorNameSuffix         = "config-llm-scheduler-latency-predictor"
 	configTokenizerNameSuffix                         = "config-llm-tokenizer" // #nosec G101
 	// Tracing configurations
@@ -84,13 +90,18 @@ var (
 	configWorkerPipelineParallelName            = configPrefix + configWorkerPipelineParallelNameSuffix
 	configWorkerDataParallelName                = configPrefix + configWorkerDataParallelNameSuffix
 	configDecodeWorkerDataParallelName          = configPrefix + configDecodeWorkerDataParallelNameSuffix
-	configPrefillTemplateName                   = configPrefix + configPrefillTemplateNameSuffix
-	configPrefillWorkerPipelineParallelName     = configPrefix + configPrefillWorkerPipelineParallelNameSuffix
-	configPrefillWorkerDataParallelName         = configPrefix + configPrefillWorkerDataParallelNameSuffix
-	configRouterSchedulerName                   = configPrefix + configRouterSchedulerNameSuffix
-	configRouterSchedulerDefaultEPPConfigName   = configPrefix + configRouterSchedulerDefaultEPPConfigNameSuffix
-	configRouterSchedulerDefaultPDEPPConfigName = configPrefix + configRouterSchedulerDefaultPDEPPConfigNameSuffix
-	configRouterRouteName                       = configPrefix + configRouterRouteNameSuffix
+	configPrefillTemplateName                    = configPrefix + configPrefillTemplateNameSuffix
+	configPrefillWorkerPipelineParallelName      = configPrefix + configPrefillWorkerPipelineParallelNameSuffix
+	configPrefillWorkerDataParallelName          = configPrefix + configPrefillWorkerDataParallelNameSuffix
+	configEncodeTemplateName                     = configPrefix + configEncodeTemplateNameSuffix
+	configEncodeWorkerPipelineParallelName       = configPrefix + configEncodeWorkerPipelineParallelNameSuffix
+	configEncodeWorkerDataParallelName           = configPrefix + configEncodeWorkerDataParallelNameSuffix
+	configRouterSchedulerName                    = configPrefix + configRouterSchedulerNameSuffix
+	configRouterSchedulerDefaultEPPConfigName    = configPrefix + configRouterSchedulerDefaultEPPConfigNameSuffix
+	configRouterSchedulerDefaultPDEPPConfigName  = configPrefix + configRouterSchedulerDefaultPDEPPConfigNameSuffix
+	configRouterSchedulerDefaultEPDEPPConfigName  = configPrefix + configRouterSchedulerDefaultEPDEPPConfigNameSuffix
+	configRouterSchedulerDefaultEPPDEPPConfigName = configPrefix + configRouterSchedulerDefaultEPPDEPPConfigNameSuffix
+	configRouterRouteName                        = configPrefix + configRouterRouteNameSuffix
 	configSchedulerLatencyPredictorName         = configPrefix + configSchedulerLatencyPredictorNameSuffix
 	configTokenizerName                         = configPrefix + configTokenizerNameSuffix
 	configTracingName                           = configPrefix + configTracingNameSuffix
@@ -112,9 +123,14 @@ var WellKnownDefaultConfigs = sets.New[string](
 	configDecodeWorkerDataParallelName,
 	configPrefillTemplateName,
 	configPrefillWorkerDataParallelName,
+	configEncodeTemplateName,
+	configEncodeWorkerDataParallelName,
+	configEncodeWorkerPipelineParallelName,
 	configRouterSchedulerName,
 	configRouterSchedulerDefaultEPPConfigName,
 	configRouterSchedulerDefaultPDEPPConfigName,
+	configRouterSchedulerDefaultEPDEPPConfigName,
+	configRouterSchedulerDefaultEPPDEPPConfigName,
 	configRouterRouteName,
 	configSchedulerLatencyPredictorName,
 	configTokenizerName,
@@ -438,9 +454,14 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 			// The presets require llm-d-router image version >= routerPresetMinVersion.
 			// Older images fall back to the hardcoded schedulerConfigText().
 			if injectDefaultSchedulerConfig && routerVersionSupportsPreset(ctx, schedulerCfg) {
-				if resolvedSpec.Prefill != nil { // P/D disagg.
+				switch {
+				case resolvedSpec.Encode != nil && resolvedSpec.Prefill != nil: // E/P/D
+					refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configRouterSchedulerDefaultEPPDEPPConfigName)})
+				case resolvedSpec.Encode != nil: // E/PD
+					refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configRouterSchedulerDefaultEPDEPPConfigName)})
+				case resolvedSpec.Prefill != nil: // P/D
 					refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configRouterSchedulerDefaultPDEPPConfigName)})
-				} else {
+				default:
 					refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configRouterSchedulerDefaultEPPConfigName)})
 				}
 			}
@@ -463,7 +484,22 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 		refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configTracingName)})
 	}
 
-	if resolvedSpec.Prefill != nil { // P/D
+	if resolvedSpec.Encode != nil { // Encode disaggregation (E/PD or E/P/D)
+		// Encode workload preset
+		switch {
+		case resolvedSpec.Encode.Worker == nil:
+			// single-node encode
+			refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configEncodeTemplateName)})
+		case resolvedSpec.Encode.Worker != nil && resolvedSpec.Encode.Parallelism.IsDataParallel():
+			// multi-node Data Parallel encode
+			refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configEncodeWorkerDataParallelName)})
+		case resolvedSpec.Encode.Worker != nil && resolvedSpec.Encode.Parallelism.IsPipelineParallel():
+			// multi-node Pipeline Parallel encode
+			refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configEncodeWorkerPipelineParallelName)})
+		}
+	}
+
+	if resolvedSpec.Prefill != nil { // P/D or E/P/D
 		// Prefill
 		switch {
 		case resolvedSpec.Prefill.Worker == nil:
@@ -476,7 +512,9 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 			// multi-node Pipeline Parallel prefill
 			refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configPrefillWorkerPipelineParallelName)})
 		}
-		// Decode
+	}
+
+	if resolvedSpec.Prefill != nil || resolvedSpec.Encode != nil { // Disaggregated (P/D, E/PD, or E/P/D) — decode workload
 		switch {
 		case resolvedSpec.Worker == nil:
 			// single-node decode
@@ -488,7 +526,7 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 			// multi-node Pipeline Parallel decode
 			refs = append(refs, corev1.LocalObjectReference{Name: wr.Resolve(llmSvc, configDecodeWorkerPipelineParallelName)})
 		}
-	} else { // Non P/D
+	} else { // Non-disaggregated (single workload)
 		switch {
 		case resolvedSpec.Worker == nil:
 			// single-node

--- a/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
@@ -426,6 +426,60 @@ func WithPrefillWorker(worker *corev1.PodSpec) LLMInferenceServiceOption {
 	}
 }
 
+func WithEncode(pod *corev1.PodSpec) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		if llmSvc.Spec.Encode == nil {
+			llmSvc.Spec.Encode = &v1alpha2.WorkloadSpec{}
+		}
+		llmSvc.Spec.Encode.Template = pod
+	}
+}
+
+func WithEncodeWorker(worker *corev1.PodSpec) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		if llmSvc.Spec.Encode == nil {
+			llmSvc.Spec.Encode = &v1alpha2.WorkloadSpec{}
+		}
+		llmSvc.Spec.Encode.Worker = worker
+	}
+}
+
+func WithEncodeReplicas(replicas int32) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		if llmSvc.Spec.Encode == nil {
+			llmSvc.Spec.Encode = &v1alpha2.WorkloadSpec{}
+		}
+		llmSvc.Spec.Encode.Replicas = &replicas
+	}
+}
+
+func WithEncodeScaling(scaling *v1alpha2.ScalingSpec) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		if llmSvc.Spec.Encode == nil {
+			llmSvc.Spec.Encode = &v1alpha2.WorkloadSpec{}
+		}
+		llmSvc.Spec.Encode.Scaling = scaling
+	}
+}
+
+func WithEncodeParallelism(parallelism *v1alpha2.ParallelismSpec) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		if llmSvc.Spec.Encode == nil {
+			llmSvc.Spec.Encode = &v1alpha2.WorkloadSpec{}
+		}
+		llmSvc.Spec.Encode.Parallelism = parallelism
+	}
+}
+
+func WithEncodeRolloutStrategy(rs *v1alpha2.RolloutStrategy) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		if llmSvc.Spec.Encode == nil {
+			llmSvc.Spec.Encode = &v1alpha2.WorkloadSpec{}
+		}
+		llmSvc.Spec.Encode.RolloutStrategy = rs
+	}
+}
+
 func ParallelismSpec(opts ...func(*v1alpha2.ParallelismSpec)) *v1alpha2.ParallelismSpec {
 	p := &v1alpha2.ParallelismSpec{}
 	for _, opt := range opts {

--- a/pkg/controller/v1alpha2/llmisvc/scaling.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling.go
@@ -69,6 +69,10 @@ func (r *LLMISVCReconciler) reconcileScaling(ctx context.Context, llmSvc *v1alph
 		return fmt.Errorf("failed to reconcile prefill workload scaling: %w", err)
 	}
 
+	if err := r.reconcileWorkloadScaling(ctx, llmSvc, config, encodeWorkloadScalingParams(llmSvc)); err != nil {
+		return fmt.Errorf("failed to reconcile encode workload scaling: %w", err)
+	}
+
 	return nil
 }
 
@@ -600,6 +604,26 @@ func mainScaleTargetRef(llmSvc *v1alpha2.LLMInferenceService) autoscalingv2.Cros
 	}
 }
 
+func encodeWorkloadScalingParams(llmSvc *v1alpha2.LLMInferenceService) workloadScalingParams {
+	var scaling *v1alpha2.ScalingSpec
+	var labels map[string]string
+	if llmSvc.Spec.Encode != nil {
+		scaling = llmSvc.Spec.Encode.Scaling
+		labels = llmSvc.Spec.Encode.Labels
+	}
+	return workloadScalingParams{
+		name:             "encode",
+		scaling:          scaling,
+		scaleTargetRef:   encodeScaleTargetRef(llmSvc),
+		hpaName:          encodeHPAName(llmSvc),
+		scaledObjectName: encodeScaledObjectName(llmSvc),
+		workloadLabels:   labels,
+		markReady:        llmSvc.MarkEncodeScalingReady,
+		markNotReady:     llmSvc.MarkEncodeScalingNotReady,
+		markUnset:        llmSvc.MarkEncodeScalingUnset,
+	}
+}
+
 func prefillScaleTargetRef(llmSvc *v1alpha2.LLMInferenceService) autoscalingv2.CrossVersionObjectReference {
 	if llmSvc.Spec.Prefill != nil && llmSvc.Spec.Prefill.Worker != nil {
 		return autoscalingv2.CrossVersionObjectReference{
@@ -615,6 +639,21 @@ func prefillScaleTargetRef(llmSvc *v1alpha2.LLMInferenceService) autoscalingv2.C
 	}
 }
 
+func encodeScaleTargetRef(llmSvc *v1alpha2.LLMInferenceService) autoscalingv2.CrossVersionObjectReference {
+	if llmSvc.Spec.Encode != nil && llmSvc.Spec.Encode.Worker != nil {
+		return autoscalingv2.CrossVersionObjectReference{
+			APIVersion: lwsapi.GroupVersion.String(),
+			Kind:       "LeaderWorkerSet",
+			Name:       encodeLWSName(llmSvc),
+		}
+	}
+	return autoscalingv2.CrossVersionObjectReference{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       encodeDeploymentName(llmSvc),
+	}
+}
+
 func mainHPAName(llmSvc *v1alpha2.LLMInferenceService) string {
 	return kmeta.ChildName(llmSvc.GetName(), "-kserve-hpa")
 }
@@ -623,10 +662,18 @@ func prefillHPAName(llmSvc *v1alpha2.LLMInferenceService) string {
 	return kmeta.ChildName(llmSvc.GetName(), "-kserve-prefill-hpa")
 }
 
+func encodeHPAName(llmSvc *v1alpha2.LLMInferenceService) string {
+	return kmeta.ChildName(llmSvc.GetName(), "-kserve-encode-hpa")
+}
+
 func mainScaledObjectName(llmSvc *v1alpha2.LLMInferenceService) string {
 	return kmeta.ChildName(llmSvc.GetName(), "-kserve-keda")
 }
 
 func prefillScaledObjectName(llmSvc *v1alpha2.LLMInferenceService) string {
 	return kmeta.ChildName(llmSvc.GetName(), "-kserve-prefill-keda")
+}
+
+func encodeScaledObjectName(llmSvc *v1alpha2.LLMInferenceService) string {
+	return kmeta.ChildName(llmSvc.GetName(), "-kserve-encode-keda")
 }

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -556,7 +556,86 @@ func schedulerConfigText(llmSvc *v1alpha2.LLMInferenceService) string {
 	}
 
 	switch {
-	case llmSvc.Spec.Prefill != nil:
+	case llmSvc.Spec.Encode != nil && llmSvc.Spec.Prefill != nil: // E/P/D topology
+		return fmt.Sprintf(`
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: encode-filter
+- type: prefill-filter
+- type: decode-filter
+- type: queue-scorer
+- type: kv-cache-utilization-scorer
+- type: active-request-scorer
+- type: prefix-cache-scorer
+- type: max-score-picker
+- type: always-disagg-multimodal-decider
+- type: always-disagg-pd-decider
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      encode: always-disagg-multimodal-decider
+      prefill: always-disagg-pd-decider
+%sschedulingProfiles:
+- name: encode
+  plugins:
+  - pluginRef: encode-filter
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: max-score-picker
+- name: prefill
+  plugins:
+  - pluginRef: prefill-filter
+%s  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: kv-cache-utilization-scorer
+    weight: 2
+  - pluginRef: max-score-picker
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+%s  - pluginRef: active-request-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`, loraPlugin, loraProfileEntry, loraProfileEntry)
+	case llmSvc.Spec.Encode != nil: // E/PD topology
+		return fmt.Sprintf(`
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: encode-filter
+- type: decode-filter
+- type: queue-scorer
+- type: kv-cache-utilization-scorer
+- type: active-request-scorer
+- type: prefix-cache-scorer
+- type: max-score-picker
+- type: always-disagg-multimodal-decider
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      encode: always-disagg-multimodal-decider
+%sschedulingProfiles:
+- name: encode
+  plugins:
+  - pluginRef: encode-filter
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: max-score-picker
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+%s  - pluginRef: active-request-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`, loraPlugin, loraProfileEntry)
+	case llmSvc.Spec.Prefill != nil: // P/D topology
 		return fmt.Sprintf(`
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -50,13 +50,19 @@ func (r *LLMISVCReconciler) reconcileMultiNodeWorkload(ctx context.Context, llmS
 		return fmt.Errorf("failed to reconcile multi-node service account: %w", err)
 	}
 	if err := r.reconcileMultiNodePrefillServiceAccount(ctx, llmSvc); err != nil {
-		return fmt.Errorf("failed to reconcile multi-node service account: %w", err)
+		return fmt.Errorf("failed to reconcile multi-node prefill service account: %w", err)
+	}
+	if err := r.reconcileMultiNodeEncodeServiceAccount(ctx, llmSvc); err != nil {
+		return fmt.Errorf("failed to reconcile multi-node encode service account: %w", err)
 	}
 	if err := r.reconcileMultiNodeMainWorkload(ctx, llmSvc, config); err != nil {
 		return fmt.Errorf("failed to reconcile multi-node main workload: %w", err)
 	}
 	if err := r.reconcileMultiNodePrefillWorkload(ctx, llmSvc, config); err != nil {
 		return fmt.Errorf("failed to reconcile multi-node prefill workload: %w", err)
+	}
+	if err := r.reconcileMultiNodeEncodeWorkload(ctx, llmSvc, config); err != nil {
+		return fmt.Errorf("failed to reconcile multi-node encode workload: %w", err)
 	}
 	return nil
 }
@@ -148,7 +154,7 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 		workerLabels[constants.LLMDRoleLabelKey] = constants.LLMDRoleDecode
 	}
 	role := constants.LLMDRoleDecode
-	if llmSvc.Spec.Prefill == nil {
+	if llmSvc.Spec.Prefill == nil && llmSvc.Spec.Encode == nil {
 		role = constants.LLMDRoleBoth
 	}
 	leaderLabels := map[string]string{
@@ -669,6 +675,223 @@ func mainLWSName(llmSvc *v1alpha2.LLMInferenceService) string {
 
 func prefillLWSName(llmSvc *v1alpha2.LLMInferenceService) string {
 	return kmeta.ChildName(llmSvc.GetName(), "-kserve-mn-prefill")
+}
+
+func encodeLWSName(llmSvc *v1alpha2.LLMInferenceService) string {
+	return kmeta.ChildName(llmSvc.GetName(), "-kserve-mn-encode")
+}
+
+func (r *LLMISVCReconciler) reconcileMultiNodeEncodeWorkload(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
+	if isStopped := utils.GetForceStopRuntime(llmSvc); isStopped || llmSvc.Spec.Encode == nil || llmSvc.Spec.Encode.Worker == nil {
+		if isStopped {
+			llmSvc.MarkEncodeWorkerWorkloadNotReady("Stopped", "Service is stopped")
+		} else {
+			llmSvc.MarkEncodeWorkerWorkloadUnset()
+		}
+		return Delete(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      encodeLWSName(llmSvc),
+				Namespace: llmSvc.GetNamespace(),
+			},
+		})
+	}
+
+	expected, err := r.expectedEncodeMultiNodeLWS(ctx, llmSvc, config)
+	if err != nil {
+		return fmt.Errorf("failed to build the expected encode LWS: %w", err)
+	}
+	if err := Reconcile(ctx, r, llmSvc, &lwsapi.LeaderWorkerSet{}, expected, semanticLWSIsEqual, PreserveLWSReplicas()); err != nil {
+		return err
+	}
+	return r.propagateLeaderWorkerSetStatus(ctx, expected, llmSvc.MarkEncodeWorkerWorkloadReady, llmSvc.MarkEncodeWorkerWorkloadNotReady)
+}
+
+func (r *LLMISVCReconciler) reconcileMultiNodeEncodeServiceAccount(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
+	serviceAccount, useExistingServiceAccount, err := r.expectedMultiNodeEncodeServiceAccount(ctx, llmSvc)
+	if err != nil {
+		return fmt.Errorf("failed to create expected multi node encode service account: %w", err)
+	}
+	if !useExistingServiceAccount {
+		if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Encode == nil || llmSvc.Spec.Encode.Worker == nil {
+			return Delete(ctx, r, llmSvc, serviceAccount)
+		}
+
+		if err := Reconcile(ctx, r, llmSvc, &corev1.ServiceAccount{}, serviceAccount, semanticServiceAccountIsEqual); err != nil {
+			return fmt.Errorf("failed to reconcile multi node encode service account %s/%s: %w", serviceAccount.GetNamespace(), serviceAccount.GetName(), err)
+		}
+	}
+
+	return nil
+}
+
+func (r *LLMISVCReconciler) expectedMultiNodeEncodeServiceAccount(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) (*corev1.ServiceAccount, bool, error) {
+	useExistingServiceAccount := false
+	expectedServiceAccountName := encodeLWSName(llmSvc)
+
+	// An existing service account attached to the encode leader template takes precedence over any attached to the encode worker template.
+	var existingServiceAccountName string
+	if llmSvc.Spec.Encode != nil && llmSvc.Spec.Encode.Template != nil && llmSvc.Spec.Encode.Template.ServiceAccountName != "" {
+		existingServiceAccountName = llmSvc.Spec.Encode.Template.ServiceAccountName
+	} else if llmSvc.Spec.Encode != nil && llmSvc.Spec.Encode.Worker != nil && llmSvc.Spec.Encode.Worker.ServiceAccountName != "" {
+		existingServiceAccountName = llmSvc.Spec.Encode.Worker.ServiceAccountName
+	}
+
+	if existingServiceAccountName != "" && existingServiceAccountName != expectedServiceAccountName {
+		useExistingServiceAccount = true
+		log.FromContext(ctx).V(2).Info("Using existing service account for multi node encode workload", "serviceAccountName", existingServiceAccountName)
+		existingServiceAccount := &corev1.ServiceAccount{}
+		err := r.Get(ctx, types.NamespacedName{Name: existingServiceAccountName, Namespace: llmSvc.Namespace}, existingServiceAccount)
+		if err != nil {
+			return nil, useExistingServiceAccount, fmt.Errorf("failed to fetch existing multi node encode service account %s/%s: %w", llmSvc.Namespace, existingServiceAccountName, err)
+		}
+		return existingServiceAccount, useExistingServiceAccount, nil
+	}
+
+	expectedServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      expectedServiceAccountName,
+			Namespace: llmSvc.GetNamespace(),
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
+			},
+		},
+	}
+
+	r.injectSecretsFromDefaultServiceAccount(ctx, expectedServiceAccount)
+
+	// Add required labels to the created service account
+	if expectedServiceAccount.Labels == nil {
+		expectedServiceAccount.Labels = make(map[string]string)
+	}
+	expectedServiceAccount.Labels[constants.KubernetesAppNameLabelKey] = llmSvc.GetName()
+	expectedServiceAccount.Labels[constants.KubernetesPartOfLabelKey] = constants.LLMInferenceServicePartOfValue
+
+	return expectedServiceAccount, useExistingServiceAccount, nil
+}
+
+func (r *LLMISVCReconciler) expectedEncodeMultiNodeLWS(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) (*lwsapi.LeaderWorkerSet, error) {
+	workerLabels := map[string]string{
+		constants.KubernetesComponentLabelKey: constants.LLMComponentWorkloadWorkerEncode,
+		constants.KubernetesAppNameLabelKey:   llmSvc.GetName(),
+		constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
+	}
+	if llmSvc.Spec.Encode != nil && llmSvc.Spec.Encode.Template == nil {
+		// When there is no leader template, workers become part of the InferencePool selector.
+		workerLabels[constants.KServeComponentLabelKey] = constants.KServeComponentWorkload
+		workerLabels[constants.LLMDRoleLabelKey] = constants.LLMDRoleEncode
+	}
+	leaderLabels := map[string]string{
+		constants.KubernetesComponentLabelKey: constants.LLMComponentWorkloadLeaderEncode,
+		constants.KubernetesAppNameLabelKey:   llmSvc.GetName(),
+		constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
+		constants.KServeComponentLabelKey:     constants.KServeComponentWorkload,
+		constants.LLMDRoleLabelKey:            constants.LLMDRoleEncode,
+	}
+
+	expected := &lwsapi.LeaderWorkerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      encodeLWSName(llmSvc),
+			Namespace: llmSvc.GetNamespace(),
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
+			},
+			Labels: workerLabels,
+		},
+		Spec: lwsapi.LeaderWorkerSetSpec{
+			LeaderWorkerTemplate: lwsapi.LeaderWorkerTemplate{
+				WorkerTemplate: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: workerLabels,
+					},
+				},
+				RestartPolicy: lwsapi.RecreateGroupOnPodRestart,
+			},
+			RolloutStrategy: lwsapi.RolloutStrategy{
+				Type:                       lwsapi.RollingUpdateStrategyType,
+				RollingUpdateConfiguration: rollingUpdateConfigFromWorkloadSpec(llmSvc.Spec.Encode),
+			},
+			StartupPolicy: lwsapi.LeaderCreatedStartupPolicy,
+		},
+	}
+
+	if llmSvc.Spec.Encode != nil && !utils.GetForceStopRuntime(llmSvc) {
+		expected.Spec.Replicas = llmSvc.Spec.Encode.Replicas
+		expected.Spec.LeaderWorkerTemplate.Size = llmSvc.Spec.Encode.Parallelism.GetSize()
+
+		serviceAccount, _, err := r.expectedMultiNodeEncodeServiceAccount(ctx, llmSvc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create expected multi node encode service account: %w", err)
+		}
+
+		currLWS := &lwsapi.LeaderWorkerSet{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(expected), currLWS); err != nil && !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+			return nil, fmt.Errorf("failed to get current encode leader worker set %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
+		}
+
+		if llmSvc.Spec.Encode.Template != nil {
+			expected.Spec.LeaderWorkerTemplate.LeaderTemplate = &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: leaderLabels,
+				},
+				Spec: *llmSvc.Spec.Encode.Template.DeepCopy(),
+			}
+
+			expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.ServiceAccountName = serviceAccount.GetName()
+
+			var currLeaderSpec corev1.PodSpec
+			if currLWS.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
+				currLeaderSpec = currLWS.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec
+			}
+
+			if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, currLeaderSpec, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, config, "main", constants.DefaultModelLocalMountPath, len(config.ResolvedLoRAAdapters) > 0); err != nil {
+				return nil, fmt.Errorf("failed to attach model artifacts to encode leader template: %w", err)
+			}
+			if llmSvc.Spec.Encode.KVCacheOffloading != nil {
+				attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, llmSvc.Spec.Encode.KVCacheOffloading.Secondary, "main")
+			}
+		}
+		if llmSvc.Spec.Encode.Worker != nil {
+			expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec = *llmSvc.Spec.Encode.Worker.DeepCopy()
+
+			expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.ServiceAccountName = serviceAccount.GetName()
+
+			if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, currLWS.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, config, "main", constants.DefaultModelLocalMountPath, len(config.ResolvedLoRAAdapters) > 0); err != nil {
+				return nil, fmt.Errorf("failed to attach model artifacts to encode worker template: %w", err)
+			}
+			if llmSvc.Spec.Encode.KVCacheOffloading != nil {
+				attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, llmSvc.Spec.Encode.KVCacheOffloading.Secondary, "main")
+			}
+		}
+
+		if llmSvc.Spec.Encode.Parallelism.IsDataParallel() && expected.Spec.LeaderWorkerTemplate.Size != nil {
+			expected.Spec.LeaderWorkerTemplate.SubGroupPolicy = &lwsapi.SubGroupPolicy{
+				SubGroupSize: expected.Spec.LeaderWorkerTemplate.Size,
+			}
+		}
+	}
+
+	r.propagateTopLevelLeaderWorkerSetMetadata(llmSvc, expected)
+
+	// Inject tracing instrumentation when spec.tracing is set
+	if llmSvc.Spec.Tracing != nil {
+		if expected.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
+			injectServerTracingIntoPodSpec(llmSvc.Spec.Tracing, llmSvc.GetNamespace(), llmSvc.GetName(), "-encode", &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec)
+		}
+		injectServerTracingIntoPodSpec(llmSvc.Spec.Tracing, llmSvc.GetNamespace(), llmSvc.GetName(), "-encode", &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec)
+	}
+
+	if llmSvc.Spec.Encode != nil {
+		if expected.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
+			utils.PropagateMap(llmSvc.Spec.Encode.Labels, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Labels)
+			utils.PropagateMap(llmSvc.Spec.Encode.Annotations, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations, AnnotationModelBasedRoutingEnabled)
+		}
+		utils.PropagateMap(llmSvc.Spec.Encode.Labels, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Labels)
+		utils.PropagateMap(llmSvc.Spec.Encode.Annotations, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations, AnnotationModelBasedRoutingEnabled)
+	}
+
+	log.FromContext(ctx).V(2).Info("Expected encode LWS", "leaderworkerset", expected)
+
+	return expected, nil
 }
 
 func rollingUpdateConfigFromWorkloadSpec(workload *v1alpha2.WorkloadSpec) *lwsapi.RollingUpdateConfiguration {

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -58,6 +58,10 @@ func (r *LLMISVCReconciler) reconcileSingleNodeWorkload(ctx context.Context, llm
 	if err := r.reconcileSingleNodePrefill(ctx, llmSvc, config); err != nil {
 		return fmt.Errorf("failed to reconcile prefill workload: %w", err)
 	}
+
+	if err := r.reconcileSingleNodeEncode(ctx, llmSvc, config); err != nil {
+		return fmt.Errorf("failed to reconcile encode workload: %w", err)
+	}
 	return nil
 }
 
@@ -88,7 +92,7 @@ func (r *LLMISVCReconciler) reconcileSingleNodeMainWorkload(ctx context.Context,
 
 func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) (*appsv1.Deployment, error) {
 	role := constants.LLMDRoleDecode
-	if llmSvc.Spec.Prefill == nil {
+	if llmSvc.Spec.Prefill == nil && llmSvc.Spec.Encode == nil {
 		role = constants.LLMDRoleBoth
 	}
 
@@ -517,6 +521,116 @@ func mainDeploymentName(llmSvc *v1alpha2.LLMInferenceService) string {
 
 func prefillDeploymentName(llmSvc *v1alpha2.LLMInferenceService) string {
 	return kmeta.ChildName(llmSvc.GetName(), "-kserve-prefill")
+}
+
+func encodeDeploymentName(llmSvc *v1alpha2.LLMInferenceService) string {
+	return kmeta.ChildName(llmSvc.GetName(), "-kserve-encode")
+}
+
+func (r *LLMISVCReconciler) reconcileSingleNodeEncode(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
+	if isStopped := utils.GetForceStopRuntime(llmSvc); isStopped || llmSvc.Spec.Encode == nil || llmSvc.Spec.Encode.Worker != nil {
+		if isStopped {
+			llmSvc.MarkEncodeWorkloadNotReady("Stopped", "Service is stopped")
+		} else {
+			llmSvc.MarkEncodeWorkloadUnset()
+		}
+		return Delete(ctx, r, llmSvc, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      encodeDeploymentName(llmSvc),
+				Namespace: llmSvc.GetNamespace(),
+			},
+		})
+	}
+
+	encode, err := r.expectedEncodeMainDeployment(ctx, llmSvc, config)
+	if err != nil {
+		return fmt.Errorf("failed to get expected encode deployment: %w", err)
+	}
+	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, encode, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
+		return fmt.Errorf("failed to reconcile encode deployment %s/%s: %w", encode.GetNamespace(), encode.GetName(), err)
+	}
+	return r.propagateWorkloadDeploymentStatus(ctx, encode, llmSvc.MarkEncodeWorkloadReady, llmSvc.MarkEncodeWorkloadNotReady)
+}
+
+func (r *LLMISVCReconciler) expectedEncodeMainDeployment(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) (*appsv1.Deployment, error) {
+	labels := map[string]string{
+		constants.KubernetesComponentLabelKey: constants.LLMComponentWorkloadEncode,
+		constants.KubernetesAppNameLabelKey:   llmSvc.GetName(),
+		constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
+		constants.KServeComponentLabelKey:     constants.KServeComponentWorkload,
+		constants.LLMDRoleLabelKey:            constants.LLMDRoleEncode,
+	}
+
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      encodeDeploymentName(llmSvc),
+			Namespace: llmSvc.GetNamespace(),
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
+			},
+			Labels: labels,
+		},
+	}
+
+	if llmSvc.Spec.Encode != nil {
+		d.Spec = appsv1.DeploymentSpec{
+			Replicas: llmSvc.Spec.Encode.Replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+			},
+		}
+		applyDeploymentRolloutStrategy(d, llmSvc.Spec.Encode)
+	}
+
+	if llmSvc.Spec.Encode != nil && llmSvc.Spec.Encode.Template != nil && !utils.GetForceStopRuntime(llmSvc) {
+		d.Spec.Template.Spec = *llmSvc.Spec.Encode.Template.DeepCopy()
+
+		var existingServiceAccount *corev1.ServiceAccount = nil
+		if llmSvc.Spec.Encode.Template.ServiceAccountName != "" {
+			existingServiceAccount = &corev1.ServiceAccount{}
+			err := r.Get(ctx, types.NamespacedName{Name: llmSvc.Spec.Encode.Template.ServiceAccountName, Namespace: llmSvc.Namespace}, existingServiceAccount)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch existing single node encode service account %s/%s: %w", llmSvc.Namespace, llmSvc.Spec.Encode.Template.ServiceAccountName, err)
+			}
+		}
+
+		curr := &appsv1.Deployment{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(d), curr); err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get current encode deployment %s/%s: %w", d.GetNamespace(), d.GetName(), err)
+		}
+		if err := r.attachModelArtifacts(ctx, existingServiceAccount, llmSvc, curr.Spec.Template.Spec, &d.Spec.Template.Spec, config, "main", constants.DefaultModelLocalMountPath, len(config.ResolvedLoRAAdapters) > 0); err != nil {
+			return nil, fmt.Errorf("failed to attach model artifacts to encode deployment: %w", err)
+		}
+		if llmSvc.Spec.Encode.KVCacheOffloading != nil {
+			attachKVCacheSecondaryTiers(&d.Spec.Template.Spec, llmSvc.Spec.Encode.KVCacheOffloading.Secondary, "main")
+		}
+	}
+
+	r.propagateDeploymentMetadata(llmSvc, d)
+
+	if llmSvc.Spec.Encode != nil {
+		utils.PropagateMap(llmSvc.Spec.Encode.Labels, &d.Spec.Template.Labels)
+		utils.PropagateMap(llmSvc.Spec.Encode.Annotations, &d.Spec.Template.Annotations, AnnotationModelBasedRoutingEnabled)
+	}
+
+	// Inject tracing instrumentation when spec.tracing is set
+	if llmSvc.Spec.Tracing != nil {
+		mainIdx := slices.IndexFunc(d.Spec.Template.Spec.Containers, func(c corev1.Container) bool {
+			return c.Name == "main"
+		})
+		if mainIdx >= 0 {
+			injectServerTracing(llmSvc.Spec.Tracing, llmSvc.GetNamespace(), llmSvc.GetName(), "-encode", &d.Spec.Template.Spec.Containers[mainIdx])
+		}
+	}
+
+	log.FromContext(ctx).V(2).Info("Expected encode deployment", "deployment", d)
+
+	return d, nil
 }
 
 func applyDeploymentRolloutStrategy(d *appsv1.Deployment, workload *v1alpha2.WorkloadSpec) {

--- a/pkg/controller/v1alpha2/llmisvc/workload_status.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_status.go
@@ -81,6 +81,14 @@ func (r *LLMISVCReconciler) observeWorkloadStatus(ctx context.Context, llmSvc *v
 		}
 	}
 
+	if llmSvc.Spec.Encode != nil {
+		if llmSvc.Spec.Encode.Worker != nil {
+			ws.Encode = observedLWS(encodeLWSName(llmSvc))
+		} else {
+			ws.Encode = observedDeployment(encodeDeploymentName(llmSvc))
+		}
+	}
+
 	ws.Service = &corev1.TypedLocalObjectReference{
 		Kind: "Service",
 		Name: workloadServiceName(llmSvc),
@@ -92,7 +100,7 @@ func (r *LLMISVCReconciler) observeWorkloadStatus(ctx context.Context, llmSvc *v
 
 	llmSvc.Status.Workloads = ws
 
-	for _, w := range []*v1alpha2.ObservedWorkloadStatus{ws.Primary, ws.Prefill, ws.Scheduler} {
+	for _, w := range []*v1alpha2.ObservedWorkloadStatus{ws.Primary, ws.Prefill, ws.Encode, ws.Scheduler} {
 		if w == nil {
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements full encode disaggregation support in the `LLMInferenceService` controller, enabling the E/PD (Encode + Prefill/Decode) and E/P/D (Encode + Prefill + Decode) serving topologies described in the llm-d e-disaggregation guide.

When `spec.encode` is set, the controller creates a dedicated encode workload (Deployment or LeaderWorkerSet) alongside the existing decode and optional prefill workloads. Encode workers carry the `llm-d.ai/role=encode` label and are targeted by the `encode-filter` EPP plugin via the `always-disagg-multimodal-decider`. This offloads multimodal encoding (images, video, audio) to dedicated workers, allowing prefill/decode workers to consume pre-computed embeddings via the EC Connector.

**Changes by commit**:

1. **API layer** — `LLMDRoleEncode` constant, `WorkloadStatus.Encode` status field, deepcopy, three new lifecycle conditions (`EncodeWorkloadReady`, `EncodeWorkerWorkloadReady`, `EncodeScalingReady`) with `Mark*` helpers, encode wired into all validation sites (parallelism, immutable parallelism, scaling, KV cache, rollout strategy)

2. **Workload reconciliation** — `reconcileSingleNodeEncode` / `expectedEncodeMainDeployment` (Deployment `{name}-kserve-encode`), `reconcileMultiNodeEncodeWorkload` / `expectedEncodeMultiNodeLWS` (LeaderWorkerSet `{name}-kserve-mn-encode`), encode service account management, `workload_status.go` populates `ws.Encode` and observes replica counts; main workload role set to `decode` (not `both`) when `spec.encode` is present

3. **Autoscaling** — `encodeWorkloadScalingParams` with HPA `{name}-kserve-encode-hpa` and ScaledObject `{name}-kserve-encode-keda`; wired into `reconcileScaling`

4. **Scheduler config** — `schedulerConfigText` extended with E/PD and E/P/D cases:
   - E/P/D: three profiles (`encode`/`prefill`/`decode`), deciders for both encode and prefill
   - E/PD: two profiles (`encode`/`decode`), multimodal decider for encode only

5. **Config merge** — encode preset names (`config-llm-encode-template`, encode worker variants, `config-llm-scheduler-eppconfig-default-epd`, `config-llm-scheduler-eppconfig-default-eppd`) added to `WellKnownDefaultConfigs`; `combineBaseRefsConfig` selects the correct EPP preset for all four topologies and injects encode workload presets

6. **Test fixtures** — `WithEncode`, `WithEncodeWorker`, `WithEncodeReplicas`, `WithEncodeScaling`, `WithEncodeParallelism`, `WithEncodeRolloutStrategy` builders

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [ ] Unit tests for encode workload reconciliation (single-node)
- [ ] Unit tests for encode workload reconciliation (multi-node LWS)
- [ ] Unit tests for encode scaling
- [ ] Unit tests for E/PD and E/P/D scheduler config text
- [ ] Integration test with e-disaggregation guide model server configs

**Special notes for your reviewer**:

- `spec.encode` was already declared as a stub field in `llm_inference_service_types.go` but had no implementation. This PR completes it end-to-end.
- v1alpha1 does not yet have an `Encode` field (same situation as `Prefill` before it was backported). The field is silently dropped on v1alpha2→v1alpha1 conversion; a follow-up can add v1alpha1 support.
- The `always-disagg-multimodal-decider` in the legacy `schedulerConfigText` path is a placeholder — the actual decider is only used by the preset-based EPP config path (router >= 0.11.0). Older router images get the text config without encode routing, which is the same no-op behaviour as they have today for text-only workloads.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
feat(llmisvc): implement encode disaggregation for multimodal serving. Setting spec.encode on an LLMInferenceService creates a dedicated encode workload (Deployment or LeaderWorkerSet) with llm-d.ai/role=encode, enabling E/PD and E/P/D topologies. The EPP scheduler config and preset selection are updated accordingly.
```