### PR TITLE
feat(helm): expose enableOciModelSupport and ociModelMode in chart values

### DIFF
--- a/charts/_common/common-patches/configmap-patch.yaml
+++ b/charts/_common/common-patches/configmap-patch.yaml
@@ -111,6 +111,12 @@ data:
         "uidModelcar": {{ .Values.kserve.storage.uidModelcar }},
         "cpuModelcar": "{{ .Values.kserve.storage.cpuModelcar }}",
         "memoryModelcar": "{{ .Values.kserve.storage.memoryModelcar }}"
+        {{- if .Values.kserve.storage.enableOciModelSupport }},
+        "enableOciModelSupport": {{ .Values.kserve.storage.enableOciModelSupport }}
+        {{- end }}
+        {{- if .Values.kserve.storage.ociModelMode }},
+        "ociModelMode": "{{ .Values.kserve.storage.ociModelMode }}"
+        {{- end }}
     }
   metricsAggregator: |-
     {

--- a/charts/_common/common-sections.yaml
+++ b/charts/_common/common-sections.yaml
@@ -38,6 +38,14 @@ kserve:
     uidModelcar: 1010
     cpuModelcar: 10m
     memoryModelcar: 15Mi
+    # enableOciModelSupport turns on any OCI-backed model storage path (modelcar,
+    # native ImageVolume, or fetch). Only rendered into the storageInitializer
+    # config when true, so the default leaves the shipped config untouched.
+    enableOciModelSupport: false
+    # ociModelMode picks the materialization strategy for oci:// storageUris that
+    # carry no explicit suffix. One of: modelcar | native | fetch.
+    # Only rendered into the storageInitializer config when non-empty.
+    ociModelMode: ''
     caBundleConfigMapName: ''
     caBundleVolumeMountPath: /etc/ssl/custom-certs
     storageSpecSecretName: storage-config

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -157,8 +157,10 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.storage.containerSecurityContext.runAsNonRoot | bool | `true` |  |
 | kserve.storage.cpuModelcar | string | `"10m"` |  |
 | kserve.storage.enableModelcar | bool | `true` |  |
+| kserve.storage.enableOciModelSupport | bool | `false` |  |
 | kserve.storage.image | string | `"kserve/storage-initializer"` |  |
 | kserve.storage.memoryModelcar | string | `"15Mi"` |  |
+| kserve.storage.ociModelMode | string | `""` |  |
 | kserve.storage.resources.limits.cpu | string | `"1"` |  |
 | kserve.storage.resources.limits.memory | string | `"1Gi"` |  |
 | kserve.storage.resources.requests.cpu | string | `"100m"` |  |

--- a/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
@@ -111,6 +111,12 @@ data:
         "uidModelcar": {{ .Values.kserve.storage.uidModelcar }},
         "cpuModelcar": "{{ .Values.kserve.storage.cpuModelcar }}",
         "memoryModelcar": "{{ .Values.kserve.storage.memoryModelcar }}"
+        {{- if .Values.kserve.storage.enableOciModelSupport }},
+        "enableOciModelSupport": {{ .Values.kserve.storage.enableOciModelSupport }}
+        {{- end }}
+        {{- if .Values.kserve.storage.ociModelMode }},
+        "ociModelMode": "{{ .Values.kserve.storage.ociModelMode }}"
+        {{- end }}
     }
   metricsAggregator: |-
     {

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -38,6 +38,14 @@ kserve:
     uidModelcar: 1010
     cpuModelcar: 10m
     memoryModelcar: 15Mi
+    # enableOciModelSupport turns on any OCI-backed model storage path (modelcar,
+    # native ImageVolume, or fetch). Only rendered into the storageInitializer
+    # config when true, so the default leaves the shipped config untouched.
+    enableOciModelSupport: false
+    # ociModelMode picks the materialization strategy for oci:// storageUris that
+    # carry no explicit suffix. One of: modelcar | native | fetch.
+    # Only rendered into the storageInitializer config when non-empty.
+    ociModelMode: ''
     caBundleConfigMapName: ''
     caBundleVolumeMountPath: /etc/ssl/custom-certs
     storageSpecSecretName: storage-config

--- a/charts/kserve-localmodel-resources/README.md
+++ b/charts/kserve-localmodel-resources/README.md
@@ -97,8 +97,10 @@ $ helm install kserve-localmodel-resources oci://ghcr.io/kserve/charts/kserve-lo
 | kserve.storage.containerSecurityContext.runAsNonRoot | bool | `true` |  |
 | kserve.storage.cpuModelcar | string | `"10m"` |  |
 | kserve.storage.enableModelcar | bool | `true` |  |
+| kserve.storage.enableOciModelSupport | bool | `false` |  |
 | kserve.storage.image | string | `"kserve/storage-initializer"` |  |
 | kserve.storage.memoryModelcar | string | `"15Mi"` |  |
+| kserve.storage.ociModelMode | string | `""` |  |
 | kserve.storage.resources.limits.cpu | string | `"1"` |  |
 | kserve.storage.resources.limits.memory | string | `"1Gi"` |  |
 | kserve.storage.resources.requests.cpu | string | `"100m"` |  |

--- a/charts/kserve-localmodel-resources/values.yaml
+++ b/charts/kserve-localmodel-resources/values.yaml
@@ -38,6 +38,14 @@ kserve:
     uidModelcar: 1010
     cpuModelcar: 10m
     memoryModelcar: 15Mi
+    # enableOciModelSupport turns on any OCI-backed model storage path (modelcar,
+    # native ImageVolume, or fetch). Only rendered into the storageInitializer
+    # config when true, so the default leaves the shipped config untouched.
+    enableOciModelSupport: false
+    # ociModelMode picks the materialization strategy for oci:// storageUris that
+    # carry no explicit suffix. One of: modelcar | native | fetch.
+    # Only rendered into the storageInitializer config when non-empty.
+    ociModelMode: ''
     caBundleConfigMapName: ''
     caBundleVolumeMountPath: /etc/ssl/custom-certs
     storageSpecSecretName: storage-config

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -125,8 +125,10 @@ $ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --v
 | kserve.storage.containerSecurityContext.runAsNonRoot | bool | `true` |  |
 | kserve.storage.cpuModelcar | string | `"10m"` |  |
 | kserve.storage.enableModelcar | bool | `true` |  |
+| kserve.storage.enableOciModelSupport | bool | `false` |  |
 | kserve.storage.image | string | `"kserve/storage-initializer"` |  |
 | kserve.storage.memoryModelcar | string | `"15Mi"` |  |
+| kserve.storage.ociModelMode | string | `""` |  |
 | kserve.storage.resources.limits.cpu | string | `"1"` |  |
 | kserve.storage.resources.limits.memory | string | `"1Gi"` |  |
 | kserve.storage.resources.requests.cpu | string | `"100m"` |  |

--- a/charts/kserve-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-resources/files/common/configmap-patch.yaml
@@ -111,6 +111,12 @@ data:
         "uidModelcar": {{ .Values.kserve.storage.uidModelcar }},
         "cpuModelcar": "{{ .Values.kserve.storage.cpuModelcar }}",
         "memoryModelcar": "{{ .Values.kserve.storage.memoryModelcar }}"
+        {{- if .Values.kserve.storage.enableOciModelSupport }},
+        "enableOciModelSupport": {{ .Values.kserve.storage.enableOciModelSupport }}
+        {{- end }}
+        {{- if .Values.kserve.storage.ociModelMode }},
+        "ociModelMode": "{{ .Values.kserve.storage.ociModelMode }}"
+        {{- end }}
     }
   metricsAggregator: |-
     {

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -38,6 +38,14 @@ kserve:
     uidModelcar: 1010
     cpuModelcar: 10m
     memoryModelcar: 15Mi
+    # enableOciModelSupport turns on any OCI-backed model storage path (modelcar,
+    # native ImageVolume, or fetch). Only rendered into the storageInitializer
+    # config when true, so the default leaves the shipped config untouched.
+    enableOciModelSupport: false
+    # ociModelMode picks the materialization strategy for oci:// storageUris that
+    # carry no explicit suffix. One of: modelcar | native | fetch.
+    # Only rendered into the storageInitializer config when non-empty.
+    ociModelMode: ''
     caBundleConfigMapName: ''
     caBundleVolumeMountPath: /etc/ssl/custom-certs
     storageSpecSecretName: storage-config


### PR DESCRIPTION
**What this PR does / why we need it**:

`enableOciModelSupport` and `ociModelMode` shipped in v0.20 via #5558, but neither is reachable from the Helm charts — there is no values entry for either, and `common-patches/configmap-patch.yaml` renders only `enableModelcar` into the `storageInitializer` block. Operators can set them by hand-editing the `inferenceservice-config` ConfigMap, but the next `helm upgrade` reverts that edit, so in practice the newer OCI switches are unusable for chart-based installs.

This adds both as chart values across `kserve-resources`, `kserve-llmisvc-resources` and `kserve-localmodel-resources`. Each renders into the `storageInitializer` block only when set (`true` / non-empty), so the default render is byte-identical to before.

**Which issue(s) this PR fixes**:
Part of #5679

**Feature/Issue validation/testing**:

- [x] Default values render unchanged — `helm template` for all three charts, diffed against the same command on `master`: **0 lines of diff** (52897 / 102352 / 10846 bytes, identical).
- [x] New values render correctly — `helm template ... --set kserve.storage.enableOciModelSupport=true --set kserve.storage.ociModelMode=fetch` puts both keys in the `storageInitializer` JSON, which still parses, with `enableModelcar` unchanged:

```json
{
    ...
    "enableModelcar": true,
    "uidModelcar": 1010,
    "cpuModelcar": "10m",
    "memoryModelcar": "15Mi",
    "enableOciModelSupport": true,
    "ociModelMode": "fetch"
}
```

- [x] Setting only one of the two renders only that key, JSON stays valid.
- [x] `make precommit` clean; `helm lint` passes on all three charts; `go build ./...` and `go vet` green.

**Special notes for your reviewer**:

Strictly additive and default-off. `enableModelcar` is untouched — no default flip, no deprecation warning, no Go changes. Those are the next steps on #5679 and deliberately not in this PR; the warning only makes sense once the replacement is actually settable, which is what this fixes.

Sources of truth edited are `charts/_common/common-sections.yaml` and `charts/_common/common-patches/configmap-patch.yaml`; everything else in the diff is regenerated output from `make precommit`.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?  — chart-render verification above; no Go code changes to unit test.
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? — website update belongs with the deprecation step.

**Release note**:
```release-note
Helm charts now expose `kserve.storage.enableOciModelSupport` and `kserve.storage.ociModelMode`, which previously could only be set by hand-editing the inferenceservice-config ConfigMap. Both default to off and are rendered only when set, so existing installs are unaffected.
```
