### PR TITLE
fix(llmisvc): don't put metadata labels in the Deployment selector

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_selector_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_selector_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+// These specs exercise Reconcile against the envtest API server rather than the
+// controller, so the selector a Deployment is created with can be chosen directly.
+// spec.selector validation - immutability, and the pod template having to satisfy the
+// selector - is enforced by the API server, so a fake client cannot stand in here.
+var _ = Describe("Deployment selector", func() {
+	const (
+		nameLabel  = "app.kubernetes.io/name"
+		queueLabel = "kueue.x-k8s.io/queue-name"
+	)
+
+	// storedSelector stands for a Deployment created by a reconciler that put the
+	// propagated queue label in the selector. The current one computes nameLabel only.
+	storedSelector := map[string]string{nameLabel: "selector-fixture", queueLabel: "team-alpha"}
+
+	// alwaysDiffer forces Update past the equality short-circuit so the write is attempted.
+	alwaysDiffer := func(expected, curr *appsv1.Deployment) bool { return false }
+
+	deployment := func(namespace string, owner *v1alpha2.LLMInferenceService, selector, podLabels map[string]string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "selector-fixture",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(owner, v1alpha2.LLMInferenceServiceGVK),
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: selector},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+					},
+				},
+			},
+		}
+	}
+
+	// owner is never created: envtest runs no garbage collector, so an ownerReference
+	// is enough to satisfy the controlled-by check in Update.
+	owner := func(namespace string) *v1alpha2.LLMInferenceService {
+		return &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "selector-fixture",
+				Namespace: namespace,
+				UID:       types.UID("11111111-2222-3333-4444-555555555555"),
+			},
+		}
+	}
+
+	reconcile := func(ctx SpecContext, o *v1alpha2.LLMInferenceService, expected *appsv1.Deployment) error {
+		c := &fakeClientWithRecorder{Client: envTest.Client, EventRecorder: record.NewFakeRecorder(10)}
+		return llmisvc.Reconcile(ctx, c, o, &appsv1.Deployment{}, expected,
+			llmisvc.SemanticEqual[*appsv1.Deployment](alwaysDiffer),
+			llmisvc.PreserveDeploymentSelector())
+	}
+
+	It("should reconcile a Deployment whose stored selector the reconciler no longer computes", func(ctx SpecContext) {
+		testNs := NewTestNamespace(ctx, envTest)
+		o := owner(testNs.Name)
+
+		stored := deployment(testNs.Name, o, storedSelector, storedSelector)
+		Expect(envTest.Create(ctx, stored)).To(Succeed())
+
+		// The pod template still carries the queue label, so it satisfies the stored
+		// selector even though the selector is no longer what would be computed.
+		expected := deployment(testNs.Name, o,
+			map[string]string{nameLabel: "selector-fixture"},
+			map[string]string{nameLabel: "selector-fixture", queueLabel: "team-alpha"})
+
+		Expect(reconcile(ctx, o, expected)).To(Succeed())
+
+		curr := &appsv1.Deployment{}
+		Expect(envTest.Get(ctx, client.ObjectKeyFromObject(stored), curr)).To(Succeed())
+		Expect(curr.Spec.Selector.MatchLabels).To(Equal(storedSelector),
+			"the stored selector must be carried over unchanged")
+	})
+
+	It("should reject the update once the pod template stops satisfying the stored selector", func(ctx SpecContext) {
+		testNs := NewTestNamespace(ctx, envTest)
+		o := owner(testNs.Name)
+
+		stored := deployment(testNs.Name, o, storedSelector, storedSelector)
+		Expect(envTest.Create(ctx, stored)).To(Succeed())
+
+		// Dropping the queue label from the LLMInferenceService removes it from the pod
+		// template, leaving the preserved selector requiring a label the pods no longer
+		// carry. Such a Deployment has to be recreated to reconcile again.
+		expected := deployment(testNs.Name, o,
+			map[string]string{nameLabel: "selector-fixture"},
+			map[string]string{nameLabel: "selector-fixture"})
+
+		err := reconcile(ctx, o, expected)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.template.metadata.labels"))
+	})
+})

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_selector_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_selector_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package llmisvc_test
 
 import (
-	"errors"
+	"context"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,112 +25,175 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
-	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	"github.com/kserve/kserve/pkg/constants"
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+	. "github.com/kserve/kserve/pkg/testing"
 )
 
-// These specs exercise Reconcile against the envtest API server rather than the
-// controller, so the selector a Deployment is created with can be chosen directly.
-// spec.selector validation - immutability, and the pod template having to satisfy the
-// selector - is enforced by the API server, so a fake client cannot stand in here.
+// These specs drive the controller against a Deployment created before the selector was
+// narrowed, so its stored selector carries a label the reconciler no longer computes.
+// spec.selector immutability and the pod template having to satisfy the selector are
+// enforced by the API server, so a fake client cannot stand in here.
 var _ = Describe("Deployment selector", func() {
-	const (
-		nameLabel  = "app.kubernetes.io/name"
-		queueLabel = "kueue.x-k8s.io/queue-name"
-	)
+	const queueName = "team-alpha"
 
-	// storedSelector stands for a Deployment created by a reconciler that put the
-	// propagated queue label in the selector. The current one computes nameLabel only.
-	storedSelector := map[string]string{nameLabel: "selector-fixture", queueLabel: "team-alpha"}
+	// identityLabels are the labels the main workload builder computes for a Deployment.
+	identityLabels := func(svcName string) map[string]string {
+		return map[string]string{
+			constants.KubernetesComponentLabelKey: constants.LLMComponentWorkload,
+			constants.KubernetesAppNameLabelKey:   svcName,
+			constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
+		}
+	}
 
-	deployment := func(namespace string, owner *v1alpha2.LLMInferenceService, selector, podLabels map[string]string) *appsv1.Deployment {
-		return &appsv1.Deployment{
+	// legacySelector adds the propagated queue label the pre-fix builders put in the
+	// selector along with the identity labels.
+	legacySelector := func(svcName string) map[string]string {
+		selector := identityLabels(svcName)
+		selector[LocalQueueNameLabelKey] = queueName
+		return selector
+	}
+
+	// plantLegacyDeployment creates an LLMInferenceService whose Deployment already
+	// exists with the legacy selector.
+	//
+	// The service is created with a BaseRef that does not resolve, which stops the
+	// reconcile before the workload, leaving the Deployment to be created here. Clearing
+	// the BaseRef then lets the controller adopt it.
+	plantLegacyDeployment := func(ctx SpecContext, svcName string, testNs *TestNamespace) *v1alpha2.LLMInferenceService {
+		GinkgoHelper()
+
+		llmSvc := LLMInferenceService(svcName,
+			InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+			WithModelURI("hf://facebook/opt-125m"),
+			WithModelName("facebook/opt-125m"),
+			WithLabels(map[string]string{LocalQueueNameLabelKey: queueName}),
+			WithBaseRefs(corev1.LocalObjectReference{Name: "does-not-exist"}),
+		)
+		Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+
+		Eventually(func(g Gomega, ctx context.Context) {
+			current := &v1alpha2.LLMInferenceService{}
+			g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+			g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "False"))
+			llmSvc = current
+		}).WithContext(ctx).Should(Succeed())
+
+		selector := legacySelector(svcName)
+		stored := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "selector-fixture",
-				Namespace: namespace,
+				Name:      svcName + "-kserve",
+				Namespace: testNs.Name,
 				OwnerReferences: []metav1.OwnerReference{
-					*metav1.NewControllerRef(owner, v1alpha2.LLMInferenceServiceGVK),
+					*metav1.NewControllerRef(llmSvc, v1alpha2.LLMInferenceServiceGVK),
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: ptr.To(int32(1)),
 				Selector: &metav1.LabelSelector{MatchLabels: selector},
 				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+					ObjectMeta: metav1.ObjectMeta{Labels: selector},
 					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+						Containers: []corev1.Container{{Name: "placeholder", Image: "busybox"}},
 					},
 				},
 			},
 		}
