### PR TITLE
fix(llmisvc): match group backends by their referenced pool

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router_group.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group.go
@@ -51,18 +51,17 @@ type resolvedMember struct {
 // setupGroupFieldIndex registers a field indexer on spec.router.route.group
 // for efficient group member discovery without listing all LLMISVCs in a namespace.
 func setupGroupFieldIndex(ctx context.Context, mgr client.FieldIndexer) error {
-	return mgr.IndexField(
-		ctx,
-		&v1alpha2.LLMInferenceService{},
-		groupFieldIndex,
-		func(obj client.Object) []string {
-			llmSvc := obj.(*v1alpha2.LLMInferenceService)
-			if g := llmSvc.Spec.Router.Group(); g != nil {
-				return []string{llmSvc.Namespace + "/" + *g}
-			}
-			return nil
-		},
-	)
+	return mgr.IndexField(ctx, &v1alpha2.LLMInferenceService{}, groupFieldIndex, groupIndexValue)
+}
+
+// groupIndexValue keys an LLMInferenceService by its namespace and group so
+// members are looked up without listing the whole namespace.
+func groupIndexValue(obj client.Object) []string {
+	llmSvc := obj.(*v1alpha2.LLMInferenceService)
+	if g := llmSvc.Spec.Router.Group(); g != nil {
+		return []string{llmSvc.Namespace + "/" + *g}
+	}
+	return nil
 }
 
 // injectGroupBackendRefs post-processes the template-rendered HTTPRoute to add
@@ -227,9 +226,6 @@ func (r *LLMISVCReconciler) finalizeGroupMembership(ctx context.Context, llmSvc 
 		return false, fmt.Errorf("finalizing group membership: %w", err)
 	}
 
-	poolName := (&v1alpha2.SchedulerSpec{}).InferencePoolName(llmSvc)
-	svcName := workloadServiceName(llmSvc)
-
 	for i := range members {
 		if members[i].Name == llmSvc.Name || !members[i].DeletionTimestamp.IsZero() {
 			continue
@@ -245,9 +241,9 @@ func (r *LLMISVCReconciler) finalizeGroupMembership(ctx context.Context, llmSvc 
 			}
 			return false, fmt.Errorf("checking member route %s for stale backendRefs: %w", routeKey.Name, err)
 		}
-		if routeReferencesBackend(route, poolName) || routeReferencesBackend(route, svcName) {
+		if routeReferencesMember(route, llmSvc) {
 			logger.Info("Waiting for member to remove backendRef before deletion",
-				"member", members[i].Name, "pool", poolName)
+				"member", members[i].Name)
 			llmSvc.MarkGroupNotReady(reasonFinalizationPending,
 				"waiting for member %s to remove backendRef before deletion", members[i].Name)
 			return false, nil
@@ -257,15 +253,29 @@ func (r *LLMISVCReconciler) finalizeGroupMembership(ctx context.Context, llmSvc 
 	return true, nil
 }
 
-func routeReferencesBackend(route *gwapiv1.HTTPRoute, backendName string) bool {
+// routeReferencesMember reports whether any rule still carries a backendRef for
+// member's backend.
+func routeReferencesMember(route *gwapiv1.HTTPRoute, member *v1alpha2.LLMInferenceService) bool {
 	for _, rule := range route.Spec.Rules {
 		for _, ref := range rule.BackendRefs {
-			if string(ref.Name) == backendName {
+			if backendRefersTo(ref, route.Namespace, member) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+// backendRefersTo reports whether ref addresses one of member's backends.
+// Backend identity comes from isExpectedBackendRef, the same matcher the group
+// rewrite uses, so an explicitly referenced InferencePool is recognised here too.
+// The namespace guard is additional: a ref may name another namespace's
+// identically named backend.
+func backendRefersTo(ref gwapiv1.HTTPBackendRef, routeNamespace string, member *v1alpha2.LLMInferenceService) bool {
+	if ptr.Deref(ref.Namespace, gwapiv1.Namespace(routeNamespace)) != gwapiv1.Namespace(member.Namespace) {
+		return false
+	}
+	return isExpectedBackendRef(member, ref.BackendRef)
 }
 
 // listGroupMembers returns all LLMISVCs in the same namespace with the same group.

--- a/pkg/controller/v1alpha2/llmisvc/router_group.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group.go
@@ -272,7 +272,12 @@ func routeReferencesMember(route *gwapiv1.HTTPRoute, member *v1alpha2.LLMInferen
 // The namespace guard is additional: a ref may name another namespace's
 // identically named backend.
 func backendRefersTo(ref gwapiv1.HTTPBackendRef, routeNamespace string, member *v1alpha2.LLMInferenceService) bool {
-	if ptr.Deref(ref.Namespace, gwapiv1.Namespace(routeNamespace)) != gwapiv1.Namespace(member.Namespace) {
+	// An unset or empty namespace means the route's own namespace.
+	refNamespace := string(ptr.Deref(ref.Namespace, ""))
+	if refNamespace == "" {
+		refNamespace = routeNamespace
+	}
+	if refNamespace != member.Namespace {
 		return false
 	}
 	return isExpectedBackendRef(member, ref.BackendRef)

--- a/pkg/controller/v1alpha2/llmisvc/router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_test.go
@@ -754,6 +754,12 @@ func TestFinalizeGroupMembership(t *testing.T) {
 		}
 	}
 
+	peerRouteInNamespace := func(backend, namespace string) *gwapiv1.HTTPRoute {
+		route := peerRoute(backend)
+		route.Spec.Rules[0].BackendRefs[0].Namespace = ptr.To(gwapiv1.Namespace(namespace))
+		return route
+	}
+
 	for _, tt := range []struct {
 		name      string
 		route     *gwapiv1.HTTPRoute
@@ -763,6 +769,8 @@ func TestFinalizeGroupMembership(t *testing.T) {
 		wantErr   bool
 	}{
 		{name: "peer released the backend", route: peerRoute("peer-kserve-workload-svc"), converged: true},
+		{name: "peer references the backend with an empty namespace", route: peerRouteInNamespace(workloadServiceName(deleting), "")},
+		{name: "peer references the backend in another namespace", route: peerRouteInNamespace(workloadServiceName(deleting), "elsewhere"), converged: true},
 		{name: "peer still references the backend", route: peerRoute(workloadServiceName(deleting))},
 		// The injected backendRef carries the referenced pool name, not the
 		// default one, so matching on the default alone would wrongly converge.

--- a/pkg/controller/v1alpha2/llmisvc/router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_test.go
@@ -17,14 +17,23 @@ limitations under the License.
 package llmisvc
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	v1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -658,54 +667,6 @@ func TestResolveMemberBackendRef(t *testing.T) {
 	}
 }
 
-func TestRouteReferencesBackend(t *testing.T) {
-	tests := []struct {
-		name    string
-		route   *gwapiv1.HTTPRoute
-		backend string
-		want    bool
-	}{
-		{
-			name: "match in first rule",
-			route: &gwapiv1.HTTPRoute{Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{
-				{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "pool-a"}}}}},
-			}}},
-			backend: "pool-a",
-			want:    true,
-		},
-		{
-			name: "no match",
-			route: &gwapiv1.HTTPRoute{Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{
-				{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "pool-a"}}}}},
-			}}},
-			backend: "pool-b",
-			want:    false,
-		},
-		{
-			name:    "empty rules",
-			route:   &gwapiv1.HTTPRoute{},
-			backend: "pool-a",
-			want:    false,
-		},
-		{
-			name: "match in second rule",
-			route: &gwapiv1.HTTPRoute{Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{
-				{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "pool-a"}}}}},
-				{BackendRefs: []gwapiv1.HTTPBackendRef{{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{Name: "pool-b"}}}}},
-			}}},
-			backend: "pool-b",
-			want:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, routeReferencesBackend(tt.route, tt.backend))
-		})
-	}
-}
-
-// memberSvc creates a minimal LLMInferenceService for group testing.
 func routableMember(name, group string, weight int32, ts metav1.Time) v1alpha2.LLMInferenceService {
 	svc := memberSvc(name, group, weight, false, ts)
 	svc.Status.SetConditions(apis.Conditions{{
@@ -749,4 +710,108 @@ func memberSvc(name, group string, weight int32, stopped bool, ts metav1.Time) v
 		}
 	}
 	return svc
+}
+
+func TestFinalizeGroupMembership(t *testing.T) {
+	const group = "group"
+	deleting := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "leaving", Namespace: "ns", DeletionTimestamp: ptr.To(metav1.Now()),
+			Finalizers: []string{"test-finalizer"},
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To(group)}},
+		},
+	}
+	peer := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "peer", Namespace: "ns"},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To(group)}},
+		},
+	}
+	peerPoolRoute := func(poolName string) *gwapiv1.HTTPRoute {
+		return &gwapiv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: kmeta.ChildName(peer.Name, "-kserve-route"), Namespace: peer.Namespace},
+			Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{{BackendRefs: []gwapiv1.HTTPBackendRef{{
+				BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+					Group: ptr.To(gwapiv1.Group(constants.InferencePoolV1Alpha2APIGroupName)),
+					Kind:  ptr.To(gwapiv1.Kind("InferencePool")),
+					Name:  gwapiv1.ObjectName(poolName),
+				}},
+			}}}}},
+		}
+	}
+	peerRoute := func(backends ...string) *gwapiv1.HTTPRoute {
+		refs := make([]gwapiv1.HTTPBackendRef, 0, len(backends))
+		for _, name := range backends {
+			refs = append(refs, gwapiv1.HTTPBackendRef{BackendRef: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{Name: gwapiv1.ObjectName(name)},
+			}})
+		}
+		return &gwapiv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: kmeta.ChildName(peer.Name, "-kserve-route"), Namespace: peer.Namespace},
+			Spec:       gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{{BackendRefs: refs}}},
+		}
+	}
+
+	for _, tt := range []struct {
+		name      string
+		route     *gwapiv1.HTTPRoute
+		poolRef   string
+		getErr    error
+		converged bool
+		wantErr   bool
+	}{
+		{name: "peer released the backend", route: peerRoute("peer-kserve-workload-svc"), converged: true},
+		{name: "peer still references the backend", route: peerRoute(workloadServiceName(deleting))},
+		// The injected backendRef carries the referenced pool name, not the
+		// default one, so matching on the default alone would wrongly converge.
+		{name: "peer still references an explicitly referenced pool", route: peerPoolRoute("user-pool"), poolRef: "user-pool"},
+		{name: "peer released an explicitly referenced pool", route: peerRoute("peer-kserve-workload-svc"), poolRef: "user-pool", converged: true},
+		{name: "peer has no route yet", converged: true},
+		{
+			name: "peer route read denied",
+			getErr: apierrors.NewForbidden(
+				schema.GroupResource{Group: gwapiv1.GroupName, Resource: "httproutes"}, "route", errors.New("denied")),
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, v1alpha2.AddToScheme(scheme))
+			require.NoError(t, gwapiv1.Install(scheme))
+
+			builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deleting, peer).
+				WithIndex(&v1alpha2.LLMInferenceService{}, groupFieldIndex, groupIndexValue)
+			if tt.route != nil {
+				builder = builder.WithObjects(tt.route)
+			}
+			if tt.getErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*gwapiv1.HTTPRoute); ok {
+							return tt.getErr
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				})
+			}
+
+			leaving := deleting.DeepCopy()
+			if tt.poolRef != "" {
+				leaving.Spec.Router.Scheduler = &v1alpha2.SchedulerSpec{
+					Pool: &v1alpha2.InferencePoolSpec{Ref: &corev1.LocalObjectReference{Name: tt.poolRef}},
+				}
+			}
+
+			r := &LLMISVCReconciler{Client: builder.Build()}
+			done, err := r.finalizeGroupMembership(t.Context(), leaving)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.converged, done)
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Group membership checks ignored a member's explicitly referenced InferencePool.

A member configured with `scheduler.pool.ref` gets that pool injected as its `backendRef`, but the finalizer looked for the default pool name instead. The check therefore never matched, concluded the group had converged, and let deletion finish while a surviving peer still routed to a pool that no longer exists. 

This PR aligns membership matching with the matcher the group rewrite already uses.

Also tightens matching to the backend's namespace, so an identically named backend elsewhere is no longer mistaken for a member's own.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] Unit coverage for group finalization against a member using `scheduler.pool.ref`, both while a peer still references that pool and after it releases it. Reverting the fix fails the first case.
- [x] Full `pkg/apis/serving/v1alpha2` and `pkg/controller/v1alpha2` suites, plus `make precommit`.

**Special notes for your reviewer**:


No configuration flag, API change, or manifest migration.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? - not user-facing

**Release note**:
```release-note
NONE
```
