### PR TITLE
fix(deps): allow pyarrow to use newer versions > 20

### DIFF
--- a/python/aiffairness/uv.lock
+++ b/python/aiffairness/uv.lock
@@ -1208,7 +1208,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/artexplainer/uv.lock
+++ b/python/artexplainer/uv.lock
@@ -1082,7 +1082,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/autogluonserver/uv.lock
+++ b/python/autogluonserver/uv.lock
@@ -2267,7 +2267,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/custom_model/uv.lock
+++ b/python/custom_model/uv.lock
@@ -1030,7 +1030,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/custom_tokenizer/uv.lock
+++ b/python/custom_tokenizer/uv.lock
@@ -904,7 +904,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/custom_transformer/uv.lock
+++ b/python/custom_transformer/uv.lock
@@ -948,7 +948,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/huggingfaceserver/uv.lock
+++ b/python/huggingfaceserver/uv.lock
@@ -2209,7 +2209,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -100,7 +100,7 @@ test = [
     "grpcio-testing<2.0.0,>=1.73.0",
     "httpx-retries>=0.4.5,<1.0.0",
     "boto3>=1.35.0,<2.0.0",
-    "pyarrow>=18.0.0,<20.0.0",
+    "pyarrow>=18.0.0",
 ]
 dev = [
     "black[colorama]>=26.3.1,<27",

--- a/python/kserve/uv.lock
+++ b/python/kserve/uv.lock
@@ -2251,7 +2251,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/lgbserver/uv.lock
+++ b/python/lgbserver/uv.lock
@@ -1330,7 +1330,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/paddleserver/uv.lock
+++ b/python/paddleserver/uv.lock
@@ -1347,7 +1347,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/pmmlserver/uv.lock
+++ b/python/pmmlserver/uv.lock
@@ -1367,7 +1367,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/predictiveserver/uv.lock
+++ b/python/predictiveserver/uv.lock
@@ -1305,7 +1305,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/sklearnserver/uv.lock
+++ b/python/sklearnserver/uv.lock
@@ -1305,7 +1305,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/test_resources/graph/error_404_isvc/uv.lock
+++ b/python/test_resources/graph/error_404_isvc/uv.lock
@@ -776,7 +776,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/test_resources/graph/success_200_isvc/uv.lock
+++ b/python/test_resources/graph/success_200_isvc/uv.lock
@@ -757,7 +757,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },

--- a/python/xgbserver/uv.lock
+++ b/python/xgbserver/uv.lock
@@ -1330,7 +1330,7 @@ test = [
     { name = "jinja2", specifier = ">=3.1.4,<4.0.0" },
     { name = "mypy", specifier = ">=0.991,<1.0" },
     { name = "portforward", specifier = ">=0.7.4,<1.0.0" },
-    { name = "pyarrow", specifier = ">=18.0.0,<20.0.0" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pytest", specifier = ">=7.4.4,<8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.4,<1.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6.0.0" },


### PR DESCRIPTION
chore:	On some systems the version being used might need to be cpomplied
	and it would require extra dependencies, like apache-arrow to be
	installed, allowing newer versions, this is not a requirement anymore
	and pyarrow can be easily installed through uv.



**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:
- No tests needed.

- Logs

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
fix(deps): allow pyarrow to use newer versions > 20
```