-	}
-
-	// owner is never created: envtest runs no garbage collector, so an ownerReference
-	// is enough to satisfy the controlled-by check in Update.
-	owner := func(namespace string) *v1alpha2.LLMInferenceService {
-		return &v1alpha2.LLMInferenceService{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "selector-fixture",
-				Namespace: namespace,
-				UID:       types.UID("11111111-2222-3333-4444-555555555555"),
-			},
-		}
-	}
-
-	reconcile := func(ctx SpecContext, o *v1alpha2.LLMInferenceService, expected *appsv1.Deployment) error {
-		c := &fakeClientWithRecorder{Client: envTest.Client, EventRecorder: record.NewFakeRecorder(10)}
-		return llmisvc.Reconcile(ctx, c, o, &appsv1.Deployment{}, expected,
-			llmisvc.SemanticEqual[*appsv1.Deployment](neverEqual),
-			llmisvc.PreserveDeploymentSelector())
-	}
-
-	It("should reconcile a Deployment whose stored selector the reconciler no longer computes", func(ctx SpecContext) {
-		testNs := NewTestNamespace(ctx, envTest)
-		o := owner(testNs.Name)
-
-		stored := deployment(testNs.Name, o, storedSelector, storedSelector)
 		Expect(envTest.Create(ctx, stored)).To(Succeed())
 
-		// The pod template still carries the queue label, so it satisfies the stored
-		// selector even though the selector is no longer what would be computed.
-		expected := deployment(testNs.Name, o,
-			map[string]string{nameLabel: "selector-fixture"},
-			map[string]string{nameLabel: "selector-fixture", queueLabel: "team-alpha"})
+		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, err := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+				llmSvc.Spec.BaseRefs = nil
+				return nil
+			})
+			return err
+		})).To(Succeed())
 
-		Expect(reconcile(ctx, o, expected)).To(Succeed())
+		return llmSvc
+	}
 
-		curr := &appsv1.Deployment{}
-		Expect(envTest.Get(ctx, client.ObjectKeyFromObject(stored), curr)).To(Succeed())
-		Expect(curr.Spec.Selector.MatchLabels).To(Equal(storedSelector),
-			"the stored selector must be carried over unchanged")
+	// deploymentOf reads the main Deployment of the given service.
+	deploymentOf := func(ctx context.Context, g Gomega, llmSvc *v1alpha2.LLMInferenceService) *appsv1.Deployment {
+		deployment := &appsv1.Deployment{}
+		g.Expect(envTest.Get(ctx, types.NamespacedName{
+			Name:      llmSvc.GetName() + "-kserve",
+			Namespace: llmSvc.GetNamespace(),
+		}, deployment)).To(Succeed())
+		return deployment
+	}
+
+	It("should keep reconciling a Deployment whose stored selector it no longer computes", func(ctx SpecContext) {
+		// given
+		svcName := "test-llm-selector-legacy"
+		testNs := NewTestNamespace(ctx, envTest)
+
+		llmSvc := plantLegacyDeployment(ctx, svcName, testNs)
+		defer testNs.DeleteAndWait(ctx, llmSvc)
+
+		// then - the controller takes the Deployment over, replacing the planted pod spec
+		Eventually(func(g Gomega, ctx context.Context) {
+			deployment := deploymentOf(ctx, g, llmSvc)
+
+			g.Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("main"))
+
+			g.Expect(deployment.Spec.Selector.MatchLabels).To(Equal(legacySelector(svcName)),
+				"the stored selector must be carried over unchanged")
+			g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(LocalQueueNameLabelKey, queueName),
+				"the pod template must still satisfy the stored selector")
+		}).WithContext(ctx).Should(Succeed())
 	})
 
