### PR TITLE
fix(utils): keep value and valueFrom paired when merging env vars

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -146,7 +146,13 @@ func MergeEnvs(baseEnvs []corev1.EnvVar, overrideEnvs []corev1.EnvVar) []corev1.
 		for i, base := range baseEnvs {
 			if override.Name == base.Name {
 				inBase = true
-				baseEnvs[i].Value = override.Value
+				// Replace the whole entry rather than only Value. An EnvVar carries
+				// either Value or ValueFrom, so copying one field across leaves the
+				// other half of the base entry behind: a ValueFrom override would be
+				// dropped, and a Value override would sit next to the base's
+				// ValueFrom, which the API server rejects with "valueFrom: may not
+				// be specified when `value` is not empty".
+				baseEnvs[i] = override
 				break
 			}
 		}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -271,6 +271,15 @@ func TestAppendVolumeIfNotExists(t *testing.T) {
 	}
 }
 
+func secretKeyRef(secretName, key string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			Key:                  key,
+		},
+	}
+}
+
 func TestMergeEnvs(t *testing.T) {
 	scenarios := map[string]struct {
 		baseEnvs     []corev1.EnvVar
@@ -396,6 +405,70 @@ func TestMergeEnvs(t *testing.T) {
 				{
 					Name:  "name4",
 					Value: "value4",
+				},
+			},
+		},
+		// An EnvVar holds either Value or ValueFrom. An override must carry both
+		// fields across, otherwise the base keeps a stale half of the pair.
+		"OverrideValueFromReplacesValue": {
+			baseEnvs: []corev1.EnvVar{
+				{
+					Name:  "AWS_ACCESS_KEY_ID",
+					Value: "literal-key",
+				},
+			},
+			overrideEnvs: []corev1.EnvVar{
+				{
+					Name:      "AWS_ACCESS_KEY_ID",
+					ValueFrom: secretKeyRef("s3-secret", "awsAccessKeyID"),
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:      "AWS_ACCESS_KEY_ID",
+					ValueFrom: secretKeyRef("s3-secret", "awsAccessKeyID"),
+				},
+			},
+		},
+		"OverrideValueFromReplacesValueFrom": {
+			baseEnvs: []corev1.EnvVar{
+				{
+					Name:      "AWS_ACCESS_KEY_ID",
+					ValueFrom: secretKeyRef("first-secret", "awsAccessKeyID"),
+				},
+			},
+			overrideEnvs: []corev1.EnvVar{
+				{
+					Name:      "AWS_ACCESS_KEY_ID",
+					ValueFrom: secretKeyRef("second-secret", "awsAccessKeyID"),
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:      "AWS_ACCESS_KEY_ID",
+					ValueFrom: secretKeyRef("second-secret", "awsAccessKeyID"),
+				},
+			},
+		},
+		// Leaving the base ValueFrom in place next to the override Value produces an
+		// EnvVar the API server rejects.
+		"OverrideValueReplacesValueFrom": {
+			baseEnvs: []corev1.EnvVar{
+				{
+					Name:      "AWS_DEFAULT_REGION",
+					ValueFrom: secretKeyRef("region-secret", "region"),
+				},
+			},
+			overrideEnvs: []corev1.EnvVar{
+				{
+					Name:  "AWS_DEFAULT_REGION",
+					Value: "us-east-1",
+				},
+			},
+			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "AWS_DEFAULT_REGION",
+					Value: "us-east-1",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

`utils.MergeEnvs` merges an override env var onto a matching base entry by copying only `Value`, at `pkg/utils/utils.go:149`. A `corev1.EnvVar` holds either `Value` or `ValueFrom`, so the other half of the base entry survives the merge and the result stops describing a single env var.

That helper is what injects storage credentials. `s3.BuildSecretEnvs` builds `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as `secretKeyRef` entries, and `CreateSecretVolumeAndEnvFromServiceAccount` merges them into the storage-initializer container at `pkg/credentials/service_account_credentials.go:296`. If that container already declares either name, the secret-backed override has an empty `Value` and is silently dropped: the container keeps its own `ValueFrom`, or is left with `Value: ""` if it held a literal, and the model download runs with no credentials.

The reverse direction fails harder. When the base entry has a `ValueFrom` and the override a plain `Value`, for example a user-set `AWS_DEFAULT_REGION` from a configMapKeyRef against an `s3-region` annotation on the secret, the merged entry carries both fields and the API server rejects the pod with `valueFrom: Invalid value: "": may not be specified when 'value' is not empty`. That is the same conflict `reconcileEnvValueConflicts` in `pkg/utils/container_merge.go` was added to prevent on the strategic-merge path. `MergeEnvs` is the merge helper that never got the equivalent treatment.

The fix assigns the whole override entry so `Value` and `ValueFrom` always move together, which is what the function's own doc comment already promises: "If an EnvVar is present in both O and B, uses the value from O in the result".

**Which issue(s) this PR fixes**:

None.

**Feature/Issue validation/testing**:

- [x] Three new cases in `TestMergeEnvs` (`pkg/utils/utils_test.go`): a `ValueFrom` override onto a literal base, a `ValueFrom` override onto another `ValueFrom`, and a literal override onto a `ValueFrom` base. All three fail on master and pass with the change.
- [x] Both packages that call `MergeEnvs` still pass, `pkg/credentials` and `pkg/webhook/admission/pod`, run under envtest with Kubernetes 1.34.1 assets.

- Logs

Running the three new cases against master, with only the test file applied:

```
$ go test -run TestMergeEnvs ./pkg/utils/
    utils_test.go:481: Test "OverrideValueFromReplacesValue" unexpected envs (-want +got):
        - 	ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{Name: "s3-secret", Key: "awsAccessKeyID"}},
        + 	ValueFrom: nil,
    utils_test.go:481: Test "OverrideValueFromReplacesValueFrom" unexpected envs (-want +got):
        - 	LocalObjectReference: v1.LocalObjectReference{Name: "second-secret"},
        + 	LocalObjectReference: v1.LocalObjectReference{Name: "first-secret"},
    utils_test.go:481: Test "OverrideValueReplacesValueFrom" unexpected envs (-want +got):
        - 	ValueFrom: nil,
        + 	ValueFrom: s"&EnvVarSource{SecretKeyRef:&SecretKeySelector{Name:region-secret,Key:region}}",
FAIL	github.com/kserve/kserve/pkg/utils	0.613s
```

With the change:

```
$ go test ./pkg/utils/...
ok  	github.com/kserve/kserve/pkg/utils	1.040s

$ KUBEBUILDER_ASSETS=<setup-envtest 1.34 path> go test ./pkg/credentials/ ./pkg/webhook/admission/pod/...
ok  	github.com/kserve/kserve/pkg/credentials	17.832s
ok  	github.com/kserve/kserve/pkg/webhook/admission/pod	13.986s

$ gofmt -l pkg/utils/utils.go pkg/utils/utils_test.go
(no output)

$ golangci-lint run --fix ./pkg/utils/...
0 issues.
```

**Special notes for your reviewer**:

The change is one assignment. `AddOrReplaceEnv` and `AddEnvVars` in the same package take a plain string or append whole entries, so neither has this problem.

The other call site, `pkg/webhook/admission/pod/metrics_aggregate_injector.go`, passes literal-valued overrides into the queue-proxy container, so its behaviour is unchanged unless the pod already declares one of those names with a `valueFrom`, which used to produce the invalid pair and now does not.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix storage credentials being dropped, or the pod being rejected for setting both value and valueFrom, when a container already declares an env var that KServe injects from a secret.
```
