### PR TITLE
fix(python): propagate model_version in InferResponse.from_bytes

### DIFF
--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -1320,6 +1320,7 @@ class InferResponse:
             infer_outputs.append(infer_output)
         return cls(
             model_name=model_name,
+            model_version=infer_res_dict.get("model_version", None),
             response_id=infer_res_dict.get("id", None),
             parameters=infer_res_dict.get("parameters", None),
             infer_outputs=infer_outputs,

--- a/python/kserve/test/test_infer_type.py
+++ b/python/kserve/test/test_infer_type.py
@@ -1054,6 +1054,26 @@ class TestInferResponse:
         with pytest.raises(InvalidInput):
             InferResponse.from_bytes(response_bytes, json_length)
 
+    def test_infer_response_from_bytes_preserves_model_version(self):
+        model_name = "test_model"
+        model_version = "v1.2.3"
+        response_bytes = b'{"id": "1", "model_name": "test_model", "model_version": "v1.2.3", "outputs": [{"name": "output1", "shape": [1], "datatype": "INT32", "data": [1]}]}'
+        json_length = len(response_bytes)
+
+        infer_response = InferResponse.from_bytes(
+            response_bytes,
+            json_length,
+        )
+
+        assert infer_response.id == "1"
+        assert infer_response.model_name == model_name
+        assert infer_response.model_version == model_version
+        assert len(infer_response.outputs) == 1
+        assert infer_response.outputs[0].name == "output1"
+        assert infer_response.outputs[0].shape == [1]
+        assert infer_response.outputs[0].datatype == "INT32"
+        assert infer_response.outputs[0].data == [1]
+
     def test_infer_response_get_output_by_name_returns_correct_output(self):
         infer_output1 = InferOutput(
             name="output1", shape=[1], datatype="INT32", data=[1]


### PR DESCRIPTION
**What this PR does / why we need it**:

`InferResponse.from_bytes` builds the response without `model_version`, while `from_rest` and `from_grpc` both set it. A REST v2 transformer that calls its predictor through the default `InferenceRESTClient.infer()` path therefore loses the predictor's `model_version`: it is present on the wire but never reaches the transformer's output. This adds the missing field to the constructor call, mirroring `from_rest`.

**Which issue(s) this PR fixes**:

Fixes #6111

**Feature/Issue validation/testing**:

- [x] New regression test `test_infer_response_from_bytes_preserves_model_version` in `python/kserve/test/test_infer_type.py`: fails on master (`model_version` is `None`), passes with this change.
- [x] Existing `from_bytes` tests in the same file still pass (`uv run pytest test/test_infer_type.py -k from_bytes`: 10 passed).

**Special notes for your reviewer**:

One-line fix plus a test; no behaviour change when `model_version` is absent from the payload (still `None`).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix InferResponse.from_bytes dropping model_version, so REST v2 transformers now propagate the predictor's model version.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qnxf2u2kSBxRM1AT7kD8BD