### PR TITLE
fix(llmisvc): report HTTPRoutesReady after a route is observed

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_routing_status_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_routing_status_test.go
@@ -311,6 +311,59 @@ var _ = Describe("Routing Status", func() {
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})
+
+	Context("HTTPRoute readiness before a Gateway observes the route", func() {
+		It("does not report HTTPRoutesReady until a Gateway controller accepts the managed route", func(ctx SpecContext) {
+			// given - a service with a managed route, and deliberately nothing simulating
+			// a Gateway controller writing route status. This is what a real cluster looks
+			// like between the route being created and a gateway reconciling it.
+			svcName := "test-llm-route-unobserved"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// The managed route reaches the cluster...
+			Eventually(func(g Gomega, ctx context.Context) {
+				routes, errList := managedRoutes(ctx, llmSvc)
+				g.Expect(errList).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+			}).WithContext(ctx).Should(Succeed(), "the managed HTTPRoute should be created")
+
+			// then - ...but readiness must not follow from its mere existence. No
+			// ensureRouterManagedResourcesAreReady here on purpose: that helper is what
+			// makes every other HTTPRoutesReady=True assertion in this suite pass, so
+			// calling it would defeat this test.
+			Eventually(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				cond := current.Status.GetCondition(v1alpha2.HTTPRoutesReady)
+				g.Expect(cond).ToNot(BeNil(), "HTTPRoutesReady should be set")
+				g.Expect(cond.IsFalse()).To(BeTrue(), "HTTPRoutesReady should be False while unobserved")
+				g.Expect(cond.Reason).To(Equal("WaitingForGateway"))
+			}).WithContext(ctx).Should(Succeed())
+
+			// and it stays that way - a cache miss on a re-read must not be mistaken for
+			// "no routes to evaluate" and flip the condition to True.
+			Consistently(func(g Gomega, ctx context.Context) {
+				current := &v1alpha2.LLMInferenceService{}
+				g.Expect(envTest.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+				cond := current.Status.GetCondition(v1alpha2.HTTPRoutesReady)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.IsTrue()).To(BeFalse(), "HTTPRoutesReady must never read True before a Gateway accepts the route")
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
 })
 
 func setGatewayStatusAddresses(ctx context.Context, c client.Client, gw *gwapiv1.Gateway, addresses ...string) {

--- a/pkg/controller/v1alpha2/llmisvc/router.go
+++ b/pkg/controller/v1alpha2/llmisvc/router.go
@@ -116,21 +116,17 @@ func (r *LLMISVCReconciler) reconcileRouter(ctx context.Context, llmSvc *v1alpha
 		return fmt.Errorf("failed to evaluate Inference Pool conditions: %w", err)
 	}
 
-	if err := r.EvaluateGatewayConditions(ctx, llmSvc, resolvedGWs); err != nil {
-		return fmt.Errorf("failed to evaluate gateway conditions: %w", err)
-	}
-
-	if err := r.EvaluateHTTPRouteConditions(ctx, llmSvc, cfg); err != nil {
-		return fmt.Errorf("failed to evaluate HTTPRoute conditions: %w", err)
-	}
+	r.EvaluateGatewayConditions(ctx, llmSvc, resolvedGWs)
 
 	return nil
 }
 
 // reconcileHTTPRoutes manages HTTPRoute resources for traffic routing.
-// It handles both custom routes (via refs) and generated routes (via spec).
-// Returns the resolved gateways discovered during URL assembly so the caller
-// can pass them to EvaluateGatewayConditions without re-fetching.
+// It handles both custom routes (via refs) and generated routes (via spec), and settles
+// HTTPRoutesReady from the route objects it holds - evaluating here rather than in the
+// caller keeps readiness off a re-read through a cache that may still hold the pre-write
+// revision. Returns the resolved gateways discovered during URL assembly so the caller
+// can pass them to the remaining evaluators without re-fetching.
 func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, cfg *Config) ([]ResolvedGateway, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconciling HTTPRoute")
@@ -142,7 +138,11 @@ func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1a
 		if _, err := r.updateRoutingStatus(ctx, llmSvc); err != nil {
 			return nil, err
 		}
-		return nil, Delete(ctx, r, llmSvc, expectedHTTPRoute)
+		if err := Delete(ctx, r, llmSvc, expectedHTTPRoute); err != nil {
+			return nil, err
+		}
+		r.EvaluateHTTPRouteConditions(ctx, llmSvc, nil)
+		return nil, nil
 	}
 
 	// Inject group members' backendRefs for traffic splitting.
@@ -204,7 +204,14 @@ func (r *LLMISVCReconciler) reconcileHTTPRoutes(ctx context.Context, llmSvc *v1a
 		r.applyGroupStatus(llmSvc, groupMatching, groupDivergent)
 	}
 
-	return r.updateRoutingStatus(ctx, llmSvc, referencedRoutes...)
+	resolvedGWs, err := r.updateRoutingStatus(ctx, llmSvc, referencedRoutes...)
+	if err != nil {
+		return nil, err
+	}
+
+	r.EvaluateHTTPRouteConditions(ctx, llmSvc, referencedRoutes)
+
+	return resolvedGWs, nil
 }
 
 // collectReferencedRoutes gathers all HTTPRoutes referenced by the service
@@ -510,19 +517,19 @@ var controllerManagedLabelKeys = []string{
 // EvaluateGatewayConditions evaluates the readiness of all Gateways referenced by the LLMInferenceService
 // and updates the GatewaysReady condition accordingly. The resolved slice is provided by
 // updateRoutingStatus so that gateways are not re-fetched from the API server.
-func (r *LLMISVCReconciler) EvaluateGatewayConditions(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, resolved []ResolvedGateway) error {
+func (r *LLMISVCReconciler) EvaluateGatewayConditions(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, resolved []ResolvedGateway) {
 	logger := log.FromContext(ctx).WithName("evaluateGatewayConditions")
 
 	if utils.GetForceStopRuntime(llmSvc) {
 		llmSvc.MarkGatewaysNotReady("Stopped", "Service is stopped")
-		return nil
+		return
 	}
 
 	// If no router or gateway configuration, mark as ready to clear any previous stopped state
 	if llmSvc.Spec.Router == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
 		logger.Info("No Gateway references found, skipping Gateway condition evaluation")
 		llmSvc.MarkGatewaysReadyUnset()
-		return nil
+		return
 	}
 
 	gateways := make([]*gwapiv1.Gateway, 0, len(resolved))
@@ -539,11 +546,10 @@ func (r *LLMISVCReconciler) EvaluateGatewayConditions(ctx context.Context, llmSv
 		}
 		llmSvc.MarkGatewaysNotReady("GatewaysNotReady", "The following Gateways are not ready: %v", gatewayNames)
 		logger.V(2).Info("Some referenced Gateways are not ready", "gateways", notReadyGateways)
-		return nil
+		return
 	}
 	llmSvc.MarkGatewaysReady()
 	logger.Info("All referenced Gateways are ready")
-	return nil
 }
 
 // CollectReferencedGateways retrieves all Gateway objects referenced in the LLMInferenceService spec
@@ -599,74 +605,71 @@ func (r *LLMISVCReconciler) CollectReferencedGateways(ctx context.Context, llmSv
 	return gateways, nil
 }
 
-// EvaluateHTTPRouteConditions evaluates the readiness of all HTTPRoutes referenced by the LLMInferenceService
-// and updates the HTTPRoutesReady condition accordingly. Also detects Gateway rejection of v1alpha2 backendRefs.
-func (r *LLMISVCReconciler) EvaluateHTTPRouteConditions(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, cfg *Config) error {
+// EvaluateHTTPRouteConditions settles HTTPRoutesReady from the routes the reconcile pass
+// already holds, so readiness never depends on re-reading an object through a cache that
+// may still hold the pre-write revision.
+func (r *LLMISVCReconciler) EvaluateHTTPRouteConditions(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, routes []*gwapiv1.HTTPRoute) {
 	logger := log.FromContext(ctx).WithName("evaluateHTTPRouteConditions")
 
 	if utils.GetForceStopRuntime(llmSvc) {
 		llmSvc.MarkHTTPRoutesNotReady("Stopped", "Service is stopped")
-		return nil
+		return
 	}
 
-	// If no router or route configuration, mark HTTPRoutes as ready (no routes to evaluate)
 	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil || llmSvc.Spec.Router.Route.HTTP == nil {
-		logger.Info("No HTTPRoute configuration found, clearing HTTPRoutesReady condition")
+		logger.V(2).Info("No HTTPRoute configuration found, clearing HTTPRoutesReady condition")
 		llmSvc.MarkHTTPRoutesReadyUnset()
-		return nil
+		return
 	}
 
-	// Collect all HTTPRoutes (both referenced and managed)
-	var allRoutes []*gwapiv1.HTTPRoute
-
-	// Get referenced routes
-	referencedRoutes, err := r.collectReferencedRoutes(ctx, llmSvc)
-	if err != nil {
-		llmSvc.MarkHTTPRoutesNotReady("HTTPRouteFetchError", "Failed to fetch referenced HTTPRoutes: %v", err.Error())
-		return fmt.Errorf("failed to fetch referenced HTTPRoutes: %w", err)
-	}
-	allRoutes = append(allRoutes, referencedRoutes...)
-
-	// Get managed route if it exists
-	if llmSvc.Spec.Router.Route.HTTP.HasSpec() {
-		expectedHTTPRoute := r.expectedHTTPRoute(ctx, llmSvc, cfg)
-		// Try to get the actual managed route from the cluster
-		managedRoute := &gwapiv1.HTTPRoute{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Namespace: expectedHTTPRoute.Namespace,
-			Name:      expectedHTTPRoute.Name,
-		}, managedRoute); err == nil {
-			allRoutes = append(allRoutes, managedRoute)
+	if len(routes) == 0 {
+		// A service declaring an inline route always has that route in the list by the
+		// time this runs. Getting here means the caller did not observe it, which must
+		// not read as ready.
+		if llmSvc.Spec.Router.Route.HTTP.HasSpec() {
+			llmSvc.MarkHTTPRoutesNotReady("HTTPRouteNotObserved", "The managed HTTPRoute has not been observed yet")
+			return
 		}
-	}
-
-	// If no routes found, mark as ready (nothing to evaluate)
-	if len(allRoutes) == 0 {
 		llmSvc.MarkHTTPRoutesReady()
-		logger.Info("No HTTPRoutes found, marking HTTPRoutesReady as true")
-		return nil
+		return
 	}
 
-	notReadyRoutes := EvaluateHTTPRouteReadiness(ctx, allRoutes)
+	notReadyRoutes := EvaluateHTTPRouteReadiness(ctx, routes)
+	if len(notReadyRoutes) == 0 {
+		llmSvc.MarkHTTPRoutesReady()
+		logger.V(2).Info("All HTTPRoutes are ready", "routes", routes)
+		return
+	}
 
-	if len(notReadyRoutes) > 0 {
-		nonReadyRouteMessages := make([]string, len(notReadyRoutes))
-		for i, route := range notReadyRoutes {
-			topLevelCondition := findNonReadyGatewayCondition(route)
-			if topLevelCondition != nil {
-				nonReadyRouteMessages[i] = fmt.Sprintf("%s/%s: %#v (reason %q, message %q)", route.Namespace, route.Name, topLevelCondition.Status, topLevelCondition.Reason, topLevelCondition.Message)
-			} else {
-				nonReadyRouteMessages[i] = fmt.Sprintf("%s/%s: %#v", route.Namespace, route.Name, route.Status)
-			}
+	// Split routes carrying a gateway controller verdict from those no controller has
+	// written an Accepted condition for. Only the former can be diagnosed from their
+	// conditions; the latter are still in flight. Formatting the whole status for those
+	// would embed pointer addresses that differ on every decode, so the message - and
+	// with it the condition - would never settle.
+	rejected := make([]string, 0, len(notReadyRoutes))
+	pending := make([]string, 0, len(notReadyRoutes))
+	for _, route := range notReadyRoutes {
+		if cond := findNonReadyGatewayCondition(route); cond != nil {
+			rejected = append(rejected, fmt.Sprintf("%s/%s: %s=%s (reason %q, message %q)", route.Namespace, route.Name, cond.Type, cond.Status, cond.Reason, cond.Message))
+			continue
 		}
-		llmSvc.MarkHTTPRoutesNotReady("HTTPRoutesNotReady", "The following HTTPRoutes are not ready: %v", nonReadyRouteMessages)
-		logger.V(2).Info("Some HTTPRoutes are not ready", "routes", notReadyRoutes)
-		return nil
+		pending = append(pending, fmt.Sprintf("%s/%s", route.Namespace, route.Name))
 	}
 
-	llmSvc.MarkHTTPRoutesReady()
-	logger.V(2).Info("All HTTPRoutes are ready", "routes", allRoutes)
-	return nil
+	// Both groups are reported whenever both exist - a rejected route must not hide the
+	// ones still waiting. The reason names whichever group is blocking on its own.
+	switch {
+	case len(rejected) > 0 && len(pending) > 0:
+		llmSvc.MarkHTTPRoutesNotReady("HTTPRoutesNotReady",
+			"The following HTTPRoutes are not ready: %v; still waiting for a Gateway to accept: %v", rejected, pending)
+	case len(rejected) > 0:
+		llmSvc.MarkHTTPRoutesNotReady("HTTPRoutesNotReady",
+			"The following HTTPRoutes are not ready: %v", rejected)
+	default:
+		llmSvc.MarkHTTPRoutesNotReady("WaitingForGateway",
+			"The following HTTPRoutes exist but no Gateway controller has accepted them yet: %v", pending)
+	}
+	logger.V(2).Info("Some HTTPRoutes are not ready", "routes", notReadyRoutes)
 }
 
 // EvaluateInferencePoolConditions evaluates the readiness of all Inference Pools in the LLMInferenceService

--- a/pkg/controller/v1alpha2/llmisvc/router_gateway_conditions_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_gateway_conditions_test.go
@@ -215,9 +215,7 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 				resolved[i] = llmisvc.ResolvedGateway{Gateway: gw}
 			}
 
-			err = reconciler.EvaluateGatewayConditions(ctx, tt.llmSvc, resolved)
-
-			g.Expect(err).ToNot(HaveOccurred())
+			reconciler.EvaluateGatewayConditions(ctx, tt.llmSvc, resolved)
 
 			tt.llmSvc.DetermineRouterReadiness()
 
@@ -287,11 +285,10 @@ func TestIsGatewayReady(t *testing.T) {
 
 func TestHTTPRouteConditionsEvaluation(t *testing.T) {
 	tests := []struct {
-		name             string
-		llmSvc           *v1alpha2.LLMInferenceService
-		httpRoutes       []*gwapiv1.HTTPRoute
-		expectedErrorMsg string
-		createAssertion  func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc
+		name            string
+		llmSvc          *v1alpha2.LLMInferenceService
+		httpRoutes      []*gwapiv1.HTTPRoute
+		createAssertion func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc
 	}{
 		{
 			name: "HTTPRoute with multiple controllers - should be ready",
@@ -389,7 +386,86 @@ func TestHTTPRouteConditionsEvaluation(t *testing.T) {
 				),
 			},
 			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
-				return assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "HTTPRoutesNotReady")
+				return assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "WaitingForGateway")
+			},
+		},
+		{
+			name: "managed HTTPRoute not yet observed by a gateway - should report WaitingForGateway",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteSpec(&gwapiv1.HTTPRouteSpec{}),
+			),
+			// A route straight out of Create: the API server discards status on CREATE,
+			// so no gateway controller has written a parent entry yet.
+			httpRoutes: []*gwapiv1.HTTPRoute{
+				HTTPRoute("test-llm-kserve-route",
+					InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+				),
+			},
+			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+				return func(g *WithT) {
+					assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "WaitingForGateway")(g)
+					g.Expect(httpRouteCondition.Message).To(Equal(
+						"The following HTTPRoutes exist but no Gateway controller has accepted them yet: [test-ns/test-llm-kserve-route]"),
+						"Operators should get a plain sentence, not a dump of the empty status struct")
+				}
+			},
+		},
+		{
+			name: "one route rejected and one still pending - both are reported",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteRefs(HTTPRouteRef("rejected-route"), HTTPRouteRef("pending-route")),
+			),
+			httpRoutes: []*gwapiv1.HTTPRoute{
+				HTTPRoute("rejected-route",
+					InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+					WithHTTPRouteNotReadyStatus("openshift.io/gateway-controller/v1", "NotAccepted", "Route was not accepted"),
+				),
+				HTTPRoute("pending-route",
+					InNamespace[*gwapiv1.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+				),
+			},
+			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+				return func(g *WithT) {
+					assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "HTTPRoutesNotReady")(g)
+					g.Expect(httpRouteCondition.Message).To(ContainSubstring("test-ns/rejected-route"))
+					g.Expect(httpRouteCondition.Message).To(ContainSubstring("test-ns/pending-route"),
+						"A rejected route must not hide the ones still waiting for a Gateway")
+				}
+			},
+		},
+		{
+			name: "route refs declared but none found - stays ready, refs are validated upstream",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteRefs(HTTPRouteRef("missing-route")),
+			),
+			httpRoutes: nil,
+			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+				return func(g *WithT) {
+					g.Expect(httpRouteCondition).ToNot(BeNil(), "HTTPRoute condition should be set")
+					g.Expect(httpRouteCondition.IsTrue()).To(BeTrue(),
+						"A missing ref is reported by validateRouterReferences as RefsInvalid, not here")
+				}
+			},
+		},
+		{
+			name: "inline route spec with no route collected - should not read as ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha2.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteSpec(&gwapiv1.HTTPRouteSpec{}),
+			),
+			httpRoutes: nil,
+			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "HTTPRouteNotObserved")
 			},
 		},
 		{
@@ -461,36 +537,8 @@ func TestHTTPRouteConditionsEvaluation(t *testing.T) {
 			g := NewGomegaWithT(t)
 			ctx := t.Context()
 
-			scheme := runtime.NewScheme()
-			err := v1alpha2.AddToScheme(scheme)
-			g.Expect(err).ToNot(HaveOccurred())
-			err = gwapiv1.Install(scheme)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			var objects []client.Object
-			objects = append(objects, tt.llmSvc)
-			for _, route := range tt.httpRoutes {
-				objects = append(objects, route)
-			}
-
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(objects...).
-				Build()
-
-			reconciler := &llmisvc.LLMISVCReconciler{
-				Client: fakeClient,
-			}
-
-			err = reconciler.EvaluateHTTPRouteConditions(ctx, tt.llmSvc, &llmisvc.Config{})
-
-			if tt.expectedErrorMsg != "" {
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErrorMsg))
-				return
-			}
-
-			g.Expect(err).ToNot(HaveOccurred())
+			reconciler := &llmisvc.LLMISVCReconciler{}
+			reconciler.EvaluateHTTPRouteConditions(ctx, tt.llmSvc, tt.httpRoutes)
 
 			tt.llmSvc.DetermineRouterReadiness()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`HTTPRoutesReady` was evaluated by re-reading the managed `HTTPRoute` through the cached client right after the reconcile pass wrote it. The cache has no read-your-writes guarantee, so a cache miss returned an empty route list, which was read as "nothing to evaluate" and marked ready. A freshly created service could report `HTTPRoutesReady=True`, and therefore `RouterReady`/`Ready`, before any Gateway had even seen the route.

`HTTPRoutesReady` now settles from the routes the reconcile pass already collected, not froma follow-up read.  A route that was declared but not yet observed reports `HTTPRouteNotObserved` instead of flashing ready, and the now-impossible re-fetch failure reason (`HTTPRouteFetchError`) is removed with it.

The first reconcile after create also used to dump the route's raw, empty status struct into the condition message, since nothing had written a parent status yet. That case now gets its own reason, `WaitingForGateway`, mirroring how `InferencePool` reports the same not-yet-accepted state.

**Feature/Issue validation/testing**:

- [x] Extended `TestHTTPRouteConditionsEvaluation` with cases for an unobserved managed route and a route pending Gateway acceptance
- [x] Full `pkg/controller/v1alpha2/llmisvc` suite, including envtest, passes

**Special notes for your reviewer**:

None.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
`HTTPRoutesReady` no longer reports True before the managed HTTPRoute has been observed by a Gateway controller. The `HTTPRouteFetchError` reason is removed; `WaitingForGateway` and `HTTPRouteNotObserved` are added.
```