-	It("should reject the update once the pod template stops satisfying the stored selector", func(ctx SpecContext) {
+	It("should report that a Deployment must be recreated once its pod template stops satisfying the stored selector", func(ctx SpecContext) {
+		// given
+		svcName := "test-llm-selector-unsatisfied"
 		testNs := NewTestNamespace(ctx, envTest)
-		o := owner(testNs.Name)
 
-		stored := deployment(testNs.Name, o, storedSelector, storedSelector)
-		Expect(envTest.Create(ctx, stored)).To(Succeed())
+		llmSvc := plantLegacyDeployment(ctx, svcName, testNs)
+		defer testNs.DeleteAndWait(ctx, llmSvc)
 
-		// Dropping the queue label from the LLMInferenceService removes it from the pod
-		// template, leaving the preserved selector requiring a label the pods no longer
-		// carry. Such a Deployment has to be recreated to reconcile again.
-		expected := deployment(testNs.Name, o,
-			map[string]string{nameLabel: "selector-fixture"},
-			map[string]string{nameLabel: "selector-fixture"})
+		Eventually(func(g Gomega, ctx context.Context) {
+			deployment := deploymentOf(ctx, g, llmSvc)
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("main"))
+		}).WithContext(ctx).Should(Succeed())
 
-		err := reconcile(ctx, o, expected)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("must be recreated to reconcile"))
-		Expect(err.Error()).To(ContainSubstring(queueLabel),
-			"the error should name the label the pod template no longer sets")
-		Expect(errors.Is(err, ctrlreconcile.TerminalError(nil))).To(BeTrue(),
-			"the error should be terminal, so the controller does not requeue it")
+		// when - dropping the queue label takes it off the pod template, which the stored
+		// selector still requires
+		Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, err := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+				delete(llmSvc.Labels, LocalQueueNameLabelKey)
+				return nil
+			})
+			return err
+		})).To(Succeed())
+
+		// then - the reconcile failure names the Deployment, the label and the remedy
+		Eventually(func(g Gomega, ctx context.Context) {
+			events := &corev1.EventList{}
+			g.Expect(envTest.List(ctx, events, client.InNamespace(testNs.Name))).To(Succeed())
+
+			messages := make([]string, 0, len(events.Items))
+			for _, event := range events.Items {
+				if event.InvolvedObject.Name == svcName {
+					messages = append(messages, event.Message)
+				}
+			}
+			g.Expect(messages).To(ContainElement(SatisfyAll(
+				ContainSubstring(svcName+"-kserve must be recreated to reconcile"),
+				ContainSubstring(LocalQueueNameLabelKey),
+			)))
+		}).WithContext(ctx).Should(Succeed())
+
+		// and the stored selector is left alone
+		Consistently(func(g Gomega, ctx context.Context) {
+			deployment := deploymentOf(ctx, g, llmSvc)
+			g.Expect(deployment.Spec.Selector.MatchLabels).To(Equal(legacySelector(svcName)))
+		}).WithContext(ctx).Should(Succeed())
 	})
 })

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_selector_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_selector_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package llmisvc_test
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -26,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
@@ -127,5 +130,7 @@ var _ = Describe("Deployment selector", func() {
 		Expect(err.Error()).To(ContainSubstring("must be recreated to reconcile"))
 		Expect(err.Error()).To(ContainSubstring(queueLabel),
 			"the error should name the label the pod template no longer sets")
+		Expect(errors.Is(err, ctrlreconcile.TerminalError(nil))).To(BeTrue(),
+			"the error should be terminal, so the controller does not requeue it")
 	})
 })

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_selector_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_selector_test.go
@@ -46,9 +46,6 @@ var _ = Describe("Deployment selector", func() {
 	// propagated queue label in the selector. The current one computes nameLabel only.
 	storedSelector := map[string]string{nameLabel: "selector-fixture", queueLabel: "team-alpha"}
 
-	// alwaysDiffer forces Update past the equality short-circuit so the write is attempted.
-	alwaysDiffer := func(expected, curr *appsv1.Deployment) bool { return false }
-
 	deployment := func(namespace string, owner *v1alpha2.LLMInferenceService, selector, podLabels map[string]string) *appsv1.Deployment {
 		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -86,7 +83,7 @@ var _ = Describe("Deployment selector", func() {
 	reconcile := func(ctx SpecContext, o *v1alpha2.LLMInferenceService, expected *appsv1.Deployment) error {
 		c := &fakeClientWithRecorder{Client: envTest.Client, EventRecorder: record.NewFakeRecorder(10)}
 		return llmisvc.Reconcile(ctx, c, o, &appsv1.Deployment{}, expected,
-			llmisvc.SemanticEqual[*appsv1.Deployment](alwaysDiffer),
+			llmisvc.SemanticEqual[*appsv1.Deployment](neverEqual),
 			llmisvc.PreserveDeploymentSelector())
 	}
 
@@ -127,6 +124,8 @@ var _ = Describe("Deployment selector", func() {
 
 		err := reconcile(ctx, o, expected)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("spec.template.metadata.labels"))
+		Expect(err.Error()).To(ContainSubstring("must be recreated to reconcile"))
+		Expect(err.Error()).To(ContainSubstring(queueLabel),
+			"the error should name the label the pod template no longer sets")
 	})
 })

--- a/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
@@ -17,12 +17,19 @@ limitations under the License.
 package llmisvc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
@@ -423,4 +430,126 @@ func TestPropagateWorkloadServiceMetadata(t *testing.T) {
 	}
 	assert.Equal(t, expectedLabels, svc.Labels)
 	assert.Equal(t, map[string]string{"prometheus.io/scrape": "true"}, svc.Annotations)
+}
+
+// TestDeploymentSelectorExcludesMetadataLabels verifies how the Deployment builders split
+// labels between spec.selector and the pod template.
+//
+// spec.selector is immutable after create, so it carries the component's identity labels
+// with the workload's own spec.labels applied on top - the override that lets one
+// LLMInferenceService's pods join another's InferencePool. Labels propagated from
+// top-level metadata, such as kueue.x-k8s.io/*, reach the pod template only.
+func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
+	const (
+		nameLabel  = "app.kubernetes.io/name"
+		queueLabel = "kueue.x-k8s.io/queue-name"
+		userLabel  = "team"
+	)
+
+	modelURI, err := apis.ParseURL("hf://facebook/opt-125m")
+	require.NoError(t, err)
+
+	newSvc := func() *v1alpha2.LLMInferenceService {
+		return &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "selector-test",
+				Namespace: "default",
+				Labels:    map[string]string{queueLabel: "team-alpha-queue"},
+			},
+			Spec: v1alpha2.LLMInferenceServiceSpec{
+				Model: v1alpha2.LLMModelSpec{URI: *modelURI},
+				WorkloadSpec: v1alpha2.WorkloadSpec{
+					Labels: map[string]string{
+						userLabel: "alpha",
+						nameLabel: "other-service",
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		// Only the main and prefill builders call propagateDeploymentMetadata, so only
+		// they receive allowlisted labels from the LLMInferenceService's own metadata.
+		propagatesMetadataLabels bool
+		build                    func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment
+	}{
+		{
+			name:                     "single-node main deployment",
+			propagatesMetadataLabels: true,
+			build: func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment {
+				d, err := r.expectedSingleNodeMainDeployment(context.Background(), newSvc(), &Config{})
+				require.NoError(t, err)
+				return d
+			},
+		},
+		{
+			name:                     "prefill deployment",
+			propagatesMetadataLabels: true,
+			build: func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment {
+				svc := newSvc()
+				svc.Spec.Prefill = &v1alpha2.WorkloadSpec{Labels: svc.Spec.Labels}
+				d, err := r.expectedPrefillMainDeployment(context.Background(), svc, &Config{})
+				require.NoError(t, err)
+				return d
+			},
+		},
+		{
+			name: "scheduler deployment",
+			build: func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment {
+				svc := newSvc()
+				svc.Spec.Router = &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{Labels: svc.Spec.Labels},
+				}
+				d, err := r.expectedSchedulerDeployment(context.Background(), svc)
+				require.NoError(t, err)
+				return d
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &LLMISVCReconciler{Client: selectorTestClient(t), Clientset: k8sfake.NewSimpleClientset()}
+			d := tt.build(t, r)
+
+			selector := d.Spec.Selector.MatchLabels
+			podLabels := d.Spec.Template.Labels
+
+			// Propagated from metadata: pod template only, never the selector.
+			if tt.propagatesMetadataLabels {
+				assert.Contains(t, podLabels, queueLabel)
+			}
+			assert.NotContains(t, selector, queueLabel,
+				"spec.selector is immutable and must not carry labels propagated from metadata")
+
+			// From spec.labels: both, so the override reaches the selector.
+			assert.Equal(t, "alpha", selector[userLabel])
+			assert.Equal(t, "other-service", selector[nameLabel],
+				"spec.labels must override the identity label in the selector")
+
+			// Kubernetes requires the pod template to satisfy the selector.
+			for k, v := range selector {
+				assert.Equal(t, v, podLabels[k],
+					"selector key %s must be satisfied by the pod template", k)
+			}
+
+			// A write to the pod template labels must not reach the selector.
+			podLabels["mutation-probe"] = "x"
+			assert.NotContains(t, selector, "mutation-probe",
+				"spec.selector must not share its backing map with the pod template")
+		})
+	}
+}
+
+// selectorTestClient returns a client with the schemes the Deployment builders read
+// through (existing Deployment, ServiceAccount) so they can run without an API server.
+func selectorTestClient(t *testing.T) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).Build()
 }

--- a/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
@@ -473,11 +474,14 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 		// Only the main and prefill builders call propagateDeploymentMetadata, so only
 		// they receive allowlisted labels from the LLMInferenceService's own metadata.
 		propagatesMetadataLabels bool
-		build                    func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment
+		// The tokenizer takes no workload labels, so its selector is identity alone.
+		appliesWorkloadLabels bool
+		build                 func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment
 	}{
 		{
 			name:                     "single-node main deployment",
 			propagatesMetadataLabels: true,
+			appliesWorkloadLabels:    true,
 			build: func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment {
 				d, err := r.expectedSingleNodeMainDeployment(context.Background(), newSvc(), &Config{})
 				require.NoError(t, err)
@@ -487,6 +491,7 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 		{
 			name:                     "prefill deployment",
 			propagatesMetadataLabels: true,
+			appliesWorkloadLabels:    true,
 			build: func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment {
 				svc := newSvc()
 				svc.Spec.Prefill = &v1alpha2.WorkloadSpec{Labels: svc.Spec.Labels}
@@ -496,7 +501,8 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 			},
 		},
 		{
-			name: "scheduler deployment",
+			name:                  "scheduler deployment",
+			appliesWorkloadLabels: true,
 			build: func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment {
 				svc := newSvc()
 				svc.Spec.Router = &v1alpha2.RouterSpec{
@@ -504,6 +510,36 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 				}
 				d, err := r.expectedSchedulerDeployment(context.Background(), svc)
 				require.NoError(t, err)
+				return d
+			},
+		},
+		{
+			name: "tokenizer deployment",
+			build: func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment {
+				d, err := r.expectedTokenizerDeployment(context.Background(), newSvc())
+				require.NoError(t, err)
+				return d
+			},
+		},
+		{
+			// Labels copied from a referenced InferencePool identify the pods that pool
+			// routes to, so they belong in the selector alongside the identity labels.
+			name:                     "single-node main deployment with an InferencePool ref",
+			propagatesMetadataLabels: true,
+			appliesWorkloadLabels:    true,
+			build: func(t *testing.T, r *LLMISVCReconciler) *appsv1.Deployment {
+				svc := newSvc()
+				svc.Spec.Router = &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Pool: &v1alpha2.InferencePoolSpec{
+							Ref: &corev1.LocalObjectReference{Name: "shared-pool"},
+						},
+					},
+				}
+				d, err := r.expectedSingleNodeMainDeployment(context.Background(), svc, &Config{})
+				require.NoError(t, err)
+				assert.Equal(t, "shared", d.Spec.Selector.MatchLabels["pool"],
+					"labels from a referenced InferencePool must reach the selector")
 				return d
 			},
 		},
@@ -525,9 +561,13 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 				"spec.selector is immutable and must not carry labels propagated from metadata")
 
 			// From spec.labels: both, so the override reaches the selector.
