### PR TITLE
feat(kernelcache): add cert-mode image signing

### DIFF
--- a/pkg/kernelcache/security/cert_sign.go
+++ b/pkg/kernelcache/security/cert_sign.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	"github.com/sigstore/cosign/v3/pkg/oci/static"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/payload"
+
+	"github.com/kserve/kserve/pkg/kernelcache/types"
+)
+
+// Default Secret data keys for the signing material: the kubernetes.io/tls layout
+// (tls.key/tls.crt) plus cert-manager's ca.crt chain. Overridable per CertConfig.
+const (
+	defaultSigningKeyKey   = "tls.key"
+	defaultSigningCertKey  = "tls.crt"
+	defaultSigningChainKey = "ca.crt"
+)
+
+// certSigner signs an image's digest with a cert-manager issued key and attaches
+// the leaf certificate plus CA chain, producing the standard cosign signature
+// format that certVerifier accepts. It uses no transparency log or SCT.
+type certSigner struct {
+	sv          signature.SignerVerifier
+	leafCert    *x509.Certificate
+	certChain   []*x509.Certificate
+	leafCertPEM []byte
+	caChainPEM  []byte
+	now         func() time.Time
+}
+
+// newCertSigner loads the signing key, leaf certificate, and CA chain from the
+// signing Secret referenced by cfg. It fails fast on missing or malformed
+// material. The load is bounded by a timeout derived from the caller's context.
+func newCertSigner(ctx context.Context, cfg types.CertConfig, src SecretSource) (*certSigner, error) {
+	// Signing needs its secret; presence is enforced here (SecurityConfig.Validate
+	// only checks syntax).
+	if cfg.SigningSecret == "" {
+		return nil, errors.New("cert.signingSecret must be set")
+	}
+	if src == nil {
+		return nil, fmt.Errorf("signing secret %q: no secret source configured", cfg.SigningSecret)
+	}
+
+	loadCtx, cancel := context.WithTimeout(ctx, secretLoadTimeout)
+	defer cancel()
+	data, err := src.GetSecret(loadCtx, cfg.SigningSecret)
+	if err != nil {
+		return nil, fmt.Errorf("signing secret %q: %w", cfg.SigningSecret, err)
+	}
+
+	keyName := cmp.Or(cfg.SigningKeyKey, defaultSigningKeyKey)
+	certName := cmp.Or(cfg.SigningCertKey, defaultSigningCertKey)
+	chainName := cmp.Or(cfg.SigningChainKey, defaultSigningChainKey)
+
+	keyPEM, err := requireDataKey(data, keyName, cfg.SigningSecret)
+	if err != nil {
+		return nil, err
+	}
+	leafPEM, err := requireDataKey(data, certName, cfg.SigningSecret)
+	if err != nil {
+		return nil, err
+	}
+	caPEM, err := requireDataKey(data, chainName, cfg.SigningSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	priv, err := cryptoutils.UnmarshalPEMToPrivateKey(keyPEM, cryptoutils.SkipPassword)
+	if err != nil {
+		return nil, fmt.Errorf("signing secret %q: parse signing key: %w", cfg.SigningSecret, err)
+	}
+	key, ok := priv.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("signing secret %q: signing key does not support signing", cfg.SigningSecret)
+	}
+	leafCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(leafPEM)
+	if err != nil {
+		return nil, fmt.Errorf("signing secret %q: parse leaf certificate (%s): %w", cfg.SigningSecret, certName, err)
+	}
+	if len(leafCerts) == 0 {
+		return nil, fmt.Errorf("signing secret %q: no certificate found in %s", cfg.SigningSecret, certName)
+	}
+	// Reject a mismatched keypair here rather than emitting a signature that only
+	// fails at verify time with a confusing "does not verify" reason.
+	if err := cryptoutils.EqualKeys(key.Public(), leafCerts[0].PublicKey); err != nil {
+		return nil, fmt.Errorf("signing secret %q: private key (%s) does not match leaf certificate (%s): %w",
+			cfg.SigningSecret, keyName, certName, err)
+	}
+	// Same reason: an expired/not-yet-valid leaf would sign but never verify.
+	if err := cryptoutils.CheckExpiration(leafCerts[0], time.Now()); err != nil {
+		return nil, fmt.Errorf("signing secret %q: leaf certificate (%s): %w", cfg.SigningSecret, certName, err)
+	}
+	caCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(caPEM)
+	if err != nil {
+		return nil, fmt.Errorf("signing secret %q: parse CA chain (%s): %w", cfg.SigningSecret, chainName, err)
+	}
+	if len(caCerts) == 0 {
+		return nil, fmt.Errorf("signing secret %q: no CA certificate found in %s", cfg.SigningSecret, chainName)
+	}
+
+	// The leaf must actually chain to the supplied CA: intermediates in tls.crt
+	// (leafCerts[1:]) bridge to the roots in ca.crt. Signing a leaf anchored to a
+	// different bundle would emit a signature the verifier can never validate.
+	// KeyUsages must be CodeSigning to match the leaf; the default ServerAuth
+	// would reject it.
+	roots := x509.NewCertPool()
+	for i, c := range caCerts {
+		if !c.IsCA {
+			return nil, fmt.Errorf("signing secret %q: certificate %d in CA chain (%s) is not a CA certificate", cfg.SigningSecret, i, chainName)
+		}
+		roots.AddCert(c)
+	}
+	intermediates := x509.NewCertPool()
+	for _, c := range leafCerts[1:] {
+		intermediates.AddCert(c)
+	}
+	verifiedChains, err := leafCerts[0].Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		CurrentTime:   time.Now(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("signing secret %q: leaf certificate does not chain to the supplied CA (%s): %w", cfg.SigningSecret, chainName, err)
+	}
+	if len(verifiedChains) == 0 {
+		return nil, fmt.Errorf("signing secret %q: no verified certificate chain found", cfg.SigningSecret)
+	}
+
+	// Cosign stores the leaf separately from its chain. cert-manager may include
+	// intermediates after the leaf in tls.crt, so normalize them into the chain
+	// annotation ahead of the CA bundle certificates.
+	leafCertPEM, err := cryptoutils.MarshalCertificateToPEM(leafCerts[0])
+	if err != nil {
+		return nil, fmt.Errorf("signing secret %q: marshal leaf certificate (%s): %w", cfg.SigningSecret, certName, err)
+	}
+	chainCerts := append([]*x509.Certificate{}, leafCerts[1:]...)
+	chainCerts = append(chainCerts, caCerts...)
+	caChainPEM, err := cryptoutils.MarshalCertificatesToPEM(chainCerts)
+	if err != nil {
+		return nil, fmt.Errorf("signing secret %q: marshal CA chain (%s): %w", cfg.SigningSecret, chainName, err)
+	}
+
+	sv, err := signature.LoadSignerVerifier(key, crypto.SHA256)
+	if err != nil {
+		return nil, fmt.Errorf("signing secret %q: load signer: %w", cfg.SigningSecret, err)
+	}
+
+	return &certSigner{
+		sv:          sv,
+		leafCert:    leafCerts[0],
+		certChain:   verifiedChains[0],
+		leafCertPEM: leafCertPEM,
+		caChainPEM:  caChainPEM,
+		now:         time.Now,
+	}, nil
+}
+
+// Sign resolves the image digest and attaches a signature over that digest
+// (never the mutable tag), so the signature is bound to the exact content. A
+// failure to resolve or write is operational and returned as an error.
+func (s *certSigner) Sign(ctx context.Context, req types.SignRequest) (types.SignResult, error) {
+	res := types.SignResult{Mode: types.ModeCert}
+
+	now := s.now()
+	for i, cert := range s.certChain {
+		if err := cryptoutils.CheckExpiration(cert, now); err != nil {
+			return res, fmt.Errorf("certificate chain element %d is no longer valid: %w", i, err)
+		}
+	}
+
+	ref, err := name.ParseReference(req.ImageRef)
+	if err != nil {
+		return res, fmt.Errorf("parse image reference %q: %w", req.ImageRef, err)
+	}
+
+	// Registry access uses the ambient keychain, matching the verifier; the
+	// wiring will inject a keychain built from imagePullSecrets.
+	keychain := authn.DefaultKeychain
+	remoteClientOpts := []remote.Option{
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(keychain),
+	}
+	remoteOpts := ociremote.WithRemoteOptions(remoteClientOpts...)
+
+	desc, err := remote.Head(ref, remoteClientOpts...)
+	if err != nil {
+		return res, fmt.Errorf("resolve image %q: %w", req.ImageRef, err)
+	}
+	res.Digest = desc.Digest.String()
+	digestRef := ref.Context().Digest(res.Digest)
+
+	pl, err := (&payload.Cosign{Image: digestRef}).MarshalJSON()
+	if err != nil {
+		return res, fmt.Errorf("build signing payload: %w", err)
+	}
+	sig, err := s.sv.SignMessage(bytes.NewReader(pl))
+	if err != nil {
+		return res, fmt.Errorf("sign payload: %w", err)
+	}
+	b64 := base64.StdEncoding.EncodeToString(sig)
+
+	ociSig, err := static.NewSignature(pl, b64, static.WithCertChain(s.leafCertPEM, s.caChainPEM))
+	if err != nil {
+		return res, fmt.Errorf("assemble signature: %w", err)
+	}
+
+	se, err := ociremote.SignedEntity(digestRef, remoteOpts)
+	if err != nil {
+		return res, fmt.Errorf("read signed entity %q: %w", res.Digest, err)
+	}
+	newSE, err := mutate.AttachSignatureToEntity(se, ociSig)
+	if err != nil {
+		return res, fmt.Errorf("attach signature: %w", err)
+	}
+	if err := ociremote.WriteSignatures(digestRef.Repository, newSE, remoteOpts); err != nil {
+		return res, fmt.Errorf("write signature for %q: %w", res.Digest, err)
+	}
+
+	return res, nil
+}

