### PR TITLE
fix(logger): bound worker dispatch to stop unbounded goroutine growth

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -62,6 +62,7 @@ var (
 	// logger flags
 	logUrl              = flag.String("log-url", "", "The URL to send request/response logs to")
 	workers             = flag.Int("workers", 5, "Number of workers")
+	logWorkQueueSize    = flag.Int("log-work-queue-size", kfslogger.LoggerWorkerQueueSize, "Size of the logger work queue; once full, new log events are dropped instead of blocking the request path")
 	sourceUri           = flag.String("source-uri", "", "The source URI to use when publishing cloudevents")
 	logMode             = flag.String("log-mode", string(v1beta1.LogAll), "Whether to log 'request', 'response' or 'all'")
 	logStorePath        = flag.String("log-store-path", "", "The path to the log output")
@@ -160,7 +161,7 @@ func main() {
 	var loggerArgs *loggerArgs
 	if *logUrl != "" {
 		logger.Info("Starting logger")
-		loggerArgs = startLogger(*workers, logStorePath, *logMarshallerUrl, *logMarshallerPort,
+		loggerArgs = startLogger(*workers, *logWorkQueueSize, logStorePath, *logMarshallerUrl, *logMarshallerPort,
 			*logBatchSize, *logBatchInterval, logger)
 	}
 
@@ -272,7 +273,7 @@ func startBatcher(logger *zap.SugaredLogger) *batcherArgs {
 	}
 }
 
-func startLogger(workers int, logStorePath *string, marshallerUrl string, marshallerPort int,
+func startLogger(workers int, workQueueSize int, logStorePath *string, marshallerUrl string, marshallerPort int,
 	batchSize int, batchInterval time.Duration, log *zap.SugaredLogger,
 ) *loggerArgs {
 	loggingMode := v1beta1.LoggerType(*logMode)
@@ -361,7 +362,7 @@ func startLogger(workers int, logStorePath *string, marshallerUrl string, marsha
 	}
 
 	log.Info("Starting the log dispatcher")
-	kfslogger.StartDispatcher(workers, store, batchStrategy, log)
+	kfslogger.StartDispatcher(workers, workQueueSize, store, batchStrategy, log)
 	return &loggerArgs{
 		loggerType:       loggingMode,
 		logUrl:           logUrlParsed,

--- a/pkg/logger/dispatcher.go
+++ b/pkg/logger/dispatcher.go
@@ -24,11 +24,15 @@ import (
 
 var WorkerQueue chan chan LogRequest
 
-func StartDispatcher(nworkers int, store Store, batchStrategy BatchStrategy, logger *zap.SugaredLogger) {
+func StartDispatcher(nworkers int, workQueueSize int, store Store, batchStrategy BatchStrategy, logger *zap.SugaredLogger) {
+	if workQueueSize <= 0 {
+		workQueueSize = LoggerWorkerQueueSize
+	}
+
 	// Reinitialize WorkQueue so that any previous dispatcher goroutines
 	// (from prior calls, e.g. in tests) lose their channel reference and
 	// cannot compete for work items.
-	WorkQueue = make(chan LogRequest, LoggerWorkerQueueSize)
+	WorkQueue = make(chan LogRequest, workQueueSize)
 
 	// Initialize the channel for workers to register their work channels.
 	WorkerQueue = make(chan chan LogRequest, nworkers)

--- a/pkg/logger/dispatcher.go
+++ b/pkg/logger/dispatcher.go
@@ -67,12 +67,12 @@ func StartDispatcher(nworkers int, store Store, batchStrategy BatchStrategy, log
 			strategy := GetStorageStrategy(work.Url.String())
 
 			if strategy == HttpStorage {
-				// Dispatch to a worker for CloudEvents delivery.
-				w := work
-				go func() {
-					worker := <-WorkerQueue
-					worker <- w
-				}()
+				// Dispatch to a worker for CloudEvents delivery. This blocks
+				// until a worker is free, so a slow/stuck log endpoint applies
+				// backpressure here instead of spawning an unbounded goroutine
+				// per event while waiting for a worker to become available.
+				worker := <-WorkerQueue
+				worker <- work
 			} else {
 				// Send to batch pipeline for blob storage.
 				batchIn <- work

--- a/pkg/logger/dispatcher_test.go
+++ b/pkg/logger/dispatcher_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KServe Authors.
+Copyright 2026 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/logger/dispatcher_test.go
+++ b/pkg/logger/dispatcher_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	pkglogging "knative.dev/pkg/logging"
+)
+
+// TestQueueLogRequestDropsWhenFull verifies that QueueLogRequest never blocks
+// the caller (the inference request path): once WorkQueue is full it must
+// reject the request immediately instead of waiting for room.
+func TestQueueLogRequestDropsWhenFull(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	original := WorkQueue
+	defer func() { WorkQueue = original }()
+	WorkQueue = make(chan LogRequest, 2)
+
+	body := []byte("payload")
+	req := LogRequest{Id: "req", Bytes: &body}
+
+	g.Expect(QueueLogRequest(req)).To(gomega.Succeed())
+	g.Expect(QueueLogRequest(req)).To(gomega.Succeed())
+
+	done := make(chan error, 1)
+	go func() { done <- QueueLogRequest(req) }()
+
+	select {
+	case err := <-done:
+		g.Expect(err).To(gomega.HaveOccurred())
+	case <-time.After(time.Second):
+		t.Fatal("QueueLogRequest blocked instead of dropping the request once the queue was full")
+	}
+}
+
+// TestDispatcherDoesNotLeakGoroutinesWhenWorkersAreBusy reproduces the
+// scenario in which a slow/stuck log endpoint causes every worker to stay
+// busy indefinitely. The dispatcher must not spawn a new goroutine per
+// queued event while waiting for a worker to free up - doing so grows
+// memory without bound until the process is OOM-killed.
+func TestDispatcherDoesNotLeakGoroutinesWhenWorkersAreBusy(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	logger, _ := pkglogging.NewLogger("", "INFO")
+
+	block := make(chan struct{})
+	stuckSvc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		<-block // simulate a downstream log endpoint that never drains
+	}))
+	// stuckSvc.Close() waits for in-flight connections to finish, so block
+	// must be closed first to unstick the handler above.
+	defer stuckSvc.Close()
+	defer close(block)
+
+	logUrl, err := url.Parse(stuckSvc.URL)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// A single worker so it's immediately saturated by the first event.
+	StartDispatcher(1, &MockStore{}, &ImmediateBatch{}, logger)
+
+	// Let the dispatcher/worker goroutines settle before measuring the baseline.
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	const numRequests = 50
+	body := []byte("payload")
+	for i := range numRequests {
+		g.Expect(QueueLogRequest(LogRequest{
+			Url:            logUrl,
+			SourceUri:      logUrl,
+			Bytes:          &body,
+			Id:             fmt.Sprintf("req-%d", i),
+			ReqType:        CEInferenceRequest,
+			OccurrenceTime: time.Now(),
+		})).To(gomega.Succeed())
+	}
+
+	// Give any (buggy) per-request goroutines time to spawn.
+	time.Sleep(200 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	g.Expect(after-before).To(gomega.BeNumerically("<", numRequests/2),
+		"expected dispatcher to bound goroutine growth while workers are busy, got %d new goroutines for %d requests", after-before, numRequests)
+}

--- a/pkg/logger/dispatcher_test.go
+++ b/pkg/logger/dispatcher_test.go
@@ -78,7 +78,7 @@ func TestDispatcherDoesNotLeakGoroutinesWhenWorkersAreBusy(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
 	// A single worker so it's immediately saturated by the first event.
-	StartDispatcher(1, &MockStore{}, &ImmediateBatch{}, logger)
+	StartDispatcher(1, LoggerWorkerQueueSize, &MockStore{}, &ImmediateBatch{}, logger)
 
 	// Let the dispatcher/worker goroutines settle before measuring the baseline.
 	time.Sleep(50 * time.Millisecond)

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -76,7 +76,7 @@ func TestLogger(t *testing.T) {
 	targetUri, err := url.Parse(predictor.URL)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	StartDispatcher(5, &MockStore{}, &ImmediateBatch{}, logger)
+	StartDispatcher(5, LoggerWorkerQueueSize, &MockStore{}, &ImmediateBatch{}, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
 	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default",
 		"default", httpProxy, nil, "", nil, true)
@@ -148,7 +148,7 @@ func TestLoggerWithMetadata(t *testing.T) {
 	targetUri, err := url.Parse(predictor.URL)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	StartDispatcher(5, &MockStore{}, &ImmediateBatch{}, logger)
+	StartDispatcher(5, LoggerWorkerQueueSize, &MockStore{}, &ImmediateBatch{}, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
 	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default",
 		"default", httpProxy, []string{"Foo", "Fizz"}, "", nil, true)
@@ -220,7 +220,7 @@ func TestLoggerWithAnnotation(t *testing.T) {
 	targetUri, err := url.Parse(predictor.URL)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	StartDispatcher(5, &MockStore{}, &ImmediateBatch{}, logger)
+	StartDispatcher(5, LoggerWorkerQueueSize, &MockStore{}, &ImmediateBatch{}, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
 	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default",
 		"default", httpProxy, nil, "", map[string]string{"Foo": "Bar", "Fizz": "Buzz"}, true)
@@ -265,7 +265,7 @@ func TestBadResponse(t *testing.T) {
 	targetUri, err := url.Parse(predictor.URL)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	StartDispatcher(1, &MockStore{}, &ImmediateBatch{}, logger)
+	StartDispatcher(1, LoggerWorkerQueueSize, &MockStore{}, &ImmediateBatch{}, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
 	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default",
 		"default", httpProxy, nil, "", nil, true)
@@ -331,7 +331,7 @@ func TestLoggerWithS3Store(t *testing.T) {
 	}
 	store := NewMockStore(spec)
 
-	StartDispatcher(5, store, &ImmediateBatch{}, logger)
+	StartDispatcher(5, LoggerWorkerQueueSize, store, &ImmediateBatch{}, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
 
 	logSvcUrl, err := url.Parse("s3://bucket")
@@ -426,7 +426,7 @@ func TestLoggerCloudEventTimestamps(t *testing.T) {
 	targetUri, err := url.Parse(predictor.URL)
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 
-	StartDispatcher(5, &MockStore{}, &ImmediateBatch{}, logger)
+	StartDispatcher(5, LoggerWorkerQueueSize, &MockStore{}, &ImmediateBatch{}, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
 	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default",
 		"default", httpProxy, nil, "", nil, true)

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -50,6 +50,9 @@ const (
 	AnnotationAttr   = "annotations"
 	RecordedTimeAttr = "recordedtime"
 
+	// LoggerWorkerQueueSize is the default WorkQueue capacity, used when
+	// StartDispatcher is called with a non-positive queue size. Callers
+	// (e.g. cmd/agent) can override it, such as via a flag.
 	LoggerWorkerQueueSize = 100
 	CloudEventsIdHeader   = "Ce-Id"
 )
@@ -66,7 +69,7 @@ func QueueLogRequest(req LogRequest) error {
 	case WorkQueue <- req:
 		return nil
 	default:
-		return fmt.Errorf("logger work queue is full (capacity %d), dropping log request %s", LoggerWorkerQueueSize, req.Id)
+		return fmt.Errorf("logger work queue is full (capacity %d), dropping log request %s", cap(WorkQueue), req.Id)
 	}
 }
 

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -57,9 +57,17 @@ const (
 // A buffered channel that we can send work requests on.
 var WorkQueue = make(chan LogRequest, LoggerWorkerQueueSize)
 
+// QueueLogRequest enqueues req without blocking the caller (the inference
+// request path). If WorkQueue is full - e.g. because the log endpoint is
+// slow or unavailable and workers can't keep up - the request is dropped
+// rather than piling up unbounded memory or stalling inference traffic.
 func QueueLogRequest(req LogRequest) error {
-	WorkQueue <- req
-	return nil
+	select {
+	case WorkQueue <- req:
+		return nil
+	default:
+		return fmt.Errorf("logger work queue is full (capacity %d), dropping log request %s", LoggerWorkerQueueSize, req.Id)
+	}
 }
 
 // NewWorker creates, and returns a new Worker object. Its only argument


### PR DESCRIPTION
**What this PR does / why we need it**:

`pkg/logger/dispatcher.go` forwarded every queued HTTP-CloudEvents log event to a worker by spawning a brand new goroutine per event (`go func() { worker := <-WorkerQueue; worker <- w }()`). If workers can't keep up - because there aren't enough of them, or because the downstream log endpoint is slow or stuck - these goroutines pile up with no bound, each retaining a full `LogRequest` including the raw request/response body. There was no backpressure and no drop policy, so memory grows until the process is OOM-killed. Since this logger runs as the reverse proxy in front of real inference traffic in this deployment mode, an OOM there also interrupts inference traffic, not just audit logging.

This PR fixes the unbounded-goroutine defect directly:
- The dispatcher no longer spawns a goroutine per event. It hands work to a worker synchronously in its own single goroutine, so a stuck/slow worker now applies backpressure at that point instead of unbounded goroutine growth.
- `QueueLogRequest` (called synchronously from the inference request path in `pkg/logger/handler.go`) now uses a non-blocking send. Once the bounded work queue (capacity 100) is full, it drops the new event and returns an error instead of blocking the caller - the existing caller already logs that error, so no caller-side change was needed. This matches the direction suggested in the issue (drop under sustained pressure rather than block or crash the request path).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

Added `pkg/logger/dispatcher_test.go` with two targeted regression tests that fail on the old code and pass with this fix:
- `TestQueueLogRequestDropsWhenFull`: fills the work queue and asserts the next `QueueLogRequest` call returns an error within 1s instead of blocking. On the old code this test times out (the send blocks forever).
- `TestDispatcherDoesNotLeakGoroutinesWhenWorkersAreBusy`: starts a real dispatcher with a single worker pointed at an HTTP server that never responds (simulating a stuck downstream log endpoint), queues 50 events, and asserts goroutine growth stays well below 50. On the old code this measured 52 new goroutines for 50 events (unbounded, one per event); with the fix it stays near 0.

Commands run and their results:
- `go build ./pkg/logger/...` - passes
- `go vet ./pkg/logger/...` - passes
- `go test ./pkg/logger/... -v` - full package suite passes (existing tests + the two new ones)
- `golangci-lint run ./pkg/logger/...` - 0 issues
- `gofmt -l` on the changed files - no output (already formatted)

Note on scope of validation: this reproduces and fixes the unbounded-goroutine defect described in the issue via a targeted unit test (goroutine-count containment under a stuck downstream endpoint). It does not reproduce the full end-to-end OOM/crash-loop in a live cluster - the defect that causes that OOM is the one being fixed here and is directly demonstrated failing-then-passing.

- [x] Verified the two new tests fail on the pre-fix code (`git stash` of the two source files) and pass after the fix, then restored the fix.

- Logs

**Special notes for your reviewer**:

The dispatcher's single goroutine now reads `WorkQueue` and can block on `<-WorkerQueue` while an HTTP worker is busy/stuck. `WorkQueue` also carries blob-storage (S3/GCS/Azure) work items in principle, so if a deployment mixed HTTP and blob-storage destinations behind one dispatcher, a stuck HTTP endpoint could now also delay blob-storage dispatch queued behind it. In this codebase's actual usage (`cmd/agent/main.go`), the storage strategy is fixed once at process startup from a single `--log-url`, so a given dispatcher only ever sees one strategy in practice and this coupling doesn't manifest today. Flagging it in case the logger is ever generalized to route to multiple destination types at once.

CI note: `master`'s own CI (Prow) is green as of this branch's base commit, so no known unrelated red checks to disclose.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix unbounded goroutine growth in the inference logger's worker dispatch: a slow or stuck log endpoint no longer causes the logger agent to grow memory without bound and OOM. The work queue now applies backpressure and drops events once full instead of spawning an unbounded goroutine per event.
```

Fixes #6167
