### PR TITLE
chore(build): stamp Go toolchain into tool cache key

### DIFF
--- a/Makefile.tools.mk
+++ b/Makefile.tools.mk
@@ -20,6 +20,14 @@ PYTEST = $(PYTHON_BIN)/pytest
 
 ## Tool versions are defined in kserve-deps.env (included in main Makefile)
 
+## Go toolchain stamp, part of the tool cache key below. Tool binaries are
+## built from source with whatever toolchain is active, so a Go upgrade leaves
+## them stale: golangci-lint then refuses to run against a .golangci.yml
+## targeting a Go version newer than the one it was built with.
+## Only major.minor matters here - that is what carries the language version -
+## so patch releases do not force a rebuild of every tool.
+GO_TOOLCHAIN := $(shell go env GOVERSION | cut -d. -f1-2)
+
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(LOCALBIN) $(DEPS_ENV)
@@ -97,16 +105,16 @@ $(PYTEST): $(UV)
 # $2 - package url which can be installed
 # $3 - specific version of package
 define go-install-tool
-@[ -f "$(1)-$(3)" ] || { \
+@[ -f "$(1)-$(3)-$(GO_TOOLCHAIN)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-rm -f $(1) || true ;\
+rm -f $(1)-$(3)* $(1) || true ;\
 GOBIN=$(LOCALBIN) go install $${package} ;\
 go mod tidy ;\
-mv $(1) $(1)-$(3) ;\
+mv $(1) $(1)-$(3)-$(GO_TOOLCHAIN) ;\
 } ;\
-ln -sf $(1)-$(3) $(1)
+ln -sf $(1)-$(3)-$(GO_TOOLCHAIN) $(1)
 endef
 
 # This clears all the installed binaries.


### PR DESCRIPTION
**What this PR does / why we need it**:

Tool binaries under `bin/` are built from source by `go-install-tool`, but the cache key only carried the tool version. A Go upgrade therefore left them in place, still built with the old toolchain. After #6127 bumped the repo to Go 1.26, `make go-lint` started failing on any checkout that already had a golangci-lint binary:

```
can't load config: the Go language version (go1.25) used to build golangci-lint
is lower than the targeted Go version (1.26)
```

The pinned version was fine - rebuilding the same `v2.9.0` under Go 1.26 works. The binary was just stale, and the only way out was a manual `make clean`.

Adding the toolchain's `major.minor` to the key to make builds reproducible.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] `make go-lint` on a checkout carrying a `go1.25.8`-built golangci-lint - rebuilds under go1.26.8, lints clean (0 issues across `.`, `qpext`, `kernelcache/mcv`)

**Special notes for your reviewer**:

Every `go-install-tool` consumer picks this up, so the first build after a Go minor bump rebuilds all of them - controller-gen, kustomize, yq and friends. That is the point, but it does make that one build slower.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
NONE
```
