### PR TITLE
fix(ci): block automerge on stale PRs

### DIFF
--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -1,6 +1,7 @@
-# This workflow checks every 10 minutes for open PRs with the lgtm label and
-# squash-merges them, provided they also have at least one approved review
-# (/approve checks the approvers role in OWNERS) and no hold label.
+# This workflow checks every 10 minutes for open PRs that are ready to merge and
+# squash-merges them. A PR is ready when it carries the lgtm label, has no hold
+# label, has an approving review from an OWNERS approver for its current head
+# commit, and its enforce-all-checks aggregate is green on that same commit.
 
 name: "Prow merge on lgtm label"
 on:
@@ -14,21 +15,47 @@ on:
         default: false
         type: boolean
 
+# The two reads are on data that is public on this repository, so the calls
+# succeed without them, but the block should say what the job actually touches.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write      # squash-merge the pull request
+  pull-requests: write # squash-merge the pull request
+  checks: read         # read the check aggregate on the head commit
+  issues: read         # list open pull requests by label
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Check out the OWNERS file
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: master
+          # The job talks to the API only, so the checkout has no use for a token.
+          persist-credentials: false
+
+      - name: Read approvers from OWNERS
+        id: owners
+        run: echo "approvers=$(yq e -o=json -I=0 '.approvers' OWNERS)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APPROVERS: ${{ steps.owners.outputs.approvers }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const mergeableStatesAllowed = new Set(['clean', 'unstable', 'has_hooks']);
+
+            // required-checks.yml runs this as the single aggregate over every other
+            // check on the PR, with allowed-conclusions: success,skipped.
+            const aggregateCheck = 'enforce-all-checks';
+
+            // 'unstable' is deliberately absent: it means "mergeable, but the commit
+            // status is non-passing", which covers both failing and still-running
+            // checks. Only these two mean everything that reported, reported green.
+            const mergeableStatesAllowed = new Set(['clean', 'has_hooks']);
+
             const debugEnabled = context.eventName === 'workflow_dispatch' && context.payload.inputs?.debug === 'true';
             const debug = (message) => {
               if (debugEnabled) {
@@ -38,19 +65,39 @@ jobs:
 
             debug(`Triggered by ${context.eventName}`);
 
-            // Load approvers from the OWNERS file
-            const { data: ownersFile } = await github.rest.repos.getContent({ owner, repo, path: 'OWNERS', ref: 'master' });
-            const ownersContent = Buffer.from(ownersFile.content, 'base64').toString();
-            const approvers = [];
-            let inApprovers = false;
-            for (const line of ownersContent.split('\n')) {
-              if (/^approvers:\s*$/.test(line)) { inApprovers = true; continue; }
-              if (/^\S/.test(line)) { inApprovers = false; continue; }
-              if (inApprovers) {
-                const m = line.match(/^\s*-\s+(.+)/);
-                if (m) approvers.push(m[1].trim().toLowerCase());
+            // Parsed by the previous step with the same yq expression that
+            // auto-assign-reviewers.yml and prepare-release.yml use on this file.
+            const approvers = JSON.parse(process.env.APPROVERS).map(a => a.toLowerCase());
+
+            const isApprover = (login) =>
+              login === 'github-actions[bot]' || approvers.includes(login.toLowerCase());
+
+            // Only the last decisive review per user counts. COMMENTED and PENDING do
+            // not change approval state, but a CHANGES_REQUESTED following an APPROVED
+            // does, and listReviews returns every review ever left on the PR.
+            const latestReviewPerUser = async (prNumber) => {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner, repo, pull_number: prNumber, per_page: 100,
+              });
+              const latest = new Map();
+              for (const review of reviews) {
+                if (review.state === 'COMMENTED' || review.state === 'PENDING') continue;
+                latest.set(review.user.login, review);
               }
-            }
+              return [...latest.values()];
+            };
+
+            // Returns 'success', a conclusion, a non-completed status, or 'absent'.
+            // Absent is a block, not a pass: a workflow that fails to start reports no
+            // check run at all, so mergeable_state has nothing to go red on.
+            const aggregateState = async (sha) => {
+              const runs = await github.paginate(github.rest.checks.listForRef, {
+                owner, repo, ref: sha, check_name: aggregateCheck, filter: 'latest', per_page: 100,
+              });
+              if (runs.length === 0) return 'absent';
+              const run = runs.reduce((a, b) => (a.started_at > b.started_at ? a : b));
+              return run.status === 'completed' ? run.conclusion : run.status;
+            };
 
             const prs = await github.paginate(github.rest.issues.listForRepo, {
               owner, repo, state: 'open', labels: 'lgtm',
@@ -60,20 +107,6 @@ jobs:
             for (const issue of prs) {
               if (!issue.pull_request) continue;
               if (issue.labels.some(l => l.name === 'hold')) continue;
-
-              const { data: reviews } = await github.rest.pulls.listReviews({
-                owner, repo, pull_number: issue.number,
-              });
-              debug(`PR #${issue.number} has ${reviews.length} reviews`);
-              const approvedByApprover = reviews.some(
-                r => r.state === 'APPROVED' &&
-                  (r.user.login === 'github-actions[bot]' || approvers.includes(r.user.login.toLowerCase()))
-              );
-
-              if (!approvedByApprover) {
-                core.info(`PR #${issue.number} has lgtm but no approved review from an OWNERS approver, skipping`);
-                continue;
-              }
 
               const { data: pr } = await github.rest.pulls.get({
                 owner, repo, pull_number: issue.number,
@@ -86,6 +119,25 @@ jobs:
                 `mergeable_state=${pr.mergeable_state}`,
                 `maintainer_can_modify=${pr.maintainer_can_modify}`,
               ].join(' | '));
+
+              // GitHub does not dismiss reviews on push, so an approval is only
+              // evidence about the commit it was left on.
+              const reviews = await latestReviewPerUser(issue.number);
+              debug(`PR #${issue.number} has ${reviews.length} decisive reviews`);
+              const approvedByApprover = reviews.some(
+                r => r.state === 'APPROVED' && isApprover(r.user.login) && r.commit_id === pr.head.sha
+              );
+
+              if (!approvedByApprover) {
+                core.info(`PR #${issue.number} has lgtm but no approved review from an OWNERS approver for head ${pr.head.sha}, skipping`);
+                continue;
+              }
+
+              const aggregate = await aggregateState(pr.head.sha);
+              if (aggregate !== 'success') {
+                core.info(`PR #${issue.number} has ${aggregateCheck}=${aggregate} on head ${pr.head.sha}, skipping`);
+                continue;
+              }
 
               let mergeablePr = pr;
               if (mergeablePr.mergeable === null || mergeablePr.mergeable_state === 'unknown') {
@@ -112,8 +164,10 @@ jobs:
               }
 
               try {
+                // Pin the merge to the head we vetted: GitHub rejects the call if the
+                // PR was pushed to since, rather than merging code nothing approved.
                 await github.rest.pulls.merge({
-                  owner, repo, pull_number: issue.number, merge_method: 'squash',
+                  owner, repo, pull_number: issue.number, merge_method: 'squash', sha: pr.head.sha,
                 });
                 core.info(`Merged PR #${issue.number}`);
               } catch (e) {

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -1,8 +1,21 @@
-# This workflow will remove the lgtm label from a PR that gets updated.
-# This prevents any un-reviewed code from being automatically merged by the lgtm-merger mechanism.
+# Removes the lgtm label when a PR is updated, so un-reviewed code cannot be
+# picked up by the automerge job in prow-pr-automerge.yml.
+#
+# pull_request_target rather than pull_request: GitHub forces the pull_request
+# token to read-only on fork PRs, so removeLabel returns 403 there, and almost
+# every kserve PR comes from a fork.
+#
+# Nothing from the fork reaches the runner, which is what makes the write token
+# safe here. Do not add:
+#   - actions/checkout - would put fork code on a runner holding the token
+#   - run: steps interpolating github.event values - script injection
+#   - caches shared with pull_request workflows - cache poisoning
+#   - any secret other than GITHUB_TOKEN
 
 name: "Prow remove lgtm label"
-on: pull_request
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 # This workflow is not applicable to merge queue
 # merge_group:
@@ -10,10 +23,28 @@ on: pull_request
 
 jobs:
   remove-lgtm:
+    # Keeps the write token out of the job entirely on the majority of pushes,
+    # where there is no label to remove.
+    if: contains(github.event.pull_request.labels.*.name, 'lgtm')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pull-requests: write
     steps:
-      - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          jobs: 'lgtm'
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: prNumber, name: 'lgtm',
+              });
+              core.info(`Removed lgtm from PR #${prNumber}`);
+            } catch (e) {
+              // 404 means the label went away between the event and this call.
+              if (e.status !== 404) throw e;
+              core.info(`PR #${prNumber} no longer carries lgtm`);
+            }


### PR DESCRIPTION
**What this PR does / why we need it**:

Automerge treated a non-passing commit status the same as a passing one, and accepted an approving review regardless of which commit it had been given on. Auditing the last 60 merges found ten that went in with a failing, cancelled, or still-running check aggregate - several with CI barely started. Approvals also never went stale on push, since GitHub does not dismiss them automatically here.

Automerge now requires the CI aggregate to have completed successfully on the pull request's current head, and requires the approving review to have been given on that same head. It also stops silently trusting a workflow that failed to start: a missing check run is treated as a failure, not as an absence of one.

Removing the `lgtm` label on push had the same gap from a different angle: it ran on an event whose token GitHub forces read-only for fork pull requests, which is nearly every pull request here, so a stale approval signal from before a push was never cleared.

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

Workflow logic has no unit test harness, so verified by replaying the actual script against real history: extracted the merge decision function and ran it against the most recently merged PRs and the presently open ones.

 Logs: refusal reasons observed in the replay, matching each PR's actual CI outcome:
  ```
  PR #6156 has enforce-all-checks=cancelled on head 3f0948f..., skipping
  PR #6146 has enforce-all-checks=failure on head 1aa56d8..., skipping
  PR #6055 has enforce-all-checks=absent on head 8442c4d..., skipping
  ```

**Special notes for your reviewer**:

The `lgtm` removal switches to `pull_request_target` to get a writable token on fork PRs, which is the only way to fix that gap. To keep that safe: no checkout of PR content, no interpolation of PR-controlled values into a shell step, permissions narrowed to `pull-requests: write` only, and the job doesn't start unless the label is already present. The full rationale is a comment at the top of the workflow file.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Automerge now requires the CI check aggregate to pass and an approving review to be current on a PR's latest commit, closing a gap where failing or unreviewed pushes could be merged automatically. NONE for downstream consumers - internal CI/repo-process fix only.
```
