### PR TITLE
fix(llmisvc): release terminating members from owned routes

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -237,17 +237,27 @@ func (r *LLMISVCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Pre/post process hooks for status management
 	reconciler.PreProcessReconcile(ctx, resource)
+	// Releasing terminating peers must not depend on this service's own desired
+	// state being valid, so it runs before and independently of r.reconcile.
+	cleanupErr := r.reconcileTerminatingGroupBackends(ctx, resource)
 	reconcileErr := r.reconcile(ctx, resource)
 	reconciler.PostProcessReconcile(ctx, resource, original)
 
-	if reconcileErr != nil {
-		logger.Error(reconcileErr, "Failed to reconcile LLMInferenceService")
-		r.Eventf(original, corev1.EventTypeWarning, "Error", "Reconciliation failed: %v", reconcileErr.Error())
+	if err := errors.Join(cleanupErr, reconcileErr); err != nil {
+		logger.Error(err, "Failed to reconcile LLMInferenceService")
+		r.Eventf(original, corev1.EventTypeWarning, "Error", "Reconciliation failed: %v", err.Error())
 	}
 
 	if err := r.updateStatus(ctx, resource); err != nil {
 		logger.Error(err, "Failed to update status for LLMInferenceService")
 		return ctrl.Result{}, err
+	}
+
+	// Returned separately rather than joined: controller-runtime recognises a
+	// TerminalError through errors.Is, so joining one in would cancel the retry
+	// that a failed cleanup still needs.
+	if cleanupErr != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to clean up terminating group backends: %w", cleanupErr)
 	}
 
 	return ctrl.Result{}, reconcileErr

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_group_cleanup_isolation_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_group_cleanup_isolation_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+// Group route cleanup runs ahead of desired-state reconciliation, so a failure
+// on either side must not mask the other: a cleanup failure stays retryable even
+// next to a TerminalError, and it must not stop workloads from reconciling.
+var _ = Describe("Group route cleanup isolation", func() {
+	denied := apierrors.NewForbidden(
+		schema.GroupResource{Group: gwapiv1.GroupName, Resource: "httproutes"}, "route", errors.New("denied"))
+	noKindMatch := &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: gwapiv1.GroupName, Kind: "HTTPRoute"}}
+
+	// cleanupFailed reports whether err carries the cleanup wrapper, which is the
+	// only part of Reconcile's error this spec makes claims about.
+	cleanupFailed := func(err error) bool {
+		return err != nil && strings.Contains(err.Error(), "failed to clean up terminating group backends")
+	}
+
+	DescribeTable("classifies errors independently",
+		func(ctx SpecContext, routeGetErr error, invalidPreset, wantCleanupErr bool) {
+			ns := NewTestNamespace(ctx, envTest)
+
+			svc := LLMInferenceService("cleanup-isolation",
+				InNamespace[*v1alpha2.LLMInferenceService](ns.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(), WithManagedGateway(), WithManagedScheduler(),
+				WithGroup("group"),
+			)
+			if invalidPreset {
+				svc.Spec.BaseRefs = []corev1.LocalObjectReference{{Name: "does-not-exist"}}
+			}
+
+			cfgMap := InferenceServiceCfgMap(constants.KServeNamespace)
+			presets := SharedConfigPresets(constants.KServeNamespace)
+			objects := make([]client.Object, 0, 4+len(presets))
+			objects = append(objects, svc, cfgMap, DefaultGateway(constants.KServeNamespace), DefaultGatewayClass())
+			for _, preset := range presets {
+				objects = append(objects, preset)
+			}
+
+			groupIndex, groupIndexValue := llmisvc.GroupFieldIndexForTest()
+			c := fake.NewClientBuilder().
+				WithScheme(envTest.Client.Scheme()).
+				WithRESTMapper(envTest.Client.RESTMapper()).
+				WithIndex(&v1alpha2.LLMInferenceService{}, groupIndex, groupIndexValue).
+				WithStatusSubresource(&v1alpha2.LLMInferenceService{}).
+				WithObjects(objects...).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*gwapiv1.HTTPRoute); ok && routeGetErr != nil {
+							return routeGetErr
+						}
+						return c.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			r := &llmisvc.LLMISVCReconciler{
+				Client:        c,
+				Clientset:     kubernetesfake.NewClientset(cfgMap),
+				EventRecorder: record.NewFakeRecorder(100),
+			}
+
+			// Twice, to prove the classification holds for repeated unchanged inputs.
+			for range 2 {
+				result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(svc)})
+				Expect(result.IsZero()).To(BeTrue(), "cleanup must not request its own requeue delay")
+
+				Expect(cleanupFailed(err)).To(Equal(wantCleanupErr), "got: %v", err)
+				if wantCleanupErr {
+					Expect(apierrors.IsForbidden(err)).To(BeTrue(), "cleanup failures must stay retryable, got: %v", err)
+					Expect(errors.Is(err, reconcile.TerminalError(nil))).To(BeFalse(),
+						"a terminal desired-state error must not swallow the cleanup retry")
+				}
+
+				if invalidPreset {
+					continue
+				}
+				// A failure reading the route must not stop the rest of reconciliation.
+				for _, suffix := range []string{"-kserve", "-kserve-router-scheduler"} {
+					Expect(c.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: svc.Name + suffix},
+						&appsv1.Deployment{})).To(Succeed())
+				}
+			}
+		},
+		Entry("healthy inputs", nil, false, false),
+		// An uninstalled Gateway API is absence for cleanup; whatever the router
+		// then makes of it is that path's own business.
+		Entry("absent HTTPRoute CRD", noKindMatch, false, false),
+		Entry("route read forbidden", denied, false, true),
+		Entry("route read forbidden alongside a terminal preset error", denied, true, true),
+	)
+})

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_router_group_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,6 +35,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+	. "github.com/kserve/kserve/pkg/testing"
 )
 
 var _ = Describe("LLMInferenceService Group Routing", func() {
@@ -480,6 +483,116 @@ var _ = Describe("LLMInferenceService Group Routing", func() {
 				g.Expect(currentA.Status.Router.Group.Members).To(HaveLen(1))
 				g.Expect(currentA.Status.Router.Group.Members[0].Name).To(Equal(svcNameA))
 			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Member deletion with an unreconcilable peer", func() {
+		It("should complete deletion when a surviving peer cannot render its desired route", func(ctx SpecContext) {
+			// given - two healthy members of one group
+			groupName := "stuck-group"
+			svcNameA := "test-stuck-a"
+			svcNameB := "test-stuck-b"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvcA := LLMInferenceService(svcNameA,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(60),
+			)
+
+			llmSvcB := LLMInferenceService(svcNameB,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithModelName("facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithGroup(groupName),
+				WithWeight(40),
+			)
+
+			Expect(envTest.Create(ctx, llmSvcA)).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvcB)).To(Succeed())
+			defer func() {
+				// A is deliberately left unreconcilable, so tear it down first:
+				// once both members terminate neither finalizer waits on the other.
+				testNs.DeleteAndWait(ctx, llmSvcA)
+				testNs.DeleteAndWait(ctx, llmSvcB)
+			}()
+
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcA)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvcB)
+
+			routeBefore := &gwapiv1.HTTPRoute{}
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(groupRoutingBackendRefs(&routes[0], llmSvcA)).To(HaveLen(2))
+				routeBefore = routes[0].DeepCopy()
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - A can no longer resolve its configuration
+			Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				current := &v1alpha2.LLMInferenceService{}
+				if err := envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), current); err != nil {
+					return err
+				}
+				current.Spec.BaseRefs = []corev1.LocalObjectReference{{Name: "does-not-exist"}}
+				return envTest.Update(ctx, current)
+			})).To(Succeed())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), current)).To(Succeed())
+				g.Expect(current.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "False"))
+				g.Expect(current.Status.GetCondition(v1alpha2.PresetsCombined).Reason).To(Equal("ConfigNotFound"))
+			}).WithContext(ctx).Should(Succeed())
+
+			// A's stored route is frozen with B's backendRef still in it
+			Consistently(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				g.Expect(backendRefNames(groupRoutingBackendRefs(&routes[0], llmSvcA))).
+					To(ContainElement(HavePrefix(svcNameB)))
+			}).WithContext(ctx).WithTimeout(5 * time.Second).Should(Succeed())
+
+			// when - B is deleted while A stays broken
+			Expect(envTest.Delete(ctx, llmSvcB)).To(Succeed())
+
+			// then - deletion finishes without anyone repairing A
+			Eventually(func(g Gomega, ctx context.Context) {
+				err := envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcB), &v1alpha2.LLMInferenceService{})
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					"deletion must not depend on repairing peer %s, got: %v", svcNameA, err)
+			}).WithContext(ctx).Should(Succeed())
+
+			// and - A survives with B pruned from its route and nothing else touched
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, err := managedRoutes(ctx, llmSvcA)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+
+				refs := groupRoutingBackendRefs(&routes[0], llmSvcA)
+				g.Expect(refs).To(HaveLen(1))
+				g.Expect(refs[0]).To(HaveBackendName(svcNameA))
+				g.Expect(refs[0].Weight).To(Equal(new(int32(60))), "surviving weights must be preserved")
+				g.Expect(routes[0].Spec.Hostnames).To(Equal(routeBefore.Spec.Hostnames))
+				g.Expect(routeRuleMatches(&routes[0])).To(Equal(routeRuleMatches(routeBefore)),
+					"pruning must not regenerate the route")
+			}).WithContext(ctx).Should(Succeed())
+
+			currentA := &v1alpha2.LLMInferenceService{}
+			Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvcA), currentA)).To(Succeed())
+			Expect(currentA.DeletionTimestamp.IsZero()).To(BeTrue())
+			Expect(currentA.Status).To(HaveCondition(string(v1alpha2.PresetsCombined), "False"),
+				"cleanup must not paper over the unresolved configuration")
 		})
 	})
 
@@ -1025,6 +1138,16 @@ func groupRoutingBackendRefs(route *gwapiv1.HTTPRoute, owner *v1alpha2.LLMInfere
 		}
 	}
 	return nil
+}
+
+// routeRuleMatches returns the match rules of every rule, so a test can assert
+// that pruning backendRefs left the routing decisions themselves alone.
+func routeRuleMatches(route *gwapiv1.HTTPRoute) [][]gwapiv1.HTTPRouteMatch {
+	matches := make([][]gwapiv1.HTTPRouteMatch, len(route.Spec.Rules))
+	for i, rule := range route.Spec.Rules {
+		matches[i] = rule.Matches
+	}
+	return matches
 }
 
 // backendRefNames extracts the backend names from a slice of HTTPBackendRef.

--- a/pkg/controller/v1alpha2/llmisvc/router_export_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_export_test.go
@@ -19,6 +19,7 @@ package llmisvc
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -26,4 +27,10 @@ import (
 
 func UpdateRoutingStatusForTest(ctx context.Context, r *LLMISVCReconciler, llmSvc *v1alpha2.LLMInferenceService, routes ...*gwapiv1.HTTPRoute) ([]ResolvedGateway, error) {
 	return r.updateRoutingStatus(ctx, llmSvc, routes...)
+}
+
+// GroupFieldIndexForTest exposes the group member index so tests outside this
+// package can register it on a fake client the way the manager does.
+func GroupFieldIndexForTest() (string, client.IndexerFunc) {
+	return groupFieldIndex, groupIndexValue
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_group.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	kmeta "knative.dev/pkg/kmeta"
@@ -236,7 +237,9 @@ func (r *LLMISVCReconciler) finalizeGroupMembership(ctx context.Context, llmSvc 
 			Namespace: members[i].GetNamespace(),
 		}
 		if err := r.Get(ctx, routeKey, route); err != nil {
-			if apierrors.IsNotFound(err) {
+			// An uninstalled Gateway API holds no reference to release; erroring
+			// here would block deletion forever.
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 				continue
 			}
 			return false, fmt.Errorf("checking member route %s for stale backendRefs: %w", routeKey.Name, err)

--- a/pkg/controller/v1alpha2/llmisvc/router_group_cleanup.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_cleanup.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmeta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// reconcileTerminatingGroupBackends drops terminating group members from this
+// service's own group HTTPRoute. A deleting member waits for its peers' routes
+// to release its backend (see finalizeGroupMembership), so this runs ahead of
+// and independently of desired-state reconciliation: a peer whose own
+// configuration is invalid must not hold a group deletion hostage.
+func (r *LLMISVCReconciler) reconcileTerminatingGroupBackends(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
+	if !llmSvc.Spec.Router.HasGroup() {
+		return nil
+	}
+
+	route := &gwapiv1.HTTPRoute{}
+	key := client.ObjectKey{Namespace: llmSvc.Namespace, Name: kmeta.ChildName(llmSvc.Name, "-kserve-route")}
+	if err := r.Get(ctx, key, route); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
+		return client.IgnoreNotFound(err)
+	}
+
+	group := route.Labels[constants.LLMRoutingGroupLabelKey]
+	if group == "" {
+		return nil
+	}
+	if !metav1.IsControlledBy(route, llmSvc) {
+		return fmt.Errorf("cannot prune group HTTPRoute %s/%s: not controlled by this service", route.Namespace, route.Name)
+	}
+
+	members := &v1alpha2.LLMInferenceServiceList{}
+	if err := r.List(ctx, members, client.InNamespace(route.Namespace),
+		client.MatchingFields{groupFieldIndex: route.Namespace + "/" + group}); err != nil {
+		return fmt.Errorf("failed to list routing group %q: %w", group, err)
+	}
+
+	stored := route.DeepCopy()
+	if removed := removeTerminatingGroupBackends(route, members.Items); len(removed) > 0 {
+		if err := r.Patch(ctx, route, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to prune terminating backends from group HTTPRoute %s/%s: %w",
+				route.Namespace, route.Name, err)
+		}
+	}
+
+	// Recompute membership even when nothing was pruned here: an earlier reconcile
+	// may have patched the route successfully and then failed to persist status.
+	// Membership comes from the member list rather than the route, so a route this
+	// service was unable to write cannot erase a live peer from status.
+	if llmSvc.Status.Router != nil && llmSvc.Status.Router.Group != nil {
+		live := make(map[string]bool, len(members.Items))
+		for i := range members.Items {
+			if members.Items[i].DeletionTimestamp.IsZero() {
+				live[members.Items[i].Name] = true
+			}
+		}
+		llmSvc.Status.Router.Group.Members = slices.DeleteFunc(llmSvc.Status.Router.Group.Members,
+			func(member v1alpha2.GroupMemberStatus) bool {
+				return !live[member.Name]
+			})
+	}
+
+	return nil
+}
+
+// removeTerminatingGroupBackends strips backendRefs belonging to terminating
+// members from every rule, leaving matches, hostnames, rule order and surviving
+// weights untouched. It returns the names of the members it pruned.
+func removeTerminatingGroupBackends(route *gwapiv1.HTTPRoute, members []v1alpha2.LLMInferenceService) []string {
+	var removed []string
+	for i := range members {
+		member := &members[i]
+		if member.DeletionTimestamp.IsZero() {
+			continue
+		}
+		changed := false
+		for j := range route.Spec.Rules {
+			rule := &route.Spec.Rules[j]
+			before := len(rule.BackendRefs)
+			rule.BackendRefs = slices.DeleteFunc(rule.BackendRefs, func(ref gwapiv1.HTTPBackendRef) bool {
+				return backendRefersTo(ref, route.Namespace, member)
+			})
+			changed = changed || len(rule.BackendRefs) != before
+		}
+		if changed {
+			removed = append(removed, member.Name)
+		}
+	}
+	return removed
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_cleanup_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_cleanup_test.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/kmeta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+const (
+	testGroup    = "group"
+	testPeerSvc  = "peer-kserve-workload-svc"
+	testPeerPool = "peer-inference-pool"
+)
+
+func TestRemoveTerminatingGroupBackends(t *testing.T) {
+	for _, tt := range []struct {
+		name                            string
+		group, kind, backend, namespace string
+		poolRef                         string
+		active, forceStopped, remove    bool
+	}{
+		{name: "workload Service", backend: testPeerSvc, remove: true},
+		{name: "v1 pool", group: constants.InferencePoolV1APIGroupName, kind: "InferencePool", backend: testPeerPool, remove: true},
+		{name: "v1alpha2 pool", group: constants.InferencePoolV1Alpha2APIGroupName, kind: "InferencePool", backend: testPeerPool, remove: true},
+		{name: "explicit own namespace", backend: testPeerSvc, namespace: "ns", remove: true},
+		// A member using scheduler.pool.ref has that pool injected as its
+		// backendRef, so cleanup must recognise it by the referenced name.
+		{name: "explicitly referenced pool", kind: "InferencePool", backend: "user-pool", poolRef: "user-pool", remove: true},
+		// Both names are recognised: a member that switched to a pool ref may still
+		// have the controller-created default pool named in a peer's stored route.
+		{name: "default pool name while a pool ref is set", kind: "InferencePool", backend: testPeerPool, poolRef: "user-pool", remove: true},
+		// isDefaultBackendRef matches the default pool by kind and name only,
+		// because the group is v1 or v1alpha2 depending on the cluster.
+		{name: "pool in an unexpected group", group: "custom.example.com", kind: "InferencePool", backend: testPeerPool, remove: true},
+		{name: "different namespace", backend: testPeerSvc, namespace: "elsewhere"},
+		{name: "different kind", kind: "CustomBackend", backend: testPeerSvc},
+		{name: "pool name in the core group", kind: "Service", backend: testPeerPool},
+		{name: "unrelated Service", backend: "custom-service"},
+		{name: "active member", backend: testPeerSvc, active: true},
+		// Force-stop is orthogonal to deletion: a terminating member must be
+		// pruned either way, or its finalizer never releases.
+		{name: "force-stopped and terminating", backend: testPeerSvc, forceStopped: true, remove: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			member := v1alpha2.LLMInferenceService{ObjectMeta: metav1.ObjectMeta{Name: "peer", Namespace: "ns"}}
+			if !tt.active {
+				member.DeletionTimestamp = ptr.To(metav1.Now())
+			}
+			if tt.forceStopped {
+				member.Annotations = map[string]string{constants.StopAnnotationKey: "true"}
+			}
+			if tt.poolRef != "" {
+				member.Spec.Router = &v1alpha2.RouterSpec{Scheduler: &v1alpha2.SchedulerSpec{
+					Pool: &v1alpha2.InferencePoolSpec{Ref: &corev1.LocalObjectReference{Name: tt.poolRef}},
+				}}
+			}
+
+			ref := gwapiv1.HTTPBackendRef{BackendRef: gwapiv1.BackendRef{
+				BackendObjectReference: gwapiv1.BackendObjectReference{Name: gwapiv1.ObjectName(tt.backend)},
+				Weight:                 ptr.To[int32](40),
+			}}
+			if tt.group != "" {
+				ref.Group = ptr.To(gwapiv1.Group(tt.group))
+			}
+			if tt.kind != "" {
+				ref.Kind = ptr.To(gwapiv1.Kind(tt.kind))
+			}
+			if tt.namespace != "" {
+				ref.Namespace = ptr.To(gwapiv1.Namespace(tt.namespace))
+			}
+
+			route := &gwapiv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: "ns"}, Spec: gwapiv1.HTTPRouteSpec{
+				Hostnames: []gwapiv1.Hostname{"models.example.com"},
+				Rules: []gwapiv1.HTTPRouteRule{{
+					Matches: []gwapiv1.HTTPRouteMatch{{Path: &gwapiv1.HTTPPathMatch{
+						Type: ptr.To(gwapiv1.PathMatchPathPrefix), Value: ptr.To("/"),
+					}}},
+					BackendRefs: []gwapiv1.HTTPBackendRef{ref, {BackendRef: gwapiv1.BackendRef{
+						BackendObjectReference: gwapiv1.BackendObjectReference{Name: "survivor"},
+						Weight:                 ptr.To[int32](60),
+					}}},
+				}},
+			}}
+
+			want := route.DeepCopy()
+			if tt.remove {
+				want.Spec.Rules[0].BackendRefs = want.Spec.Rules[0].BackendRefs[1:]
+			}
+
+			removed := removeTerminatingGroupBackends(route, []v1alpha2.LLMInferenceService{member})
+			assert.Equal(t, want, route, "matches, hostnames and surviving weights must be untouched")
+			if tt.remove {
+				assert.Equal(t, []string{"peer"}, removed)
+			} else {
+				assert.Empty(t, removed)
+			}
+
+			assert.Empty(t, removeTerminatingGroupBackends(route, []v1alpha2.LLMInferenceService{member}),
+				"pruning must be idempotent")
+			assert.Equal(t, want, route)
+		})
+	}
+}
+
+func TestGroupBackendCleanupSkipsUnownedAndAbsentRoutes(t *testing.T) {
+	grouped := func() *v1alpha2.LLMInferenceService {
+		return &v1alpha2.LLMInferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "ns", UID: "owner-uid"},
+			Spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To(testGroup)}},
+			},
+		}
+	}
+	noKindMatch := &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: gwapiv1.GroupName, Kind: "HTTPRoute"}}
+
+	t.Run("non-grouped service reads nothing", func(t *testing.T) {
+		svc := grouped()
+		svc.Spec.Router.Route.Group = nil
+		c := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				t.Fatal("a non-grouped service must not read any route")
+				return nil
+			},
+		}).Build()
+		require.NoError(t, (&LLMISVCReconciler{Client: c}).reconcileTerminatingGroupBackends(t.Context(), svc))
+	})
+
+	t.Run("absent HTTPRoute CRD", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				require.IsType(t, &gwapiv1.HTTPRoute{}, obj)
+				return noKindMatch
+			},
+		}).Build()
+		require.NoError(t, (&LLMISVCReconciler{Client: c}).reconcileTerminatingGroupBackends(t.Context(), grouped()),
+			"an absent optional CRD means there are no routes to prune")
+	})
+
+	t.Run("route not created yet", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(cleanupScheme(t)).Build()
+		require.NoError(t, (&LLMISVCReconciler{Client: c}).reconcileTerminatingGroupBackends(t.Context(), grouped()))
+	})
+
+	t.Run("forbidden stays an error", func(t *testing.T) {
+		denied := apierrors.NewForbidden(schema.GroupResource{Group: gwapiv1.GroupName, Resource: "httproutes"}, "route", errors.New("denied"))
+		c := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return denied
+			},
+		}).Build()
+		err := (&LLMISVCReconciler{Client: c}).reconcileTerminatingGroupBackends(t.Context(), grouped())
+		require.True(t, apierrors.IsForbidden(err), "an RBAC denial is not absence: %v", err)
+	})
+
+	t.Run("route without a group label", func(t *testing.T) {
+		owner := grouped()
+		route := groupRoute(owner, gwapiv1.HTTPBackendRef{BackendRef: gwapiv1.BackendRef{
+			BackendObjectReference: gwapiv1.BackendObjectReference{Name: testPeerSvc},
+		}})
+		route.Labels = nil
+		c := fake.NewClientBuilder().WithScheme(cleanupScheme(t)).WithObjects(route).Build()
+		require.NoError(t, (&LLMISVCReconciler{Client: c}).reconcileTerminatingGroupBackends(t.Context(), owner))
+
+		current := &gwapiv1.HTTPRoute{}
+		require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(route), current))
+		require.Len(t, current.Spec.Rules[0].BackendRefs, 1, "an unlabelled route is not a group route")
+	})
+
+	t.Run("route owned by somebody else", func(t *testing.T) {
+		owner := grouped()
+		other := grouped()
+		other.Name, other.UID = "intruder", "intruder-uid"
+		route := groupRoute(owner)
+		route.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(other, v1alpha2.LLMInferenceServiceGVK)}
+		c := fake.NewClientBuilder().WithScheme(cleanupScheme(t)).WithObjects(route).Build()
+
+		err := (&LLMISVCReconciler{Client: c}).reconcileTerminatingGroupBackends(t.Context(), owner)
+		require.ErrorContains(t, err, "not controlled by this service")
+	})
+
+	t.Run("list failure is retryable", func(t *testing.T) {
+		owner := grouped()
+		c := fake.NewClientBuilder().WithScheme(cleanupScheme(t)).WithObjects(groupRoute(owner)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+					return apierrors.NewServiceUnavailable("apiserver is down")
+				},
+			}).Build()
+
+		err := (&LLMISVCReconciler{Client: c}).reconcileTerminatingGroupBackends(t.Context(), owner)
+		require.True(t, apierrors.IsServiceUnavailable(err), "got: %v", err)
+	})
+}
+
+func TestGroupBackendCleanupConvergesAfterConflict(t *testing.T) {
+	owner := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "ns", UID: "owner-uid"},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To(testGroup)}},
+		},
+	}
+	peer := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "peer", Namespace: "ns",
+			DeletionTimestamp: ptr.To(metav1.Now()), Finalizers: []string{"test-finalizer"},
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{Route: &v1alpha2.GatewayRoutesSpec{Group: ptr.To(testGroup)}},
+		},
+	}
+	peerRef := gwapiv1.BackendObjectReference{Name: testPeerSvc}
+	memberStatus := func() []v1alpha2.GroupMemberStatus {
+		return []v1alpha2.GroupMemberStatus{{Name: peer.Name, BackendRef: &peerRef}}
+	}
+	owner.Status.Router = &v1alpha2.RouterStatus{
+		Group: &v1alpha2.GroupStatus{Name: testGroup, Members: memberStatus()},
+	}
+
+	route := groupRoute(owner,
+		gwapiv1.HTTPBackendRef{BackendRef: gwapiv1.BackendRef{BackendObjectReference: peerRef}},
+		gwapiv1.HTTPBackendRef{BackendRef: gwapiv1.BackendRef{
+			BackendObjectReference: gwapiv1.BackendObjectReference{Name: "owner-kserve-workload-svc"},
+		}})
+
+	patches := 0
+	c := fake.NewClientBuilder().WithScheme(cleanupScheme(t)).WithObjects(owner, peer, route).
+		WithIndex(&v1alpha2.LLMInferenceService{}, groupFieldIndex, groupIndexValue).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				patches++
+				if patches == 1 {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: gwapiv1.GroupName, Resource: "httproutes"}, obj.GetName(), nil)
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+	r := &LLMISVCReconciler{Client: c}
+	ctx := t.Context()
+
+	err := r.reconcileTerminatingGroupBackends(ctx, owner)
+	require.True(t, apierrors.IsConflict(err), "conflicts must reach controller-runtime for retry: %v", err)
+	require.Len(t, owner.Status.Router.Group.Members, 1, "uncommitted pruning must not be published as applied")
+
+	require.NoError(t, r.reconcileTerminatingGroupBackends(ctx, owner))
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(route), route))
+	require.Len(t, route.Spec.Rules[0].BackendRefs, 1)
+	require.Empty(t, owner.Status.Router.Group.Members)
+
+	// A route patch that lands while the parent status write fails leaves stale
+	// membership behind; the next no-op cleanup must still repair it.
+	owner.Status.Router.Group.Members = memberStatus()
+	require.NoError(t, r.reconcileTerminatingGroupBackends(ctx, owner))
+	assert.Empty(t, owner.Status.Router.Group.Members)
+	assert.Equal(t, 2, patches, "a route with nothing left to prune must not be patched again")
+}
+
+func cleanupScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+	require.NoError(t, gwapiv1.Install(scheme))
+	return scheme
+}
+
+// groupRoute builds the managed group HTTPRoute owned by owner.
+func groupRoute(owner *v1alpha2.LLMInferenceService, refs ...gwapiv1.HTTPBackendRef) *gwapiv1.HTTPRoute {
+	return &gwapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            kmeta.ChildName(owner.Name, "-kserve-route"),
+			Namespace:       owner.Namespace,
+			Labels:          map[string]string{constants.LLMRoutingGroupLabelKey: testGroup},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(owner, v1alpha2.LLMInferenceServiceGVK)},
+		},
+		Spec: gwapiv1.HTTPRouteSpec{Rules: []gwapiv1.HTTPRouteRule{{BackendRefs: refs}}},
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -777,6 +778,11 @@ func TestFinalizeGroupMembership(t *testing.T) {
 		{name: "peer still references an explicitly referenced pool", route: peerPoolRoute("user-pool"), poolRef: "user-pool"},
 		{name: "peer released an explicitly referenced pool", route: peerRoute("peer-kserve-workload-svc"), poolRef: "user-pool", converged: true},
 		{name: "peer has no route yet", converged: true},
+		{
+			name:      "HTTPRoute CRD is not installed",
+			getErr:    &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: gwapiv1.GroupName, Kind: "HTTPRoute"}},
+			converged: true,
+		},
 		{
 			name: "peer route read denied",
 			getErr: apierrors.NewForbidden(


### PR DESCRIPTION
**What this PR does / why we need it**:

Probably edge-case, but deleting a member of a routing group can wait indefinitely on an unrelated peer.

A deleting member's finalizer waits for its peers' stored `HTTPRoutes` to drop its `backendRef`. A peer only rewrites that route through reconciliation, which returns early on any configuration failure - a missing preset, for instance, is terminal and never retries. Deleting one member therefore ends up blocked.

With this PR, releasing a terminating peer no longer depends on the surviving member's own configuration being valid. The contract stays narrow: terminating members are removed from controller-owned group routes.

> [!IMPORTANT]
> One thing I am going to follow up seperately: a user-authored rule in `spec.router.route.http.spec` that references a peer's backend without referencing the route owner's own backend is skipped by `rewriteRulesForGroup`, since that only rewrites rules naming the owner's backend. Cleanup prunes the peer's ref from such a rule and the same reconcile pass re-renders it from spec, so the terminating peer keeps blocking - as it does today, so this is not a regression, but worth scoped PR to address soon.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] Envtest regression covering two healthy group members where one is then pointed at a nonexistent preset. On master, deleting the other member never completes; the peer loops on `terminal error: LLMInferenceServiceConfig "does-not-exist" not found` while the delete hangs:

```
[FAILED] Timed out after 30.000s.
deletion must not depend on repairing peer test-stuck-a, got: <nil>
```

With the fix, deletion completes, the peer survives untouched, and its route keeps its own matches, hostnames and weights.

- [x] The regression runs through the real manager and its existing peer watch, so it would fail if the deletion event never reached the surviving member.
- [x] Fault injection covering backend filtering, ownership and absence cases, and error classification - a failing cleanup stays retryable next to a terminal configuration error, and workloads and the scheduler still reconcile when their own inputs are valid.
- [x] Full `pkg/apis/serving/v1alpha2` and `pkg/controller/v1alpha2` suites, plus `make precommit`.

**Special notes for your reviewer**:

Worth a look: cleanup runs before desired-state reconciliation and its error is returned separately rather than joined with it. Joining would let a `reconcile.TerminalError` swallow the retry that a failed cleanup still needs, since controller-runtime detects terminal errors through `errors.Is`.

No configuration flag, API change, or manifest migration.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? - not user-facing

**Release note**:
```release-note
Fixed deletion of an `LLMInferenceService` routing group member hanging indefinitely when another member of the group cannot reconcile its own configuration. Removing a member no longer requires repairing an unrelated peer first.
```
