### PR TITLE
test: helpers for ConfigMap and HTTPRoute

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_tls_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_tls_test.go
@@ -18,7 +18,6 @@ package llmisvc_test
 
 import (
 	"context"
-	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,7 +26,6 @@ import (
 	"knative.dev/pkg/kmeta"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
-	"github.com/kserve/kserve/pkg/constants"
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
 )
 
@@ -37,27 +35,11 @@ var _ = Describe("LLMInferenceService TLS Toggle", func() {
 			svcName := "test-llm-tls-off"
 			testNs := NewTestNamespace(ctx, envTest)
 
-			// Patch the global ConfigMap to disable TLS
-			cfgMap := &corev1.ConfigMap{}
-			cfgMapKey := types.NamespacedName{
-				Name:      constants.InferenceServiceConfigMapName,
-				Namespace: constants.KServeNamespace,
-			}
-			Expect(envTest.Get(ctx, cfgMapKey, cfgMap)).To(Succeed())
-
-			originalIngress := cfgMap.Data["ingress"]
-			var ingressCfg map[string]interface{}
-			Expect(json.Unmarshal([]byte(originalIngress), &ingressCfg)).To(Succeed())
-			ingressCfg["enableLLMInferenceServiceTLS"] = false
-			updatedIngress, err := json.Marshal(ingressCfg)
-			Expect(err).ToNot(HaveOccurred())
-			cfgMap.Data["ingress"] = string(updatedIngress)
-			Expect(envTest.Client.Update(ctx, cfgMap)).To(Succeed())
-
+			// Patch the global ConfigMap to disable TLS. The fixture ConfigMap
+			// enables it, so cleanup restores that rather than the raw JSON.
+			PatchIngressConfigKey(ctx, envTest.Client, "enableLLMInferenceServiceTLS", false)
 			DeferCleanup(func(ctx context.Context) {
-				Expect(envTest.Get(ctx, cfgMapKey, cfgMap)).To(Succeed())
-				cfgMap.Data["ingress"] = originalIngress
-				Expect(envTest.Client.Update(ctx, cfgMap)).To(Succeed())
+				PatchIngressConfigKey(ctx, envTest.Client, "enableLLMInferenceServiceTLS", true)
 			})
 
 			// Create configs and LLMInferenceService

--- a/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_model_based_routing_int_test.go
@@ -18,18 +18,14 @@ package llmisvc_test
 
 import (
 	"context"
-	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
-	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
 	. "github.com/kserve/kserve/pkg/testing"
@@ -51,21 +47,7 @@ func countModelRoutingRules(rules []gwapiv1.HTTPRouteRule) int {
 }
 
 func patchIngressModelBasedRoutingMode(ctx context.Context, mode string) {
-	isvcConfigMap := &corev1.ConfigMap{}
-	Expect(envTest.Client.Get(ctx, types.NamespacedName{
-		Name:      constants.InferenceServiceConfigMapName,
-		Namespace: constants.KServeNamespace,
-	}, isvcConfigMap)).To(Succeed())
-
-	var ingressConfig map[string]interface{}
-	Expect(json.Unmarshal([]byte(isvcConfigMap.Data["ingress"]), &ingressConfig)).To(Succeed())
-	ingressConfig["modelBasedRoutingMode"] = mode
-	updatedIngress, err := json.Marshal(ingressConfig)
-	Expect(err).NotTo(HaveOccurred())
-
-	patch := client.MergeFrom(isvcConfigMap.DeepCopy())
-	isvcConfigMap.Data["ingress"] = string(updatedIngress)
-	Expect(envTest.Client.Patch(ctx, isvcConfigMap, patch)).To(Succeed())
+	PatchIngressConfigKey(ctx, envTest.Client, "modelBasedRoutingMode", mode)
 }
 
 func restoreIngressModelBasedRoutingMode(ctx context.Context) {

--- a/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
@@ -18,13 +18,16 @@ package fixture
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
@@ -92,6 +95,39 @@ func DefaultGatewayClass() *gwapiv1.GatewayClass {
 
 func InferenceServiceCfgMap(ns string) *corev1.ConfigMap {
 	return InferenceServiceCfgMapWithUrlScheme(ns, "")
+}
+
+// SetIngressConfigKey sets one key in the ingress section of an
+// inferenceservice-config ConfigMap; a nil value removes the key.
+func SetIngressConfigKey(cm *corev1.ConfigMap, key string, value any) {
+	var ingress map[string]any
+	if err := json.Unmarshal([]byte(cm.Data["ingress"]), &ingress); err != nil {
+		panic(err) // For test fixtures, panic is acceptable
+	}
+	if value == nil {
+		delete(ingress, key)
+	} else {
+		ingress[key] = value
+	}
+	raw, err := json.Marshal(ingress)
+	if err != nil {
+		panic(err)
+	}
+	cm.Data["ingress"] = string(raw)
+}
+
+// PatchIngressConfigKey applies SetIngressConfigKey to the live
+// inferenceservice-config ConfigMap.
+func PatchIngressConfigKey(ctx context.Context, c client.Client, key string, value any) {
+	ginkgo.GinkgoHelper()
+	cm := &corev1.ConfigMap{}
+	gomega.Expect(c.Get(ctx, types.NamespacedName{
+		Name:      constants.InferenceServiceConfigMapName,
+		Namespace: constants.KServeNamespace,
+	}, cm)).To(gomega.Succeed())
+	patch := client.MergeFrom(cm.DeepCopy())
+	SetIngressConfigKey(cm, key, value)
+	gomega.Expect(c.Patch(ctx, cm, patch)).To(gomega.Succeed())
 }
 
 func InferenceServiceCfgMapWithUrlScheme(ns, urlScheme string) *corev1.ConfigMap {

--- a/test/e2e/llmisvc/test_gateway_section_name.py
+++ b/test/e2e/llmisvc/test_gateway_section_name.py
@@ -38,6 +38,7 @@ from .fixtures import (
 from .diagnostic import collect_diagnostics
 from .test_llm_inference_service import (
     KSERVE_PLURAL_LLMINFERENCESERVICE,
+    get_managed_httproutes,
     wait_for,
 )
 from .test_resources import make_router_gateway
@@ -88,18 +89,6 @@ def _delete_llmisvc_config(kserve_client, name, namespace):
         )
     except client.ApiException:
         pass
-
-
-def _get_managed_httproutes(kserve_client, service_name, namespace):
-    """List HTTPRoutes owned by a given LLMInferenceService."""
-    routes = kserve_client.api_instance.list_namespaced_custom_object(
-        "gateway.networking.k8s.io",
-        "v1",
-        namespace,
-        "httproutes",
-        label_selector=f"app.kubernetes.io/name={service_name},app.kubernetes.io/part-of=llminferenceservice",
-    )
-    return routes.get("items", [])
 
 
 def _find_gateway_parent_ref(routes, gateway_name):
@@ -186,9 +175,7 @@ def test_gateway_section_name_propagation(
         )
 
         def assert_managed_route_exists():
-            routes = _get_managed_httproutes(
-                kserve_client, service_name, test_namespace
-            )
+            routes = get_managed_httproutes(kserve_client, service_name, test_namespace)
             assert len(routes) >= 1, (
                 f"Expected at least 1 managed HTTPRoute, got {len(routes)}"
             )

--- a/test/e2e/llmisvc/test_llm_canary_lifecycle.py
+++ b/test/e2e/llmisvc/test_llm_canary_lifecycle.py
@@ -48,6 +48,7 @@ from kubernetes import client as k8s_client, config
 from .diagnostic import collect_diagnostics
 from .fixtures import DEFAULT_LLMISVC_ANNOTATIONS, LLMD_SIMULATOR_SECURITY_CONTEXT
 from .namespace import skip_deletion, skip_deletion_on_failure
+from .test_llm_inference_service import MODEL_ROUTING_HEADER, publisher_model
 
 logger = logging.getLogger(__name__)
 
@@ -899,7 +900,7 @@ class TestCanaryLifecycle:
         gateway = get_gateway_base_url(api, v1, ns)
         driver = traffic_driver(
             url=f"{gateway}/v1/completions",
-            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+            headers={MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
             payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
             rate=2,
             timeout=15.0,
@@ -918,7 +919,7 @@ class TestCanaryLifecycle:
         wait_for_healthy_route(
             f"{gateway}/v1/completions",
             {
-                "X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}",
+                MODEL_ROUTING_HEADER: publisher_model(ns, MODEL),
                 "Content-Type": "application/json",
             },
             {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
@@ -934,7 +935,7 @@ class TestCanaryLifecycle:
         wait_for_healthy_route(
             f"{gateway}/v1/completions",
             {
-                "X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}",
+                MODEL_ROUTING_HEADER: publisher_model(ns, MODEL),
                 "Content-Type": "application/json",
             },
             {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
@@ -1023,7 +1024,7 @@ class TestCanaryLifecycle:
             gateway = get_gateway_base_url(api, v1.name, ns)
             driver = traffic_driver(
                 url=f"{gateway}/v1/completions",
-                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                headers={MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
                 rate=2,
                 timeout=15.0,
@@ -1038,7 +1039,7 @@ class TestCanaryLifecycle:
 
             wait_for_healthy_route(
                 f"{gateway}/v1/completions",
-                {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                {MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
                 expect_header=("x-inference-pod", v1.name),
             )
@@ -1104,7 +1105,7 @@ class TestCanaryLifecycle:
             gateway = get_gateway_base_url(api, v1.name, ns)
             driver = traffic_driver(
                 url=f"{gateway}/v1/completions",
-                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                headers={MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
                 rate=2,
                 timeout=15.0,
@@ -1204,7 +1205,7 @@ class TestCanaryLifecycle:
             wait_for_member_count(api, v1.name, ns, 3)
 
             gateway = get_gateway_base_url(api, v1.name, ns)
-            route_headers = {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"}
+            route_headers = {MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)}
             route_payload = {"model": MODEL, "prompt": "Hello", "max_tokens": 5}
 
             wait_for_healthy_route(
@@ -1256,7 +1257,7 @@ class TestCanaryLifecycle:
             gateway = get_gateway_base_url(api, v1.name, ns)
             driver = traffic_driver(
                 url=f"{gateway}/v1/completions",
-                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                headers={MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
                 rate=2,
                 timeout=15.0,
@@ -1272,7 +1273,7 @@ class TestCanaryLifecycle:
             wait_for_member_count(api, v1.name, ns, 2)
             wait_for_healthy_route(
                 f"{gateway}/v1/completions",
-                {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                {MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
             )
 
@@ -1313,7 +1314,7 @@ class TestCanaryLifecycle:
             gateway = get_gateway_base_url(api, v1.name, ns)
             driver = traffic_driver(
                 url=f"{gateway}/v1/completions",
-                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                headers={MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
                 rate=2,
                 timeout=15.0,
@@ -1356,14 +1357,14 @@ class TestCanaryLifecycle:
             gateway = get_gateway_base_url(api, v1.name, ns)
             driver = traffic_driver(
                 url=f"{gateway}/v1/completions",
-                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                headers={MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
                 rate=2,
                 timeout=15.0,
                 warmup=True,
             )
 
-            route_headers = {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"}
+            route_headers = {MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)}
             route_payload = {"model": MODEL, "prompt": "Hello", "max_tokens": 5}
 
             # Promote v2
@@ -1428,7 +1429,7 @@ class TestCanaryLifecycle:
             gateway = get_gateway_base_url(api, v1.name, ns)
             driver = traffic_driver(
                 url=f"{gateway}/v1/completions",
-                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                headers={MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
                 rate=2,
                 timeout=15.0,
@@ -1445,7 +1446,7 @@ class TestCanaryLifecycle:
             # Route ownership handoff: v1's route is deleted, v2 creates a new one.
             wait_for_healthy_route(
                 f"{gateway}/v1/completions",
-                {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                {MODEL_ROUTING_HEADER: publisher_model(ns, MODEL)},
                 {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
                 expect_header=("x-inference-pod", v2.name),
             )

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -125,6 +125,30 @@ MODEL_ROUTING_ADDRESS_SUFFIX = "-model-routing"
 MODEL_ROUTING_HEADER = "X-Gateway-Model-Name"
 
 
+def publisher_model(namespace: str, model: str) -> str:
+    """The fully-qualified model identity the gateway matches on, and the form
+    the X-Gateway-Model-Name header carries. Mirrors publisherModel in the Go
+    integration tests."""
+    return f"publishers/{namespace}/models/{model}"
+
+
+def get_managed_httproutes(kserve_client, service_name, namespace):
+    """List the HTTPRoutes a given LLMInferenceService owns. Selecting by label
+    rather than by generated route name keeps callers working if the naming
+    scheme changes, and returns every managed route rather than one."""
+    routes = kserve_client.api_instance.list_namespaced_custom_object(
+        "gateway.networking.k8s.io",
+        "v1",
+        namespace,
+        "httproutes",
+        label_selector=(
+            f"app.kubernetes.io/name={service_name},"
+            "app.kubernetes.io/part-of=llminferenceservice"
+        ),
+    )
+    return routes.get("items", [])
+
+
 @log_execution
 def get_model_routing_url(
     kserve_client: KServeClient, llm_isvc: V1alpha1LLMInferenceService


### PR DESCRIPTION
**What this PR does / why we need it**:

Flipping a single key in the ingress section of `inferenceservice-config` is something llmisvc tests do frequently, and every one performs the same unmarshal-set-marshal round trip by hand.

The Python e2e suite had the same problem from the other direction: a private HTTPRoute lister that only one module could reach, and the gateway model identity pasted inline multiple times.

Both now have one shared helper apiece, so a new test that needs either gets it for free instead of copying eight lines and a label selector it has to keep in sync by hand.

No behaviour change - the helpers do exactly what the code they replace did.

**Special notes for your reviewer**:

One behaviour-preserving difference worth a look: the TLS toggle test used to restore the ingress section by replaying the original raw JSON string. It now sets `enableLLMInferenceServiceTLS` back to the value the fixture ConfigMap ships. Same result - the set path already round-tripped the JSON through a map, so the original formatting was never preserved anyway - and the write is a merge patch rather than an update, which is friendlier to a reconciler writing concurrently.

The Python helper is named `publisher_model` to match the existing Go `publisherModel`, so both suites call the same concept the same thing.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
NONE
```
