### PR TITLE
fix(localmodel): reject downloads that exceed available storage

### DIFF
--- a/charts/kserve-localmodel-resources/files/resources.yaml
+++ b/charts/kserve-localmodel-resources/files/resources.yaml
@@ -156,10 +156,21 @@ rules:
   - serving.kserve.io
   resources:
   - clusterstoragecontainers
+  - localmodelcaches
+  - localmodelnamespacecaches
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
   - localmodelnodegroups
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - serving.kserve.io

--- a/config/rbac/localmodelnode/role.yaml
+++ b/config/rbac/localmodelnode/role.yaml
@@ -49,10 +49,21 @@ rules:
   - serving.kserve.io
   resources:
   - clusterstoragecontainers
+  - localmodelcaches
+  - localmodelnamespacecaches
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
   - localmodelnodegroups
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - serving.kserve.io

--- a/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/localmodel-full-install-with-manifests.sh
@@ -6750,10 +6750,21 @@ rules:
   - serving.kserve.io
   resources:
   - clusterstoragecontainers
+  - localmodelcaches
+  - localmodelnamespacecaches
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
   - localmodelnodegroups
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - serving.kserve.io

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kubebuilder:rbac:groups=serving.kserve.io,resources=localmodelnodegroups,verbs=get;list;watch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=localmodelnodegroups,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=localmodelcaches;localmodelnamespacecaches,verbs=get;list;watch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=clusterstoragecontainers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=localmodelnodes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=localmodelnodes/status,verbs=get;update;patch
@@ -39,6 +40,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -114,19 +116,97 @@ func (c *LocalModelNodeReconciler) getNodeGroupFromNode(ctx context.Context, nod
 	return nil, fmt.Errorf("did not find matching nodegroup for node: %s", nodeName)
 }
 
+func (c *LocalModelNodeReconciler) getNodeGroup(ctx context.Context, modelInfo v1alpha1.LocalModelInfo) (*v1alpha1.LocalModelNodeGroup, error) {
+	if modelInfo.NodeGroup == "" {
+		return c.getNodeGroupFromNode(ctx, nodeName)
+	}
+	nodeGroup := &v1alpha1.LocalModelNodeGroup{}
+	if err := c.Get(ctx, types.NamespacedName{Name: modelInfo.NodeGroup}, nodeGroup); err != nil {
+		return nil, err
+	}
+	return nodeGroup, nil
+}
+
+func (c *LocalModelNodeReconciler) getModelSize(ctx context.Context, modelInfo v1alpha1.LocalModelInfo) (resource.Quantity, bool, error) {
+	if modelInfo.Namespace == "" {
+		cache := &v1alpha1.LocalModelCache{}
+		if err := c.Get(ctx, types.NamespacedName{Name: modelInfo.ModelName}, cache); err != nil {
+			if errors.IsNotFound(err) {
+				return resource.Quantity{}, false, nil
+			}
+			return resource.Quantity{}, false, err
+		}
+		return cache.Spec.ModelSize.DeepCopy(), true, nil
+	}
+
+	cache := &v1alpha1.LocalModelNamespaceCache{}
+	if err := c.Get(ctx, types.NamespacedName{Name: modelInfo.ModelName, Namespace: modelInfo.Namespace}, cache); err != nil {
+		if errors.IsNotFound(err) {
+			return resource.Quantity{}, false, nil
+		}
+		return resource.Quantity{}, false, err
+	}
+	return cache.Spec.ModelSize.DeepCopy(), true, nil
+}
+
+func (c *LocalModelNodeReconciler) availableStorage(ctx context.Context, modelInfo v1alpha1.LocalModelInfo, availableByNodeGroup map[string]resource.Quantity) (*v1alpha1.LocalModelNodeGroup, resource.Quantity, error) {
+	nodeGroup, err := c.getNodeGroup(ctx, modelInfo)
+	if err != nil {
+		return nil, resource.Quantity{}, err
+	}
+	if available, ok := availableByNodeGroup[nodeGroup.Name]; ok {
+		return nodeGroup, available.DeepCopy(), nil
+	}
+
+	used, filesystemAvailable, err := fsHelper.getStorageUsage()
+	if err != nil {
+		return nil, resource.Quantity{}, err
+	}
+	available := nodeGroup.Spec.StorageLimit.DeepCopy()
+	available.Sub(used)
+	if available.Sign() < 0 {
+		available.Set(0)
+	}
+	if filesystemAvailable.Cmp(available) < 0 {
+		available = filesystemAvailable.DeepCopy()
+	}
+	if nodeGroup.Status.Used.Cmp(used) != 0 || nodeGroup.Status.Available.Cmp(available) != 0 {
+		nodeGroup.Status.Used = used.DeepCopy()
+		nodeGroup.Status.Available = available.DeepCopy()
+		if err := c.Update(ctx, nodeGroup); err != nil {
+			return nil, resource.Quantity{}, err
+		}
+	}
+	availableByNodeGroup[nodeGroup.Name] = available.DeepCopy()
+	return nodeGroup, available, nil
+}
+
+func (c *LocalModelNodeReconciler) reserveStorageForDownload(ctx context.Context, modelInfo v1alpha1.LocalModelInfo, availableByNodeGroup map[string]resource.Quantity) error {
+	nodeGroup, available, err := c.availableStorage(ctx, modelInfo, availableByNodeGroup)
+	if err != nil {
+		return err
+	}
+	modelSize, found, err := c.getModelSize(ctx, modelInfo)
+	if err != nil || !found {
+		return err
+	}
+	if modelSize.Cmp(available) > 0 {
+		return fmt.Errorf("model %q requires %s but node group %q has only %s available", modelInfo.ModelName, modelSize.String(), nodeGroup.Name, available.String())
+	}
+	available.Sub(modelSize)
+	availableByNodeGroup[nodeGroup.Name] = available.DeepCopy()
+	return nil
+}
+
 func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode v1alpha1.LocalModelNode, modelInfo v1alpha1.LocalModelInfo) (*batchv1.Job, error) {
 	jobName := modelInfo.ModelName + "-" + localModelNode.Name
 
-	// Use NodeGroup from modelInfo if set, otherwise fall back to getNodeGroupFromNode
-	nodeGroupName := modelInfo.NodeGroup
-	if nodeGroupName == "" {
-		nodeGroup, err := c.getNodeGroupFromNode(ctx, nodeName)
-		if nodeGroup == nil {
-			c.Log.Error(err, "Failed to get node group for current node", "node name", nodeName)
-			return nil, err
-		}
-		nodeGroupName = nodeGroup.Name
+	nodeGroup, err := c.getNodeGroup(ctx, modelInfo)
+	if err != nil {
+		c.Log.Error(err, "Failed to get node group for current node", "node name", nodeName)
+		return nil, err
 	}
+	nodeGroupName := nodeGroup.Name
 
 	pvcName := modelInfo.ModelName + "-" + nodeGroupName
 	if modelInfo.Namespace != "" {
@@ -350,11 +430,16 @@ func (c *LocalModelNodeReconciler) downloadModels(ctx context.Context, localMode
 	newStatus := map[string]v1alpha1.ModelStatus{}
 	// Track which storage keys (URI hashes) have been processed for download deduplication
 	processedStorageKeys := map[string]v1alpha1.ModelStatus{}
+	availableByNodeGroup := map[string]resource.Quantity{}
 
 	for _, modelInfo := range localModelNode.Spec.LocalModels {
 		statusKey := modelInfo.GetStatusKey()
 		storageKey := v1alpha1.GetStorageKey(modelInfo.SourceModelUri)
 		c.Log.Info("checking model from spec", "model", modelInfo.ModelName, "namespace", modelInfo.Namespace, "statusKey", statusKey, "storageKey", storageKey)
+		if _, _, err := c.availableStorage(ctx, modelInfo, availableByNodeGroup); err != nil {
+			c.Log.Error(err, "Failed to get available storage", "model", modelInfo.ModelName)
+			return err
+		}
 
 		// Check if another CR with the same URI has already been processed
 		// If so, reuse its status (storage deduplication - same folder on disk)
@@ -389,6 +474,9 @@ func (c *LocalModelNodeReconciler) downloadModels(ctx context.Context, localMode
 			// If job is not found, create a new one. Because download could be incomplete.
 			if job == nil {
 				c.Log.Info("Model folder exists, creating download job", "model", modelInfo.ModelName, "storageKey", storageKey)
+				if err := c.reserveStorageForDownload(ctx, modelInfo, availableByNodeGroup); err != nil {
+					return err
+				}
 				job, err = c.launchJob(ctx, *localModelNode, modelInfo)
 				if err != nil {
 					c.Log.Error(err, "Failed to create Job", "model", modelInfo.ModelName, "node", nodeName)
@@ -416,6 +504,9 @@ func (c *LocalModelNodeReconciler) downloadModels(ctx context.Context, localMode
 			// To retry the download, users can manually fix the issue and delete the failed job.
 			// Add the job count check for protection to ensure not creating more than 2 jobs including the previous one.
 			if job == nil || (job.Status.Succeeded > 0 && jobCount < 2) {
+				if err := c.reserveStorageForDownload(ctx, modelInfo, availableByNodeGroup); err != nil {
+					return err
+				}
 				job, err = c.launchJob(ctx, *localModelNode, modelInfo)
 				if err != nil {
 					c.Log.Error(err, "Failed to create job", "model", modelInfo.ModelName, "node", nodeName)

--- a/pkg/controller/v1alpha1/localmodelnode/controller_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller_test.go
@@ -53,6 +53,8 @@ type mockFileSystem struct {
 	FileSystemInterface
 	// represents the dirs under models root
 	subDirs []os.DirEntry
+	used    resource.Quantity
+	free    resource.Quantity
 }
 
 func (f *mockFileSystem) removeModel(model string) error {
@@ -92,14 +94,20 @@ func (f *mockFileSystem) ensureModelRootFolderExists() error {
 	return nil
 }
 
+func (f *mockFileSystem) getStorageUsage() (resource.Quantity, resource.Quantity, error) {
+	return f.used.DeepCopy(), f.free.DeepCopy(), nil
+}
+
 func (f *mockFileSystem) clear() {
 	f.subDirs = []os.DirEntry{}
+	f.used = resource.MustParse("0")
+	f.free = resource.MustParse("100Gi")
 }
 
 func newMockFileSystem() *mockFileSystem {
-	return &mockFileSystem{
-		subDirs: []os.DirEntry{},
-	}
+	fs := &mockFileSystem{}
+	fs.clear()
+	return fs
 }
 
 var _ = Describe("LocalModelNode controller", func() {
@@ -134,6 +142,7 @@ var _ = Describe("LocalModelNode controller", func() {
 			},
 		}
 		localModelNodeGroupSpec = v1alpha1.LocalModelNodeGroupSpec{
+			StorageLimit: resource.MustParse("10Gi"),
 			PersistentVolumeSpec: corev1.PersistentVolumeSpec{
 				AccessModes:                   []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				VolumeMode:                    ptr.To(corev1.PersistentVolumeFilesystem),
@@ -256,6 +265,13 @@ var _ = Describe("LocalModelNode controller", func() {
 				return err == nil && len(jobs.Items) == 1
 			}, timeout, interval).Should(BeTrue(), "Download job should be created")
 
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeGroup.Name}, nodeGroup); err != nil {
+					return false
+				}
+				return nodeGroup.Status.Used.Cmp(fsMock.used) == 0 && nodeGroup.Status.Available.Cmp(resource.MustParse("10Gi")) == 0
+			}, timeout, interval).Should(BeTrue(), "Node group should report observed storage usage")
+
 			// Now let's update the job status to be successful
 			fsMock.mockModel(&MockFileInfo{name: storageKey, isDir: true})
 			job := &jobs.Items[0]
@@ -293,6 +309,87 @@ var _ = Describe("LocalModelNode controller", func() {
 				return !ok
 			}, timeout, interval).Should(BeTrue(), "Model should be removed from the status field")
 		})
+
+		It("Should not create a download job when the model does not fit", func() {
+			ctx := context.Background()
+			fsMock.clear()
+			fsMock.used = resource.MustParse("9Gi")
+			fsMock.free = resource.MustParse("1Gi")
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(ctx, configMap)).Should(Succeed())
+			defer k8sClient.Delete(ctx, configMap)
+
+			clusterStorageContainer := &v1alpha1.ClusterStorageContainer{
+				ObjectMeta: metav1.ObjectMeta{Name: "capacity-test"},
+				Spec:       clusterStorageContainerSpec,
+			}
+			Expect(k8sClient.Create(ctx, clusterStorageContainer)).Should(Succeed())
+			defer k8sClient.Delete(ctx, clusterStorageContainer)
+
+			nodeGroup := &v1alpha1.LocalModelNodeGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "capacity-nodegroup"},
+				Spec:       localModelNodeGroupSpec,
+			}
+			Expect(k8sClient.Create(ctx, nodeGroup)).Should(Succeed())
+			defer k8sClient.Delete(ctx, nodeGroup)
+
+			modelCache := &v1alpha1.LocalModelCache{
+				ObjectMeta: metav1.ObjectMeta{Name: "capacity-model"},
+				Spec: v1alpha1.LocalModelCacheSpec{
+					SourceModelUri: sourceModelUri,
+					ModelSize:      resource.MustParse("2Gi"),
+					NodeGroups:     []string{nodeGroup.Name},
+				},
+			}
+			Expect(k8sClient.Create(ctx, modelCache)).Should(Succeed())
+			defer k8sClient.Delete(ctx, modelCache)
+
+			nodeName = "capacity-worker"
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": "gpu",
+					},
+				},
+				Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}},
+			}
+			Expect(k8sClient.Create(ctx, node)).Should(Succeed())
+			defer k8sClient.Delete(ctx, node)
+
+			localModelNode := &v1alpha1.LocalModelNode{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Spec: v1alpha1.LocalModelNodeSpec{LocalModels: []v1alpha1.LocalModelInfo{{
+					SourceModelUri: sourceModelUri,
+					ModelName:      modelCache.Name,
+					NodeGroup:      nodeGroup.Name,
+				}}},
+			}
+			Expect(k8sClient.Create(ctx, localModelNode)).Should(Succeed())
+			defer k8sClient.Delete(ctx, localModelNode)
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeGroup.Name}, nodeGroup); err != nil {
+					return false
+				}
+				return nodeGroup.Status.Used.Cmp(fsMock.used) == 0 && nodeGroup.Status.Available.Cmp(fsMock.free) == 0
+			}, timeout, interval).Should(BeTrue(), "Node group should report storage before rejecting the download")
+
+			jobs := &batchv1.JobList{}
+			labelSelector := map[string]string{"model": modelCache.Name, "node": nodeName}
+			Consistently(func() int {
+				Expect(k8sClient.List(ctx, jobs, client.InNamespace(jobNamespace), client.MatchingLabels(labelSelector))).To(Succeed())
+				return len(jobs.Items)
+			}, duration, interval).Should(Equal(0), "Download job should not be created when model size exceeds available storage")
+		})
+
 		It("Should use storageKey hash as the download job SubPath for storage deduplication", func() {
 			ctx := context.Background()
 			fsMock.clear()

--- a/pkg/controller/v1alpha1/localmodelnode/file_utils.go
+++ b/pkg/controller/v1alpha1/localmodelnode/file_utils.go
@@ -18,15 +18,21 @@ package localmodelnode
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
+	"syscall"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type FileSystemInterface interface {
 	removeModel(modelName string) error
 	hasModelFolder(modelName string) (bool, error)
 	getModelFolders() ([]os.DirEntry, error)
+	getStorageUsage() (resource.Quantity, resource.Quantity, error)
 	ensureModelRootFolderExists() error
 }
 
@@ -59,6 +65,40 @@ func (f *FileSystemHelper) getModelFolders() ([]os.DirEntry, error) {
 		return nil, err
 	}
 	return entries, nil
+}
+
+func (f *FileSystemHelper) getStorageUsage() (resource.Quantity, resource.Quantity, error) {
+	var used int64
+	if err := filepath.WalkDir(f.modelsRootFolder, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		used += info.Size()
+		return nil
+	}); err != nil {
+		return resource.Quantity{}, resource.Quantity{}, err
+	}
+
+	var stats syscall.Statfs_t
+	if err := syscall.Statfs(f.modelsRootFolder, &stats); err != nil {
+		return resource.Quantity{}, resource.Quantity{}, err
+	}
+	if stats.Bsize <= 0 {
+		return resource.Quantity{}, resource.Quantity{}, fmt.Errorf("invalid filesystem block size: %d", stats.Bsize)
+	}
+	blockSize := uint64(stats.Bsize)
+	if stats.Bavail > uint64(math.MaxInt64)/blockSize {
+		return resource.Quantity{}, resource.Quantity{}, errors.New("available filesystem storage exceeds supported quantity")
+	}
+	available := int64(stats.Bavail * blockSize) //nolint:gosec // G115: bounds check above ensures the value fits int64.
+	return *resource.NewQuantity(used, resource.BinarySI), *resource.NewQuantity(available, resource.BinarySI), nil
 }
 
 func (f *FileSystemHelper) hasModelFolder(modelName string) (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the local model node agent to report the model-cache storage it observes in `LocalModelNodeGroup.status.used` and `status.available`.

Before creating a download Job, the agent now compares the cache's declared `modelSize` with that available capacity. Downloads that cannot fit are rejected before the Job reaches the storage initializer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6137

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/controller/v1alpha1/localmodelnode -run TestAPIs -count=1`
- [x] `make precommit` through Go vet/lint, Python format/lint, shell lint, and e2e collection; its Python SDK generator is CI-only here because a Java runtime is unavailable.

**Special notes for your reviewer**:

The node agent resolves `modelSize` from the existing cache object, so this keeps the LocalModelNode API unchanged. Available capacity is the lower of free filesystem space and the node group's remaining `storageLimit`.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Local model downloads now stop before creating a Job when the declared model size exceeds available node group capacity. LocalModelNodeGroup status reports observed used and available cache storage.
```