-			assert.Equal(t, "alpha", selector[userLabel])
-			assert.Equal(t, "other-service", selector[nameLabel],
-				"spec.labels must override the identity label in the selector")
+			if tt.appliesWorkloadLabels {
+				assert.Equal(t, "alpha", selector[userLabel])
+				assert.Equal(t, "other-service", selector[nameLabel],
+					"spec.labels must override the identity label in the selector")
+			} else {
+				assert.NotContains(t, selector, userLabel)
+			}
 
 			// Kubernetes requires the pod template to satisfy the selector.
 			for k, v := range selector {
@@ -544,12 +584,24 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 }
 
 // selectorTestClient returns a client with the schemes the Deployment builders read
-// through (existing Deployment, ServiceAccount) so they can run without an API server.
+// through (existing Deployment, ServiceAccount, InferencePool) so they can run without
+// an API server, seeded with the InferencePool the ref case looks up.
 func selectorTestClient(t *testing.T) client.Client {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1alpha2.AddToScheme(scheme))
 	require.NoError(t, appsv1.AddToScheme(scheme))
 	require.NoError(t, corev1.AddToScheme(scheme))
-	return fake.NewClientBuilder().WithScheme(scheme).Build()
+	require.NoError(t, igwapi.Install(scheme))
+
+	pool := &igwapi.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-pool", Namespace: "default"},
+		Spec: igwapi.InferencePoolSpec{
+			Selector: igwapi.LabelSelector{
+				MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{"pool": "shared"},
+			},
+		},
+	}
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(pool).Build()
 }

--- a/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
@@ -435,12 +435,12 @@ func TestPropagateWorkloadServiceMetadata(t *testing.T) {
 }
 
 // TestDeploymentSelectorExcludesMetadataLabels verifies how the Deployment builders split
-// labels between spec.selector and the pod template.
+// labels between spec.selector, the pod template and the Deployment's own metadata.
 //
-// spec.selector is immutable after create, so it carries the component's identity labels
-// with the workload's own spec.labels applied on top - the override that lets one
-// LLMInferenceService's pods join another's InferencePool. Labels propagated from
-// top-level metadata, such as kueue.x-k8s.io/*, reach the pod template only.
+// spec.selector carries the component's identity labels, taking the values spec.labels
+// sets for those keys. Labels propagated from top-level metadata, such as
+// kueue.x-k8s.io/*, and spec.labels keys that identity does not define reach the pod
+// template only.
 func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 	const (
 		nameLabel  = "app.kubernetes.io/name"
@@ -562,18 +562,19 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 			assert.NotContains(t, selector, queueLabel,
 				"spec.selector is immutable and must not carry labels propagated from metadata")
 
-			// From spec.labels: selector and pod template, but not the Deployment's own
-			// metadata - the propagation helpers target the pod template alone.
+			// From spec.labels: the value it sets for an identity key reaches the
+			// selector, a key identity does not define reaches the pod template only,
+			// and neither reaches the Deployment's own metadata.
+			assert.NotContains(t, selector, userLabel,
+				"spec.selector must carry identity keys only")
 			if tt.appliesWorkloadLabels {
-				assert.Equal(t, "alpha", selector[userLabel])
+				assert.Equal(t, "alpha", podLabels[userLabel])
 				assert.Equal(t, "other-service", selector[nameLabel],
 					"spec.labels must override the identity label in the selector")
 				assert.NotContains(t, metaLabels, userLabel,
 					"spec.labels must not reach the Deployment's own metadata")
 				assert.Equal(t, "selector-test", metaLabels[nameLabel],
 					"the Deployment's own metadata keeps the identity label")
-			} else {
-				assert.NotContains(t, selector, userLabel)
 			}
 
 			// Kubernetes requires the pod template to satisfy the selector.
@@ -629,9 +630,9 @@ func TestDeploymentSelectorLabels(t *testing.T) {
 			want:     map[string]string{"app.kubernetes.io/name": "svc"},
 		},
 		{
-			name:           "nil identity labels",
+			name:           "nil identity labels leave nothing for workload labels to override",
 			workloadLabels: map[string]string{"team": "alpha"},
-			want:           map[string]string{"team": "alpha"},
+			want:           map[string]string{},
 		},
 		{
 			name: "both nil",
@@ -640,12 +641,17 @@ func TestDeploymentSelectorLabels(t *testing.T) {
 		{
 			name:           "workload labels override identity labels",
 			identity:       map[string]string{"app.kubernetes.io/name": "svc", "kserve.io/component": "workload"},
-			workloadLabels: map[string]string{"app.kubernetes.io/name": "other", "team": "alpha"},
+			workloadLabels: map[string]string{"app.kubernetes.io/name": "other"},
 			want: map[string]string{
 				"app.kubernetes.io/name": "other",
 				"kserve.io/component":    "workload",
-				"team":                   "alpha",
 			},
+		},
+		{
+			name:           "workload labels that identity does not define are left out",
+			identity:       map[string]string{"app.kubernetes.io/name": "svc"},
+			workloadLabels: map[string]string{"app.kubernetes.io/name": "other", "team": "alpha"},
+			want:           map[string]string{"app.kubernetes.io/name": "other"},
 		},
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
@@ -18,6 +18,7 @@ package llmisvc
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -604,4 +605,49 @@ func selectorTestClient(t *testing.T) client.Client {
 	}
 
 	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(pool).Build()
+}
+
+func TestDeploymentSelectorLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		identity       map[string]string
+		workloadLabels map[string]string
+		want           map[string]string
+	}{
+		{
+			name:     "nil workload labels leave the identity labels alone",
+			identity: map[string]string{"app.kubernetes.io/name": "svc"},
+			want:     map[string]string{"app.kubernetes.io/name": "svc"},
+		},
+		{
+			name:           "nil identity labels",
+			workloadLabels: map[string]string{"team": "alpha"},
+			want:           map[string]string{"team": "alpha"},
+		},
+		{
+			name: "both nil",
+			want: map[string]string{},
+		},
+		{
+			name:           "workload labels override identity labels",
+			identity:       map[string]string{"app.kubernetes.io/name": "svc", "kserve.io/component": "workload"},
+			workloadLabels: map[string]string{"app.kubernetes.io/name": "other", "team": "alpha"},
+			want: map[string]string{
+				"app.kubernetes.io/name": "other",
+				"kserve.io/component":    "workload",
+				"team":                   "alpha",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity := maps.Clone(tt.identity)
+
+			got := deploymentSelectorLabels(identity, tt.workloadLabels)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.identity, identity, "the identity map must not be modified")
+		})
+	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/label_propagation_test.go
@@ -553,6 +553,7 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 
 			selector := d.Spec.Selector.MatchLabels
 			podLabels := d.Spec.Template.Labels
+			metaLabels := d.Labels
 
 			// Propagated from metadata: pod template only, never the selector.
 			if tt.propagatesMetadataLabels {
@@ -561,11 +562,16 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 			assert.NotContains(t, selector, queueLabel,
 				"spec.selector is immutable and must not carry labels propagated from metadata")
 
-			// From spec.labels: both, so the override reaches the selector.
+			// From spec.labels: selector and pod template, but not the Deployment's own
+			// metadata - the propagation helpers target the pod template alone.
 			if tt.appliesWorkloadLabels {
 				assert.Equal(t, "alpha", selector[userLabel])
 				assert.Equal(t, "other-service", selector[nameLabel],
 					"spec.labels must override the identity label in the selector")
+				assert.NotContains(t, metaLabels, userLabel,
+					"spec.labels must not reach the Deployment's own metadata")
+				assert.Equal(t, "selector-test", metaLabels[nameLabel],
+					"the Deployment's own metadata keeps the identity label")
 			} else {
 				assert.NotContains(t, selector, userLabel)
 			}
@@ -576,10 +582,13 @@ func TestDeploymentSelectorExcludesMetadataLabels(t *testing.T) {
 					"selector key %s must be satisfied by the pod template", k)
 			}
 
-			// A write to the pod template labels must not reach the selector.
+			// A write to the pod template labels must not reach the selector or the
+			// Deployment's own metadata: all three are separate maps.
 			podLabels["mutation-probe"] = "x"
 			assert.NotContains(t, selector, "mutation-probe",
 				"spec.selector must not share its backing map with the pod template")
+			assert.NotContains(t, metaLabels, "mutation-probe",
+				"metadata.labels must not share its backing map with the pod template")
 		})
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/lifecycle_crud.go
+++ b/pkg/controller/v1alpha2/llmisvc/lifecycle_crud.go
@@ -201,7 +201,8 @@ type UpdateOption[T client.Object] func(*updateOptions[T])
 // AfterDryRunFunc is a callback function type for AfterDryRun options.
 // It receives:
 //   - expected: the object after dry-run (with server defaults applied) - modify this to take effect
