### PR TITLE
fix(llmisvc): recognizes header case-insensitively

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -773,8 +773,8 @@ func stripModelBasedRoutingRules(rules []gwapiv1.HTTPRouteRule, headerName strin
 // model. Matches within a Gateway API rule are OR'd, so a rule ends up matching
 // "base model OR adapter-1 OR adapter-2 …" — all targeting the same InferencePool.
 //
-// Only matches whose header name equals headerName are duplicated; path-only rules
-// and rules with unrelated headers are left untouched.
+// Only matches naming headerName are duplicated; path-only rules and rules with
+// unrelated headers are left untouched.
 func expandLoRAAdapterMatches(rules []gwapiv1.HTTPRouteRule, namespace string, adapters []v1alpha2.LLMModelSpec, headerName string) {
 	if headerName == "" || len(adapters) == 0 {
 		return
@@ -798,7 +798,7 @@ func expandLoRAAdapterMatches(rules []gwapiv1.HTTPRouteRule, namespace string, a
 				}
 				am := *match.DeepCopy()
 				for h := range am.Headers {
-					if string(am.Headers[h].Name) == headerName {
+					if isModelRoutingHeader(am.Headers[h].Name, headerName) {
 						am.Headers[h].Value = fullyQualifiedModelName(namespace, *adapter.Name)
 					}
 				}

--- a/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
@@ -348,3 +348,94 @@ var _ = Describe("Model Based Routing", func() {
 		})
 	})
 })
+
+var _ = Describe("Model Based Routing with a case-variant header", func() {
+	// Gateway API header names are case-insensitive and the API server keeps
+	// whatever spelling the author wrote, so a hand-authored route spelling the
+	// model-routing header in lower case is a live model-routing rule that the
+	// controller must treat exactly like the canonical spelling.
+	const lowercaseHeader = "x-gateway-model-name"
+
+	customModelRoutingSpec := func(ctx context.Context, testNs *TestNamespace, gatewayName string) *gwapiv1.HTTPRouteSpec {
+		gateway := Gateway(gatewayName,
+			InNamespace[*gwapiv1.Gateway](testNs.Name),
+			WithListener(gwapiv1.HTTPProtocolType),
+			WithAddresses("203.0.113.42"),
+		)
+		Expect(envTest.Client.Create(ctx, gateway)).To(Succeed())
+		ensureGatewayReady(ctx, envTest.Client, gateway)
+
+		return &HTTPRoute("custom-model-routing",
+			InNamespace[*gwapiv1.HTTPRoute](testNs.Name),
+			WithParentRef(GatewayParentRef(gatewayName, testNs.Name)),
+			WithHTTPRule(
+				Matches(ExactPathWithHeaderMatch("/v1/completions", lowercaseHeader,
+					publisherModel(testNs.Name, "base-model"))),
+				WithBackendRefs(ServiceRef("custom-backend", 8000, 1)),
+			),
+		).Spec
+	}
+
+	It("should expand LoRA adapter matches under the author's spelling", func(ctx SpecContext) {
+		// given
+		testNs := NewTestNamespace(ctx, envTest)
+
+		llmSvc := LLMInferenceService("test-mbr-case-expand",
+			InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+			WithModelURI("hf://facebook/opt-125m"),
+			WithModelName("base-model"),
+			WithLoRAAdapters("lora-adapter-a", "lora-adapter-b"),
+			WithHTTPRouteSpec(customModelRoutingSpec(ctx, testNs, "mbr-case-expand-gw")),
+			WithSpecAnnotations(map[string]string{
+				llmisvc.AnnotationModelBasedRoutingEnabled: "true",
+			}),
+		)
+
+		// when
+		Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+		defer func() {
+			testNs.DeleteAndWait(ctx, llmSvc)
+		}()
+
+		// then - the adapter matches keep the lower-case spelling they were authored with
+		Eventually(func(g Gomega, ctx context.Context) {
+			routes, err := managedRoutes(ctx, llmSvc)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(routes).To(HaveLen(1))
+
+			g.Expect(&routes[0]).To(HaveHeaderMatch(lowercaseHeader, publisherModel(testNs.Name, "base-model")))
+			g.Expect(&routes[0]).To(HaveHeaderMatch(lowercaseHeader, publisherModel(testNs.Name, "lora-adapter-a")))
+			g.Expect(&routes[0]).To(HaveHeaderMatch(lowercaseHeader, publisherModel(testNs.Name, "lora-adapter-b")))
+		}).WithContext(ctx).Should(Succeed())
+	})
+
+	It("should strip the match when model-based routing is disabled", func(ctx SpecContext) {
+		// given
+		testNs := NewTestNamespace(ctx, envTest)
+
+		llmSvc := LLMInferenceService("test-mbr-case-strip",
+			InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+			WithModelURI("hf://facebook/opt-125m"),
+			WithModelName("base-model"),
+			WithHTTPRouteSpec(customModelRoutingSpec(ctx, testNs, "mbr-case-strip-gw")),
+			WithSpecAnnotations(map[string]string{
+				llmisvc.AnnotationModelBasedRoutingEnabled: "false",
+			}),
+		)
+
+		// when
+		Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+		defer func() {
+			testNs.DeleteAndWait(ctx, llmSvc)
+		}()
+
+		// then
+		Eventually(func(g Gomega, ctx context.Context) {
+			routes, err := managedRoutes(ctx, llmSvc)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(routes).To(HaveLen(1))
+
+			g.Expect(&routes[0]).NotTo(HaveHeaderMatch(lowercaseHeader, publisherModel(testNs.Name, "base-model")))
+		}).WithContext(ctx).Should(Succeed())
+	})
+})

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -371,21 +371,28 @@ func extractRoutePaths(route *gwapiv1.HTTPRoute, modelRoutingHeader string) []st
 // for the configured model-based routing header.
 //
 // This distinguishes controller-managed model-routing rules from arbitrary
