### PR TITLE
test(llmisvc): wait for workload readiness

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -184,6 +184,15 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					Kind:     "Deployment",
 					Name:     kmeta.ChildName(svcName, "-kserve-router-scheduler"),
 				}))
+
+				// The refs are populated on the first reconcile after the
+				// Deployments exist, before the Deployment status writes this test
+				// makes are observed. Ready plus the observed replica counts is
+				// what tells us the status has settled, which the idempotency
+				// snapshot below depends on.
+				g.Expect(current.Status).To(HaveCondition("Ready", "True"))
+				g.Expect(current.Status.Workloads.Primary.ReadyReplicas).To(Equal(ptr.To[int32](1)))
+				g.Expect(current.Status.Workloads.Scheduler.ReadyReplicas).To(Equal(ptr.To[int32](1)))
 			})).WithContext(ctx).Should(Succeed())
 
 			// Idempotency: trigger a no-op requeue and verify status.workloads


### PR DESCRIPTION
**What this PR does / why we need it**:

`TestLLMInferenceServiceController` flakes on "should create a basic single node deployment with just base refs" - the Go Test workflow has failed on master several times lately.

The spec's readiness gate never waited for the workload to reach a settled state. Under envtest it only checked that the status carried the right resource references, and the controller populates those on the same reconcile that first
observes the Deployment - before the test's own status update marking that Deployment available has been read back. 

The spec then snapshotted the workload status and asserted it stayed unchanged across a follow-up no-op reconcile, so
whenever the settled replica count landed inside that window rather than before it, the snapshot no longer matched.

The gate now also requires the service to report Ready and both workloads to report their expected replica count, so the snapshot can only be taken once the status has actually settled. The suite takes around ten minutes, which makes a
rerun an expensive way to clear this.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/controller/v1alpha2/llmisvc/...` green, plus repeated focused runs of the affected spec.
- [x] `make precommit` clean.

**Special notes for your reviewer**:

Test-only change, no controller behaviour is touched.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