-//   - expectedGiven: the original object before dry-run - use this to check what was originally set
+//   - expectedGiven: the object as the caller built it, copied before any BeforeDryRun
+//     callback and before the dry-run - use this to check what was originally set
 //   - curr: the current state of the resource in the cluster
 type AfterDryRunFunc[T client.Object] func(expected, expectedGiven, curr T)
 

--- a/pkg/controller/v1alpha2/llmisvc/lifecycle_crud.go
+++ b/pkg/controller/v1alpha2/llmisvc/lifecycle_crud.go
@@ -152,7 +152,9 @@ func Update[O client.Object, T client.Object](ctx context.Context, c clientWithR
 
 	// Apply before dry-run mutations (e.g., carry over immutable fields from curr)
 	for _, fn := range options.beforeDryRunFns {
-		fn(expected, curr)
+		if err := fn(expected, curr); err != nil {
+			return err
+		}
 	}
 
 	if err := c.Update(ctx, expected, client.DryRunAll); err != nil {
@@ -210,7 +212,10 @@ type AfterDryRunFunc[T client.Object] func(expected, expectedGiven, curr T)
 // It receives:
 //   - expected: the object about to be sent as a dry-run Update - modify this to take effect
 //   - curr: the current state of the resource in the cluster
-type BeforeDryRunFunc[T client.Object] func(expected, curr T)
+//
+// Returning an error aborts the update, so a callback can reject a write it can tell
+// the API server will not accept.
+type BeforeDryRunFunc[T client.Object] func(expected, curr T) error
 
 type updateOptions[T client.Object] struct {
 	beforeDryRunFns []BeforeDryRunFunc[T]

--- a/pkg/controller/v1alpha2/llmisvc/lifecycle_crud.go
+++ b/pkg/controller/v1alpha2/llmisvc/lifecycle_crud.go
@@ -149,6 +149,12 @@ func Update[O client.Object, T client.Object](ctx context.Context, c clientWithR
 	expectedGiven := expected.DeepCopyObject().(T)
 
 	expected.SetResourceVersion(curr.GetResourceVersion())
+
+	// Apply before dry-run mutations (e.g., carry over immutable fields from curr)
+	for _, fn := range options.beforeDryRunFns {
+		fn(expected, curr)
+	}
+
 	if err := c.Update(ctx, expected, client.DryRunAll); err != nil {
 		return fmt.Errorf("failed to get defaults for %s %s/%s: %w", typeLogLine, expected.GetNamespace(), expected.GetName(), err)
 	}
@@ -199,8 +205,28 @@ type UpdateOption[T client.Object] func(*updateOptions[T])
 //   - curr: the current state of the resource in the cluster
 type AfterDryRunFunc[T client.Object] func(expected, expectedGiven, curr T)
 
+// BeforeDryRunFunc is a callback function type for BeforeDryRun options.
+// It receives:
+//   - expected: the object about to be sent as a dry-run Update - modify this to take effect
+//   - curr: the current state of the resource in the cluster
+type BeforeDryRunFunc[T client.Object] func(expected, curr T)
+
 type updateOptions[T client.Object] struct {
-	afterDryRunFns []AfterDryRunFunc[T]
+	beforeDryRunFns []BeforeDryRunFunc[T]
+	afterDryRunFns  []AfterDryRunFunc[T]
+}
+
+// BeforeDryRun configures Update to call the provided function before the dry-run
+// Update is issued.
+//
+// Multiple BeforeDryRun options can be provided and they will be applied in order.
+//
+// Use this for fields the API server validates on the dry-run request itself, such as
+// immutable fields. AfterDryRun callbacks run once that request has returned.
+func BeforeDryRun[T client.Object](fn BeforeDryRunFunc[T]) UpdateOption[T] {
+	return func(o *updateOptions[T]) {
+		o.beforeDryRunFns = append(o.beforeDryRunFns, fn)
+	}
 }
 
 // AfterDryRun configures Update to call the provided function after the dry-run

--- a/pkg/controller/v1alpha2/llmisvc/lifecycle_crud_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/lifecycle_crud_test.go
@@ -46,6 +46,9 @@ type fakeClientWithRecorder struct {
 	record.EventRecorder
 }
 
+// neverEqual forces Update past its equality short-circuit so the write is attempted.
+func neverEqual(expected, curr *appsv1.Deployment) bool { return false }
+
 func TestDelete_WhenCRDNotInstalled_ShouldNotFail(t *testing.T) {
 	// given - a client that returns NoMatchError (CRD not installed)
 	scheme := runtime.NewScheme()
@@ -294,8 +297,6 @@ func TestPreserveDeploymentSelector(t *testing.T) {
 				Client:        fakeClient,
 				EventRecorder: record.NewFakeRecorder(10),
 			}
-
-			neverEqual := func(expected, curr *appsv1.Deployment) bool { return false }
 
 			err := llmisvc.Reconcile(t.Context(), clientWithRecorder, owner, &appsv1.Deployment{},
 				newExpected(), llmisvc.SemanticEqual[*appsv1.Deployment](neverEqual), tt.opts...)

--- a/pkg/controller/v1alpha2/llmisvc/lifecycle_crud_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/lifecycle_crud_test.go
@@ -18,9 +18,13 @@ package llmisvc_test
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -178,5 +182,138 @@ func TestNoMatchError_ShouldBeDistinguishedFromNotFound(t *testing.T) {
 	}
 	if meta.IsNoMatchError(notFoundErr) {
 		t.Error("NotFound error should NOT be identified as NoMatchError")
+	}
+}
+
+// TestPreserveDeploymentSelector covers Update against a Deployment whose stored
+// spec.selector differs from the one the caller computes. spec.selector is immutable,
+// so the value already on the object is the only one the API server accepts; the
+// interceptor below stands in for that validation.
+func TestPreserveDeploymentSelector(t *testing.T) {
+	storedSelector := map[string]string{
+		"app.kubernetes.io/name":    "test-llm",
+		"kueue.x-k8s.io/queue-name": "team-alpha",
+	}
+	computedSelector := map[string]string{
+		"app.kubernetes.io/name": "test-llm",
+	}
+
+	newExpected := func() *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-llm-kserve", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: computedSelector},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: storedSelector},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		opts      []llmisvc.UpdateOption[*appsv1.Deployment]
+		wantErr   bool
+		wantSent  map[string]string
+		errSubstr string
+	}{
+		{
+			name:     "with PreserveDeploymentSelector the stored selector is sent",
+			opts:     []llmisvc.UpdateOption[*appsv1.Deployment]{llmisvc.PreserveDeploymentSelector()},
+			wantSent: storedSelector,
+		},
+		{
+			name:      "without it the computed selector is rejected",
+			wantErr:   true,
+			wantSent:  computedSelector,
+			errSubstr: "field is immutable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add corev1 to scheme: %v", err)
+			}
+			if err := appsv1.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add appsv1 to scheme: %v", err)
+			}
+			if err := v1alpha2.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add v1alpha2 to scheme: %v", err)
+			}
+
+			owner := &v1alpha2.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-llm", Namespace: "default", UID: "test-uid"},
+			}
+			stored := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-llm-kserve",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(owner, v1alpha2.LLMInferenceServiceGVK),
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: storedSelector},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: storedSelector},
+					},
+				},
+			}
+
+			mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{appsv1.SchemeGroupVersion})
+			mapper.Add(appsv1.SchemeGroupVersion.WithKind("Deployment"), meta.RESTScopeNamespace)
+
+			var sent map[string]string
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRESTMapper(mapper).
+				WithObjects(stored).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+						d, ok := obj.(*appsv1.Deployment)
+						if !ok {
+							return c.Update(ctx, obj, opts...)
+						}
+						sent = d.Spec.Selector.MatchLabels
+
+						curr := &appsv1.Deployment{}
+						if err := c.Get(ctx, client.ObjectKeyFromObject(d), curr); err != nil {
+							return err
+						}
+						if !equality.Semantic.DeepEqual(curr.Spec.Selector, d.Spec.Selector) {
+							return errors.New(`Deployment.apps "test-llm-kserve" is invalid: spec.selector: field is immutable`)
+						}
+						return c.Update(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			clientWithRecorder := &fakeClientWithRecorder{
+				Client:        fakeClient,
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			neverEqual := func(expected, curr *appsv1.Deployment) bool { return false }
+
+			err := llmisvc.Reconcile(t.Context(), clientWithRecorder, owner, &appsv1.Deployment{},
+				newExpected(), llmisvc.SemanticEqual[*appsv1.Deployment](neverEqual), tt.opts...)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got: %v", tt.errSubstr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("Reconcile should succeed, got: %v", err)
+			}
+
+			if !equality.Semantic.DeepEqual(sent, tt.wantSent) {
+				t.Errorf("selector sent to the API server = %v, want %v", sent, tt.wantSent)
+			}
+		})
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/lifecycle_crud_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/lifecycle_crud_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -201,24 +202,27 @@ func TestPreserveDeploymentSelector(t *testing.T) {
 		"app.kubernetes.io/name": "test-llm",
 	}
 
