### PR TITLE
feat(otel): inject OTEL vars into InferenceService

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/tracing.go
+++ b/pkg/controller/v1alpha2/llmisvc/tracing.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/tracing"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 const (
@@ -34,7 +36,7 @@ const (
 func otelResourceAttributeEnvVars(namespace, llmisvcName string) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
-			Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+			Name: tracing.EnvOtelResourceAttributesNodeName,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					APIVersion: "v1",
@@ -43,7 +45,7 @@ func otelResourceAttributeEnvVars(namespace, llmisvcName string) []corev1.EnvVar
 			},
 		},
 		{
-			Name: "OTEL_RESOURCE_ATTRIBUTES_POD_NAME",
+			Name: tracing.EnvOtelResourceAttributesPodName,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					APIVersion: "v1",
@@ -52,10 +54,10 @@ func otelResourceAttributeEnvVars(namespace, llmisvcName string) []corev1.EnvVar
 			},
 		},
 		{
-			Name: "OTEL_RESOURCE_ATTRIBUTES",
+			Name: tracing.EnvOtelResourceAttributes,
 			Value: "k8s.namespace.name=" + namespace +
-				",k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME)" +
-				",k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)" +
+				",k8s.node.name=$(" + tracing.EnvOtelResourceAttributesNodeName + ")" +
+				",k8s.pod.name=$(" + tracing.EnvOtelResourceAttributesPodName + ")" +
 				",llmisvc.name=" + llmisvcName,
 		},
 	}
@@ -72,23 +74,23 @@ func injectSchedulerTracing(t *v1alpha2.TracingSpec, namespace, llmisvcName stri
 		return false
 	}
 
