### PR TITLE
fix(localmodel): finish cache deletion when node group is gone

### DIFF
--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -76,12 +77,20 @@ func (c *LocalModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
+	deleting := !localModel.DeletionTimestamp.IsZero()
 	defaultNodeGroup := &v1alpha1.LocalModelNodeGroup{}
 	nodeGroups := map[string]*v1alpha1.LocalModelNodeGroup{}
 	for idx, nodeGroupName := range localModel.Spec.NodeGroups {
 		nodeGroup := &v1alpha1.LocalModelNodeGroup{}
 		nodeGroupNamespacedName := types.NamespacedName{Name: nodeGroupName}
 		if err := c.Get(ctx, nodeGroupNamespacedName, nodeGroup); err != nil {
+			if deleting && apierr.IsNotFound(err) {
+				// A node group deleted before the cache (nothing guards that order)
+				// must not strand cache deletion. Record it as nil so the leftover
+				// per-node entries it left behind are swept before the finalizer goes.
+				nodeGroups[nodeGroupName] = nil
+				continue
+			}
 			return reconcile.Result{}, err
 		}
 		nodeGroups[nodeGroupName] = nodeGroup
@@ -102,6 +111,9 @@ func (c *LocalModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 		}
 	} else {
+		// DeleteModelFromNodes removes the finalizer only after every cleanup step
+		// (node entries, missing-group sweep, storage) succeeded, so a failure is
+		// retried instead of being lost once the cache is gone.
 		return DeleteModelFromNodes(ctx, c.Client, c.Clientset, c.Log, localModel, nil, nodeGroups)
 	}
 

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler_test.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelcache_reconciler_test.go
@@ -1,0 +1,482 @@
+// Copyright 2026 The KServe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcilers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+// newCacheReconcilerClientset returns a fake-client scheme plus a typed clientset
+// backed by an in-memory server that serves the inferenceservice-config
+// ConfigMap read at the start of every reconcile.
+func newCacheReconcilerClientset(t *testing.T) (*kubernetes.Clientset, *runtime.Scheme) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to add scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to add core scheme: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"inferenceservice-config","namespace":"kserve"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: srv.URL})
+	if err != nil {
+		t.Fatalf("unable to build clientset: %v", err)
+	}
+	return clientset, scheme
+}
+
+func TestLocalModelCacheDeletionSucceedsWhenNodeGroupDeletedFirst(t *testing.T) {
+	clientset, scheme := newCacheReconcilerClientset(t)
+
+	now := metav1.NewTime(time.Now())
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-model",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{FinalizerName},
+		},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			// The referenced node group no longer exists: it was deleted
+			// (or renamed) before the cache. Nothing guards that order.
+			NodeGroups: []string{"decommissioned-group"},
+		},
+	}
+
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache).Build()
+
+	r := &LocalModelReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cache.Name},
+	})
+	if err != nil {
+		t.Fatalf("reconcile of a deleting cache must not fail when its node group is gone: %v", err)
+	}
+
+	// Removing the finalizer lets the API server reap the deleting object; the
+	// fake client mirrors that by dropping the object once it carries a deletion
+	// timestamp and no finalizers. A cache whose finalizer was not removed would
+	// still exist here, so "gone" is exactly the property under test.
+	updated := &v1alpha1.LocalModelCache{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), updated); !apierr.IsNotFound(err) {
+		t.Fatalf("expected cache to be reaped after deletion reconcile, got: %v", err)
+	}
+}
+
+func TestNonDeletingCacheWithMissingNodeGroupStillErrors(t *testing.T) {
+	clientset, scheme := newCacheReconcilerClientset(t)
+
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-model",
+		},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"decommissioned-group"},
+		},
+	}
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache).Build()
+	r := &LocalModelReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cache.Name},
+	})
+	if err == nil {
+		t.Fatalf("live cache with a missing node group should keep erroring (loud), not silently succeed")
+	}
+}
+
+func TestDeletionSweepsStaleEntriesFromAllLocalModelNodes(t *testing.T) {
+	clientset, scheme := newCacheReconcilerClientset(t)
+
+	now := metav1.NewTime(time.Now())
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-model",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{FinalizerName},
+		},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"decommissioned-group"},
+		},
+	}
+	// Node of the already-deleted group still carries the model entry.
+	node := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-of-decommissioned-group"},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: ""},
+				{ModelName: "other-model", Namespace: ""},
+			},
+		},
+	}
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache, node).Build()
+	r := &LocalModelReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cache.Name},
+	})
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	updatedNode := &v1alpha1.LocalModelNode{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(node), updatedNode); err != nil {
+		t.Fatalf("failed to get node after reconcile: %v", err)
+	}
+	unrelatedEntryPresent := false
+	for _, m := range updatedNode.Spec.LocalModels {
+		if m.ModelName == "my-model" {
+			t.Fatalf("stale entry for deleted cache still present on node")
+		}
+		if m.ModelName == "other-model" {
+			unrelatedEntryPresent = true
+		}
+	}
+	if !unrelatedEntryPresent {
+		t.Fatalf("unrelated model entry was removed by the sweep")
+	}
+}
+
+func TestDeletionSweepFailureKeepsFinalizerForRetry(t *testing.T) {
+	clientset, scheme := newCacheReconcilerClientset(t)
+
+	now := metav1.NewTime(time.Now())
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-model",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{FinalizerName},
+		},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"decommissioned-group"},
+		},
+	}
+	// Node of the already-deleted group still carries the model entry.
+	node := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-of-decommissioned-group"},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: ""},
+			},
+		},
+	}
+	failSweepOnce := true
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache, node).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*v1alpha1.LocalModelNode); ok && failSweepOnce {
+					failSweepOnce = false
+					return apierr.NewInternalError(errors.New("injected sweep failure"))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := &LocalModelReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: cache.Name}}
+
+	// The sweep must run before the finalizer is removed: a failed sweep leaves
+	// the cache in place (finalizer intact) so the next reconcile retries it.
+	if _, err := r.Reconcile(context.Background(), req); err == nil {
+		t.Fatalf("expected reconcile to fail when the sweep fails")
+	}
+	kept := &v1alpha1.LocalModelCache{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), kept); err != nil {
+		t.Fatalf("cache disappeared after a failed sweep; expected it to be retained for retry: %v", err)
+	}
+	if !slices.Contains(kept.Finalizers, FinalizerName) {
+		t.Fatalf("finalizer was removed although the sweep failed")
+	}
+
+	// Retry: sweep succeeds, finalizer is removed, cache is reaped.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile after sweep failure should succeed: %v", err)
+	}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), kept); !apierr.IsNotFound(err) {
+		t.Fatalf("expected cache to be gone after successful retry, got: %v", err)
+	}
+}
+
+func TestDeletionHandlesMixedExistingAndMissingNodeGroups(t *testing.T) {
+	clientset, scheme := newCacheReconcilerClientset(t)
+
+	now := metav1.NewTime(time.Now())
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-model",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{FinalizerName},
+		},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"live-group", "decommissioned-group"},
+		},
+	}
+	// Existing group with a matching node; its entries go through the regular
+	// group-membership path.
+	nodeGroup := &v1alpha1.LocalModelNodeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "live-group"},
+		Spec: v1alpha1.LocalModelNodeGroupSpec{
+			PersistentVolumeSpec: corev1.PersistentVolumeSpec{
+				NodeAffinity: &corev1.VolumeNodeAffinity{
+					Required: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+							MatchExpressions: []corev1.NodeSelectorRequirement{{
+								Key:      "kubernetes.io/hostname",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"node-of-live-group"},
+							}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	coreNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-of-live-group",
+			Labels: map[string]string{"kubernetes.io/hostname": "node-of-live-group"},
+		},
+	}
+	liveNode := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-of-live-group"},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: ""},
+				{ModelName: "other-model", Namespace: ""},
+			},
+		},
+	}
+	// Node of the already-deleted group still carries the model entry; it can
+	// only be reached by the all-node sweep.
+	orphanNode := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-of-decommissioned-group"},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: ""},
+			},
+		},
+	}
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache, nodeGroup, coreNode, liveNode, orphanNode).Build()
+	r := &LocalModelReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cache.Name},
+	}); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	updatedLive := &v1alpha1.LocalModelNode{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: liveNode.Name}, updatedLive); err != nil {
+		t.Fatalf("failed to get live node after reconcile: %v", err)
+	}
+	if len(updatedLive.Spec.LocalModels) != 1 || updatedLive.Spec.LocalModels[0].ModelName != "other-model" {
+		t.Fatalf("live group node entries not cleaned precisely: %+v", updatedLive.Spec.LocalModels)
+	}
+	updatedOrphan := &v1alpha1.LocalModelNode{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: orphanNode.Name}, updatedOrphan); err != nil {
+		t.Fatalf("failed to get orphan node after reconcile: %v", err)
+	}
+	if len(updatedOrphan.Spec.LocalModels) != 0 {
+		t.Fatalf("orphan node entry was not swept: %+v", updatedOrphan.Spec.LocalModels)
+	}
+	gone := &v1alpha1.LocalModelCache{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), gone); !apierr.IsNotFound(err) {
+		t.Fatalf("expected cache to be gone after deletion, got: %v", err)
+	}
+}
+
+func TestDeletionCleansEntriesFromExistingNodeGroupNodes(t *testing.T) {
+	clientset, scheme := newCacheReconcilerClientset(t)
+
+	now := metav1.NewTime(time.Now())
+	cache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-model",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{FinalizerName},
+		},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"live-group"},
+		},
+	}
+	// Every referenced node group still exists, so cleanup must go through
+	// group membership (ready and not-ready nodes alike) and the all-node
+	// sweep must not run.
+	nodeGroup := &v1alpha1.LocalModelNodeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "live-group"},
+		Spec: v1alpha1.LocalModelNodeGroupSpec{
+			PersistentVolumeSpec: corev1.PersistentVolumeSpec{
+				NodeAffinity: &corev1.VolumeNodeAffinity{
+					Required: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+							MatchExpressions: []corev1.NodeSelectorRequirement{{
+								Key:      "kubernetes.io/hostname",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"node-of-live-group", "node-of-live-group-notready"},
+							}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	readyCoreNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-of-live-group",
+			Labels: map[string]string{"kubernetes.io/hostname": "node-of-live-group"},
+		},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}},
+	}
+	notReadyCoreNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-of-live-group-notready",
+			Labels: map[string]string{"kubernetes.io/hostname": "node-of-live-group-notready"},
+		},
+	}
+	readyModelNode := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: readyCoreNode.Name},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: ""},
+				{ModelName: "other-model", Namespace: ""},
+			},
+		},
+	}
+	notReadyModelNode := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: notReadyCoreNode.Name},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: ""},
+			},
+		},
+	}
+	// Not part of the group's affinity; if the all-node sweep ran, it would
+	// remove this entry too, so its survival proves deletion stayed on the
+	// group-membership path.
+	outsiderNode := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-outside-the-group"},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: ""},
+			},
+		},
+	}
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(cache, nodeGroup, readyCoreNode, notReadyCoreNode, readyModelNode, notReadyModelNode, outsiderNode).
+		Build()
+	r := &LocalModelReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cache.Name},
+	}); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	for _, want := range []struct {
+		name string
+		kept []string // model names that must survive on the node
+	}{
+		{name: readyCoreNode.Name, kept: []string{"other-model"}},
+		{name: notReadyCoreNode.Name, kept: nil},
+	} {
+		got := &v1alpha1.LocalModelNode{}
+		if err := cl.Get(context.Background(), types.NamespacedName{Name: want.name}, got); err != nil {
+			t.Fatalf("failed to get node %q after reconcile: %v", want.name, err)
+		}
+		if len(got.Spec.LocalModels) != len(want.kept) {
+			t.Fatalf("node %q entries not cleaned precisely: got %+v, want %d entries", want.name, got.Spec.LocalModels, len(want.kept))
+		}
+		for i, m := range got.Spec.LocalModels {
+			if m.ModelName != want.kept[i] {
+				t.Fatalf("node %q entry %d = %q, want %q", want.name, i, m.ModelName, want.kept[i])
+			}
+		}
+	}
+	outsider := &v1alpha1.LocalModelNode{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: outsiderNode.Name}, outsider); err != nil {
+		t.Fatalf("failed to get outsider node: %v", err)
+	}
+	if len(outsider.Spec.LocalModels) != 1 || outsider.Spec.LocalModels[0].ModelName != "my-model" {
+		t.Fatalf("outsider entry was touched; deletion should stay on the group-membership path: %+v", outsider.Spec.LocalModels)
+	}
+	gone := &v1alpha1.LocalModelCache{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), gone); !apierr.IsNotFound(err) {
+		t.Fatalf("expected cache to be gone after deletion, got: %v", err)
+	}
+}

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -76,12 +77,21 @@ func (c *LocalModelNamespaceCacheReconciler) Reconcile(ctx context.Context, req 
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
+	deleting := !localModel.DeletionTimestamp.IsZero()
 	defaultNodeGroup := &v1alpha1.LocalModelNodeGroup{}
 	nodeGroups := map[string]*v1alpha1.LocalModelNodeGroup{}
 	for idx, nodeGroupName := range localModel.Spec.NodeGroups {
 		nodeGroup := &v1alpha1.LocalModelNodeGroup{}
 		nodeGroupNamespacedName := types.NamespacedName{Name: nodeGroupName}
 		if err := c.Get(ctx, nodeGroupNamespacedName, nodeGroup); err != nil {
+			if deleting && apierr.IsNotFound(err) {
+				// A node group deleted before the cache (nothing guards that order)
+				// must not strand cache deletion. Keep a nil entry so name-based
+				// cleanup (PV/PVC) still runs and leftover per-node entries are
+				// swept before the finalizer goes.
+				nodeGroups[nodeGroupName] = nil
+				continue
+			}
 			return reconcile.Result{}, err
 		}
 		nodeGroups[nodeGroupName] = nodeGroup
@@ -102,6 +112,9 @@ func (c *LocalModelNamespaceCacheReconciler) Reconcile(ctx context.Context, req 
 			}
 		}
 	} else {
+		// DeleteModelFromNodes removes the finalizer only after every cleanup step
+		// (node entries, missing-group sweep, PV/PVC) succeeded, so a failure is
+		// retried instead of being lost once the cache is gone.
 		return DeleteModelFromNodes(ctx, c.Client, c.Clientset, c.Log, nil, localModel, nodeGroups)
 	}
 

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler_test.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/localmodelnamespacecache_reconciler_test.go
@@ -1,0 +1,410 @@
+// Copyright 2026 The KServe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcilers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+func newNamespaceCacheClientset(t *testing.T) (*kubernetes.Clientset, *runtime.Scheme) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to add scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to add core scheme: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "configmaps") {
+			_, _ = fmt.Fprint(w, `{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"inferenceservice-config","namespace":"kserve"}}`)
+			return
+		}
+		// PV/PVC lookups during deletion must 404 so cleanup treats them as absent.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"not found","reason":"NotFound","code":404}`)
+	}))
+	t.Cleanup(srv.Close)
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: srv.URL})
+	if err != nil {
+		t.Fatalf("unable to build clientset: %v", err)
+	}
+	return clientset, scheme
+}
+
+func TestNamespaceCacheDeletionSucceedsWhenNodeGroupDeletedFirst(t *testing.T) {
+	clientset, scheme := newNamespaceCacheClientset(t)
+
+	now := metav1.NewTime(time.Now())
+	cache := &v1alpha1.LocalModelNamespaceCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-model",
+			Namespace:         "team-a",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{NamespaceCacheFinalizerName},
+		},
+		Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"decommissioned-group"},
+		},
+	}
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache).Build()
+	r := &LocalModelNamespaceCacheReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cache.Name, Namespace: cache.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile of a deleting namespace cache must not fail when its node group is gone: %v", err)
+	}
+
+	updated := &v1alpha1.LocalModelNamespaceCache{}
+	err = cl.Get(context.Background(), client.ObjectKeyFromObject(cache), updated)
+	if err == nil {
+		t.Fatalf("cache still exists after deletion reconcile, expected it to be reaped")
+	}
+	if !apierr.IsNotFound(err) {
+		t.Fatalf("expected cache to be gone after deletion reconcile, got: %v", err)
+	}
+}
+
+func TestNamespaceCacheDeletionSweepsStaleEntriesFromAllLocalModelNodes(t *testing.T) {
+	clientset, scheme := newNamespaceCacheClientset(t)
+
+	now := metav1.NewTime(time.Now())
+	cache := &v1alpha1.LocalModelNamespaceCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-model",
+			Namespace:         "team-a",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{NamespaceCacheFinalizerName},
+		},
+		Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"decommissioned-group"},
+		},
+	}
+	// The node of the already-deleted group still carries the model entry; it
+	// can only be reached by the all-node sweep.
+	orphanNode := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-of-decommissioned-group"},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: "team-a"},
+			},
+		},
+	}
+	// A node serving the same model name from another namespace, or another
+	// model from this one, must be left alone: the sweep matches the exact
+	// (model name, namespace) pair of the cache being deleted.
+	unrelatedNode := &v1alpha1.LocalModelNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-serving-other-caches"},
+		Spec: v1alpha1.LocalModelNodeSpec{
+			LocalModels: []v1alpha1.LocalModelInfo{
+				{ModelName: "my-model", Namespace: "team-b"},
+				{ModelName: "other-model", Namespace: "team-a"},
+			},
+		},
+	}
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache, orphanNode, unrelatedNode).Build()
+	r := &LocalModelNamespaceCacheReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cache.Name, Namespace: cache.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	updatedOrphan := &v1alpha1.LocalModelNode{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(orphanNode), updatedOrphan); err != nil {
+		t.Fatalf("failed to get node after reconcile: %v", err)
+	}
+	if len(updatedOrphan.Spec.LocalModels) != 0 {
+		t.Fatalf("stale entry for deleted namespace cache was not swept: %+v", updatedOrphan.Spec.LocalModels)
+	}
+	updatedUnrelated := &v1alpha1.LocalModelNode{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(unrelatedNode), updatedUnrelated); err != nil {
+		t.Fatalf("failed to get unrelated node after reconcile: %v", err)
+	}
+	kept := map[string]bool{}
+	for _, m := range updatedUnrelated.Spec.LocalModels {
+		kept[m.ModelName+"/"+m.Namespace] = true
+	}
+	if len(kept) != 2 || !kept["my-model/team-b"] || !kept["other-model/team-a"] {
+		t.Fatalf("sweep touched entries of other caches: %+v", updatedUnrelated.Spec.LocalModels)
+	}
+	gone := &v1alpha1.LocalModelNamespaceCache{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), gone); !apierr.IsNotFound(err) {
+		t.Fatalf("expected cache to be gone after deletion reconcile, got: %v", err)
+	}
+}
+
+func TestNamespaceCacheDeletionAbortsWhenConfigMapUnavailable(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to add scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to add core scheme: %v", err)
+	}
+	// Namespace-scoped caches must explicitly delete their PVs/PVCs (no owner
+	// references), which needs the job namespace from the config map. If the
+	// config map cannot be read, deletion must abort so the download PVC is not
+	// leaked while the finalizer is removed anyway.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "configmaps") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"not found","reason":"NotFound","code":404}`)
+	}))
+	defer srv.Close()
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: srv.URL})
+	if err != nil {
+		t.Fatalf("unable to build clientset: %v", err)
+	}
+
+	now := metav1.NewTime(time.Now())
+	cache := &v1alpha1.LocalModelNamespaceCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-model",
+			Namespace:         "team-a",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{NamespaceCacheFinalizerName},
+		},
+		Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     []string{"decommissioned-group"},
+		},
+	}
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache).Build()
+	nodeGroups := map[string]*v1alpha1.LocalModelNodeGroup{"decommissioned-group": nil}
+	if _, err := DeleteModelFromNodes(context.Background(), cl, clientset, ctrl.Log.WithName("test"), nil, cache, nodeGroups); err == nil {
+		t.Fatalf("expected deletion to abort when the config map cannot be read")
+	}
+	kept := &v1alpha1.LocalModelNamespaceCache{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), kept); err != nil {
+		t.Fatalf("cache disappeared despite failed cleanup: %v", err)
+	}
+	if !slices.Contains(kept.Finalizers, NamespaceCacheFinalizerName) {
+		t.Fatalf("finalizer was removed although download PVC cleanup failed")
+	}
+}
+
+const (
+	namespaceCacheStorageConfigMap = `{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"inferenceservice-config","namespace":"kserve"},"data":{"localModel":"{\"enabled\":true,\"jobNamespace\":\"kserve-localmodel-jobs\"}"}}`
+	namespaceCachePVJSON           = `{"kind":"PersistentVolume","apiVersion":"v1","metadata":{"name":"placeholder"},"spec":{}}`
+	namespaceCachePVCJSON          = `{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"placeholder","namespace":"kserve-localmodel-jobs"},"spec":{}}`
+)
+
+// storageRecorder records which PV/PVC paths a deletion run asked the API
+// server to delete, so tests can assert storage cleanup actually happened.
+type storageRecorder struct {
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (r *storageRecorder) recordDelete(path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deleted = append(r.deleted, path)
+}
+
+func (r *storageRecorder) deletedPaths() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.deleted...)
+}
+
+// newNamespaceCacheStorageClientset serves the inferenceservice-config
+// ConfigMap and reports PV/PVC objects as present, so the namespace-scoped
+// deletion path exercises real GET/DELETE calls instead of the not-found
+// shortcut. When failFirstPVGet is set, the first PersistentVolume GET fails,
+// simulating a transient API error during cleanup.
+func newNamespaceCacheStorageClientset(t *testing.T, failFirstPVGet *atomic.Bool) (*kubernetes.Clientset, *runtime.Scheme, *storageRecorder) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to add scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to add core scheme: %v", err)
+	}
+	rec := &storageRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/configmaps/"):
+			_, _ = fmt.Fprint(w, namespaceCacheStorageConfigMap)
+		case strings.Contains(r.URL.Path, "/persistentvolumeclaims/"):
+			if r.Method == http.MethodDelete {
+				rec.recordDelete(r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			_, _ = fmt.Fprint(w, namespaceCachePVCJSON)
+		case strings.Contains(r.URL.Path, "/persistentvolumes/"):
+			if failFirstPVGet != nil && failFirstPVGet.CompareAndSwap(true, false) && r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if r.Method == http.MethodDelete {
+				rec.recordDelete(r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			_, _ = fmt.Fprint(w, namespaceCachePVJSON)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","reason":"NotFound","code":404}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: srv.URL})
+	if err != nil {
+		t.Fatalf("unable to build clientset: %v", err)
+	}
+	return clientset, scheme, rec
+}
+
+func newDeletingNamespaceCache(name, namespace string, nodeGroups ...string) *v1alpha1.LocalModelNamespaceCache {
+	now := metav1.NewTime(time.Now())
+	return &v1alpha1.LocalModelNamespaceCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{NamespaceCacheFinalizerName},
+		},
+		Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+			SourceModelUri: "s3://bucket/model",
+			ModelSize:      resource.MustParse("1Gi"),
+			NodeGroups:     nodeGroups,
+		},
+	}
+}
+
+func TestNamespaceCacheDeletionDeletesStorageLeftBehindForMissingNodeGroup(t *testing.T) {
+	clientset, scheme, rec := newNamespaceCacheStorageClientset(t, nil)
+
+	cache := newDeletingNamespaceCache("my-model", "team-a", "decommissioned-group")
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache).Build()
+	r := &LocalModelNamespaceCacheReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cache.Name, Namespace: cache.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	// The download PV/PVC and the serving PV are all named after the deleted
+	// node group; cleanup must reach them even though the group object is gone.
+	wantPaths := []string{
+		"/api/v1/persistentvolumes/my-model-decommissioned-group-team-a-download",
+		"/api/v1/namespaces/kserve-localmodel-jobs/persistentvolumeclaims/my-model-decommissioned-group-team-a-download",
+		"/api/v1/persistentvolumes/my-model-decommissioned-group-team-a",
+	}
+	deleted := rec.deletedPaths()
+	for _, want := range wantPaths {
+		if !slices.Contains(deleted, want) {
+			t.Fatalf("expected storage deletion for %q; deleted: %v", want, deleted)
+		}
+	}
+	gone := &v1alpha1.LocalModelNamespaceCache{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), gone); !apierr.IsNotFound(err) {
+		t.Fatalf("expected cache to be gone after deletion reconcile, got: %v", err)
+	}
+}
+
+func TestNamespaceCacheDeletionRetriesWhenStorageCleanupFails(t *testing.T) {
+	failFirstPVGet := &atomic.Bool{}
+	failFirstPVGet.Store(true)
+	clientset, scheme, rec := newNamespaceCacheStorageClientset(t, failFirstPVGet)
+
+	cache := newDeletingNamespaceCache("my-model", "team-a", "decommissioned-group")
+	cl := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(cache).Build()
+	r := &LocalModelNamespaceCacheReconciler{
+		Client:    cl,
+		Clientset: clientset,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    scheme,
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: cache.Name, Namespace: cache.Namespace}}
+
+	if _, err := r.Reconcile(context.Background(), req); err == nil {
+		t.Fatalf("expected reconcile to fail when storage cleanup fails")
+	}
+	kept := &v1alpha1.LocalModelNamespaceCache{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), kept); err != nil {
+		t.Fatalf("cache disappeared after a failed storage cleanup: %v", err)
+	}
+	if !slices.Contains(kept.Finalizers, NamespaceCacheFinalizerName) {
+		t.Fatalf("finalizer was removed although storage cleanup failed")
+	}
+
+	// Retry: the transient failure is gone, cleanup completes and the cache is
+	// reaped once the finalizer is removed.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile after storage failure should succeed: %v", err)
+	}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(cache), kept); !apierr.IsNotFound(err) {
+		t.Fatalf("expected cache to be gone after successful retry, got: %v", err)
+	}
+	if len(rec.deletedPaths()) != 3 {
+		t.Fatalf("expected all three storage objects to be deleted on retry, deleted: %v", rec.deletedPaths())
+	}
+}

