### PR TITLE
fix(ci): use kustomize binary from <project_root>/bin/

### DIFF
--- a/hack/setup/scripts/install-script-generator/pkg/manifest_builder.py
+++ b/hack/setup/scripts/install-script-generator/pkg/manifest_builder.py
@@ -41,6 +41,17 @@ def to_bool_string(value: Any) -> str:
     return "true" if str(value).lower() in ["true", "1", "yes"] else "false"
 
 
+def _find_kustomize_binary(kustomize_dir: Path) -> str:
+    """Find kustomize binary in bin/ relative to the git root."""
+    current = kustomize_dir.resolve()
+    while current != current.parent:
+        candidate = current / "bin" / "kustomize"
+        if candidate.exists():
+            return str(candidate)
+        current = current.parent
+    return "kustomize"
+
+
 def run_kustomize_build(kustomize_dir: Path) -> str:
     """Run kustomize build on a directory.
 
@@ -54,9 +65,10 @@ def run_kustomize_build(kustomize_dir: Path) -> str:
         subprocess.CalledProcessError: If kustomize build fails
         FileNotFoundError: If kustomize command not found
     """
+    kustomize_bin = _find_kustomize_binary(kustomize_dir)
     try:
         result = subprocess.run(
-            ["kustomize", "build", str(kustomize_dir)],
+            [kustomize_bin, "build", str(kustomize_dir)],
             capture_output=True,
             text=True,
             check=True,
@@ -69,7 +81,7 @@ def run_kustomize_build(kustomize_dir: Path) -> str:
         )
     except FileNotFoundError:
         raise FileNotFoundError(
-            "kustomize command not found. Please install kustomize."
+            "kustomize command not found. Please install kustomize or run 'make kustomize'."
         )
 
 

--- a/hack/setup/scripts/install-script-generator/tests/test_manifest_builder.py
+++ b/hack/setup/scripts/install-script-generator/tests/test_manifest_builder.py
@@ -24,6 +24,48 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from pkg import manifest_builder  # noqa: E402
+from pkg import file_reader  # noqa: E402
+
+
+def test_find_kustomize_binary_uses_project_bin():
+    """Test that _find_kustomize_binary resolves to the project's bin/kustomize."""
+    repo_root = file_reader.find_git_root(Path(__file__).parent)
+    expected = repo_root / "bin" / "kustomize"
+    assert expected.exists(), (
+        f"bin/kustomize not found at {expected} — run 'make kustomize'"
+    )
+
+    kustomize_dir = repo_root / "config" / "crd" / "full"
+    result = manifest_builder._find_kustomize_binary(kustomize_dir)
+    assert result == str(expected)
+
+
+def test_find_kustomize_binary_fallback(tmp_path):
+    """Test that _find_kustomize_binary falls back to 'kustomize' when not in bin/."""
+    nested_dir = tmp_path / "config" / "crd"
+    nested_dir.mkdir(parents=True)
+
+    result = manifest_builder._find_kustomize_binary(nested_dir)
+    assert result == "kustomize"
+
+
+def test_run_kustomize_build_uses_project_bin(monkeypatch):
+    """Test that run_kustomize_build invokes the project's bin/kustomize."""
+    from unittest.mock import MagicMock
+
+    repo_root = file_reader.find_git_root(Path(__file__).parent)
+    expected_bin = str(repo_root / "bin" / "kustomize")
+    kustomize_dir = repo_root / "config" / "crd" / "full"
+
+    mock_run = MagicMock(return_value=MagicMock(stdout=""))
+    monkeypatch.setattr(manifest_builder.subprocess, "run", mock_run)
+
+    manifest_builder.run_kustomize_build(kustomize_dir)
+
+    called_binary = mock_run.call_args[0][0][0]
+    assert called_binary == expected_bin, (
+        f"Expected {expected_bin}, got '{called_binary}'"
+    )
 
 
 def test_get_embed_component_values_from_component_env():


### PR DESCRIPTION
chore:	The manifest_builder.py python script was using the kustomize
	command expecting it is present in the PATH, however, to guarantee
	consistency, we download the binary to <project_root>/bin/ so
	it always uses the same version, this change fixes this behavior
	by first trying to use the kustomize from bin/ and if it is not found
	fallback to `kustomize`, in case the fallback option is used,
	it will also fail if there is nothing in the PATH.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:
`make precommit` should use use the `kustomize` binary from <project_root>/bin and the command should successfully finish.,

- [ ] Tests added on `hack/setup/scripts/install-script-generator/tests/test_manifest_builder.py`

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
