### PR TITLE
fix: enforce LocalModelCache storage limits

### DIFF
--- a/pkg/localmodelcache/storage_capacity.go
+++ b/pkg/localmodelcache/storage_capacity.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localmodelcache
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+// StorageReservation describes the storage requested by a local model cache.
+type StorageReservation struct {
+	Name       string
+	Namespace  string
+	ModelSize  resource.Quantity
+	NodeGroups []string
+}
+
+// ValidateStorageCapacity validates that the requested storage fits within the
+// storage limit of every targeted LocalModelNodeGroup. Existing reservations
+// from both LocalModelCache and LocalModelNamespaceCache are included.
+func ValidateStorageCapacity(
+	ctx context.Context,
+	c client.Client,
+	current StorageReservation,
+) error {
+	localModelCaches := &v1alpha1.LocalModelCacheList{}
+	if err := c.List(ctx, localModelCaches); err != nil {
+		return fmt.Errorf("unable to list LocalModelCaches: %w", err)
+	}
+
+	localModelNamespaceCaches := &v1alpha1.LocalModelNamespaceCacheList{}
+	if err := c.List(ctx, localModelNamespaceCaches); err != nil {
+		return fmt.Errorf("unable to list LocalModelNamespaceCaches: %w", err)
+	}
+
+	for _, nodeGroupName := range current.NodeGroups {
+		nodeGroup := &v1alpha1.LocalModelNodeGroup{}
+		if err := c.Get(ctx, client.ObjectKey{Name: nodeGroupName}, nodeGroup); err != nil {
+			return fmt.Errorf("unable to get LocalModelNodeGroup %s: %w", nodeGroupName, err)
+		}
+
+		var totalModelSize resource.Quantity
+		totalModelSize.Add(current.ModelSize)
+
+		for _, cache := range localModelCaches.Items {
+			if cache.Name == current.Name && current.Namespace == "" {
+				continue
+			}
+
+			if containsNodeGroup(cache.Spec.NodeGroups, nodeGroupName) {
+				totalModelSize.Add(cache.Spec.ModelSize)
+			}
+		}
+
+		for _, cache := range localModelNamespaceCaches.Items {
+			if cache.Name == current.Name && cache.Namespace == current.Namespace {
+				continue
+			}
+
+			if containsNodeGroup(cache.Spec.NodeGroups, nodeGroupName) {
+				totalModelSize.Add(cache.Spec.ModelSize)
+			}
+		}
+
+		if totalModelSize.Cmp(nodeGroup.Spec.StorageLimit) > 0 {
+			return fmt.Errorf(
+				"local model cache %s would use %s of %s storage in LocalModelNodeGroup %s, exceeding the storage limit of %s",
+				current.Name,
+				totalModelSize.String(),
+				nodeGroup.Spec.StorageLimit.String(),
+				nodeGroupName,
+				nodeGroup.Spec.StorageLimit.String(),
+			)
+		}
+	}
+
+	return nil
+}
+
+func containsNodeGroup(nodeGroups []string, nodeGroupName string) bool {
+	for _, name := range nodeGroups {
+		if name == nodeGroupName {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/localmodelcache/storage_capacity_test.go
+++ b/pkg/localmodelcache/storage_capacity_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localmodelcache
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+func TestValidateStorageCapacity_AllowsWithinLimit(t *testing.T) {
+	nodeGroup := &v1alpha1.LocalModelNodeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu1"},
+		Spec: v1alpha1.LocalModelNodeGroupSpec{
+			StorageLimit: resource.MustParse("10Gi"),
+		},
+	}
+
+	err := ValidateStorageCapacity(
+		context.Background(),
+		newStorageCapacityTestClient(t, nodeGroup),
+		StorageReservation{
+			Name:       "iris",
+			ModelSize:  resource.MustParse("5Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateStorageCapacity_RejectsWhenLimitExceeded(t *testing.T) {
+	nodeGroup := &v1alpha1.LocalModelNodeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu1"},
+		Spec: v1alpha1.LocalModelNodeGroupSpec{
+			StorageLimit: resource.MustParse("10Gi"),
+		},
+	}
+
+	err := ValidateStorageCapacity(
+		context.Background(),
+		newStorageCapacityTestClient(t, nodeGroup),
+		StorageReservation{
+			Name:       "iris",
+			ModelSize:  resource.MustParse("11Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	)
+
+	if err == nil {
+		t.Fatal("expected storage capacity validation to fail")
+	}
+}
+
+func TestValidateStorageCapacity_RejectsAggregateLimitExceeded(t *testing.T) {
+	nodeGroup := &v1alpha1.LocalModelNodeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu1"},
+		Spec: v1alpha1.LocalModelNodeGroupSpec{
+			StorageLimit: resource.MustParse("10Gi"),
+		},
+	}
+
+	existingCache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "existing"},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			ModelSize:  resource.MustParse("6Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	}
+
+	err := ValidateStorageCapacity(
+		context.Background(),
+		newStorageCapacityTestClient(t, nodeGroup, existingCache),
+		StorageReservation{
+			Name:       "new",
+			ModelSize:  resource.MustParse("5Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	)
+
+	if err == nil {
+		t.Fatal("expected aggregate storage capacity validation to fail")
+	}
+}
+
+func TestValidateStorageCapacity_IncludesBothCacheTypes(t *testing.T) {
+	nodeGroup := &v1alpha1.LocalModelNodeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu1"},
+		Spec: v1alpha1.LocalModelNodeGroupSpec{
+			StorageLimit: resource.MustParse("10Gi"),
+		},
+	}
+
+	existingCache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-cache"},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			ModelSize:  resource.MustParse("6Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	}
+
+	existingNamespaceCache := &v1alpha1.LocalModelNamespaceCache{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "namespace-cache",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.LocalModelNamespaceCacheSpec{
+			ModelSize:  resource.MustParse("2Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	}
+
+	err := ValidateStorageCapacity(
+		context.Background(),
+		newStorageCapacityTestClient(t, nodeGroup, existingCache, existingNamespaceCache),
+		StorageReservation{
+			Name:       "new",
+			ModelSize:  resource.MustParse("3Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	)
+
+	if err == nil {
+		t.Fatal("expected storage capacity validation to fail")
+	}
+}
+
+func TestValidateStorageCapacity_DoesNotCountCurrentCache(t *testing.T) {
+	nodeGroup := &v1alpha1.LocalModelNodeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu1"},
+		Spec: v1alpha1.LocalModelNodeGroupSpec{
+			StorageLimit: resource.MustParse("10Gi"),
+		},
+	}
+
+	currentCache := &v1alpha1.LocalModelCache{
+		ObjectMeta: metav1.ObjectMeta{Name: "iris"},
+		Spec: v1alpha1.LocalModelCacheSpec{
+			ModelSize:  resource.MustParse("6Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	}
+
+	err := ValidateStorageCapacity(
+		context.Background(),
+		newStorageCapacityTestClient(t, nodeGroup, currentCache),
+		StorageReservation{
+			Name:       "iris",
+			ModelSize:  resource.MustParse("6Gi"),
+			NodeGroups: []string{"gpu1"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected current cache to be excluded, got %v", err)
+	}
+}
+
+func newStorageCapacityTestClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add v1alpha1 scheme: %v", err)
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
@@ -69,6 +69,18 @@ func (v *LocalModelCacheValidator) ValidateCreate(ctx context.Context, obj runti
 	if localModelCacheWithSameStorageURI != nil {
 		return admission.Warnings{}, fmt.Errorf("LocalModelCache %s has the same StorageURI %s", localModelCacheWithSameStorageURI.Name, localModelCacheWithSameStorageURI.Spec.SourceModelUri)
 	}
+
+	if err := localmodelcache.ValidateStorageCapacity(
+		ctx,
+		v.Client,
+		localmodelcache.StorageReservation{
+			Name:       localModelCache.Name,
+			ModelSize:  localModelCache.Spec.ModelSize,
+			NodeGroups: localModelCache.Spec.NodeGroups,
+		},
+	); err != nil {
+		return nil, err
+	}
 	return nil, nil
 }
 
@@ -90,6 +102,17 @@ func (v *LocalModelCacheValidator) ValidateUpdate(ctx context.Context, oldObj, n
 	}
 	if localModelCacheWithSameStorageURI != nil {
 		return admission.Warnings{}, fmt.Errorf("LocalModelCache %s has the same StorageURI %s", localModelCacheWithSameStorageURI.Name, localModelCacheWithSameStorageURI.Spec.SourceModelUri)
+	}
+	if err := localmodelcache.ValidateStorageCapacity(
+		ctx,
+		v.Client,
+		localmodelcache.StorageReservation{
+			Name:       localModelCache.Name,
+			ModelSize:  localModelCache.Spec.ModelSize,
+			NodeGroups: localModelCache.Spec.NodeGroups,
+		},
+	); err != nil {
+		return nil, err
 	}
 	return nil, nil
 }

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
@@ -287,7 +287,19 @@ func TestValidateUpdate_LocalModelCacheWithUniqueStorageURI(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to add scheme : %v", err)
 	}
-	fakeClient := fake.NewClientBuilder().WithObjects(&existingLmc).WithScheme(s).Build()
+	nodeGroup := v1alpha1.LocalModelNodeGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu1",
+		},
+		Spec: v1alpha1.LocalModelNodeGroupSpec{
+			StorageLimit: resource.MustParse("10Gi"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(&existingLmc, &nodeGroup).
+		WithScheme(s).
+		Build()
 	validator := LocalModelCacheValidator{fakeClient}
 	// newLmc has a unique StorageURI
 	newLmc := makeTestLocalModelCacheWithDifferentStorageURI()

--- a/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
+++ b/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
@@ -65,6 +65,18 @@ func (v *LocalModelNamespaceCacheValidator) ValidateCreate(ctx context.Context, 
 	if err := v.validateNodeGroups(ctx, localModelNamespaceCache); err != nil {
 		return nil, err
 	}
+	if err := localmodelcache.ValidateStorageCapacity(
+		ctx,
+		v.Client,
+		localmodelcache.StorageReservation{
+			Name:       localModelNamespaceCache.Name,
+			Namespace:  localModelNamespaceCache.Namespace,
+			ModelSize:  localModelNamespaceCache.Spec.ModelSize,
+			NodeGroups: localModelNamespaceCache.Spec.NodeGroups,
+		},
+	); err != nil {
+		return nil, err
+	}
 
 	return nil, nil
 }
@@ -82,6 +94,18 @@ func (v *LocalModelNamespaceCacheValidator) ValidateUpdate(ctx context.Context, 
 	localModelNamespaceCacheValidatorLogger.Info("validate update", "name", localModelNamespaceCache.Name, "namespace", localModelNamespaceCache.Namespace)
 
 	if err := v.validateNodeGroups(ctx, localModelNamespaceCache); err != nil {
+		return nil, err
+	}
+	if err := localmodelcache.ValidateStorageCapacity(
+		ctx,
+		v.Client,
+		localmodelcache.StorageReservation{
+			Name:       localModelNamespaceCache.Name,
+			Namespace:  localModelNamespaceCache.Namespace,
+			ModelSize:  localModelNamespaceCache.Spec.ModelSize,
+			NodeGroups: localModelNamespaceCache.Spec.NodeGroups,
+		},
+	); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`LocalModelCache` and `LocalModelNamespaceCache` define `modelSize`, while `LocalModelNodeGroup` defines a per-node-group `storageLimit`. However, these values were not being used to validate whether the requested model storage could fit within the configured limit.

As a result, multiple caches targeting the same `LocalModelNodeGroup` could be admitted even when their combined declared `modelSize` exceeded the group's `storageLimit`. The resulting model download would only fail later when the node's storage was exhausted, without providing an admission-time capacity signal.

This PR adds admission-time storage capacity validation for both `LocalModelCache` and `LocalModelNamespaceCache`.

The validation:

* Checks every `LocalModelNodeGroup` targeted by the cache.
* Includes the current cache's declared `modelSize` in the requested capacity.
* Aggregates `modelSize` from existing `LocalModelCache` and `LocalModelNamespaceCache` objects targeting the same node group.
* Rejects the cache when the aggregate declared storage exceeds the node group's `storageLimit`.
* Uses a shared validation helper so both cache types enforce the same capacity rules.

This prevents configurations that are known to exceed the declared node-group storage limit from being admitted in the first place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #6137

**Feature/Issue validation/testing**:

* [x] Unit tests for storage capacity validation
* [x] LocalModelCache webhook validation tests
* [x] LocalModelNamespaceCache webhook validation tests
* [x] Go vet
* [x] golangci-lint

Tests cover:

* A cache whose `modelSize` is within the node group's `storageLimit`.
* A cache whose `modelSize` exceeds the `storageLimit`.
* Aggregate storage usage across multiple `LocalModelCache` objects.
* Aggregate storage usage across `LocalModelCache` and `LocalModelNamespaceCache` objects.
* Ensuring the object currently being validated is not double-counted.

Commands run:

```text
go test ./pkg/localmodelcache
go test ./pkg/webhook/admission/localmodelcache
go test ./pkg/webhook/admission/localmodelnamespacecache

make test TEST_PKGS="./pkg/localmodelcache ./pkg/webhook/admission/localmodelcache ./pkg/webhook/admission/localmodelnamespacecache"

go vet ./...

./bin/golangci-lint run --fix --timeout=10m
```

Results:

* All targeted tests passed.
* `go vet` passed.
* `golangci-lint` completed successfully with 0 issues.

The repository's default `make precommit` lint invocation exceeded its default timeout. The same lint command was subsequently run with a 10-minute timeout and completed successfully with 0 issues.

**Special notes for your reviewer**:

The implementation intentionally uses the declared `modelSize` values at admission time rather than attempting to measure physical disk usage.

`LocalModelCache` and `LocalModelNamespaceCache` both contribute models to `LocalModelNode` storage, so the validation aggregates reservations from both cache types.

A cache targeting multiple node groups is validated independently against each targeted node group's `storageLimit`.

This is intended as a minimal first step toward preventing disk-capacity failures during model downloads. Actual runtime disk usage/status reporting is not changed by this PR.

**Checklist**:

* [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
* [x] Has code been commented, particularly in hard-to-understand areas?
* [ ] Have you made corresponding changes to the [[documentation](https://github.com/kserve/website)](https://github.com/kserve/website)?

**Release note**:

```release-note
Prevent LocalModelCache and LocalModelNamespaceCache objects from exceeding the configured LocalModelNodeGroup storage limit based on declared modelSize.
```