-// user-provided header rules. Only matches whose header name equals the
-// configured modelRoutingHeader (e.g. "X-Gateway-Model-Name") are treated as
+// user-provided header rules. Only matches naming the configured
+// modelRoutingHeader (e.g. "X-Gateway-Model-Name") are treated as
 // model-routing endpoints. When modelRoutingHeader is empty (feature not
 // configured), no match qualifies — so header-bearing rules are simply ignored
 // during path extraction, preserving the pre-model-routing behavior.
 func isModelBasedRoutingMatch(match gwapiv1.HTTPRouteMatch, modelRoutingHeader string) bool {
-	if modelRoutingHeader == "" {
-		return false
-	}
 	for _, h := range match.Headers {
-		if string(h.Name) == modelRoutingHeader {
+		if isModelRoutingHeader(h.Name, modelRoutingHeader) {
 			return true
 		}
 	}
 	return false
+}
+
+// isModelRoutingHeader reports whether name is the configured model-routing
+// header. HTTP header names are case-insensitive and the API server keeps
+// whatever spelling the author wrote, so every model-routing path compares
+// through here: matching a case variant in one place but not another would
+// make the same rule visible to expansion but invisible to stripping and URL
+// discovery. An empty modelRoutingHeader disables the feature.
+func isModelRoutingHeader(name gwapiv1.HTTPHeaderName, modelRoutingHeader string) bool {
+	return modelRoutingHeader != "" && strings.EqualFold(string(name), modelRoutingHeader)
 }
 
 // hasServiceBackend returns true if the rule has at least one backendRef with Kind "Service"

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_internal_test.go
@@ -19,6 +19,7 @@ package llmisvc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -84,4 +85,29 @@ func TestResolvedGatewayKeys(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestModelRoutingHeaderRecognitionIsShared pins that every model-routing path
+// agrees on which header is the routing header. HTTP header names are
+// case-insensitive and the API server keeps whatever spelling the author wrote,
+// so recognizing a case variant in one place but not another would make the same
+// rule visible to LoRA expansion but invisible to stripping and URL discovery.
+func TestModelRoutingHeaderRecognitionIsShared(t *testing.T) {
+	const configured = "X-Gateway-Model-Name"
+
+	for _, name := range []string{"X-Gateway-Model-Name", "x-gateway-model-name", "X-GATEWAY-MODEL-NAME"} {
+		match := gwapiv1.HTTPRouteMatch{
+			Headers: []gwapiv1.HTTPHeaderMatch{{Name: gwapiv1.HTTPHeaderName(name), Value: "v"}},
+		}
+		assert.True(t, isModelRoutingHeader(gwapiv1.HTTPHeaderName(name), configured), "header %q", name)
+		assert.True(t, isModelBasedRoutingMatch(match, configured),
+			"match on %q must be recognized by every model-routing path", name)
+	}
+
+	assert.False(t, isModelRoutingHeader("X-Other", configured))
+	// An unconfigured header disables the feature rather than matching everything.
+	assert.False(t, isModelRoutingHeader("X-Gateway-Model-Name", ""))
+	assert.False(t, isModelBasedRoutingMatch(gwapiv1.HTTPRouteMatch{
+		Headers: []gwapiv1.HTTPHeaderMatch{{Name: "X-Gateway-Model-Name"}},
+	}, ""))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Gateway API header names are case-insensitive, and nothing normalises the spelling  - the CRD pattern accepts any case and there is no defaulting webhook. The llmisvc controller compared the configured model-routing header with `==`, so a hand-authored `spec.router.route.http.spec` spelling it `x-gateway-model-name` was a live model-routing rule in the data plane that the controller could not see.

Every model-routing path now compares through one recogniser, so the same rule can no longer be visible to one consumer and invisible to the rest.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

- [x] `TestModelRoutingHeaderRecognitionIsShared` - pins that every model-routing path agrees on case variants of the configured header, and that an empty configured header disables the feature rather than matching everything.
- [x] Two envtest specs - a lowercase header in a hand-authored inline route spec is expanded with LoRA adapter matches, and stripped when model-based routing is disabled, identically to the canonical spelling. Both fail on `master` and pass with this change; verified by reverting the fix rather than by inspection.
- [x] Full `./pkg/controller/v1alpha2/llmisvc/...` suite and `make precommit`.

**Special notes for your reviewer**:

Preset-generated routes always use the configured spelling, so they render exactly as before. The behaviour change is confined to routes a user hand-authored with a different case, which the controller previously ignored. Rare edge case, but maybe worth noting in release notes?

`HaveHeaderMatch` is deliberately left case-sensitive - the assertion worth making is that the controller recognises the author's spelling while preserving it.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