-	newExpected := func() *appsv1.Deployment {
+	newExpected := func(templateLabels map[string]string) *appsv1.Deployment {
 		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-llm-kserve", Namespace: "default"},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: computedSelector},
 				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{Labels: storedSelector},
+					ObjectMeta: metav1.ObjectMeta{Labels: templateLabels},
 				},
 			},
 		}
 	}
 
 	tests := []struct {
-		name      string
-		opts      []llmisvc.UpdateOption[*appsv1.Deployment]
-		wantErr   bool
-		wantSent  map[string]string
-		errSubstr string
+		name string
+		opts []llmisvc.UpdateOption[*appsv1.Deployment]
+		// templateLabels defaults to storedSelector, which the stored selector accepts.
+		templateLabels map[string]string
+		wantErr        bool
+		wantTerminal   bool
+		wantSent       map[string]string
+		errSubstr      string
 	}{
 		{
 			name:     "with PreserveDeploymentSelector the stored selector is sent",
@@ -230,6 +234,14 @@ func TestPreserveDeploymentSelector(t *testing.T) {
 			wantErr:   true,
 			wantSent:  computedSelector,
 			errSubstr: "field is immutable",
+		},
+		{
+			name:           "a pod template that does not satisfy the stored selector fails terminally",
+			opts:           []llmisvc.UpdateOption[*appsv1.Deployment]{llmisvc.PreserveDeploymentSelector()},
+			templateLabels: computedSelector,
+			wantErr:        true,
+			wantTerminal:   true,
+			errSubstr:      `kueue.x-k8s.io/queue-name="team-alpha"`,
 		},
 	}
 
@@ -298,8 +310,13 @@ func TestPreserveDeploymentSelector(t *testing.T) {
 				EventRecorder: record.NewFakeRecorder(10),
 			}
 
+			templateLabels := tt.templateLabels
+			if templateLabels == nil {
+				templateLabels = storedSelector
+			}
+
 			err := llmisvc.Reconcile(t.Context(), clientWithRecorder, owner, &appsv1.Deployment{},
-				newExpected(), llmisvc.SemanticEqual[*appsv1.Deployment](neverEqual), tt.opts...)
+				newExpected(templateLabels), llmisvc.SemanticEqual[*appsv1.Deployment](neverEqual), tt.opts...)
 
 			if tt.wantErr {
 				if err == nil {
@@ -307,6 +324,9 @@ func TestPreserveDeploymentSelector(t *testing.T) {
 				}
 				if !strings.Contains(err.Error(), tt.errSubstr) {
 					t.Errorf("expected error containing %q, got: %v", tt.errSubstr, err)
+				}
+				if isTerminal := errors.Is(err, reconcile.TerminalError(nil)); isTerminal != tt.wantTerminal {
+					t.Errorf("errors.Is(err, TerminalError) = %v, want %v; got: %v", isTerminal, tt.wantTerminal, err)
 				}
 			} else if err != nil {
 				t.Fatalf("Reconcile should succeed, got: %v", err)

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -417,7 +417,7 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: maps.Clone(labels),
 				},
 			},
 		},

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -212,7 +212,7 @@ func (r *LLMISVCReconciler) reconcileSchedulerDeployment(ctx context.Context, ll
 		}
 		return Delete(ctx, r, llmSvc, scheduler)
 	}
-	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, scheduler, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, scheduler, semanticDeploymentIsEqual, PreserveDeploymentReplicas(), PreserveDeploymentSelector()); err != nil {
 		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", scheduler.GetNamespace(), scheduler.GetName(), err)
 	}
 	return r.propagateComponentDeploymentStatus(ctx, scheduler, llmSvc.MarkSchedulerWorkloadReady, llmSvc.MarkSchedulerWorkloadNotReady)

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -387,6 +387,12 @@ func (r *LLMISVCReconciler) expectedSchedulerInferencePoolV1Alpha2(ctx context.C
 
 func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) (*appsv1.Deployment, error) {
 	labels := SchedulerLabels(llmSvc)
+
+	var schedulerLabels map[string]string
+	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil {
+		schedulerLabels = llmSvc.Spec.Router.Scheduler.Labels
+	}
+
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      schedulerDeploymentName(llmSvc),
@@ -407,7 +413,7 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: deploymentSelectorLabels(labels, schedulerLabels),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/v1alpha2/llmisvc/tokenizer.go
+++ b/pkg/controller/v1alpha2/llmisvc/tokenizer.go
@@ -201,8 +201,10 @@ func (r *LLMISVCReconciler) expectedTokenizerDeployment(ctx context.Context, llm
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
+			// The tokenizer takes no user-supplied labels, so its selector is the
+			// identity labels alone.
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: deploymentSelectorLabels(labels, nil),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/v1alpha2/llmisvc/tokenizer.go
+++ b/pkg/controller/v1alpha2/llmisvc/tokenizer.go
@@ -170,7 +170,7 @@ func (r *LLMISVCReconciler) reconcileTokenizerDeployment(ctx context.Context, ll
 		return Delete(ctx, r, llmSvc, expected)
 	}
 
-	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, expected, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, expected, semanticDeploymentIsEqual, PreserveDeploymentReplicas(), PreserveDeploymentSelector()); err != nil {
 		return fmt.Errorf("failed to reconcile tokenizer deployment %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
 	}
 

--- a/pkg/controller/v1alpha2/llmisvc/tokenizer.go
+++ b/pkg/controller/v1alpha2/llmisvc/tokenizer.go
@@ -19,6 +19,7 @@ package llmisvc
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -208,7 +209,7 @@ func (r *LLMISVCReconciler) expectedTokenizerDeployment(ctx context.Context, llm
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: maps.Clone(labels),
 				},
 			},
 		},

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -259,6 +259,20 @@ func PreserveDeploymentReplicas() UpdateOption[*appsv1.Deployment] {
 	})
 }
 
+// PreserveDeploymentSelector returns an UpdateOption that carries the stored
+// Deployment's spec.selector over to the object being written.
+//
+// spec.selector is immutable, so the value already on the object is the only one the
+// API server accepts. A Deployment keeps the selector it was created with, and a change
+// to how the selector is computed applies only to Deployments created afterwards.
+func PreserveDeploymentSelector() UpdateOption[*appsv1.Deployment] {
+	return BeforeDryRun(func(expected, curr *appsv1.Deployment) {
+		if curr.Spec.Selector != nil {
+			expected.Spec.Selector = curr.Spec.Selector.DeepCopy()
+		}
+	})
+}
+
 // PreserveLWSReplicas returns an UpdateOption that preserves the current
 // LeaderWorkerSet's replica count when the owner doesn't explicitly set it.
 // This allows external controllers to manage replicas without the

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -263,15 +264,12 @@ func PreserveDeploymentReplicas() UpdateOption[*appsv1.Deployment] {
 }
 
 // PreserveDeploymentSelector returns an UpdateOption that carries the stored
-// Deployment's spec.selector over to the object being written.
+// Deployment's spec.selector over to the object being written, since spec.selector is
+// immutable and the API server accepts no other value.
 //
-// spec.selector is immutable, so the value already on the object is the only one the
-// API server accepts. A Deployment keeps the selector it was created with, and a change
-// to how the selector is computed applies only to Deployments created afterwards.
-//
-// The pod template is still rebuilt on every reconcile. A Deployment whose template stops
-// carrying a key its stored selector requires is rejected, since the template no longer
-// matches the selector, and has to be recreated to reconcile again.
+// If the pod template does not satisfy that selector, it returns a
+// reconcile.TerminalError naming the labels it is missing: the Deployment has to be
+// recreated, so requeuing the update cannot change the outcome.
 func PreserveDeploymentSelector() UpdateOption[*appsv1.Deployment] {
 	return BeforeDryRun(func(expected, curr *appsv1.Deployment) error {
 		if curr.Spec.Selector == nil {
@@ -290,9 +288,10 @@ func PreserveDeploymentSelector() UpdateOption[*appsv1.Deployment] {
 		}
 		slices.Sort(unsatisfied)
 
-		return fmt.Errorf("deployment %s/%s must be recreated to reconcile: its selector is "+
-			"immutable and requires %s, which the pod template no longer sets",
-			curr.GetNamespace(), curr.GetName(), strings.Join(unsatisfied, ", "))
+		return reconcile.TerminalError(fmt.Errorf(
+			"deployment %s/%s must be recreated to reconcile: its selector is "+
+				"immutable and requires %s, which the pod template no longer sets",
+			curr.GetNamespace(), curr.GetName(), strings.Join(unsatisfied, ", ")))
 	})
 }
 

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -183,9 +185,10 @@ func GetWorkloadLabelSelector(meta metav1.ObjectMeta, _ *v1alpha2.LLMInferenceSe
 // mirroring the identity its pod template carries.
 //
 // Labels propagated from the LLMInferenceService's top-level metadata are excluded.
-// spec.selector is immutable, so any key it does carry - including one supplied through
-// spec.labels, which is not validated as immutable - can only be changed by recreating
-// the Deployment.
+// spec.selector is immutable, so any key it does carry can only be changed by recreating
+// the Deployment. That applies to keys the identity labels do not control: spec.labels is
+// not validated as immutable, and identity can also carry the match labels of a
+// referenced InferencePool, which is a separate object that may be edited or swapped out.
 func deploymentSelectorLabels(identity, workloadLabels map[string]string) map[string]string {
 	selector := make(map[string]string, len(identity)+len(workloadLabels))
 	maps.Copy(selector, identity)
@@ -272,10 +275,26 @@ func PreserveDeploymentReplicas() UpdateOption[*appsv1.Deployment] {
 // carrying a key its stored selector requires is rejected, since the template no longer
 // matches the selector, and has to be recreated to reconcile again.
 func PreserveDeploymentSelector() UpdateOption[*appsv1.Deployment] {
-	return BeforeDryRun(func(expected, curr *appsv1.Deployment) {
-		if curr.Spec.Selector != nil {
-			expected.Spec.Selector = curr.Spec.Selector.DeepCopy()
+	return BeforeDryRun(func(expected, curr *appsv1.Deployment) error {
+		if curr.Spec.Selector == nil {
+			return nil
 		}
+		expected.Spec.Selector = curr.Spec.Selector.DeepCopy()
+
+		var unsatisfied []string
+		for k, v := range curr.Spec.Selector.MatchLabels {
+			if expected.Spec.Template.Labels[k] != v {
+				unsatisfied = append(unsatisfied, fmt.Sprintf("%s=%q", k, v))
+			}
+		}
+		if len(unsatisfied) == 0 {
+			return nil
+		}
+		slices.Sort(unsatisfied)
+
+		return fmt.Errorf("deployment %s/%s must be recreated to reconcile: its selector is "+
+			"immutable and requires %s, which the pod template no longer sets",
+			curr.GetNamespace(), curr.GetName(), strings.Join(unsatisfied, ", "))
 	})
 }
 

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -181,18 +181,16 @@ func GetWorkloadLabelSelector(meta metav1.ObjectMeta, _ *v1alpha2.LLMInferenceSe
 }
 
 // deploymentSelectorLabels returns the labels for a workload Deployment's spec.selector:
-// the component's identity labels with the workload's own spec.labels applied on top,
-// mirroring the identity its pod template carries.
-//
-// Labels propagated from the LLMInferenceService's top-level metadata are excluded.
-// spec.selector is immutable, so any key it does carry can only be changed by recreating
-// the Deployment. That applies to keys the identity labels do not control: spec.labels is
-// not validated as immutable, and identity can also carry the match labels of a
-// referenced InferencePool, which is a separate object that may be edited or swapped out.
+// the component's identity labels, taking the values workloadLabels sets for those keys.
+// workloadLabels keys that identity does not define are left out.
 func deploymentSelectorLabels(identity, workloadLabels map[string]string) map[string]string {
-	selector := make(map[string]string, len(identity)+len(workloadLabels))
+	selector := make(map[string]string, len(identity))
 	maps.Copy(selector, identity)
-	maps.Copy(selector, workloadLabels)
+	for k, v := range workloadLabels {
+		if _, isIdentity := selector[k]; isIdentity {
+			selector[k] = v
+		}
+	}
 	return selector
 }
 

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -19,6 +19,7 @@ package llmisvc
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -175,6 +176,19 @@ func GetWorkloadLabelSelector(meta metav1.ObjectMeta, _ *v1alpha2.LLMInferenceSe
 	// TODO https://github.com/llm-d/llm-d-router/issues/220 and DP template
 
 	return s
+}
+
+// deploymentSelectorLabels returns the labels for a workload Deployment's spec.selector:
+// the component's identity labels with the workload's own spec.labels applied on top,
+// mirroring the identity its pod template carries.
+//
+// Labels propagated from the LLMInferenceService's top-level metadata are excluded:
+// spec.selector is immutable after create, so it holds only labels that stay fixed for
+// the life of the Deployment.
+func deploymentSelectorLabels(identity, workloadLabels map[string]string) map[string]string {
+	selector := maps.Clone(identity)
+	maps.Copy(selector, workloadLabels)
+	return selector
 }
 
 func (r *LLMISVCReconciler) propagateInferencePoolRefLabelSelector(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, labels map[string]string) error {

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -182,11 +182,13 @@ func GetWorkloadLabelSelector(meta metav1.ObjectMeta, _ *v1alpha2.LLMInferenceSe
 // the component's identity labels with the workload's own spec.labels applied on top,
 // mirroring the identity its pod template carries.
 //
-// Labels propagated from the LLMInferenceService's top-level metadata are excluded:
-// spec.selector is immutable after create, so it holds only labels that stay fixed for
-// the life of the Deployment.
+// Labels propagated from the LLMInferenceService's top-level metadata are excluded.
+// spec.selector is immutable, so any key it does carry - including one supplied through
+// spec.labels, which is not validated as immutable - can only be changed by recreating
+// the Deployment.
 func deploymentSelectorLabels(identity, workloadLabels map[string]string) map[string]string {
-	selector := maps.Clone(identity)
+	selector := make(map[string]string, len(identity)+len(workloadLabels))
+	maps.Copy(selector, identity)
 	maps.Copy(selector, workloadLabels)
 	return selector
 }
@@ -265,6 +267,10 @@ func PreserveDeploymentReplicas() UpdateOption[*appsv1.Deployment] {
 // spec.selector is immutable, so the value already on the object is the only one the
 // API server accepts. A Deployment keeps the selector it was created with, and a change
 // to how the selector is computed applies only to Deployments created afterwards.
+//
+// The pod template is still rebuilt on every reconcile. A Deployment whose template stops
+// carrying a key its stored selector requires is rejected, since the template no longer
+// matches the selector, and has to be recreated to reconcile again.
 func PreserveDeploymentSelector() UpdateOption[*appsv1.Deployment] {
 	return BeforeDryRun(func(expected, curr *appsv1.Deployment) {
 		if curr.Spec.Selector != nil {

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -127,7 +127,7 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 		Spec: appsv1.DeploymentSpec{
 			Replicas: llmSvc.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: deploymentSelectorLabels(labels, llmSvc.Spec.Labels),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -255,7 +255,7 @@ func (r *LLMISVCReconciler) expectedPrefillMainDeployment(ctx context.Context, l
 		d.Spec = appsv1.DeploymentSpec{
 			Replicas: llmSvc.Spec.Prefill.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: deploymentSelectorLabels(labels, llmSvc.Spec.Prefill.Labels),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -80,7 +80,7 @@ func (r *LLMISVCReconciler) reconcileSingleNodeMainWorkload(ctx context.Context,
 	if err != nil {
 		return fmt.Errorf("failed to get expected main deployment: %w", err)
 	}
-	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, expected, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, expected, semanticDeploymentIsEqual, PreserveDeploymentReplicas(), PreserveDeploymentSelector()); err != nil {
 		return err
 	}
 	return r.propagateWorkloadDeploymentStatus(ctx, expected, llmSvc.MarkMainWorkloadReady, llmSvc.MarkMainWorkloadNotReady)
@@ -220,7 +220,7 @@ func (r *LLMISVCReconciler) reconcileSingleNodePrefill(ctx context.Context, llmS
 	if err != nil {
 		return fmt.Errorf("failed to get expected prefill deployment: %w", err)
 	}
-	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, prefill, semanticDeploymentIsEqual, PreserveDeploymentReplicas()); err != nil {
+	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, prefill, semanticDeploymentIsEqual, PreserveDeploymentReplicas(), PreserveDeploymentSelector()); err != nil {
 		return fmt.Errorf("failed to reconcile prefill deployment %s/%s: %w", prefill.GetNamespace(), prefill.GetName(), err)
 	}
 	return r.propagateWorkloadDeploymentStatus(ctx, prefill, llmSvc.MarkPrefillWorkloadReady, llmSvc.MarkPrefillWorkloadNotReady)

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -131,7 +131,7 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      maps.Clone(labels),
 					Annotations: deploymentAnnotations,
 				},
 			},
@@ -259,7 +259,7 @@ func (r *LLMISVCReconciler) expectedPrefillMainDeployment(ctx context.Context, l
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: maps.Clone(labels),
 				},
 			},
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

The LLMInferenceService Deployment builders assigned a single Go map to `metadata.labels`, `spec.selector.matchLabels` and `spec.template.metadata.labels`. Maps are references, so labels later propagated onto the pod template also landed in `spec.selector`, which is immutable after create.

That swept in the allowlisted `kueue.x-k8s.io/*` labels copied from the LLMInferenceService's own metadata by `propagateDeploymentMetadata`. Those describe queue membership, not pod identity, and change over the object's lifetime. Moving a service to a different LocalQueue or changing its workload priority class left the Deployment permanently unreconcilable:

```
failed to get defaults for v1.Deployment ns/llama-kserve: Deployment.apps "llama-kserve" is invalid: spec.selector: Invalid value: {...}: field is immutable
```

Recovery required deleting and recreating the service. The wrapping in "failed to get defaults for" — it surfaces from the dry-run `Update` in `Update()` — made it hard to attribute.

`TestPropagateDeploymentMetadata` already specified the intended split ("Deployment only gets approved-prefix labels/annotations from top-level metadata"), but it runs the propagation helpers against a hand-built `&appsv1.Deployment{}` whose three label fields are independent nil maps, so the builders themselves were never exercised.

This PR:

1. Builds the selector explicitly from the component's identity labels plus the workload's own `spec.labels`. `spec.labels` deliberately stays in the selector — overriding `app.kubernetes.io/name` through it is how one service's pods join another's InferencePool, per `docs/samples/llmisvc/multi-gpu-vendor`. Labels propagated from top-level metadata now reach the pod template only.
2. Adds `PreserveDeploymentSelector`, which carries the stored selector over on update. Without it, Deployments created before this change would be sent a narrower selector and rejected on every reconcile — a regression introduced by (1). This needs a new `BeforeDryRun` hook, since `AfterDryRun` fires after the dry-run request has already been rejected.
3. Reports which label blocks an update. A Deployment whose pod template stops carrying a label its stored selector requires must be recreated; the error now names the Deployment, the labels, and the remedy instead of passing through the raw API server validation message.

**Feature/Issue validation/testing**:

- [x] `TestDeploymentSelectorExcludesMetadataLabels` — drives the four Deployment builders (main, prefill, scheduler, tokenizer, plus main with an InferencePool ref) and asserts propagated metadata labels reach the pod template but not the selector, that `spec.labels` does override identity in the selector, and that the three label maps are distinct.
- [x] `TestDeploymentSelectorLabels` — selector composition: nil identity, nil workload labels, override precedence, and that the caller's map is not mutated.
- [x] `TestPreserveDeploymentSelector` — with the option the stored selector is sent; without it the update is rejected as immutable.
- [x] `Deployment selector` envtest specs — against a real API server, since `spec.selector` immutability and the template-satisfies-selector rule cannot be exercised with a fake client. One asserts a Deployment whose stored selector the reconciler no longer computes keeps reconciling; the other asserts the targeted error once the pod template stops satisfying it.
- [x] Full `pkg/controller/v1alpha2/llmisvc/...` suite green, including `docsamples`, which validates the multi-gpu-vendor pooling manifests.
- [x] Reproduced on a live minikube cluster before and after: creating an LLMInferenceService with `kueue.x-k8s.io/queue-name` put the label in the Deployment's selector, and changing the queue name wedged reconcile permanently.

Each new test was verified to fail with the fix reverted, not merely to pass with it.

**Special notes for reviewer**:

`spec.labels` staying in the selector is deliberate and load-bearing. An earlier version of this change excluded it, which broke the multi-GPU-vendor pooling test: the AMD service sets `app.kubernetes.io/name` to the NVIDIA service's name so its pods match that InferencePool's selector. With the selector pinned to the service's own identity, the pod template no longer satisfied it and the Deployment was rejected outright. The label is pod identity here, so it belongs in the selector.

Two known limitations, both documented in the code and covered by tests:

- Deployments created before this change keep the queue label in their selector. `PreserveDeploymentSelector` stops the upgrade itself from breaking them, but a queue change on one still fails until the Deployment is recreated. The Kueue suspend design recreates Deployments on admission, so services placed under a queue heal on their own.
- The selector can also carry the match labels of a referenced InferencePool, which is a separate object outside the LLMInferenceService's control. Editing or repointing it has the same effect. This predates the PR — the shared map had those labels in the selector too — but is now explicit.

A recreate-on-drift path would converge both cases. I left it out deliberately: silently deleting a Deployment restarts GPU pods and reloads model weights, so it should be opt-in and reviewed on its own terms. Happy to open a follow-up.

`BeforeDryRunFunc` is exported and gains an error return, which is source-breaking for any out-of-tree implementer. Nothing in tree implements it.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Fixed LLMInferenceService Deployments becoming permanently unreconcilable when a label changed on the service. These labels are no longer written to the Deployment's immutable `spec.selector`. LLMInferenceServices created before this change keep their existing selector: changing a label on one still requires recreating the service, and the reconciler now reports which label is responsible.
```
