### PR TITLE
refactor(kernelcache): extract security data contracts into types package

### DIFF
--- a/pkg/kernelcache/security/cert_verify.go
+++ b/pkg/kernelcache/security/cert_verify.go
@@ -28,6 +28,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+
+	"github.com/kserve/kserve/pkg/kernelcache/types"
 )
 
 // trustBundleTimeout bounds the one-time load of the CA bundle at construction.
@@ -46,7 +48,7 @@ type certVerifier struct {
 // newCertVerifier loads the CA bundle from src and prepares the identity match.
 // It fails fast on a missing or invalid trust bundle. The load is bounded by a
 // timeout derived from the caller's context.
-func newCertVerifier(ctx context.Context, cfg CertConfig, src SecretSource) (*certVerifier, error) {
+func newCertVerifier(ctx context.Context, cfg types.CertConfig, src SecretSource) (*certVerifier, error) {
 	// Anchor the operator's regexp so it must match the whole SAN, not just a
 	// substring (cosign matches identity regexps unanchored). The pattern itself
 	// was already validated by SecurityConfig.Validate.
@@ -75,7 +77,7 @@ func loadTrustBundle(ctx context.Context, src SecretSource, ref, key string) ([]
 		return nil, fmt.Errorf("trust bundle %q: no secret source configured", ref)
 	}
 	if key == "" {
-		key = DefaultTrustBundleKey
+		key = types.DefaultTrustBundleKey
 	}
 
 	var problems []string
@@ -106,8 +108,8 @@ func loadTrustBundle(ctx context.Context, src SecretSource, ref, key string) ([]
 // is operational (retryable) and returns an error, whereas a completed check
 // that fails returns VerifyResult{Verified: false} with the digest still set so
 // a warn policy can pin it.
-func (v *certVerifier) Verify(ctx context.Context, req VerifyRequest) (VerifyResult, error) {
-	res := VerifyResult{Mode: ModeCert}
+func (v *certVerifier) Verify(ctx context.Context, req types.VerifyRequest) (types.VerifyResult, error) {
+	res := types.VerifyResult{Mode: types.ModeCert}
 
 	ref, err := name.ParseReference(req.ImageRef)
 	if err != nil {

--- a/pkg/kernelcache/security/cert_verify_test.go
+++ b/pkg/kernelcache/security/cert_verify_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/kernelcache/security"
 	"github.com/kserve/kserve/pkg/kernelcache/security/fixture"
+	"github.com/kserve/kserve/pkg/kernelcache/types"
 )
 
 // verifierTrusting builds a cert-mode Verifier trusting caPEM (stored as a
@@ -41,10 +42,10 @@ func verifierTrusting(t *testing.T, caPEM []byte, subjectRE string) security.Ver
 // verifierWith builds a cert-mode Verifier over an explicit source and trust-bundle key.
 func verifierWith(t *testing.T, src security.SecretSource, key, subjectRE string) security.Verifier {
 	t.Helper()
-	v, err := security.NewVerifier(context.Background(), security.SecurityConfig{
-		Mode:          security.ModeCert,
-		FailurePolicy: security.FailurePolicyReject,
-		Cert:          security.CertConfig{TrustBundle: "kserve/ca", TrustBundleKey: key, SubjectRegexp: subjectRE},
+	v, err := security.NewVerifier(context.Background(), types.SecurityConfig{
+		Mode:          types.ModeCert,
+		FailurePolicy: types.FailurePolicyReject,
+		Cert:          types.CertConfig{TrustBundle: "kserve/ca", TrustBundleKey: key, SubjectRegexp: subjectRE},
 	}, src)
 	require.NoError(t, err)
 	return v
@@ -63,10 +64,10 @@ func TestCertVerify_TrustedMatchingSAN(t *testing.T) {
 	fixture.Sign(t, ref, digest, leafKey, leafPEM, ca.CertPEM)
 
 	v := verifierTrusting(t, ca.CertPEM, "^spiffe://kserve-test/.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.True(t, res.Verified)
-	assert.Equal(t, security.ModeCert, res.Mode)
+	assert.Equal(t, types.ModeCert, res.Mode)
 	assert.Equal(t, digest, res.Digest)
 }
 
@@ -80,7 +81,7 @@ func TestCertVerify_UntrustedCA(t *testing.T) {
 	fixture.Sign(t, ref, digest, leafKey, leafPEM, untrusted.CertPEM)
 
 	v := verifierTrusting(t, trusted.CertPEM, "^spiffe://.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.False(t, res.Verified)
 }
@@ -94,7 +95,7 @@ func TestCertVerify_SANMismatch(t *testing.T) {
 	fixture.Sign(t, ref, digest, leafKey, leafPEM, ca.CertPEM)
 
 	v := verifierTrusting(t, ca.CertPEM, "^spiffe://other/.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.False(t, res.Verified)
 	assert.NotEmpty(t, res.Reason, "a failed check should record a reason")
@@ -107,7 +108,7 @@ func TestCertVerify_NoSignature(t *testing.T) {
 	ref, _ := fixture.PushImage(t, host, "kc/nosig")
 
 	v := verifierTrusting(t, ca.CertPEM, "^spiffe://.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.False(t, res.Verified)
 }
@@ -123,7 +124,7 @@ func TestCertVerify_MultiCARotation(t *testing.T) {
 
 	bundle := append(append([]byte{}, caOld.CertPEM...), caNew.CertPEM...)
 	v := verifierTrusting(t, bundle, "^spiffe://kserve-test/.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.True(t, res.Verified)
 }
@@ -137,7 +138,7 @@ func TestCertVerify_DigestFilledOnFailure(t *testing.T) {
 	fixture.Sign(t, ref, digest, leafKey, leafPEM, ca.CertPEM)
 
 	v := verifierTrusting(t, ca.CertPEM, "^spiffe://other/.*$") // mismatch
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.False(t, res.Verified)
 	assert.Equal(t, digest, res.Digest)
@@ -155,7 +156,7 @@ func TestCertVerify_CustomBundleKey(t *testing.T) {
 		"kserve/ca": {"cabundle.pem": ca.CertPEM},
 	}}
 	v := verifierWith(t, src, "cabundle.pem", "^spiffe://kserve-test/.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.True(t, res.Verified)
 }
@@ -172,7 +173,7 @@ func TestCertVerify_ConfigMapSource(t *testing.T) {
 		"kserve/ca": {"ca.crt": string(ca.CertPEM)},
 	}}
 	v := verifierWith(t, src, "", "^spiffe://kserve-test/.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.True(t, res.Verified)
 }
@@ -193,7 +194,7 @@ func TestCertVerify_SecretPrecedence(t *testing.T) {
 		ConfigMaps: map[string]map[string]string{"kserve/ca": {"ca.crt": string(cmCA.CertPEM)}},
 	}
 	v := verifierWith(t, src, "", "^spiffe://kserve-test/.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.True(t, res.Verified)
 }
@@ -211,7 +212,7 @@ func TestCertVerify_SignatureTransplant(t *testing.T) {
 	fixture.Transplant(t, refA, digA, refB, digB) // move A's signature onto B
 
 	v := verifierTrusting(t, ca.CertPEM, "^spiffe://kserve-test/.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: refB.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: refB.Name()})
 	require.NoError(t, err)
 	assert.False(t, res.Verified, "a signature for another image must not verify")
 }
@@ -225,7 +226,7 @@ func TestCertVerify_ExpiredCert(t *testing.T) {
 	fixture.Sign(t, ref, digest, leafKey, leafPEM, ca.CertPEM)
 
 	v := verifierTrusting(t, ca.CertPEM, "^spiffe://kserve-test/.*$")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.False(t, res.Verified, "an expired signing cert must not verify")
 }
@@ -242,7 +243,7 @@ func TestCertVerify_SubjectRegexpIsAnchored(t *testing.T) {
 
 	// unanchored pattern: a substring match would wrongly accept the lookalike.
 	v := verifierTrusting(t, ca.CertPEM, "spiffe://kserve-test/kc-signer")
-	res, err := v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	res, err := v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	require.NoError(t, err)
 	assert.False(t, res.Verified, "a lookalike SAN must not match an anchored pattern")
 }
@@ -255,6 +256,6 @@ func TestCertVerify_ImageNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	v := verifierTrusting(t, ca.CertPEM, "^spiffe://.*$")
-	_, err = v.Verify(context.Background(), security.VerifyRequest{ImageRef: ref.Name()})
+	_, err = v.Verify(context.Background(), types.VerifyRequest{ImageRef: ref.Name()})
 	assert.Error(t, err)
 }

--- a/pkg/kernelcache/security/factory.go
+++ b/pkg/kernelcache/security/factory.go
@@ -14,27 +14,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package security builds Verifiers and Signers for kernel cache OCI images
+// from a types.SecurityConfig. It owns the mode-agnostic Verifier and Signer
+// interfaces and the factories that select a mode; each mode's implementation
+// lives here too. The data contracts (config, request/result types) live in
+// pkg/kernelcache/types so callers can reference them without importing this
+// package and its verification dependencies. A new mode is added as a factory
+// case alongside its implementation; today the disabled no-op and the cert mode
+// (verification) are wired.
 package security
 
 import (
 	"context"
 	"fmt"
+
+	"github.com/kserve/kserve/pkg/kernelcache/types"
 )
 
 // NewVerifier builds the Verifier for the configured mode. The config is
 // defaulted and validated first. ctx bounds any construction-time I/O (such as
 // loading a trust bundle); src provides key and trust material to the mode
 // implementations and is unused by the disabled mode.
-func NewVerifier(ctx context.Context, cfg SecurityConfig, src SecretSource) (Verifier, error) {
+func NewVerifier(ctx context.Context, cfg types.SecurityConfig, src SecretSource) (Verifier, error) {
 	cfg.Default()
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
 	switch cfg.Mode {
-	case ModeDisabled:
+	case types.ModeDisabled:
 		return noopVerifier{}, nil
-	case ModeCert:
+	case types.ModeCert:
 		// Assign through a concrete error check so a nil *certVerifier is never
 		// wrapped in a non-nil Verifier interface (typed-nil trap).
 		cv, err := newCertVerifier(ctx, cfg.Cert, src)
@@ -44,7 +54,7 @@ func NewVerifier(ctx context.Context, cfg SecurityConfig, src SecretSource) (Ver
 		return cv, nil
 	default:
 		// Unreachable after Validate, kept as a defensive guard.
-		return nil, fmt.Errorf("%w: %q", ErrUnknownMode, cfg.Mode)
+		return nil, fmt.Errorf("%w: %q", types.ErrUnknownMode, cfg.Mode)
 	}
 }
 
@@ -52,14 +62,14 @@ func NewVerifier(ctx context.Context, cfg SecurityConfig, src SecretSource) (Ver
 // The config is defaulted and validated first; ctx bounds any construction-time
 // I/O and src provides key material to the signing modes. Only the disabled
 // mode is wired here -- the signing modes (cert, keyless) add their own cases.
-func NewSigner(ctx context.Context, cfg SecurityConfig, src SecretSource) (Signer, error) {
+func NewSigner(ctx context.Context, cfg types.SecurityConfig, src SecretSource) (Signer, error) {
 	cfg.Default()
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
 	switch cfg.Mode {
-	case ModeDisabled:
+	case types.ModeDisabled:
 		return noopSigner{}, nil
 	default:
 		// Validate accepts every known mode, so a mode reaching here is valid
@@ -74,8 +84,8 @@ type noopSigner struct{}
 var _ Signer = noopSigner{}
 
 // Sign is a no-op that reports the disabled mode without contacting a registry.
-func (noopSigner) Sign(_ context.Context, _ SignRequest) (SignResult, error) {
-	return SignResult{Mode: ModeDisabled}, nil
+func (noopSigner) Sign(_ context.Context, _ types.SignRequest) (types.SignResult, error) {
+	return types.SignResult{Mode: types.ModeDisabled}, nil
 }
 
 // noopVerifier performs no signature check. It backs the disabled mode.
@@ -86,9 +96,9 @@ var _ Verifier = noopVerifier{}
 // Verify reports the image as not verified without contacting any registry.
 // Digest resolution for the disabled mode is added together with the shared
 // registry helper used by the real verifiers.
-func (noopVerifier) Verify(_ context.Context, _ VerifyRequest) (VerifyResult, error) {
-	return VerifyResult{
-		Mode:     ModeDisabled,
+func (noopVerifier) Verify(_ context.Context, _ types.VerifyRequest) (types.VerifyResult, error) {
+	return types.VerifyResult{
+		Mode:     types.ModeDisabled,
 		Verified: false,
 		Reason:   "verification disabled",
 	}, nil

--- a/pkg/kernelcache/security/factory_test.go
+++ b/pkg/kernelcache/security/factory_test.go
@@ -22,31 +22,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kserve/kserve/pkg/kernelcache/types"
 )
 
 func TestNewVerifier(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("disabled returns a working no-op", func(t *testing.T) {
-		v, err := NewVerifier(ctx, SecurityConfig{Mode: ModeDisabled}, nil)
+		v, err := NewVerifier(ctx, types.SecurityConfig{Mode: types.ModeDisabled}, nil)
 		require.NoError(t, err)
 		require.NotNil(t, v)
 
-		res, err := v.Verify(ctx, VerifyRequest{ImageRef: "registry/img:tag"})
+		res, err := v.Verify(ctx, types.VerifyRequest{ImageRef: "registry/img:tag"})
 		require.NoError(t, err)
 		assert.False(t, res.Verified)
-		assert.Equal(t, ModeDisabled, res.Mode)
+		assert.Equal(t, types.ModeDisabled, res.Mode)
 	})
 
 	t.Run("empty mode defaults to disabled", func(t *testing.T) {
-		v, err := NewVerifier(ctx, SecurityConfig{}, nil)
+		v, err := NewVerifier(ctx, types.SecurityConfig{}, nil)
 		require.NoError(t, err)
 		assert.IsType(t, noopVerifier{}, v)
 	})
 
 	t.Run("unknown mode errors", func(t *testing.T) {
-		v, err := NewVerifier(ctx, SecurityConfig{Mode: "bogus"}, nil)
+		v, err := NewVerifier(ctx, types.SecurityConfig{Mode: "bogus"}, nil)
 		assert.Nil(t, v)
-		assert.ErrorIs(t, err, ErrUnknownMode)
+		assert.ErrorIs(t, err, types.ErrUnknownMode)
 	})
 }

--- a/pkg/kernelcache/security/sign.go
+++ b/pkg/kernelcache/security/sign.go
@@ -16,25 +16,14 @@ limitations under the License.
 
 package security
 
-import "context"
+import (
+	"context"
 
-// SignRequest describes the image to sign.
-type SignRequest struct {
-	// ImageRef is the image to sign, by tag or digest.
-	ImageRef string
-}
-
-// SignResult reports the outcome of a signing operation.
-type SignResult struct {
-	// Digest is the resolved image digest the signature was bound to.
-	Digest string
-
-	// Mode is the signing mode that produced the result.
-	Mode Mode
-}
+	"github.com/kserve/kserve/pkg/kernelcache/types"
+)
 
 // Signer attaches a signature to a container image so a matching Verifier can
 // later confirm it. Implementations sign by digest, never by mutable tag.
 type Signer interface {
-	Sign(ctx context.Context, req SignRequest) (SignResult, error)
+	Sign(ctx context.Context, req types.SignRequest) (types.SignResult, error)
 }

--- a/pkg/kernelcache/security/sign_test.go
+++ b/pkg/kernelcache/security/sign_test.go
@@ -22,31 +22,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kserve/kserve/pkg/kernelcache/types"
 )
 
 func TestNewSigner(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("disabled returns a working no-op", func(t *testing.T) {
-		s, err := NewSigner(ctx, SecurityConfig{Mode: ModeDisabled}, nil)
+		s, err := NewSigner(ctx, types.SecurityConfig{Mode: types.ModeDisabled}, nil)
 		require.NoError(t, err)
 		require.NotNil(t, s)
 
-		res, err := s.Sign(ctx, SignRequest{ImageRef: "registry/img:tag"})
+		res, err := s.Sign(ctx, types.SignRequest{ImageRef: "registry/img:tag"})
 		require.NoError(t, err)
-		assert.Equal(t, ModeDisabled, res.Mode)
+		assert.Equal(t, types.ModeDisabled, res.Mode)
 		assert.Empty(t, res.Digest)
 	})
 
 	t.Run("empty mode defaults to disabled", func(t *testing.T) {
-		s, err := NewSigner(ctx, SecurityConfig{}, nil)
+		s, err := NewSigner(ctx, types.SecurityConfig{}, nil)
 		require.NoError(t, err)
 		assert.IsType(t, noopSigner{}, s)
 	})
 
 	t.Run("unknown mode errors", func(t *testing.T) {
-		s, err := NewSigner(ctx, SecurityConfig{Mode: "bogus"}, nil)
+		s, err := NewSigner(ctx, types.SecurityConfig{Mode: "bogus"}, nil)
 		assert.Nil(t, s)
-		assert.ErrorIs(t, err, ErrUnknownMode)
+		assert.ErrorIs(t, err, types.ErrUnknownMode)
 	})
 }

--- a/pkg/kernelcache/types/cert.go
+++ b/pkg/kernelcache/types/cert.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package security
+package types
 
 import (
 	"errors"

--- a/pkg/kernelcache/types/cert_test.go
+++ b/pkg/kernelcache/types/cert_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package security
+package types
 
 import (
 	"testing"

--- a/pkg/kernelcache/types/config.go
+++ b/pkg/kernelcache/types/config.go
@@ -14,22 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package security defines the contracts for verifying kernel cache OCI images.
-// It exposes a mode-agnostic Verifier interface plus the configuration that
-// selects a verification mode. Only the disabled mode exists here; each real
-// mode (and any config it needs) is added together with its implementation.
-package security
+// Package types holds the data contracts for the kernel cache security
+// subsystem: the configuration read from the inferenceservice-config ConfigMap
+// and the request/result structures exchanged with the security package's
+// Verifier and Signer. It carries data only (no behaviour beyond validation and
+// the ShouldBlock decision), so any package can reference these types without
+// importing the verification implementation and its dependencies.
+package types
 
 import (
 	"errors"
 	"fmt"
 )
 
-// Mode selects how kernel cache images are verified.
+// Mode selects the security mechanism for kernel cache images, applied to both
+// verification and signing.
 type Mode string
 
 const (
-	// ModeDisabled performs no signature verification.
+	// ModeDisabled performs no verification or signing.
 	ModeDisabled Mode = "disabled"
 )
 

--- a/pkg/kernelcache/types/config_test.go
+++ b/pkg/kernelcache/types/config_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package security
+package types
 
 import (
 	"encoding/json"

--- a/pkg/kernelcache/types/sign.go
+++ b/pkg/kernelcache/types/sign.go
@@ -14,20 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package security
+package types
 
-import (
-	"context"
+// SignRequest describes the image to sign.
+type SignRequest struct {
+	// ImageRef is the image to sign, by tag or digest.
+	ImageRef string
+}
 
-	"github.com/kserve/kserve/pkg/kernelcache/types"
-)
+// SignResult reports the outcome of a signing operation.
+type SignResult struct {
+	// Digest is the resolved image digest the signature was bound to.
+	Digest string
 
-// Verifier verifies a kernel cache image according to a configured mode.
-//
-// The returned error is reserved for operational failures (network, registry,
-// misconfiguration) that a caller may retry. A completed check that fails is
-// reported as types.VerifyResult{Verified: false} with a nil error, so the
-// caller can apply its FailurePolicy uniformly.
-type Verifier interface {
-	Verify(ctx context.Context, req types.VerifyRequest) (types.VerifyResult, error)
+	// Mode is the signing mode that produced the result.
+	Mode Mode
 }

--- a/pkg/kernelcache/types/verify.go
+++ b/pkg/kernelcache/types/verify.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+// VerifyRequest carries the inputs for a verification. It is a struct rather
+// than a bare image reference so new inputs (for example, delegated-mode
+// annotations) can be added without changing the security.Verifier interface.
+type VerifyRequest struct {
+	// ImageRef is the image to verify (tag or digest reference).
+	ImageRef string
+
+	// Annotations carries out-of-band metadata a mode may need. The kyverno
+	// mode reads the policy-engine verification result from here; other modes
+	// ignore it.
+	Annotations map[string]string
+}
+
+// VerifyResult is the outcome of a completed verification attempt. Digest is
+// populated whenever the reference could be resolved, even when Verified is
+// false, so callers can still pin an immutable reference under a warn policy.
+type VerifyResult struct {
+	// Digest is the resolved sha256 digest of the image.
+	Digest string
+
+	// Verified reports whether the signature check passed.
+	Verified bool
+
+	// Mode is the mode that produced this result.
+	Mode Mode
+
+	// Reason is a human-readable explanation, used for status and logging.
+	Reason string
+}
+
+// ShouldBlock reports whether a consumer must block use of the image given a
+// failure policy. It centralises the allow/block decision so callers do not
+// reimplement the subtle cases (in particular, disabled mode is a deliberate
+// skip, not a failure, and must never block).
+//
+// Rules:
+//   - disabled mode: never blocks (verification was intentionally skipped).
+//   - verified: never blocks.
+//   - not verified: blocks only under FailurePolicyReject.
+//
+// Operational errors (a nil, non-completed result) are handled by the caller
+// separately and are outside this decision.
+func (r VerifyResult) ShouldBlock(policy FailurePolicy) bool {
+	if r.Mode == ModeDisabled || r.Verified {
+		return false
+	}
+	return policy == FailurePolicyReject
+}

--- a/pkg/kernelcache/types/verify_test.go
+++ b/pkg/kernelcache/types/verify_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package security
+package types
 
 import (
 	"testing"


### PR DESCRIPTION
**What this PR does / why we need it**:

Pulls the kernel cache security data contracts out of pkg/kernelcache/security into a new pkg/kernelcache/types package: the config (SecurityConfig, CertConfig, Mode, FailurePolicy) and the request/result types (VerifyRequest/Result, SignRequest/Result). A caller that only needs to read a result or build a request -- a controller, a webhook, status reporting -- can now import types without dragging in the verifier implementation and its cosign dependency.

The interfaces (Verifier, Signer, SecretSource), the factories, and the mode implementations stay in security. types imports nothing from security, so the dependency stays one-way. No behaviour change, just where the types live.

Unit tests only -- `go test ./pkg/kernelcache/...`.

**Which issue(s) this PR fixes**:
Part of #6097

**Release note**:
```release-note
NONE
```
