### PR TITLE
fix(llmisvc): expose scheduler references without routing

### DIFF
--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types.go
@@ -812,8 +812,8 @@ type ObservedSchedulerStatus struct {
 }
 
 // RouterStatus records the networking resources observed during the last
-// successful routing reconciliation. Nil when routing is not configured or
-// the service is stopped.
+// successful routing reconciliation.
+// Nil when the service is stopped or neither a route nor a scheduler is configured.
 type RouterStatus struct {
 	// Gateways lists the Gateway resources observed as attached to this service,
 	// each with the listeners and HTTPRoutes bound through them.
@@ -970,7 +970,7 @@ type LLMInferenceServiceStatus struct {
 	Addresses []SourcedAddress `json:"addresses,omitempty"`
 
 	// Router records the observed networking topology for this service.
-	// Nil when routing is not configured or the service is stopped.
+	// Nil when the service is stopped or neither a route nor a scheduler is configured.
 	// +optional
 	Router *RouterStatus `json:"router,omitempty"`
 

--- a/pkg/controller/v1alpha2/llmisvc/controller_handlers_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_handlers_test.go
@@ -125,9 +125,9 @@ func TestHasRoutingHTTPRouteRefReturnsFalseWithoutObservedRoutes(t *testing.T) {
 	}, gwapiv1.ObjectName("llm-route"), "routing")).To(BeFalse())
 }
 
