### PR TITLE
fix(storage): prevent S3 prefix matching sibling directories

### DIFF
--- a/pkg/agent/storage/s3.go
+++ b/pkg/agent/storage/s3.go
@@ -77,6 +77,13 @@ func (m *S3Provider) DownloadModel(modelDir string, modelName string, storageUri
 			if strings.HasSuffix(*object.Key, "/") {
 				continue
 			}
+			// S3's ListObjectsV2 Prefix is a plain string match, not a path-segment
+			// match, so a prefix like "model-a" also matches keys under the sibling
+			// "model-a-2/" directory. Require the key to equal the prefix exactly
+			// (single-object case) or to continue at a "/" boundary.
+			if prefix != "" && *object.Key != prefix && !strings.HasPrefix(*object.Key, prefix+"/") {
+				continue
+			}
 			subObjectKey := strings.TrimPrefix(*object.Key, prefix)
 			fileName := filepath.Join(modelDir, modelName, subObjectKey)
 

--- a/pkg/agent/storage/s3_test.go
+++ b/pkg/agent/storage/s3_test.go
@@ -252,3 +252,41 @@ func TestDownloadModel_NoPrefixInURI(t *testing.T) {
 		t.Error("expected model.pt to exist")
 	}
 }
+
+func TestDownloadModel_SiblingPrefixCollision(t *testing.T) {
+	// S3 ListObjectsV2 uses a plain string prefix match, so "merlinite-7b-lab"
+	// also matches objects under the sibling "merlinite-7b-lab-hf/" directory.
+	// DownloadModel must skip any key that does not equal the prefix or start
+	// at a "/" boundary.
+	syscall.Umask(0)
+	modelDir := t.TempDir()
+
+	provider := &S3Provider{
+		Client: &mocks.MockS3PaginatedClient{
+			Pages: [][]string{
+				{
+					"merlinite-7b-lab/config.json",
+					"merlinite-7b-lab-hf/config.json",
+				},
+			},
+		},
+		TransferClient: &mocks.MockS3TransferClient{},
+	}
+
+	err := provider.DownloadModel(modelDir, "model", "s3://modelRepo/merlinite-7b-lab")
+	if err != nil {
+		t.Fatalf("DownloadModel failed: %v", err)
+	}
+
+	// Only the exact-prefix file should have been downloaded
+	wantPath := filepath.Join(modelDir, "model", "config.json")
+	if !FileExists(wantPath) {
+		t.Errorf("expected %s to exist", wantPath)
+	}
+
+	// The sibling-prefix file must not have been downloaded
+	siblingPath := filepath.Join(modelDir, "model", "-hf", "config.json")
+	if FileExists(siblingPath) {
+		t.Errorf("sibling-prefix file %s should not have been downloaded", siblingPath)
+	}
+}


### PR DESCRIPTION
**What this PR does**:

`S3 ListObjectsV2` matches `Prefix` as a plain string, not a path segment, so a model path like `merlinite-7b-lab` also matches objects under the sibling `merlinite-7b-lab-hf/` directory. The storage initializer would then download every file from both directories into the same model dir.

This PR adds a path-boundary check inside the paginator loop: each listed key must either equal the prefix exactly (single-object download case) or start with `prefix + "/"` before it is downloaded.

**Which issue(s) this PR fixes**:
Fixes #3776

**Checklist**
- [x] Tests updated (`TestDownloadModel_SiblingPrefixCollision` added)
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags