### PR TITLE
fix(controller): set InvalidSpec for unsupported storageUri scheme

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -115,6 +115,10 @@ func (p *Predictor) buildPredictorResources(ctx context.Context, isvc *v1beta1.I
 	// Only add annotations for single storage URI case. Multiple storage URIs are handled directly by reconcilers.
 	if sourceURI := predictor.GetStorageUri(); sourceURI != nil {
 		if err := p.addStorageInitializerAnnotations(ctx, predictor, annotations, isvc.Spec.Predictor.StorageContainerName); err != nil {
+			isvc.Status.UpdateModelTransitionStatus(v1beta1.InvalidSpec, &v1beta1.FailureInfo{
+				Reason:  v1beta1.InvalidPredictorSpec,
+				Message: err.Error(),
+			})
 			return nil, err
 		}
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
@@ -106,6 +106,46 @@ func TestAddStorageInitializerAnnotationsOciNative(t *testing.T) {
 	assert.Equal(t, ociNativeURI, annotationVal)
 }
 
+func TestBuildPredictorResourcesUnsupportedStorageURIWritesInvalidSpec(t *testing.T) {
+	// An unsupported storageUri scheme is a spec error caught only on the controller
+	// side (the webhook does not check scheme support). buildPredictorResources must
+	// surface it as InvalidSpec in status instead of failing silently.
+	s := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add v1alpha1 to scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	p := &Predictor{
+		client:                 fakeClient,
+		inferenceServiceConfig: &v1beta1.InferenceServicesConfig{},
+	}
+
+	storageURI := "ftp://example.com/model"
+	isvc := &v1beta1.InferenceService{
+		Spec: v1beta1.InferenceServiceSpec{
+			Predictor: v1beta1.PredictorSpec{
+				Model: &v1beta1.ModelSpec{
+					ModelFormat: v1beta1.ModelFormat{Name: "sklearn"},
+					PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+						StorageURI: &storageURI,
+					},
+				},
+			},
+		},
+	}
+	// Simulate a service that was previously mid-rollout, to show the stale
+	// transition status is overwritten rather than left untouched.
+	isvc.Status.ModelStatus.TransitionStatus = v1beta1.InProgress
+
+	_, err := p.buildPredictorResources(context.Background(), isvc, false)
+	assert.Error(t, err, "unsupported storageUri scheme must fail resource building")
+	assert.Equal(t, v1beta1.InvalidSpec, isvc.Status.ModelStatus.TransitionStatus,
+		"status must report InvalidSpec instead of leaving the stale transition status")
+	if assert.NotNil(t, isvc.Status.ModelStatus.LastFailureInfo) {
+		assert.Equal(t, v1beta1.InvalidPredictorSpec, isvc.Status.ModelStatus.LastFailureInfo.Reason)
+	}
+}
+
 func ptrInt32(v int32) *int32 { return &v }
 
 func TestAdjustStableMinReplicasForCanaries(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

An InferenceService predictor whose `storageUri` uses a scheme the storage initializer does not support (e.g. `ftp://...`) is admitted by the webhook — scheme support is not checked there — and only fails later inside the controller, in `buildPredictorResources` -> `addStorageInitializerAnnotations` -> `ValidateStorageURI`. That failure path returned the error without writing anything to `isvc.Status`, so `status.modelStatus.transitionStatus` was left stale (e.g. stuck at `InProgress` forever) with no `InvalidSpec` condition and no `LastFailureInfo`, leaving users with no signal that their spec is invalid.

This PR makes that error path write `InvalidSpec` / `InvalidPredictorSpec` to `isvc.Status`, following the exact same `UpdateModelTransitionStatus(v1beta1.InvalidSpec, &v1beta1.FailureInfo{...})` pattern already used a few lines away in the same file (e.g. `reconcileModel`'s `RuntimeNotRecognized` handling, `buildPodSpec`'s placeholder-replacement error handling).

Scope note: the linked issue also points at a second, structurally similar silent-error path in `buildPodSpec` (a transformer-container merge failure). That path is not changed here — `MergeRuntimeContainers` merges two well-typed `corev1.Container` values via a JSON strategic-merge-patch, which in practice cannot be made to fail with valid Go values, so there was no way to write a real failing-then-passing test for it. Fixing it without a test to back it up felt like guessing, so it's left as a known follow-up rather than bundled in here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6136


**Feature/Issue validation/testing**:

- [x] Unit test `TestBuildPredictorResourcesUnsupportedStorageURIWritesInvalidSpec` in `pkg/controller/v1beta1/inferenceservice/components/predictor_test.go`: builds predictor resources for an isvc with `storageUri: ftp://example.com/model`, pre-seeded with a stale `InProgress` transition status, and asserts the call errors and `isvc.Status.ModelStatus.TransitionStatus` becomes `InvalidSpec` with `LastFailureInfo.Reason == InvalidPredictorSpec`. Verified this test fails against the pre-fix code (`TransitionStatus` stays `InProgress`, `LastFailureInfo` stays nil) and passes with the fix.
- [x] `go vet ./pkg/controller/v1beta1/inferenceservice/...` — clean.
- [x] `golangci-lint run pkg/controller/v1beta1/inferenceservice/components/...` — 0 issues.
- [x] `gofmt -l` on both changed files — clean.
- [x] Full package suite including the envtest-backed Ginkgo suite:
  `KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.34 -p path)" go test ./pkg/controller/v1beta1/inferenceservice/...` — all pass (122 specs).

Not run: the repo-wide `make test` (`go test ./pkg/... ./cmd...`). The local environment this change was validated in had very little free disk space, and a whole-repo build/test run was not reliable there. The change itself is localized to one error-handling branch in one function and reuses an already-exercised status-update helper, so I'm confident in it, but flagging this limit plainly rather than claiming a full-repo run that didn't happen.

**Special notes for your reviewer**:

Note: at the time of writing, `master`'s own push-triggered CI (Go License Check, Validate manifests) was green, so no known pre-existing red checks to account for here.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fixed: an InferenceService predictor with an unsupported `storageUri` scheme now surfaces an `InvalidSpec` status with a `LastFailureInfo` reason of `InvalidPredictorSpec` instead of silently leaving `status.modelStatus.transitionStatus` at its previous, stale value.
```

Fixes #6136