-	if !hasArg(container.Args, "--tracing") &&
-		!hasArg(container.Args, "-tracing") {
+	if !tracing.HasArg(container.Args, "--tracing") &&
+		!tracing.HasArg(container.Args, "-tracing") {
 		container.Args = append(container.Args, "--tracing=true")
 	}
 
 	resourceAttrs := otelResourceAttributeEnvVars(namespace, llmisvcName)
 	tracingEnvVars := make([]corev1.EnvVar, 0, 5+len(resourceAttrs))
 	tracingEnvVars = append(tracingEnvVars,
-		corev1.EnvVar{Name: "OTEL_SERVICE_NAME", Value: defaultSchedulerServiceName},
-		corev1.EnvVar{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: ptr.Deref(t.ExporterEndpoint, "")},
-		corev1.EnvVar{Name: "OTEL_TRACES_EXPORTER", Value: ptr.Deref(t.Exporter, "")},
-		corev1.EnvVar{Name: "OTEL_TRACES_SAMPLER", Value: ptr.Deref(t.Sampler, "")},
-		corev1.EnvVar{Name: "OTEL_TRACES_SAMPLER_ARG", Value: ptr.Deref(t.SamplerArg, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelServiceName, Value: defaultSchedulerServiceName},
+		corev1.EnvVar{Name: tracing.EnvOtelExporterEndpoint, Value: ptr.Deref(t.ExporterEndpoint, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesExporter, Value: ptr.Deref(t.Exporter, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesSampler, Value: ptr.Deref(t.Sampler, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesSamplerArg, Value: ptr.Deref(t.SamplerArg, "")},
 	)
 	tracingEnvVars = append(tracingEnvVars, resourceAttrs...)
 
-	container.Env = mergeEnvVars(container.Env, tracingEnvVars)
+	container.Env = utils.AppendEnvVarIfNotExists(container.Env, tracingEnvVars...)
 	return true
 }
 
@@ -109,11 +111,11 @@ func injectServerTracing(t *v1alpha2.TracingSpec, namespace, llmisvcName, roleSu
 		return false
 	}
 
-	if !hasArg(container.Args, "--otlp-traces-endpoint") {
+	if !tracing.HasArg(container.Args, "--otlp-traces-endpoint") {
 		container.Args = append(container.Args, "--otlp-traces-endpoint", endpoint)
 	}
 
-	if !hasArg(container.Args, "--collect-detailed-traces") {
+	if !tracing.HasArg(container.Args, "--collect-detailed-traces") {
 		container.Args = append(container.Args, "--collect-detailed-traces", "all")
 	}
 
@@ -122,15 +124,15 @@ func injectServerTracing(t *v1alpha2.TracingSpec, namespace, llmisvcName, roleSu
 
 	tracingEnvVars := make([]corev1.EnvVar, 0, 5+len(resourceAttrs))
 	tracingEnvVars = append(tracingEnvVars,
-		corev1.EnvVar{Name: "OTEL_SERVICE_NAME", Value: serviceName},
-		corev1.EnvVar{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: endpoint},
-		corev1.EnvVar{Name: "OTEL_TRACES_EXPORTER", Value: ptr.Deref(t.Exporter, "")},
-		corev1.EnvVar{Name: "OTEL_TRACES_SAMPLER", Value: ptr.Deref(t.Sampler, "")},
-		corev1.EnvVar{Name: "OTEL_TRACES_SAMPLER_ARG", Value: ptr.Deref(t.SamplerArg, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelServiceName, Value: serviceName},
+		corev1.EnvVar{Name: tracing.EnvOtelExporterEndpoint, Value: endpoint},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesExporter, Value: ptr.Deref(t.Exporter, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesSampler, Value: ptr.Deref(t.Sampler, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesSamplerArg, Value: ptr.Deref(t.SamplerArg, "")},
 	)
 	tracingEnvVars = append(tracingEnvVars, resourceAttrs...)
 
-	container.Env = mergeEnvVars(container.Env, tracingEnvVars)
+	container.Env = utils.AppendEnvVarIfNotExists(container.Env, tracingEnvVars...)
 	return true
 }
 
@@ -140,32 +142,6 @@ func injectServerTracingIntoPodSpec(t *v1alpha2.TracingSpec, namespace, llmisvcN
 	for i := range podSpec.Containers {
 		if podSpec.Containers[i].Name == "main" {
 			return injectServerTracing(t, namespace, llmisvcName, roleSuffix, &podSpec.Containers[i])
-		}
-	}
-	return false
-}
-
-// mergeEnvVars appends env vars from src into dst, skipping any that already
-// exist in dst (by name). This ensures user-provided env vars take precedence.
-func mergeEnvVars(dst, src []corev1.EnvVar) []corev1.EnvVar {
-	existing := make(map[string]struct{}, len(dst))
-	for _, e := range dst {
-		existing[e.Name] = struct{}{}
-	}
-	for _, e := range src {
-		if _, ok := existing[e.Name]; !ok {
-			dst = append(dst, e)
-		}
-	}
-	return dst
-}
-
-// hasArg checks whether any element in args starts with the given flag name.
-// It handles both --flag=value and --flag value forms.
-func hasArg(args []string, flag string) bool {
-	for _, a := range args {
-		if a == flag || len(a) > len(flag) && a[:len(flag)+1] == flag+"=" {
-			return true
 		}
 	}
 	return false

--- a/pkg/controller/v1alpha2/llmisvc/tracing_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/tracing_test.go
@@ -258,50 +258,6 @@ func TestOtelResourceAttributeEnvVars(t *testing.T) {
 	g.Expect(envVars[2].Value).To(ContainSubstring("k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)"))
 }
 
-func TestMergeEnvVars(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	dst := []corev1.EnvVar{
-		{Name: "EXISTING", Value: "keep"},
-		{Name: "OTEL_SERVICE_NAME", Value: "user-value"},
-	}
-	src := []corev1.EnvVar{
-		{Name: "OTEL_SERVICE_NAME", Value: "injected-value"},
-		{Name: "NEW_VAR", Value: "new"},
-	}
-
-	result := mergeEnvVars(dst, src)
-
-	envMap := envToMap(result)
-	g.Expect(envMap).To(HaveKeyWithValue("EXISTING", "keep"))
-	g.Expect(envMap).To(HaveKeyWithValue("OTEL_SERVICE_NAME", "user-value"))
-	g.Expect(envMap).To(HaveKeyWithValue("NEW_VAR", "new"))
-	g.Expect(result).To(HaveLen(3))
-}
-
-func TestHasArg(t *testing.T) {
-	tests := []struct {
-		name   string
-		args   []string
-		flag   string
-		expect bool
-	}{
-		{"exact match", []string{"--tracing=true"}, "--tracing", true},
-		{"flag=value form", []string{"--otlp-traces-endpoint=http://x"}, "--otlp-traces-endpoint", true},
-		{"flag alone", []string{"--tracing"}, "--tracing", true},
-		{"no match", []string{"--other"}, "--tracing", false},
-		{"empty args", []string{}, "--tracing", false},
-		{"partial prefix doesn't match", []string{"--tracing-extra"}, "--tracing", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-			g.Expect(hasArg(tt.args, tt.flag)).To(Equal(tt.expect))
-		})
-	}
-}
-
 func envToMap(envVars []corev1.EnvVar) map[string]string {
 	m := make(map[string]string, len(envVars))
 	for _, e := range envVars {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -123,10 +123,10 @@ func (p *Predictor) buildPredictorResources(ctx context.Context, isvc *v1beta1.I
 
 	var podSpec corev1.PodSpec
 	var sRuntime v1alpha1.ServingRuntimeSpec
+	var runtimeAnnotations map[string]string
 
 	// If Model is specified, prioritize using that. Otherwise, we will assume a framework object was specified.
 	if isvc.Spec.Predictor.Model != nil {
-		var runtimeAnnotations map[string]string
 		var err error
 		sRuntime, runtimeAnnotations, err = p.reconcileModel(ctx, isvc, multiNodeEnabled)
 		if err != nil {
@@ -153,6 +153,18 @@ func (p *Predictor) buildPredictorResources(ctx context.Context, isvc *v1beta1.I
 		containerName := podSpec.Containers[i].Name
 		if err := isvcutils.AddEnvVarToPodSpec(&podSpec, containerName, constants.InferenceServiceNameEnvVarKey, isvc.Name); err != nil {
 			return nil, errors.Wrapf(err, "failed to add INFERENCE_SERVICE_NAME environment variable to container %s", containerName)
+		}
+	}
+
+	if isvc.Spec.Tracing != nil {
+		serverType := runtimeAnnotations[constants.ServerTypeAnnotationKey]
+		if serverType == "" && isvc.Spec.Predictor.Model != nil && isvc.Spec.Predictor.Model.Runtime != nil {
+			serverType = constants.GetServerTypeFromRuntimeName(*isvc.Spec.Predictor.Model.Runtime)
+		}
+		variant := isvc.Spec.Predictor.Name
+
+		for i := range podSpec.Containers {
+			isvcutils.InjectPredictorTracing(isvc.Spec.Tracing, isvc.Namespace, isvc.Name, variant, serverType, &podSpec.Containers[i])
 		}
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/tracing_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/tracing_test.go
@@ -1,0 +1,477 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferenceservice
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/tracing"
+)
+
+func envToMapFromContainer(envVars []corev1.EnvVar) map[string]string {
+	m := make(map[string]string, len(envVars))
+	for _, e := range envVars {
+		m[e.Name] = e.Value
+	}
+	return m
+}
+
+func findContainer(podSpec corev1.PodSpec) *corev1.Container {
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == constants.InferenceServiceContainerName {
+			return &podSpec.Containers[i]
+		}
+	}
+	return nil
+}
+
+var _ = Describe("Tracing injection into predictor deployments", func() {
+	configs := getRawKubeTestConfigs()
+
+	Context("When creating an InferenceService with tracing enabled", func() {
+		It("Should inject OTEL env vars into the predictor Deployment", func() {
+			configMap := createInferenceServiceConfigMap(configs)
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			servingRuntime := getServingRuntime("tf-tracing", "default")
+			Expect(k8sClient.Create(context.TODO(), &servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), &servingRuntime)
+
+			serviceName := "tracing-basic-test"
+			ctx := context.Background()
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        serviceName,
+					Namespace:   "default",
+					Annotations: getDefaultAnnotations(constants.AutoscalerClassNone),
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Tracing: &v1beta1.TracingSpec{
+						ExporterEndpoint: ptr.To("http://otel-collector:4317"),
+						Sampler:          ptr.To("parentbased_traceidratio"),
+						SamplerArg:       ptr.To("0.05"),
+						Exporter:         ptr.To("otlp"),
+					},
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(1)),
+						},
+						Model: &v1beta1.ModelSpec{
+							ModelFormat: v1beta1.ModelFormat{Name: "tensorflow"},
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     proto.String("s3://test/model"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceName),
+				Namespace: "default",
+			}
+
+			deploy := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, deploy)
+			}, timeout, interval).Should(Succeed())
+
+			container := findContainer(deploy.Spec.Template.Spec)
+			Expect(container).NotTo(BeNil())
+
+			envMap := envToMapFromContainer(container.Env)
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelServiceName, serviceName+"-predictor"))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelExporterEndpoint, "http://otel-collector:4317"))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesExporter, "otlp"))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesSampler, "parentbased_traceidratio"))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesSamplerArg, "0.05"))
+			Expect(envMap).To(HaveKey(tracing.EnvOtelResourceAttributes))
+			Expect(envMap[tracing.EnvOtelResourceAttributes]).To(ContainSubstring("isvc.name=" + serviceName))
+			Expect(envMap[tracing.EnvOtelResourceAttributes]).To(ContainSubstring("isvc.component=predictor"))
+			Expect(envMap[tracing.EnvOtelResourceAttributes]).NotTo(ContainSubstring("isvc.predictor.variant"))
+		})
+
+		It("Should NOT inject OTEL env vars when tracing is nil", func() {
+			configMap := createInferenceServiceConfigMap(configs)
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			servingRuntime := getServingRuntime("tf-no-tracing", "default")
+			Expect(k8sClient.Create(context.TODO(), &servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), &servingRuntime)
+
+			serviceName := "tracing-disabled-test"
+			ctx := context.Background()
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        serviceName,
+					Namespace:   "default",
+					Annotations: getDefaultAnnotations(constants.AutoscalerClassNone),
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(1)),
+						},
+						Model: &v1beta1.ModelSpec{
+							ModelFormat: v1beta1.ModelFormat{Name: "tensorflow"},
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     proto.String("s3://test/model"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceName),
+				Namespace: "default",
+			}
+
+			deploy := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, deploy)
+			}, timeout, interval).Should(Succeed())
+
+			container := findContainer(deploy.Spec.Template.Spec)
+			Expect(container).NotTo(BeNil())
+
+			envMap := envToMapFromContainer(container.Env)
+			Expect(envMap).NotTo(HaveKey(tracing.EnvOtelServiceName))
+			Expect(envMap).NotTo(HaveKey(tracing.EnvOtelExporterEndpoint))
+		})
+	})
+
+	Context("When creating a vLLM InferenceService with tracing", func() {
+		It("Should inject vLLM CLI args alongside OTEL env vars", func() {
+			configMap := createInferenceServiceConfigMap(configs)
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			vllmRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.VLLMServer,
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.ServerTypeAnnotationKey: constants.ServerTypeVLLMServer,
+					},
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							AutoSelect: ptr.To(true),
+							Name:       "vLLM",
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:      constants.InferenceServiceContainerName,
+								Image:     "kserve/vllm:latest",
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), vllmRuntime)).To(Succeed())
+			defer k8sClient.Delete(context.TODO(), vllmRuntime)
+
+			serviceName := "tracing-vllm-test"
+			ctx := context.Background()
+			endpoint := "http://otel-collector:4317"
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        serviceName,
+					Namespace:   "default",
+					Annotations: getDefaultAnnotations(constants.AutoscalerClassNone),
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Tracing: &v1beta1.TracingSpec{
+						ExporterEndpoint: ptr.To(endpoint),
+						Sampler:          ptr.To("parentbased_traceidratio"),
+						SamplerArg:       ptr.To("0.05"),
+						Exporter:         ptr.To("otlp"),
+					},
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(1)),
+						},
+						Model: &v1beta1.ModelSpec{
+							ModelFormat: v1beta1.ModelFormat{Name: "vLLM"},
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								RuntimeVersion: ptr.To("latest"),
+								Container: corev1.Container{
+									Name: constants.InferenceServiceContainerName,
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											constants.NvidiaGPUResourceType: resource.MustParse("1"),
+										},
+										Requests: corev1.ResourceList{
+											constants.NvidiaGPUResourceType: resource.MustParse("1"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceName),
+				Namespace: "default",
+			}
+
+			deploy := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, deploy)
+			}, timeout, interval).Should(Succeed())
+
+			container := findContainer(deploy.Spec.Template.Spec)
+			Expect(container).NotTo(BeNil())
+
+			Expect(container.Args).To(ContainElements("--otlp-traces-endpoint", endpoint))
+			Expect(container.Args).To(ContainElements("--collect-detailed-traces", "all"))
+
+			envMap := envToMapFromContainer(container.Env)
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelServiceName, serviceName+"-predictor"))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelExporterEndpoint, endpoint))
+		})
+	})
+
+	Context("When creating an InferenceService with canary and tracing", func() {
+		It("Should inject variant attribute for canary predictor", func() {
+			configMap := createInferenceServiceConfigMap(configs)
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			servingRuntime := getServingRuntime("tf-canary-tracing", "default")
+			Expect(k8sClient.Create(context.TODO(), &servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), &servingRuntime)
+
+			serviceName := "tracing-canary-test"
+			ctx := context.Background()
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        serviceName,
+					Namespace:   "default",
+					Annotations: getDefaultAnnotations(constants.AutoscalerClassNone),
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Tracing: &v1beta1.TracingSpec{
+						ExporterEndpoint: ptr.To("http://otel-collector:4317"),
+						Sampler:          ptr.To("parentbased_traceidratio"),
+						SamplerArg:       ptr.To("0.05"),
+						Exporter:         ptr.To("otlp"),
+					},
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(2)),
+						},
+						Model: &v1beta1.ModelSpec{
+							ModelFormat: v1beta1.ModelFormat{Name: "tensorflow"},
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     proto.String("s3://test/model-v1"),
+								RuntimeVersion: proto.String("0.14.0"),
+							},
+						},
+					},
+					Canary: []v1beta1.CanarySpec{
+						{
+							TrafficPercent: 25,
+							Predictor: v1beta1.PredictorSpec{
+								Name: "v2",
+								Model: &v1beta1.ModelSpec{
+									ModelFormat: v1beta1.ModelFormat{Name: "tensorflow"},
+									PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+										StorageURI:     proto.String("s3://test/model-v2"),
+										RuntimeVersion: proto.String("0.14.0"),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			// Verify stable predictor has no variant attribute
+			stableKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceName),
+				Namespace: "default",
+			}
+			stableDeploy := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, stableKey, stableDeploy)
+			}, timeout, interval).Should(Succeed())
+
+			stableContainer := findContainer(stableDeploy.Spec.Template.Spec)
+			Expect(stableContainer).NotTo(BeNil())
+
+			stableEnvMap := envToMapFromContainer(stableContainer.Env)
+			Expect(stableEnvMap).To(HaveKey(tracing.EnvOtelResourceAttributes))
+			Expect(stableEnvMap[tracing.EnvOtelResourceAttributes]).NotTo(ContainSubstring("isvc.predictor.variant"))
+
+			// Verify canary predictor has variant attribute
+			canaryKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceName, "v2"),
+				Namespace: "default",
+			}
+			canaryDeploy := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, canaryKey, canaryDeploy)
+			}, timeout, interval).Should(Succeed())
+
+			canaryContainer := findContainer(canaryDeploy.Spec.Template.Spec)
+			Expect(canaryContainer).NotTo(BeNil())
+
+			canaryEnvMap := envToMapFromContainer(canaryContainer.Env)
+			Expect(canaryEnvMap).To(HaveKey(tracing.EnvOtelResourceAttributes))
+			Expect(canaryEnvMap[tracing.EnvOtelResourceAttributes]).To(ContainSubstring("isvc.predictor.variant=v2"))
+			Expect(canaryEnvMap).To(HaveKeyWithValue(tracing.EnvOtelServiceName, serviceName+"-predictor"))
+		})
+	})
+
+	Context("When creating an MLServer InferenceService with tracing", func() {
+		It("Should inject MLSERVER_TRACING_SERVER alongside OTEL env vars", func() {
+			configMap := createInferenceServiceConfigMap(configs)
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			mlserverRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.MLServer,
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.ServerTypeAnnotationKey: constants.ServerTypeMLServer,
+					},
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "sklearn",
+							AutoSelect: ptr.To(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:      constants.InferenceServiceContainerName,
+								Image:     "seldonio/mlserver:latest",
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), mlserverRuntime)).To(Succeed())
+			defer k8sClient.Delete(context.TODO(), mlserverRuntime)
+
+			serviceName := "tracing-mlserver-test"
+			ctx := context.Background()
+			endpoint := "http://otel-collector:4317"
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        serviceName,
+					Namespace:   "default",
+					Annotations: getDefaultAnnotations(constants.AutoscalerClassNone),
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Tracing: &v1beta1.TracingSpec{
+						ExporterEndpoint: ptr.To(endpoint),
+						Sampler:          ptr.To("parentbased_traceidratio"),
+						SamplerArg:       ptr.To("0.05"),
+						Exporter:         ptr.To("otlp"),
+					},
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(1)),
+						},
+						Model: &v1beta1.ModelSpec{
+							ModelFormat: v1beta1.ModelFormat{Name: "sklearn"},
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     proto.String("s3://test/sklearn-model"),
+								RuntimeVersion: proto.String("latest"),
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceName),
+				Namespace: "default",
+			}
+
+			deploy := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, deploy)
+			}, timeout, interval).Should(Succeed())
+
+			container := findContainer(deploy.Spec.Template.Spec)
+			Expect(container).NotTo(BeNil())
+
+			envMap := envToMapFromContainer(container.Env)
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvMLServerTracingServer, endpoint))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelServiceName, serviceName+"-predictor"))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelExporterEndpoint, endpoint))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesExporter, "otlp"))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesSampler, "parentbased_traceidratio"))
+			Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesSamplerArg, "0.05"))
+			Expect(container.Args).NotTo(ContainElement("--otlp-traces-endpoint"))
+		})
+	})
+})

