### PR TITLE
fix(inferenceservice): report InvalidSpec for unsupported storageUri

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -115,6 +115,10 @@ func (p *Predictor) buildPredictorResources(ctx context.Context, isvc *v1beta1.I
 	// Only add annotations for single storage URI case. Multiple storage URIs are handled directly by reconcilers.
 	if sourceURI := predictor.GetStorageUri(); sourceURI != nil {
 		if err := p.addStorageInitializerAnnotations(ctx, predictor, annotations, isvc.Spec.Predictor.StorageContainerName); err != nil {
+			isvc.Status.UpdateModelTransitionStatus(v1beta1.InvalidSpec, &v1beta1.FailureInfo{
+				Reason:  v1beta1.InvalidPredictorSpec,
+				Message: fmt.Sprintf("Invalid storage URI: %v", err),
+			})
 			return nil, err
 		}
 	}

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
@@ -106,6 +106,28 @@ func TestAddStorageInitializerAnnotationsOciNative(t *testing.T) {
 	assert.Equal(t, ociNativeURI, annotationVal)
 }
 
+func TestAddStorageInitializerAnnotationsInvalidURI(t *testing.T) {
+	// ftp:// is not in SupportedStorageURIPrefixList, so ValidateStorageURI should fail
+	s := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add v1alpha1 to scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	p := &Predictor{client: fakeClient}
+
+	unsupportedURI := "ftp://example.com/model"
+	model := &v1beta1.ModelSpec{
+		PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+			StorageURI: &unsupportedURI,
+		},
+	}
+	annotations := map[string]string{}
+
+	err := p.addStorageInitializerAnnotations(context.Background(), model, annotations, nil)
+	assert.Error(t, err, "ftp:// should fail ValidateStorageURI")
+	assert.Contains(t, err.Error(), "StorageURI not supported")
+}
+
 func ptrInt32(v int32) *int32 { return &v }
 
 func TestAdjustStableMinReplicasForCanaries(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

An InferenceService whose predictor `storageUri` uses an unsupported scheme (for example `ftp://example.com/model`) is admitted by the validating webhook, because scheme validation happens in the reconciler when `addStorageInitializerAnnotations` runs. That call fails, `buildPredictorResources` returns the error, and nothing writes `InvalidSpec` to `status.modelStatus`. The service sits in `InProgress` with no condition explaining why.

Every other spec error in this file (runtime not found, placeholder replacement, container merge) calls `UpdateModelTransitionStatus(InvalidSpec, ...)` with `InvalidPredictorSpec` before returning. This adds the same call on the unsupported-storage-URI path, so the failure is visible in status like its neighbours.

**Which issue(s) this PR fixes**:

Fixes #6136

**Feature/Issue validation/testing**:

- [x] Added `TestAddStorageInitializerAnnotationsInvalidURI`, which confirms an `ftp://` URI is rejected by `ValidateStorageURI` on this path (the precondition for the new status write).
- [x] `go test ./pkg/controller/v1beta1/inferenceservice/components/ -run TestAddStorageInitializerAnnotations -count=1` passes; `go build ./pkg/controller/...` clean.

**Special notes for your reviewer**:

Four-line change on one error path. I did not add a controller-level assertion on `status.modelStatus` because the existing predictor unit tests do not exercise the reconcile loop; happy to add one if you can point me at the right harness.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
InferenceServices with an unsupported predictor storageUri scheme now report InvalidSpec in status.modelStatus instead of staying InProgress with no explanation.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qnxf2u2kSBxRM1AT7kD8BD