--- a/pkg/kernelcache/security/cert_sign.go
+++ b/pkg/kernelcache/security/cert_sign.go
@@ -53,7 +53,6 @@ const (
 // format that certVerifier accepts. It uses no transparency log or SCT.
 type certSigner struct {
 	sv          signature.SignerVerifier
-	leafCert    *x509.Certificate
 	certChain   []*x509.Certificate
 	leafCertPEM []byte
 	caChainPEM  []byte
@@ -119,7 +118,10 @@ func newCertSigner(ctx context.Context, cfg types.CertConfig, src SecretSource) 
 			cfg.SigningSecret, keyName, certName, err)
 	}
 	// Same reason: an expired/not-yet-valid leaf would sign but never verify.
-	if err := cryptoutils.CheckExpiration(leafCerts[0], time.Now()); err != nil {
+	// Capture now once so the leaf expiry check and the chain verification below
+	// agree on a single instant, avoiding a boundary race between the two calls.
+	now := time.Now()
+	if err := cryptoutils.CheckExpiration(leafCerts[0], now); err != nil {
 		return nil, fmt.Errorf("signing secret %q: leaf certificate (%s): %w", cfg.SigningSecret, certName, err)
 	}
 	caCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(caPEM)
@@ -150,7 +152,7 @@ func newCertSigner(ctx context.Context, cfg types.CertConfig, src SecretSource) 
 		Roots:         roots,
 		Intermediates: intermediates,
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
-		CurrentTime:   time.Now(),
+		CurrentTime:   now,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("signing secret %q: leaf certificate does not chain to the supplied CA (%s): %w", cfg.SigningSecret, chainName, err)
@@ -180,7 +182,6 @@ func newCertSigner(ctx context.Context, cfg types.CertConfig, src SecretSource) 
 
 	return &certSigner{
 		sv:          sv,
-		leafCert:    leafCerts[0],
 		certChain:   verifiedChains[0],
 		leafCertPEM: leafCertPEM,
 		caChainPEM:  caChainPEM,

--- a/pkg/kernelcache/security/cert_sign_internal_test.go
+++ b/pkg/kernelcache/security/cert_sign_internal_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kserve/kserve/pkg/kernelcache/types"
+)
+
+// A reusable signer whose leaf expires after construction must reject further
+// signing: the re-check at the top of Sign uses the signer's clock, so we can
+// advance it past NotAfter synchronously instead of sleeping. The expiry check
+// runs before any registry access, so an unreachable ref never gets touched.
+func TestCertSigner_RejectsExpiredLeafAtSignTime(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	notAfter := time.Now().Add(time.Hour)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	// Advance the clock past the leaf's NotAfter.
+	s := &certSigner{
+		leafCert:  leaf,
+		certChain: []*x509.Certificate{leaf},
+		now:       func() time.Time { return notAfter.Add(time.Minute) },
+	}
+
+	_, err = s.Sign(context.Background(), types.SignRequest{ImageRef: "example.com/kc/whatever:latest"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate chain element 0 is no longer valid")
+}
+
+func TestCertSigner_RejectsExpiredIssuerAtSignTime(t *testing.T) {
+	now := time.Now()
+	leaf := &x509.Certificate{
+		NotBefore: now.Add(-time.Hour),
+		NotAfter:  now.Add(time.Hour),
+	}
+	issuer := &x509.Certificate{
+		NotBefore: now.Add(-time.Hour),
+		NotAfter:  now.Add(-time.Minute),
+	}
+	s := &certSigner{
+		certChain: []*x509.Certificate{leaf, issuer},
+		now:       func() time.Time { return now },
+	}
+
+	_, err := s.Sign(context.Background(), types.SignRequest{ImageRef: "example.com/kc/whatever:latest"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate chain element 1 is no longer valid")
+}

--- a/pkg/kernelcache/security/cert_sign_internal_test.go
+++ b/pkg/kernelcache/security/cert_sign_internal_test.go
@@ -52,7 +52,6 @@ func TestCertSigner_RejectsExpiredLeafAtSignTime(t *testing.T) {
 
 	// Advance the clock past the leaf's NotAfter.
 	s := &certSigner{
-		leafCert:  leaf,
 		certChain: []*x509.Certificate{leaf},
 		now:       func() time.Time { return notAfter.Add(time.Minute) },
 	}

--- a/pkg/kernelcache/security/cert_sign_test.go
+++ b/pkg/kernelcache/security/cert_sign_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kserve/kserve/pkg/kernelcache/security"
+	"github.com/kserve/kserve/pkg/kernelcache/security/fixture"
+	"github.com/kserve/kserve/pkg/kernelcache/types"
+)
+
+const (
+	signerSAN     = "spiffe://kserve-test/kc-signer"
+	signerSubject = `^spiffe://kserve-test/.*$`
+)
+
+// signerOver builds a cert-mode Signer that loads its material from src under the
+// given signing-secret ref.
+func signerOver(t *testing.T, src security.SecretSource, secretRef string) security.Signer {
+	t.Helper()
+	s, err := security.NewSigner(context.Background(), types.SecurityConfig{
+		Mode: types.ModeCert,
+		Cert: types.CertConfig{SigningSecret: secretRef},
+	}, src)
+	require.NoError(t, err)
+	return s
+}
+
+// TestCertSign_RoundTrip is the core contract: what the signer produces, the
+// verifier accepts. Run for both key encodings cert-manager can emit.
+func TestCertSign_RoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		pkcs8 bool
+	}{
+		{"pkcs8 key", true},
+		{"sec1 key", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ca := fixture.NewCA(t)
+			leafKey, leafPEM := ca.IssueLeaf(t, fixture.WithSAN(signerSAN))
+			host := fixture.StartRegistry(t)
+			ref, wantDigest := fixture.PushImage(t, host, "kc/sign")
+
+			src := &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, leafKey, tc.pkcs8), leafPEM, ca.CertPEM),
+				"kserve/ca":     {"ca.crt": ca.CertPEM},
+			}}
+
+			sres, err := signerOver(t, src, "kserve/signer").Sign(ctx, types.SignRequest{ImageRef: ref.Name()})
+			require.NoError(t, err)
+			assert.Equal(t, types.ModeCert, sres.Mode)
+			assert.Equal(t, wantDigest, sres.Digest)
+
+			v, err := security.NewVerifier(ctx, types.SecurityConfig{
+				Mode: types.ModeCert,
+				Cert: types.CertConfig{TrustBundle: "kserve/ca", SubjectRegexp: signerSubject},
+			}, src)
+			require.NoError(t, err)
+			vres, err := v.Verify(ctx, types.VerifyRequest{ImageRef: ref.Name()})
+			require.NoError(t, err)
+			assert.True(t, vres.Verified, "reason: %s", vres.Reason)
+			assert.Equal(t, sres.Digest, vres.Digest)
+		})
+	}
+}
+
+func TestCertSign_IntermediateRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	root := fixture.NewCA(t)
+	intermediate := root.IssueIntermediate(t)
+	leafKey, leafPEM := intermediate.IssueLeaf(t, fixture.WithSAN(signerSAN))
+	tlsCertPEM := append(append([]byte{}, leafPEM...), intermediate.CertPEM...)
+	host := fixture.StartRegistry(t)
+	ref, wantDigest := fixture.PushImage(t, host, "kc/intermediate")
+
+	src := &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+		"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, leafKey, true), tlsCertPEM, root.CertPEM),
+		"kserve/ca":     {"ca.crt": root.CertPEM},
+	}}
+
+	sres, err := signerOver(t, src, "kserve/signer").Sign(ctx, types.SignRequest{ImageRef: ref.Name()})
+	require.NoError(t, err)
+	assert.Equal(t, wantDigest, sres.Digest)
+
+	v, err := security.NewVerifier(ctx, types.SecurityConfig{
+		Mode: types.ModeCert,
+		Cert: types.CertConfig{TrustBundle: "kserve/ca", SubjectRegexp: signerSubject},
+	}, src)
+	require.NoError(t, err)
+	vres, err := v.Verify(ctx, types.VerifyRequest{ImageRef: ref.Name()})
+	require.NoError(t, err)
+	assert.True(t, vres.Verified, "reason: %s", vres.Reason)
+	assert.Equal(t, sres.Digest, vres.Digest)
+}
+
+// A user-provided Secret with non-cert-manager key names works when the config
+// overrides them (mirrors verify's TrustBundleKey).
+func TestCertSign_CustomSecretKeys(t *testing.T) {
+	ctx := context.Background()
+	ca := fixture.NewCA(t)
+	leafKey, leafPEM := ca.IssueLeaf(t, fixture.WithSAN(signerSAN))
+	host := fixture.StartRegistry(t)
+	ref, _ := fixture.PushImage(t, host, "kc/customkeys")
+
+	src := &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+		"kserve/signer": {
+			"signer.key": fixture.LeafKeyPEM(t, leafKey, true),
+			"signer.crt": leafPEM,
+			"chain.pem":  ca.CertPEM,
+		},
+		"kserve/ca": {"ca.crt": ca.CertPEM},
+	}}
+	cfg := types.SecurityConfig{Mode: types.ModeCert, Cert: types.CertConfig{
+		TrustBundle: "kserve/ca", SubjectRegexp: signerSubject, SigningSecret: "kserve/signer",
+		SigningKeyKey: "signer.key", SigningCertKey: "signer.crt", SigningChainKey: "chain.pem",
+	}}
+
+	s, err := security.NewSigner(ctx, cfg, src)
+	require.NoError(t, err)
+	_, err = s.Sign(ctx, types.SignRequest{ImageRef: ref.Name()})
+	require.NoError(t, err)
+
+	v, err := security.NewVerifier(ctx, cfg, src)
+	require.NoError(t, err)
+	vres, err := v.Verify(ctx, types.VerifyRequest{ImageRef: ref.Name()})
+	require.NoError(t, err)
+	assert.True(t, vres.Verified, "reason: %s", vres.Reason)
+}
+
+// A signer needs its signing secret; a cert config without one is a construction
+// error, not a silent no-op.
+func TestNewSigner_RequiresSigningSecret(t *testing.T) {
+	_, err := security.NewSigner(context.Background(), types.SecurityConfig{Mode: types.ModeCert}, &fixture.FakeSecretSource{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signingSecret")
+}
+
+// A mismatched key/cert pair must fail at construction, not at verify time.
+func TestCertSign_KeyCertMismatch(t *testing.T) {
+	ca := fixture.NewCA(t)
+	keyA, _ := ca.IssueLeaf(t, fixture.WithSAN(signerSAN))
+	_, certB := ca.IssueLeaf(t, fixture.WithSAN(signerSAN))
+
+	src := &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+		"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, keyA, true), certB, ca.CertPEM),
+	}}
+
+	s, err := security.NewSigner(context.Background(), types.SecurityConfig{
+		Mode: types.ModeCert,
+		Cert: types.CertConfig{SigningSecret: "kserve/signer"},
+	}, src)
+	assert.Nil(t, s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestCertSign_RejectsNonCAInCAChain(t *testing.T) {
+	ca := fixture.NewCA(t)
+	leafKey, leafPEM := ca.IssueLeaf(t, fixture.WithSAN(signerSAN))
+	src := &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+		"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, leafKey, true), leafPEM, leafPEM),
+	}}
+
+	s, err := security.NewSigner(context.Background(), types.SecurityConfig{
+		Mode: types.ModeCert,
+		Cert: types.CertConfig{SigningSecret: "kserve/signer"},
+	}, src)
+	assert.Nil(t, s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a CA certificate")
+}
+
+// A leaf whose key/cert come from one CA but whose ca.crt chain is an unrelated
+// CA must fail construction: signing it would emit a signature the verifier
+// (anchored to a different trust bundle) can never validate.
+func TestCertSign_UnrelatedCAChain(t *testing.T) {
+	caA := fixture.NewCA(t)
+	caB := fixture.NewCA(t, fixture.WithCACommonName("kserve-kernelcache-unrelated-test-ca"))
+	leafKey, leafPEM := caA.IssueLeaf(t, fixture.WithSAN(signerSAN))
+	src := &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+		"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, leafKey, true), leafPEM, caB.CertPEM),
+	}}
+	s, err := security.NewSigner(context.Background(), types.SecurityConfig{
+		Mode: types.ModeCert,
+		Cert: types.CertConfig{SigningSecret: "kserve/signer"},
+	}, src)
+	assert.Nil(t, s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not chain")
+}
+
+// The signer must accept an RSA leaf key encoded as PKCS#1, since cert-manager
+// can emit that layout. Full sign -> verify round trip.
+func TestCertSign_RoundTripRSA_PKCS1(t *testing.T) {
+	ctx := context.Background()
+	ca := fixture.NewCA(t)
+	leafKey, leafPEM := ca.IssueLeafRSA(t, fixture.WithSAN(signerSAN))
+	host := fixture.StartRegistry(t)
+	ref, wantDigest := fixture.PushImage(t, host, "kc/sign-rsa")
+
+	src := &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+		"kserve/signer": fixture.SigningSecret(fixture.RSAKeyPEMPKCS1(t, leafKey), leafPEM, ca.CertPEM),
+		"kserve/ca":     {"ca.crt": ca.CertPEM},
+	}}
+
+	sres, err := signerOver(t, src, "kserve/signer").Sign(ctx, types.SignRequest{ImageRef: ref.Name()})
+	require.NoError(t, err)
+	assert.Equal(t, wantDigest, sres.Digest)
+
+	v, err := security.NewVerifier(ctx, types.SecurityConfig{
+		Mode: types.ModeCert,
+		Cert: types.CertConfig{TrustBundle: "kserve/ca", SubjectRegexp: signerSubject},
+	}, src)
+	require.NoError(t, err)
+	vres, err := v.Verify(ctx, types.VerifyRequest{ImageRef: ref.Name()})
+	require.NoError(t, err)
+	assert.True(t, vres.Verified, "reason: %s", vres.Reason)
+}
+
+func TestCertSign_ConstructionErrors(t *testing.T) {
+	ctx := context.Background()
+	ca := fixture.NewCA(t)
+	leafKey, leafPEM := ca.IssueLeaf(t, fixture.WithSAN(signerSAN))
+	expiredKey, expiredPEM := ca.IssueLeaf(t, fixture.WithSAN(signerSAN), fixture.Expired())
+	notYetKey, notYetPEM := ca.IssueLeaf(t, fixture.WithSAN(signerSAN), fixture.NotYetValid())
+
+	tests := []struct {
+		name string
+		src  *fixture.FakeSecretSource
+	}{
+		{
+			name: "secret ref absent",
+			src:  &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{}},
+		},
+		{
+			name: "tls.key missing",
+			src: &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": {"tls.crt": leafPEM, "ca.crt": ca.CertPEM},
+			}},
+		},
+		{
+			name: "malformed key",
+			src: &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": fixture.SigningSecret([]byte("not a pem key"), leafPEM, ca.CertPEM),
+			}},
+		},
+		{
+			name: "malformed leaf cert",
+			src: &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, leafKey, true), []byte("not a certificate"), ca.CertPEM),
+			}},
+		},
+		{
+			name: "malformed ca chain",
+			src: &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, leafKey, true), leafPEM, []byte("not a certificate")),
+			}},
+		},
+		{
+			name: "leaf cert blank (no PEM block)",
+			src: &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, leafKey, true), []byte("   \n  "), ca.CertPEM),
+			}},
+		},
+		{
+			name: "ca chain missing",
+			src: &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": {"tls.key": fixture.LeafKeyPEM(t, leafKey, true), "tls.crt": leafPEM},
+			}},
+		},
+		{
+			name: "expired leaf cert",
+			src: &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, expiredKey, true), expiredPEM, ca.CertPEM),
+			}},
+		},
+		{
+			name: "not-yet-valid leaf cert",
+			src: &fixture.FakeSecretSource{Secrets: map[string]map[string][]byte{
+				"kserve/signer": fixture.SigningSecret(fixture.LeafKeyPEM(t, notYetKey, true), notYetPEM, ca.CertPEM),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := security.NewSigner(ctx, types.SecurityConfig{
+				Mode: types.ModeCert,
+				Cert: types.CertConfig{SigningSecret: "kserve/signer"},
+			}, tt.src)
+			assert.Nil(t, s)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/pkg/kernelcache/security/cert_test.go
+++ b/pkg/kernelcache/security/cert_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kserve/kserve/pkg/kernelcache/types"
+)
+
+// Required fields are enforced per role at construction, not by Validate, so a
+// verify-only or sign-only config both pass Validate but the wrong constructor
+// still rejects a config that lacks its material.
+func TestCertConfig_ConstructorRequirements(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("verifier needs trust bundle", func(t *testing.T) {
+		_, err := newCertVerifier(ctx, types.CertConfig{SubjectRegexp: ".*"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trustBundle")
+	})
+	t.Run("verifier needs subject regexp", func(t *testing.T) {
+		_, err := newCertVerifier(ctx, types.CertConfig{TrustBundle: "kserve/ca"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "subjectRegexp")
+	})
+	t.Run("signer needs signing secret", func(t *testing.T) {
+		_, err := newCertSigner(ctx, types.CertConfig{}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signingSecret")
+	})
+}

--- a/pkg/kernelcache/security/cert_verify.go
+++ b/pkg/kernelcache/security/cert_verify.go
@@ -19,6 +19,7 @@ package security
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -32,8 +33,9 @@ import (
 	"github.com/kserve/kserve/pkg/kernelcache/types"
 )
 
-// trustBundleTimeout bounds the one-time load of the CA bundle at construction.
-const trustBundleTimeout = 5 * time.Second
+// secretLoadTimeout bounds the one-time load of key/trust material (CA bundle or
+// signing secret) from the SecretSource at construction.
+const secretLoadTimeout = 5 * time.Second
 
 // certVerifier verifies a signature made with a cert-manager issued key by
 // checking the X.509 chain against a CA bundle plus a SAN identity. It does not
@@ -49,12 +51,21 @@ type certVerifier struct {
 // It fails fast on a missing or invalid trust bundle. The load is bounded by a
 // timeout derived from the caller's context.
 func newCertVerifier(ctx context.Context, cfg types.CertConfig, src SecretSource) (*certVerifier, error) {
+	// Verification needs both the trust anchor and the identity to match against;
+	// presence is enforced here (SecurityConfig.Validate only checks syntax).
+	if cfg.TrustBundle == "" {
+		return nil, errors.New("cert.trustBundle must be set")
+	}
+	if cfg.SubjectRegexp == "" {
+		return nil, errors.New("cert.subjectRegexp must be set")
+	}
+
 	// Anchor the operator's regexp so it must match the whole SAN, not just a
-	// substring (cosign matches identity regexps unanchored). The pattern itself
-	// was already validated by SecurityConfig.Validate.
+	// substring (cosign matches identity regexps unanchored). The pattern's
+	// syntax was already validated by SecurityConfig.Validate.
 	subjectPattern := "^(?:" + cfg.SubjectRegexp + ")$"
 
-	loadCtx, cancel := context.WithTimeout(ctx, trustBundleTimeout)
+	loadCtx, cancel := context.WithTimeout(ctx, secretLoadTimeout)
 	defer cancel()
 	caPEM, err := loadTrustBundle(loadCtx, src, cfg.TrustBundle, cfg.TrustBundleKey)
 	if err != nil {
@@ -65,6 +76,18 @@ func newCertVerifier(ctx context.Context, cfg types.CertConfig, src SecretSource
 		return nil, fmt.Errorf("trust bundle %q: no valid CA certificate found", cfg.TrustBundle)
 	}
 	return &certVerifier{caPool: pool, subjectPattern: subjectPattern}, nil
+}
+
+// requireDataKey returns a non-empty value for key in secret/configmap data,
+// or a clear error. An empty value is treated the same as a missing one so a
+// blank field does not slip through to a later, murkier parse failure.
+// Used by both signing and verification material loading.
+func requireDataKey(data map[string][]byte, key, ref string) ([]byte, error) {
+	v, ok := data[key]
+	if !ok || len(v) == 0 {
+		return nil, fmt.Errorf("key %q not present in %q", key, ref)
+	}
+	return v, nil
 }
 
 // loadTrustBundle reads the CA PEM under key from the referenced Secret or

--- a/pkg/kernelcache/security/cert_verify_test.go
+++ b/pkg/kernelcache/security/cert_verify_test.go
@@ -209,7 +209,7 @@ func TestCertVerify_SignatureTransplant(t *testing.T) {
 	refA, digA := fixture.PushImage(t, host, "kc/transplant-a")
 	fixture.Sign(t, refA, digA, leafKey, leafPEM, ca.CertPEM) // A is validly signed
 	refB, digB := fixture.PushImage(t, host, "kc/transplant-b")
-	fixture.Transplant(t, refA, digA, refB, digB) // move A's signature onto B
+	fixture.ReplaySignaturesOntoImage(t, refA, digA, refB, digB) // move A's signature onto B
 
 	v := verifierTrusting(t, ca.CertPEM, "^spiffe://kserve-test/.*$")
 	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: refB.Name()})

--- a/pkg/kernelcache/security/factory.go
+++ b/pkg/kernelcache/security/factory.go
@@ -21,7 +21,7 @@ limitations under the License.
 // pkg/kernelcache/types so callers can reference them without importing this
 // package and its verification dependencies. A new mode is added as a factory
 // case alongside its implementation; today the disabled no-op and the cert mode
-// (verification) are wired.
+// (verification and signing) are wired.
 package security
 
 import (
@@ -41,17 +41,17 @@ func NewVerifier(ctx context.Context, cfg types.SecurityConfig, src SecretSource
 		return nil, err
 	}
 
+	v, err := buildCertVerifier(ctx, cfg.Mode, cfg.Cert, src)
+	if err != nil {
+		return nil, err
+	}
+	if v != nil {
+		return v, nil
+	}
+
 	switch cfg.Mode {
 	case types.ModeDisabled:
 		return noopVerifier{}, nil
-	case types.ModeCert:
-		// Assign through a concrete error check so a nil *certVerifier is never
-		// wrapped in a non-nil Verifier interface (typed-nil trap).
-		cv, err := newCertVerifier(ctx, cfg.Cert, src)
-		if err != nil {
-			return nil, err
-		}
-		return cv, nil
 	default:
 		// Unreachable after Validate, kept as a defensive guard.
 		return nil, fmt.Errorf("%w: %q", types.ErrUnknownMode, cfg.Mode)
@@ -60,22 +60,58 @@ func NewVerifier(ctx context.Context, cfg types.SecurityConfig, src SecretSource
 
 // NewSigner builds the Signer for the configured mode, mirroring NewVerifier.
 // The config is defaulted and validated first; ctx bounds any construction-time
-// I/O and src provides key material to the signing modes. Only the disabled
-// mode is wired here -- the signing modes (cert, keyless) add their own cases.
+// I/O and src provides key material to the signing modes. The disabled mode
+// never signs; cert signs with a cert-manager issued key. Further signing modes
+// (keyless) add their own cases.
 func NewSigner(ctx context.Context, cfg types.SecurityConfig, src SecretSource) (Signer, error) {
 	cfg.Default()
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
+	s, err := buildCertSigner(ctx, cfg.Mode, cfg.Cert, src)
+	if err != nil {
+		return nil, err
+	}
+	if s != nil {
+		return s, nil
+	}
+
 	switch cfg.Mode {
 	case types.ModeDisabled:
 		return noopSigner{}, nil
 	default:
-		// Validate accepts every known mode, so a mode reaching here is valid
-		// but has no signer wired yet (cert, keyless) or never signs (kyverno).
-		return nil, fmt.Errorf("signing not implemented for mode %q", cfg.Mode)
+		// Unreachable after Validate, kept as a defensive guard.
+		return nil, fmt.Errorf("%w: %q", types.ErrUnknownMode, cfg.Mode)
 	}
+}
+
+// buildCertVerifier constructs a certVerifier for ModeCert or returns nil for
+// other modes. Ensures NewVerifier/NewSigner use the same nil-trap pattern and
+// logic flow for consistency.
+func buildCertVerifier(ctx context.Context, mode types.Mode, cfg types.CertConfig, src SecretSource) (Verifier, error) {
+	if mode != types.ModeCert {
+		return nil, nil
+	}
+	cv, err := newCertVerifier(ctx, cfg, src)
+	if err != nil {
+		return nil, err
+	}
+	return cv, nil
+}
+
+// buildCertSigner constructs a certSigner for ModeCert or returns nil for
+// other modes. Ensures NewVerifier/NewSigner use the same nil-trap pattern and
+// logic flow for consistency.
+func buildCertSigner(ctx context.Context, mode types.Mode, cfg types.CertConfig, src SecretSource) (Signer, error) {
+	if mode != types.ModeCert {
+		return nil, nil
+	}
+	cs, err := newCertSigner(ctx, cfg, src)
+	if err != nil {
+		return nil, err
+	}
+	return cs, nil
 }
 
 // noopSigner signs nothing. It backs the disabled mode.

--- a/pkg/kernelcache/security/fixture/ca.go
+++ b/pkg/kernelcache/security/fixture/ca.go
@@ -23,6 +23,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -81,6 +82,29 @@ func NewCA(tb testing.TB, opts ...CAOption) *TestCA {
 	return &TestCA{Cert: cert, Key: key, CertPEM: pemBlock("CERTIFICATE", der)}
 }
 
+// IssueIntermediate issues an intermediate CA from the test CA.
+func (ca *TestCA) IssueIntermediate(tb testing.TB) *TestCA {
+	tb.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(tb, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(3),
+		Subject:               pkix.Name{CommonName: "kserve-kernelcache-test-intermediate"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.Cert, &key.PublicKey, ca.Key)
+	require.NoError(tb, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(tb, err)
+	return &TestCA{Cert: cert, Key: key, CertPEM: pemBlock("CERTIFICATE", der)}
+}
+
 type leafOptions struct {
 	san       string
 	notBefore time.Time
@@ -108,6 +132,14 @@ func Expired() LeafOption {
 	}
 }
 
+// NotYetValid makes the leaf certificate's validity window start in the future.
+func NotYetValid() LeafOption {
+	return func(o *leafOptions) {
+		o.notBefore = time.Now().Add(24 * time.Hour)
+		o.notAfter = time.Now().Add(48 * time.Hour)
+	}
+}
+
 // IssueLeaf issues a signing (leaf) cert from the CA. Defaults: a spiffe URI SAN
 // and a validity window of an hour ago for 24 hours.
 func (ca *TestCA) IssueLeaf(tb testing.TB, opts ...LeafOption) (leafKey *ecdsa.PrivateKey, leafCertPEM []byte) {
@@ -126,6 +158,36 @@ func (ca *TestCA) IssueLeaf(tb testing.TB, opts ...LeafOption) (leafKey *ecdsa.P
 	u, err := url.Parse(o.san)
 	require.NoError(tb, err)
 
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "kc-signer"},
+		NotBefore:    o.notBefore,
+		NotAfter:     o.notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		URIs:         []*url.URL{u},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.Cert, &key.PublicKey, ca.Key)
+	require.NoError(tb, err)
+	return key, pemBlock("CERTIFICATE", der)
+}
+
+// IssueLeafRSA issues an RSA signing (leaf) cert from the CA, for exercising the
+// PKCS#1 key path. Same defaults as IssueLeaf otherwise.
+func (ca *TestCA) IssueLeafRSA(tb testing.TB, opts ...LeafOption) (leafKey *rsa.PrivateKey, leafCertPEM []byte) {
+	tb.Helper()
+	o := leafOptions{
+		san:       "spiffe://kserve-test/kc-signer",
+		notBefore: time.Now().Add(-time.Hour),
+		notAfter:  time.Now().Add(24 * time.Hour),
+	}
+	for _, f := range opts {
+		f(&o)
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(tb, err)
+	u, err := url.Parse(o.san)
+	require.NoError(tb, err)
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(2),
 		Subject:      pkix.Name{CommonName: "kc-signer"},

--- a/pkg/kernelcache/security/fixture/sign.go
+++ b/pkg/kernelcache/security/fixture/sign.go
@@ -35,7 +35,10 @@ import (
 // Sign attaches a cosign signature over the image's digest, signed by leafKey
 // and carrying the leaf cert + CA chain. This is the standard cosign signature
 // format, so certVerifier can verify it.
-func Sign(tb testing.TB, ref name.Reference, digest string, leafKey *ecdsa.PrivateKey, leafCertPEM, caCertPEM []byte) {
+//
+// Mirrors production certSigner.Sign but takes key material directly, so
+// verify-side tests need not depend on the signer. Keep the two in sync.
+func Sign(tb testing.TB, ref name.Reference, digest string, leafKey *ecdsa.PrivateKey, leafCertPEM, caChainPEM []byte) {
 	tb.Helper()
 	digestRef := ref.Context().Digest(digest)
 
@@ -48,7 +51,7 @@ func Sign(tb testing.TB, ref name.Reference, digest string, leafKey *ecdsa.Priva
 	require.NoError(tb, err)
 	b64 := base64.StdEncoding.EncodeToString(sig)
 
-	ociSig, err := static.NewSignature(pl, b64, static.WithCertChain(leafCertPEM, caCertPEM))
+	ociSig, err := static.NewSignature(pl, b64, static.WithCertChain(leafCertPEM, caChainPEM))
 	require.NoError(tb, err)
 
 	se, err := ociremote.SignedEntity(digestRef)
@@ -58,10 +61,10 @@ func Sign(tb testing.TB, ref name.Reference, digest string, leafKey *ecdsa.Priva
 	require.NoError(tb, ociremote.WriteSignatures(digestRef.Repository, newSE))
 }
 
-// Transplant copies the signatures attached to (fromRef@fromDigest) onto
-// (toRef@toDigest). Used to prove a signature for one image cannot be replayed
-// onto another.
-func Transplant(tb testing.TB, fromRef name.Reference, fromDigest string, toRef name.Reference, toDigest string) {
+// ReplaySignaturesOntoImage copies the signatures attached to (fromRef@fromDigest)
+// onto (toRef@toDigest). Used to prove a signature for one image cannot be
+// replayed onto another.
+func ReplaySignaturesOntoImage(tb testing.TB, fromRef name.Reference, fromDigest string, toRef name.Reference, toDigest string) {
 	tb.Helper()
 	seFrom, err := ociremote.SignedEntity(fromRef.Context().Digest(fromDigest))
 	require.NoError(tb, err)

--- a/pkg/kernelcache/security/fixture/signkey.go
+++ b/pkg/kernelcache/security/fixture/signkey.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixture
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// LeafKeyPEM encodes an EC private key as PEM. With pkcs8=true it uses PKCS#8
+// ("PRIVATE KEY"); otherwise SEC1 ("EC PRIVATE KEY"). cert-manager emits SEC1
+// unless privateKey.encoding: PKCS8 is set, so a signer must accept both.
+func LeafKeyPEM(tb testing.TB, key *ecdsa.PrivateKey, pkcs8 bool) []byte {
+	tb.Helper()
+	if pkcs8 {
+		der, err := x509.MarshalPKCS8PrivateKey(key)
+		require.NoError(tb, err)
+		return pemBlock("PRIVATE KEY", der)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	require.NoError(tb, err)
+	return pemBlock("EC PRIVATE KEY", der)
+}
+
+// RSAKeyPEMPKCS1 encodes an RSA private key as PKCS#1 PEM ("RSA PRIVATE KEY").
+// cert-manager can emit this layout, so a signer must accept it.
+func RSAKeyPEMPKCS1(tb testing.TB, key *rsa.PrivateKey) []byte {
+	tb.Helper()
+	der := x509.MarshalPKCS1PrivateKey(key)
+	return pemBlock("RSA PRIVATE KEY", der)
+}
+
+// SigningSecret assembles a cert-manager style Secret map (tls.key / tls.crt /
+// ca.crt) so a signer can load its material from a FakeSecretSource.
+func SigningSecret(keyPEM, leafCertPEM, caChainPEM []byte) map[string][]byte {
+	return map[string][]byte{
+		"tls.key": keyPEM,
+		"tls.crt": leafCertPEM,
+		"ca.crt":  caChainPEM,
+	}
+}

--- a/pkg/kernelcache/types/cert.go
+++ b/pkg/kernelcache/types/cert.go
@@ -17,7 +17,6 @@ limitations under the License.
 package types
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 )
@@ -45,19 +44,34 @@ type CertConfig struct {
 	TrustBundleKey string `json:"trustBundleKey,omitempty"`
 
 	// SubjectRegexp matches the accepted signer identity (the leaf certificate
-	// SAN). Required: without it any cert chaining to the CA would be accepted.
+	// SAN). Required for verification: without it any cert chaining to the CA
+	// would be accepted.
 	SubjectRegexp string `json:"subjectRegexp"`
+
+	// SigningSecret references the Secret ("namespace/name") holding the signing
+	// material: the private key, leaf certificate, and CA chain. Required for
+	// signing; unused by verification.
+	SigningSecret string `json:"signingSecret,omitempty"`
+
+	// SigningKeyKey, SigningCertKey, and SigningChainKey override the data keys
+	// read from SigningSecret. They default to the kubernetes.io/tls layout plus
+	// cert-manager's chain key (tls.key, tls.crt, ca.crt); set them only for a
+	// Secret that stores the material under different names.
+	SigningKeyKey   string `json:"signingKeyKey,omitempty"`
+	SigningCertKey  string `json:"signingCertKey,omitempty"`
+	SigningChainKey string `json:"signingChainKey,omitempty"`
 }
 
+// validate only checks role-independent syntax (SubjectRegexp compiles).
+// Required-field presence is enforced per role by the constructors:
+// newCertVerifier requires trustBundle + subjectRegexp (verify-only fields),
+// newCertSigner requires signingSecret (signing-only fields). A verify-only
+// or sign-only config both pass here.
 func (c CertConfig) validate() error {
-	if c.TrustBundle == "" {
-		return errors.New("cert.trustBundle must be set")
-	}
-	if c.SubjectRegexp == "" {
-		return errors.New("cert.subjectRegexp must be set")
-	}
-	if _, err := regexp.Compile(c.SubjectRegexp); err != nil {
-		return fmt.Errorf("cert.subjectRegexp is not a valid regexp: %w", err)
+	if c.SubjectRegexp != "" {
+		if _, err := regexp.Compile(c.SubjectRegexp); err != nil {
+			return fmt.Errorf("cert.subjectRegexp is not a valid regexp: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/kernelcache/types/cert_test.go
+++ b/pkg/kernelcache/types/cert_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// cert config validation (via SecurityConfig.Validate with mode=cert).
+// cert config validation (via SecurityConfig.Validate with mode=cert) is
+// role-independent: it only rejects a malformed regexp. Which fields are
+// required is a per-role construction concern, tested with the constructors.
 func TestCertConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -30,9 +32,8 @@ func TestCertConfigValidate(t *testing.T) {
 		wantErr bool
 	}{
 		{"valid", CertConfig{TrustBundle: "kserve/ca", SubjectRegexp: ".*@kserve"}, false},
-		{"empty trustBundle", CertConfig{SubjectRegexp: ".*"}, true},
-		{"empty subjectRegexp", CertConfig{TrustBundle: "kserve/ca"}, true},
-		{"invalid subjectRegexp", CertConfig{TrustBundle: "kserve/ca", SubjectRegexp: "([a-z"}, true},
+		{"empty is accepted here", CertConfig{}, false},
+		{"invalid subjectRegexp", CertConfig{SubjectRegexp: "([a-z"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/kernelcache/types/config.go
+++ b/pkg/kernelcache/types/config.go
@@ -66,7 +66,7 @@ type SecurityConfig struct {
 }
 
 // ErrUnknownMode is returned when the configured mode is not recognised.
-var ErrUnknownMode = errors.New("unknown verification mode")
+var ErrUnknownMode = errors.New("unknown security mode")
 
 // Default fills empty fields with safe defaults. An unset mode defaults to
 // disabled so an unconfigured feature performs no verification rather than

--- a/pkg/kernelcache/types/config_test.go
+++ b/pkg/kernelcache/types/config_test.go
@@ -64,7 +64,7 @@ func TestSecurityConfigValidate(t *testing.T) {
 	}{
 		{"disabled reject", SecurityConfig{Mode: ModeDisabled, FailurePolicy: FailurePolicyReject}, false},
 		{"disabled warn", SecurityConfig{Mode: ModeDisabled, FailurePolicy: FailurePolicyWarn}, false},
-		{"unknown mode", SecurityConfig{Mode: "cert", FailurePolicy: FailurePolicyReject}, true},
+		{"unknown mode", SecurityConfig{Mode: "bogus", FailurePolicy: FailurePolicyReject}, true},
 		{"empty mode", SecurityConfig{Mode: "", FailurePolicy: FailurePolicyReject}, true},
 		{"bad failure policy", SecurityConfig{Mode: ModeDisabled, FailurePolicy: "explode"}, true},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the "cert" signing mode for kernel cache images. Full description in #6123.

Unit tests only -- `go test ./pkg/kernelcache/security/...`.

**Which issue(s) this PR fixes**:
Fixes #6123

**Release note**:
```release-note
NONE
```
