### PR TITLE
fix(rbac): add leader election role for localmodel controller

### DIFF
--- a/charts/kserve-localmodel-resources/files/resources.yaml
+++ b/charts/kserve-localmodel-resources/files/resources.yaml
@@ -183,6 +183,23 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodel-leader-election-rolebinding
+  namespace: kserve
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kserve-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/config/rbac/localmodel/kustomization.yaml
+++ b/config/rbac/localmodel/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
 - role_binding.yaml
 - role.yaml
+- leader_election_role_binding.yaml
 - service_account.yaml

--- a/config/rbac/localmodel/leader_election_role_binding.yaml
+++ b/config/rbac/localmodel/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kserve-localmodel-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kserve-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: kserve-localmodel-controller-manager

--- a/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
@@ -6777,6 +6777,23 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: localmodel
+    app.kubernetes.io/name: kserve
+  name: kserve-localmodel-leader-election-rolebinding
+  namespace: kserve
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kserve-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
## What this PR does / why we need it

The localmodel controller uses leader election when `--leader-elect` is enabled, but the corresponding RBAC to access `leases.coordination.k8s.io` was missing. This causes the controller to fail with:

```
leases.coordination.k8s.io "kserve-local-model-manager-leader-lock" is forbidden:
User "system:serviceaccount:...:kserve-localmodel-controller-manager"
cannot get resource "leases" in API group "coordination.k8s.io"
```

## Changes

- Add `leader_election_role.yaml` granting `leases` (coordination.k8s.io) create/get/list/update
- Add `leader_election_role_binding.yaml` binding the role to `kserve-localmodel-controller-manager` SA
- Update `config/rbac/localmodel/kustomization.yaml` to include the new resources

Follows the same pattern used by the kserve (`config/rbac/leader_election_role.yaml`) and llmisvc (`config/rbac/llmisvc/leader_election_role.yaml`) controllers.

## Test plan

- `kustomize build config/rbac/localmodel` renders correctly
- Verified on OpenShift cluster that the localmodel controller successfully acquires the leader lease after applying this RBAC