### PR TITLE
fix(llmisvc): grant events create/patch to the scheduler Role

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1162,6 +1162,23 @@ schedulingProfiles:
 				}
 			}
 			Expect(hasGIEPermission).To(BeTrue(), "Expected scheduler role to have inference.networking.k8s.io API group permission for inferencepools, inferenceobjectives, and inferencemodels")
+
+			// Verify events permission exists for leader election event recording
+			hasEventsPermission := false
+			for _, rule := range expectedRole.Rules {
+				for _, apiGroup := range rule.APIGroups {
+					if apiGroup == "" { // core API group
+						for _, resource := range rule.Resources {
+							if resource == "events" {
+								hasEventsPermission = true
+								// Verify verbs for event recording during leader election
+								Expect(rule.Verbs).To(ContainElements("create", "patch"))
+							}
+						}
+					}
+				}
+			}
+			Expect(hasEventsPermission).To(BeTrue(), "Expected scheduler role to have events permission for leader election event recording")
 		})
 	})
 

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -768,6 +768,7 @@ func (r *LLMISVCReconciler) expectedSchedulerRole(llmSvc *v1alpha2.LLMInferenceS
 			{APIGroups: []string{constants.LLMDAIAPIGroupName}, Resources: []string{"inferenceobjectives", "inferencemodelrewrites"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"discovery.k8s.io"}, Resources: []string{"endpointslices"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"coordination.k8s.io"}, Resources: []string{"leases"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
+			{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create", "patch"}},
 		},
 	}
 	return role


### PR DESCRIPTION
**What this PR does / why we need it**:

When an `LLMInferenceService` sets `spec.router.scheduler.replicas > 1`, the EPP runs client-go leader election. On lease acquisition the leader-election recorder emits a Kubernetes Event, and the scheduler ServiceAccount is refused: `events is forbidden: User ... cannot create resource "events"`. The Role built in `expectedSchedulerRole` grants `coordination.k8s.io/leases` but no core `events` rule.

This adds `{APIGroups: [""], Resources: ["events"], Verbs: ["create", "patch"]}` to that Role. The lease itself already works, so this is an observability fix: the forbidden error disappears from the EPP logs and the leader-election events become visible. The verbs match the controller's own `+kubebuilder:rbac` marker for events.

**Which issue(s) this PR fixes**:

Fixes #6131

**Feature/Issue validation/testing**:

- [x] Extended the "Scheduler RBAC" integration test in `controller_int_scheduler_config_test.go` to assert the expected Role carries a core-group `events` rule with `create` and `patch`.
- [x] `go build ./pkg/controller/...`, `go vet ./pkg/controller/v1alpha2/llmisvc/` and `gofmt -l` are clean. I could not run the envtest-based integration suite locally, so I am relying on CI for the new assertion.

**Special notes for your reviewer**:

One-line RBAC change. `update` was left out since client-go's event recorder only creates and patches.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
The LLMInferenceService scheduler Role now permits creating and patching Events, so multi-replica scheduler leader election no longer logs "events is forbidden".
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qnxf2u2kSBxRM1AT7kD8BD