--- a/pkg/controller/v1beta1/inferenceservice/utils/tracing.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/tracing.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/tracing"
+	"github.com/kserve/kserve/pkg/utils"
+)
+
+func otelResourceAttributeEnvVars(namespace, isvcName, component, variant string) []corev1.EnvVar {
+	attrs := "k8s.namespace.name=" + namespace +
+		",k8s.node.name=$(" + tracing.EnvOtelResourceAttributesNodeName + ")" +
+		",k8s.pod.name=$(" + tracing.EnvOtelResourceAttributesPodName + ")" +
+		",isvc.name=" + isvcName +
+		",isvc.component=" + component
+	if variant != "" {
+		attrs += ",isvc.predictor.variant=" + variant
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name: tracing.EnvOtelResourceAttributesNodeName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "spec.nodeName",
+				},
+			},
+		},
+		{
+			Name: tracing.EnvOtelResourceAttributesPodName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.name",
+				},
+			},
+		},
+		{
+			Name:  tracing.EnvOtelResourceAttributes,
+			Value: attrs,
+		},
+	}
+}
+
+// InjectPredictorTracing injects OTEL tracing env vars and runtime-specific
+// configuration into a predictor container. Returns true if the container was
+// mutated.
+//
+// variant identifies the canary variant name (empty for the primary predictor).
+// serverType is the serving runtime type (e.g. constants.ServerTypeVLLMServer).
+func InjectPredictorTracing(t *v1beta1.TracingSpec, namespace, isvcName, variant, serverType string, container *corev1.Container) bool {
+	if t == nil {
+		return false
+	}
+
+	endpoint := ptr.Deref(t.ExporterEndpoint, "")
+	resourceAttrs := otelResourceAttributeEnvVars(namespace, isvcName, "predictor", variant)
+	tracingEnvVars := make([]corev1.EnvVar, 0, 6+len(resourceAttrs))
+	tracingEnvVars = append(tracingEnvVars,
+		corev1.EnvVar{Name: tracing.EnvOtelServiceName, Value: isvcName + "-predictor"},
+		corev1.EnvVar{Name: tracing.EnvOtelExporterEndpoint, Value: endpoint},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesExporter, Value: ptr.Deref(t.Exporter, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesSampler, Value: ptr.Deref(t.Sampler, "")},
+		corev1.EnvVar{Name: tracing.EnvOtelTracesSamplerArg, Value: ptr.Deref(t.SamplerArg, "")},
+	)
+	tracingEnvVars = append(tracingEnvVars, resourceAttrs...)
+
+	switch serverType {
+	case constants.ServerTypeVLLMServer:
+		if !tracing.HasArg(container.Args, "--otlp-traces-endpoint") {
+			container.Args = append(container.Args, "--otlp-traces-endpoint", endpoint)
+		}
+		if !tracing.HasArg(container.Args, "--collect-detailed-traces") {
+			container.Args = append(container.Args, "--collect-detailed-traces", "all")
+		}
+	case constants.ServerTypeMLServer:
+		tracingEnvVars = append(tracingEnvVars,
+			corev1.EnvVar{Name: tracing.EnvMLServerTracingServer, Value: endpoint},
+		)
+	}
+
+	container.Env = utils.AppendEnvVarIfNotExists(container.Env, tracingEnvVars...)
+	return true
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/tracing_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/tracing_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/tracing"
+)
+
+func envToMap(envVars []corev1.EnvVar) map[string]string {
+	m := make(map[string]string, len(envVars))
+	for _, e := range envVars {
+		m[e.Name] = e.Value
+	}
+	return m
+}
+
+func TestInjectPredictorTracing(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       *v1beta1.TracingSpec
+		namespace  string
+		isvcName   string
+		variant    string
+		serverType string
+		container  *corev1.Container
+		wantMut    bool
+		check      func(g *GomegaWithT, c *corev1.Container)
+	}{
+		{
+			name:      "nil TracingSpec returns false",
+			spec:      nil,
+			container: &corev1.Container{Name: "main"},
+			wantMut:   false,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				g.Expect(c.Env).To(BeEmpty())
+				g.Expect(c.Args).To(BeEmpty())
+			},
+		},
+		{
+			name:      "populated TracingSpec sets all OTEL env vars",
+			spec:      fullTracingSpec(),
+			namespace: "prod-ns",
+			isvcName:  "llm-prod",
+			container: &corev1.Container{Name: "main"},
+			wantMut:   true,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				envMap := envToMap(c.Env)
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelServiceName, "llm-prod-predictor"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelExporterEndpoint, "http://collector:4317"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesExporter, "otlp"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesSampler, "parentbased_traceidratio"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesSamplerArg, "0.1"))
+			},
+		},
+		{
+			name:       "vLLM predictor with endpoint injects CLI args",
+			spec:       fullTracingSpec(),
+			namespace:  "ns",
+			isvcName:   "vllm-isvc",
+			serverType: constants.ServerTypeVLLMServer,
+			container:  &corev1.Container{Name: "main"},
+			wantMut:    true,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				g.Expect(c.Args).To(ContainElements("--otlp-traces-endpoint", "http://collector:4317"))
+				g.Expect(c.Args).To(ContainElements("--collect-detailed-traces", "all"))
+			},
+		},
+		{
+			name:       "non-vLLM predictor gets env vars only",
+			spec:       fullTracingSpec(),
+			namespace:  "ns",
+			isvcName:   "triton-isvc",
+			serverType: "triton",
+			container:  &corev1.Container{Name: "main"},
+			wantMut:    true,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				g.Expect(c.Args).To(BeEmpty())
+				envMap := envToMap(c.Env)
+				g.Expect(envMap).To(HaveKey(tracing.EnvOtelServiceName))
+				g.Expect(envMap).NotTo(HaveKey(tracing.EnvMLServerTracingServer))
+			},
+		},
+		{
+			name:       "MLServer predictor with endpoint injects MLSERVER_TRACING_SERVER and OTEL env vars",
+			spec:       fullTracingSpec(),
+			namespace:  "ns",
+			isvcName:   "mlserver-isvc",
+			serverType: constants.ServerTypeMLServer,
+			container:  &corev1.Container{Name: "main"},
+			wantMut:    true,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				envMap := envToMap(c.Env)
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvMLServerTracingServer, "http://collector:4317"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelServiceName, "mlserver-isvc-predictor"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelExporterEndpoint, "http://collector:4317"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesExporter, "otlp"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesSampler, "parentbased_traceidratio"))
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelTracesSamplerArg, "0.1"))
+				g.Expect(envMap).To(HaveKey(tracing.EnvOtelResourceAttributes))
+				g.Expect(c.Args).To(BeEmpty())
+			},
+		},
+		{
+			name:      "canary variant included in resource attributes",
+			spec:      fullTracingSpec(),
+			namespace: "ns",
+			isvcName:  "my-isvc",
+			variant:   "canary-v2",
+			container: &corev1.Container{Name: "main"},
+			wantMut:   true,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				envMap := envToMap(c.Env)
+				g.Expect(envMap[tracing.EnvOtelResourceAttributes]).To(ContainSubstring("isvc.predictor.variant=canary-v2"))
+			},
+		},
+		{
+			name:      "primary predictor has no variant in resource attributes",
+			spec:      fullTracingSpec(),
+			namespace: "ns",
+			isvcName:  "my-isvc",
+			variant:   "",
+			container: &corev1.Container{Name: "main"},
+			wantMut:   true,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				envMap := envToMap(c.Env)
+				g.Expect(envMap[tracing.EnvOtelResourceAttributes]).NotTo(ContainSubstring("isvc.predictor.variant"))
+			},
+		},
+		{
+			name:      "user-set OTEL env var not overwritten",
+			spec:      fullTracingSpec(),
+			namespace: "ns",
+			isvcName:  "my-isvc",
+			container: &corev1.Container{
+				Name: "main",
+				Env: []corev1.EnvVar{
+					{Name: tracing.EnvOtelServiceName, Value: "user-override"},
+				},
+			},
+			wantMut: true,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				envMap := envToMap(c.Env)
+				g.Expect(envMap).To(HaveKeyWithValue(tracing.EnvOtelServiceName, "user-override"))
+				g.Expect(envMap).To(HaveKey(tracing.EnvOtelExporterEndpoint))
+			},
+		},
+		{
+			name:       "idempotent re-injection does not duplicate env vars or args",
+			spec:       fullTracingSpec(),
+			namespace:  "ns",
+			isvcName:   "my-isvc",
+			serverType: constants.ServerTypeVLLMServer,
+			container:  &corev1.Container{Name: "main"},
+			wantMut:    true,
+			check: func(g *GomegaWithT, c *corev1.Container) {
+				envCountBefore := len(c.Env)
+				argsCountBefore := len(c.Args)
+
+				InjectPredictorTracing(fullTracingSpec(), "ns", "my-isvc", "", constants.ServerTypeVLLMServer, c)
+
+				g.Expect(c.Env).To(HaveLen(envCountBefore))
+				g.Expect(c.Args).To(HaveLen(argsCountBefore))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			mutated := InjectPredictorTracing(tt.spec, tt.namespace, tt.isvcName, tt.variant, tt.serverType, tt.container)
+			g.Expect(mutated).To(Equal(tt.wantMut))
+			tt.check(g, tt.container)
+		})
+	}
+}
+
+func TestOtelResourceAttributeEnvVars(t *testing.T) {
+	g := NewGomegaWithT(t)
+	envVars := otelResourceAttributeEnvVars("my-namespace", "my-isvc", "predictor", "")
+
+	g.Expect(envVars).To(HaveLen(3))
+
+	g.Expect(envVars[0].Name).To(Equal(tracing.EnvOtelResourceAttributesNodeName))
+	g.Expect(envVars[0].ValueFrom.FieldRef.FieldPath).To(Equal("spec.nodeName"))
+
+	g.Expect(envVars[1].Name).To(Equal(tracing.EnvOtelResourceAttributesPodName))
+	g.Expect(envVars[1].ValueFrom.FieldRef.FieldPath).To(Equal("metadata.name"))
+
+	g.Expect(envVars[2].Name).To(Equal(tracing.EnvOtelResourceAttributes))
+	g.Expect(envVars[2].Value).To(ContainSubstring("k8s.namespace.name=my-namespace"))
+	g.Expect(envVars[2].Value).To(ContainSubstring("isvc.name=my-isvc"))
+	g.Expect(envVars[2].Value).To(ContainSubstring("isvc.component=predictor"))
+	g.Expect(envVars[2].Value).NotTo(ContainSubstring("isvc.predictor.variant"))
+}
+
+func TestOtelResourceAttributeEnvVars_WithVariant(t *testing.T) {
+	g := NewGomegaWithT(t)
+	envVars := otelResourceAttributeEnvVars("ns", "isvc", "predictor", "canary-v1")
+
+	g.Expect(envVars[2].Value).To(ContainSubstring("isvc.predictor.variant=canary-v1"))
+}
+
+func fullTracingSpec() *v1beta1.TracingSpec {
+	return &v1beta1.TracingSpec{
+		ExporterEndpoint: ptr.To("http://collector:4317"),
+		Sampler:          ptr.To("parentbased_traceidratio"),
+		SamplerArg:       ptr.To("0.1"),
+		Exporter:         ptr.To("otlp"),
+	}
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+const (
+	EnvOtelServiceName                = "OTEL_SERVICE_NAME"
+	EnvOtelExporterEndpoint           = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	EnvOtelTracesExporter             = "OTEL_TRACES_EXPORTER"
+	EnvOtelTracesSampler              = "OTEL_TRACES_SAMPLER"
+	EnvOtelTracesSamplerArg           = "OTEL_TRACES_SAMPLER_ARG"
+	EnvOtelResourceAttributes         = "OTEL_RESOURCE_ATTRIBUTES"
+	EnvOtelResourceAttributesNodeName = "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME"
+	EnvOtelResourceAttributesPodName  = "OTEL_RESOURCE_ATTRIBUTES_POD_NAME"
+
+	EnvMLServerTracingServer = "MLSERVER_TRACING_SERVER"
+)
+
+// HasArg checks whether any element in args starts with the given flag name.
+// It handles both --flag=value and --flag value forms.
+func HasArg(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag || len(a) > len(flag) && a[:len(flag)+1] == flag+"=" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHasArg(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		flag   string
+		expect bool
+	}{
+		{"exact match", []string{"--tracing=true"}, "--tracing", true},
+		{"flag=value form", []string{"--otlp-traces-endpoint=http://x"}, "--otlp-traces-endpoint", true},
+		{"flag alone", []string{"--tracing"}, "--tracing", true},
+		{"no match", []string{"--other"}, "--tracing", false},
+		{"empty args", []string{}, "--tracing", false},
+		{"partial prefix doesn't match", []string{"--tracing-extra"}, "--tracing", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(HasArg(tt.args, tt.flag)).To(Equal(tt.expect))
+		})
+	}
+}


### PR DESCRIPTION
chore:	This commit unifies common methods and constants used by llmisvc and isvc to
	configure OTEL env, it enables OTEL configuration for vllm runtime intially.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:


- [ ] Unit tests to test methods
- [ ] Integration test for ISVC OTEL config


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
feat(OTEL): inject OTEL vars into InferenceService
```