-func TestSetRoutingPoolStatusOnlyWritesWhenRoutingExists(t *testing.T) {
+// TestSetRoutingPoolStatusInitializesRouterWhenNeeded publishes pool refs and allocates router status.
+func TestSetRoutingPoolStatusInitializesRouterWhenNeeded(t *testing.T) {
 	g := NewGomegaWithT(t)
-	llmSvc := &v1alpha2.LLMInferenceService{}
 	poolRef := gwapiv1.ObjectReference{
 		Group: "inference.networking.k8s.io",
 		Kind:  "InferencePool",
@@ -137,27 +137,36 @@ func TestSetRoutingPoolStatusOnlyWritesWhenRoutingExists(t *testing.T) {
 		Kind: "Service",
 		Name: "epp-service",
 	}
+	expectedScheduler := &v1alpha2.ObservedSchedulerStatus{
+		InferencePool: &poolRef,
+		Service:       &svcRef,
+	}
 
-	setRoutingPoolStatus(llmSvc, poolRef, svcRef)
-	g.Expect(llmSvc.Status.Router).To(BeNil())
+	empty := &v1alpha2.LLMInferenceService{}
+	setRoutingPoolStatus(empty, poolRef, svcRef)
+	g.Expect(empty.Status.Router).ToNot(BeNil())
+	g.Expect(empty.Status.Router.Gateways).To(BeEmpty())
+	g.Expect(empty.Status.Router.Scheduler).To(Equal(expectedScheduler))
 
-	llmSvc.Status.Router = &v1alpha2.RouterStatus{
-		Gateways: []v1alpha2.ObservedGateway{
-			{
-				ObjectReference: gwapiv1.ObjectReference{
-					Group: "gateway.networking.k8s.io",
-					Kind:  "Gateway",
-					Name:  "kserve-gateway",
+	preSeeded := &v1alpha2.LLMInferenceService{
+		Status: v1alpha2.LLMInferenceServiceStatus{
+			Router: &v1alpha2.RouterStatus{
+				Gateways: []v1alpha2.ObservedGateway{
+					{
+						ObjectReference: gwapiv1.ObjectReference{
+							Group: "gateway.networking.k8s.io",
+							Kind:  "Gateway",
+							Name:  "kserve-gateway",
+						},
+					},
 				},
 			},
 		},
 	}
-	setRoutingPoolStatus(llmSvc, poolRef, svcRef)
-	g.Expect(llmSvc.Status.Router).ToNot(BeNil())
-	g.Expect(llmSvc.Status.Router.Scheduler.InferencePool).ToNot(BeNil())
-	g.Expect(string(llmSvc.Status.Router.Scheduler.InferencePool.Name)).To(Equal("managed-pool"))
-	g.Expect(llmSvc.Status.Router.Scheduler.Service).ToNot(BeNil())
-	g.Expect(string(llmSvc.Status.Router.Scheduler.Service.Name)).To(Equal("epp-service"))
+	setRoutingPoolStatus(preSeeded, poolRef, svcRef)
+	g.Expect(preSeeded.Status.Router.Gateways).To(HaveLen(1))
+	g.Expect(string(preSeeded.Status.Router.Gateways[0].Name)).To(Equal("kserve-gateway"))
+	g.Expect(preSeeded.Status.Router.Scheduler).To(Equal(expectedScheduler))
 }
 
 func TestRequestsForInferencePoolChangeMatchesExternalPoolRefs(t *testing.T) {

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_routing_status_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_routing_status_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/client-go/util/retry"
+	"knative.dev/pkg/kmeta"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -308,6 +309,52 @@ var _ = Describe("Routing Status", func() {
 						g.Expect(modelNames).To(ContainElement("adapter-1"))
 					}
 				}
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Managed scheduler without route or gateway refs", func() {
+		It("publishes status.router.scheduler without a managed HTTPRoute", func(ctx SpecContext) {
+			svcName := "test-status-probe"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithReplicas(1),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			poolName := kmeta.ChildName(svcName, "-inference-pool")
+			eppName := kmeta.ChildName(svcName, "-epp-service")
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				g.Expect(current.Spec.Router).ToNot(BeNil())
+				g.Expect(current.Spec.Router.Scheduler).ToNot(BeNil(), "admission must keep scheduler: {}")
+				g.Expect(current.Spec.Router.Route).To(BeNil(), "admission must not inject spec.router.route")
+				g.Expect(current.Spec.Router.Gateway).To(BeNil(), "admission must not inject spec.router.gateway")
+
+				// Reconcile merges presets onto an in-memory spec. Stored Route/Gateway nil
+				// does not prove routing stayed absent during reconciliation.
+				routes, err := managedRoutes(ctx, current)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(BeEmpty(), "controller must not create a managed HTTPRoute")
+
+				g.Expect(current.Status.Router).ToNot(BeNil())
+				g.Expect(current.Status.Router.Gateways).To(BeEmpty())
+				g.Expect(current.Status.Router.Group).To(BeNil())
+				g.Expect(current.Status.Router.Scheduler).ToNot(BeNil())
+				g.Expect(current.Status.Router.Scheduler.InferencePool).ToNot(BeNil())
+				g.Expect(string(current.Status.Router.Scheduler.InferencePool.Name)).To(Equal(poolName))
+				g.Expect(current.Status.Router.Scheduler.Service).ToNot(BeNil())
+				g.Expect(string(current.Status.Router.Scheduler.Service.Name)).To(Equal(eppName))
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -2147,11 +2147,10 @@ func SchedulerLabels(llmSvc *v1alpha2.LLMInferenceService) map[string]string {
 }
 
 // setRoutingPoolStatus writes the InferencePool and EPP Service refs into status.router.
-// If status.router has not yet been created from routing discovery, it is intentionally
-// not initialised to avoid marking routing as populated without gateway information.
+// Initializes router status when needed.
 func setRoutingPoolStatus(llmSvc *v1alpha2.LLMInferenceService, pool, svc gwapiv1.ObjectReference) {
 	if llmSvc.Status.Router == nil {
-		return
+		llmSvc.Status.Router = &v1alpha2.RouterStatus{}
 	}
 	llmSvc.Status.Router.Scheduler = &v1alpha2.ObservedSchedulerStatus{
 		InferencePool: &pool,


### PR DESCRIPTION
**What this PR does / why we need it**:

When an LLMInferenceService has a scheduler configured without routing, its existing `status.router.scheduler` fields now report the InferencePool and EPP Service references. This lets consumers discover the pool reference for their own routing configuration instead of deriving its name from KServe's naming convention.

Gateway observations remain absent when no routing is observed. Readiness continues to use the existing conditions.

**Which issue(s) this PR fixes**:

Fixes #6095

**Feature/Issue validation/testing**:

Complete the checks below and record the results before submitting:

- [x] Updated setter unit test passes.
- [x] Routing Status envtest specs pass, including the scheduler-only regression.
- [x] The new scheduler-only regression fails with the original setter and passes with this change.
- [x] `make precommit` completes successfully, and its resulting diff has been reviewed.

The focused tests can be run with:

```sh
GOFLAGS=-mod=readonly go test ./pkg/controller/v1alpha2/llmisvc \
  -run '^TestSetRoutingPoolStatusInitializesRouterWhenNeeded$' -count=1 -v

GOFLAGS=-mod=readonly go test ./pkg/controller/v1alpha2/llmisvc \
  -run '^TestLLMInferenceServiceController$' \
  -ginkgo.focus='Routing Status' -count=1 -timeout=5m -v
```

Set `KUBEBUILDER_ASSETS` to the installed envtest asset directory for the integration suite. Record the Go version, envtest version, and result summary here when completing validation. No live-cluster traffic validation is claimed.

**Special notes for your reviewer**:

This also allows scheduler-only status for external `pool.ref` configurations. The existing EPP Service-name derivation is unchanged, so that reference can contain `<name>-epp-service` even when the external pool points to a differently named Service.

**Checklist**:

- [x] Added a controller integration regression and updated the existing setter unit test.
- [x] Commented the preset-merging detail that matters to the regression test.
- [ ] Corresponding website documentation changes: none proposed; the existing API comments are updated.

**Release note**:

```release-note
LLMInferenceService now reports scheduler InferencePool and EPP Service references in status when routing is not configured.
```