--- a/pkg/controller/v1alpha1/localmodel/reconcilers/utils.go
+++ b/pkg/controller/v1alpha1/localmodel/reconcilers/utils.go
@@ -226,7 +226,15 @@ func DeleteModelFromNodes(
 	}
 	log.Info("deleting model", "name", params.Name, "namespace", params.Namespace)
 
-	for nodeGroupName, nodeGroup := range nodeGroups {
+	// A nil entry means the referenced node group no longer exists. Its nodes
+	// cannot be enumerated through group membership, so only the all-node
+	// sweep below applies.
+	missingGroup := false
+	for _, nodeGroup := range nodeGroups {
+		if nodeGroup == nil {
+			missingGroup = true
+			continue
+		}
 		readyNodes, notReadyNodes, err := GetNodesFromNodeGroup(ctx, nodeGroup, c)
 		if err != nil {
 			log.Error(err, "getNodesFromNodeGroup node error")
@@ -250,38 +258,63 @@ func DeleteModelFromNodes(
 				return ctrl.Result{}, err
 			}
 		}
+	}
 
-		// For namespace-scoped LocalModelNamespaceCache, PVs cannot have owner references
-		// (Kubernetes limitation: cluster-scoped resources cannot be owned by namespace-scoped resources)
-		// So we must explicitly delete them here
-		if params.IsNamespaceScoped {
+	// A node group deleted before the cache (nothing guards that order) leaves
+	// per-node entries that cannot be reached through group membership. Sweep
+	// every node for a matching entry before the finalizer is removed so that a
+	// failure here is retried instead of stranding entries forever.
+	if missingGroup {
+		if err := deleteModelFromAllNodes(ctx, c, log, params); err != nil {
+			log.Error(err, "failed to sweep leftover model entries from LocalModelNodes")
+			return ctrl.Result{}, err
+		}
+	}
+
+	// For namespace-scoped LocalModelNamespaceCache, PVs cannot have owner references
+	// (Kubernetes limitation: cluster-scoped resources cannot be owned by namespace-scoped resources)
+	// So we must explicitly delete them here. Any failure aborts the run before
+	// the finalizer is removed so deletion is retried instead of leaking storage.
+	if params.IsNamespaceScoped && len(nodeGroups) > 0 {
+		// The download PVC lives in the job namespace from the config map; it
+		// cannot be deleted without it, so a read failure aborts the deletion.
+		isvcConfigMap, cfgErr := v1beta1.GetInferenceServiceConfigMap(ctx, clientset)
+		if cfgErr != nil {
+			log.Error(cfgErr, "failed to get configmap for download PVC cleanup")
+			return ctrl.Result{}, cfgErr
+		}
+		localModelConfig, cfgErr := v1beta1.NewLocalModelConfig(isvcConfigMap)
+		if cfgErr != nil {
+			log.Error(cfgErr, "failed to parse configmap for download PVC cleanup")
+			return ctrl.Result{}, cfgErr
+		}
+		for nodeGroupName := range nodeGroups {
 			// Delete download PV: {modelName}-{nodeGroup}-{namespace}-download
 			downloadPVName := params.Name + "-" + nodeGroupName + "-" + params.Namespace + "-download"
 			if err := DeletePV(ctx, clientset, log, downloadPVName); err != nil {
 				log.Error(err, "failed to delete download PV", "name", downloadPVName)
+				return ctrl.Result{}, err
 			}
 
 			// Delete download PVC from jobNamespace (where download jobs run)
 			downloadPVCName := downloadPVName
-			isvcConfigMap, cfgErr := v1beta1.GetInferenceServiceConfigMap(ctx, clientset)
-			if cfgErr == nil {
-				localModelConfig, cfgErr := v1beta1.NewLocalModelConfig(isvcConfigMap)
-				if cfgErr == nil {
-					if err := DeletePVC(ctx, clientset, log, downloadPVCName, localModelConfig.JobNamespace); err != nil {
-						log.Error(err, "failed to delete download PVC from jobNamespace", "name", downloadPVCName, "namespace", localModelConfig.JobNamespace)
-					}
-				}
+			if err := DeletePVC(ctx, clientset, log, downloadPVCName, localModelConfig.JobNamespace); err != nil {
+				log.Error(err, "failed to delete download PVC from jobNamespace", "name", downloadPVCName, "namespace", localModelConfig.JobNamespace)
+				return ctrl.Result{}, err
 			}
 
 			// Delete serving PV: {modelName}-{nodeGroup}-{namespace}
 			servingPVName := params.Name + "-" + nodeGroupName + "-" + params.Namespace
 			if err := DeletePV(ctx, clientset, log, servingPVName); err != nil {
 				log.Error(err, "failed to delete serving PV", "name", servingPVName)
+				return ctrl.Result{}, err
 			}
 		}
 	}
 
-	// Remove finalizer
+	// Remove finalizer last: every cleanup above must succeed first so that a
+	// failure is retried on the next reconcile instead of being lost once the
+	// object is gone.
 	if localModelCache != nil {
 		patch := client.MergeFrom(localModelCache.DeepCopy())
 		localModelCache.Finalizers = utils.RemoveString(localModelCache.Finalizers, params.FinalizerName)
@@ -768,6 +801,24 @@ func ReconcileLocalModelNode(
 			if err := c.Status().Update(ctx, localModelNamespaceCache); err != nil {
 				log.Error(err, "cannot update model status from node", "name", params.Name, "namespace", params.Namespace)
 			}
+		}
+	}
+	return nil
+}
+
+// deleteModelFromAllNodes removes the cache's model entry from every LocalModelNode.
+// It is used when a node group referenced by a deleting cache no longer exists, so
+// its nodes cannot be enumerated through group membership. Removal is a no-op on
+// nodes that do not hold the model.
+func deleteModelFromAllNodes(ctx context.Context, c client.Client, log logr.Logger, params LocalModelParams) error {
+	nodeList := &v1alpha1.LocalModelNodeList{}
+	if err := c.List(ctx, nodeList); err != nil {
+		log.Error(err, "failed to list LocalModelNodes during cache deletion sweep")
+		return err
+	}
+	for i := range nodeList.Items {
+		if err := DeleteModelFromNode(ctx, c, log, &nodeList.Items[i], params.Name, params.Namespace); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

`LocalModelCache` and `LocalModelNamespaceCache` could never finish deleting when a referenced `LocalModelNodeGroup` was deleted first. Both reconcilers resolve every entry in `Spec.NodeGroups` before they reach the deletion branch: the `Get` on the deleted group returns NotFound, `Reconcile` returns the error, and the deletion branch, the only place the finalizer is removed, is never reached. The cache stays in Terminating forever, and for namespace-scoped caches the download/serving PVs and the download PVC (which cannot be released through owner references) are never cleaned up either.

This PR:
- treats a node group that no longer exists as absent while the cache is being deleted, keeping its name in the map so name-based PV/PVC cleanup still runs;
- sweeps leftover `LocalModelNode` entries that can no longer be reached through group membership, matching the exact (model name, namespace) pair so other caches' entries are untouched;
- makes namespace-scoped PV/PVC cleanup failures abort the run instead of being logged and ignored;
- removes the finalizer only after every cleanup step succeeded, so a failure is retried instead of being lost once the cache is gone.

**Which issue(s) this PR fixes**:
Fixes #6154

**Feature/Issue validation/testing**:

- [x] Added unit tests for both reconcilers in `pkg/controller/v1alpha1/localmodel/reconcilers`: deletion completes when the referenced node group is gone, the sweep removes only matching (model name, namespace) entries (other caches' entries untouched), and existing and missing node groups can be mixed
- [x] Added failure-injection tests: a failed sweep and a failed PV cleanup both keep the finalizer and complete on retry; for a missing node group, the download PV/PVC and the serving PV named after it are deleted
- [x] `go test ./pkg/controller/v1alpha1/localmodel/reconcilers/ -count=1` passes, also with `-race`; `go vet` and `golangci-lint run` on the package report 0 issues

**Special notes for your reviewer**:

The sweep only runs when a referenced node group is missing. With all groups present, deletion keeps the previous per-group behavior; making the sweep unconditional would add a cluster-wide `LocalModelNode` list to every deletion for no benefit.

Namespace-scoped storage cleanup previously logged PV/PVC deletion errors and removed the finalizer anyway; it now aborts and retries, so a failed cleanup no longer leaks storage silently.

A live (non-deleting) cache that references a missing node group still errors loudly, unchanged.

The envtest suites under `pkg/controller/v1alpha1/localmodel` need a test control plane and were not run locally; the changed paths are covered by the unit tests above.

Disclosure: an AI assistant helped draft this PR; the code and tests were reviewed against current master before opening.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
LocalModelCache and LocalModelNamespaceCache deletion no longer gets stuck in Terminating when a referenced LocalModelNodeGroup was deleted first.
```