### PR TITLE
fix(llmisvc): grant EPP Role permission to create leader-election events

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1082,7 +1082,7 @@ schedulingProfiles:
 	})
 
 	Context("Scheduler RBAC", func() {
-		It("should create scheduler role with leases permission for leader election", func(ctx SpecContext) {
+		It("should create scheduler role with leases and events permission for leader election", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-scheduler-rbac"
 			nsName := kmeta.ChildName(svcName, "-test")
@@ -1136,6 +1136,22 @@ schedulingProfiles:
 				}
 			}
 			Expect(hasLeasesPermission).To(BeTrue(), "Expected scheduler role to have leases permission for leader election")
+
+			// Verify core events permission exists (leader election records a Kubernetes Event)
+			hasEventsPermission := false
+			for _, rule := range expectedRole.Rules {
+				for _, apiGroup := range rule.APIGroups {
+					if apiGroup == "" {
+						for _, resource := range rule.Resources {
+							if resource == "events" {
+								hasEventsPermission = true
+								Expect(rule.Verbs).To(ContainElements("create", "patch"))
+							}
+						}
+					}
+				}
+			}
+			Expect(hasEventsPermission).To(BeTrue(), "Expected scheduler role to have events permission for leader election")
 
 			// Verify llm-d.ai API group permission exists for inferenceobjectives and inferencemodelrewrites
 			hasLLMDAIPermission := false

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -768,6 +768,8 @@ func (r *LLMISVCReconciler) expectedSchedulerRole(llmSvc *v1alpha2.LLMInferenceS
 			{APIGroups: []string{constants.LLMDAIAPIGroupName}, Resources: []string{"inferenceobjectives", "inferencemodelrewrites"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"discovery.k8s.io"}, Resources: []string{"endpointslices"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"coordination.k8s.io"}, Resources: []string{"leases"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
+			// client-go leader election records a core Event after acquiring the lease.
+			{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create", "patch"}},
 		},
 	}
 	return role

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -2919,4 +2920,28 @@ func TestMigrateProducerParams(t *testing.T) {
 			tt.validate(g, result)
 		})
 	}
+}
+
+func TestExpectedSchedulerRoleIncludesLeaderElectionEvents(t *testing.T) {
+	g := NewWithT(t)
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-svc",
+			Namespace: "test-ns",
+			UID:       "uid-1",
+		},
+	}
+
+	role := (&LLMISVCReconciler{}).expectedSchedulerRole(llmSvc)
+
+	g.Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+		APIGroups: []string{""},
+		Resources: []string{"events"},
+		Verbs:     []string{"create", "patch"},
+	}))
+	g.Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+		APIGroups: []string{"coordination.k8s.io"},
+		Resources: []string{"leases"},
+		Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+	}))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When an `LLMInferenceService` scheduler runs with HA (`replicas > 1`, `--ha-enable-leader-election`), client-go records a core Kubernetes Event after acquiring the lease. The per-service EPP Role created by `expectedSchedulerRole()` already grants `coordination.k8s.io/leases`, but not core `events`.

The EPP then logs:

```
"Server rejected event (will not retry!)" err="events is forbidden: User \"system:serviceaccount:<ns>:<name>-epp-sa\" cannot create resource \"events\" in API group \"\" in the namespace \"<ns>\""
```

Leader election and request routing still work; only the Event is rejected. This matches the leader-election Role shipped by llm-d-router (`create`/`patch` on `events`).

**Which issue(s) this PR fixes**:
Fixes #6131

**Feature/Issue validation/testing**:

- [x] Unit test `TestExpectedSchedulerRoleIncludesLeaderElectionEvents`
- [x] Extended envtest `should create scheduler role with leases and events permission for leader election`

**Special notes for your reviewer**:

Lease RBAC landed in #5032 without the companion Event permission that client-go's leader-election recorder requires.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
Grant the LLMInferenceService EPP Role permission to create core Events so HA scheduler leader election can record Kubernetes Events.
```