### PR TITLE
feat(kernelcache): add mcv container images based on gpu flavor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,7 @@
 !pkg/
 !tools/
 !qpext/
+!kernelcache/
 
 # License (used by go-licenses in all builds)
 !LICENSE

--- a/.github/workflows/mcv-build-test.yml
+++ b/.github/workflows/mcv-build-test.yml
@@ -69,16 +69,64 @@ jobs:
         with:
           cache-binary: true
 
-      - name: Build mcv container image
+      - name: Build mcv-minimal container image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           platforms: linux/amd64
-          context: kernelcache/mcv
+          context: .
           file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-minimal
           push: false
           load: true
-          tags: ${{ env.IMAGE_NAME }}:test
-          # https://github.com/docker/buildx/issues/1533
+          tags: ${{ env.IMAGE_NAME }}:test-minimal
+          provenance: false
+
+      - name: Build mcv-rocm container image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/amd64
+          context: .
+          file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-rocm
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test-rocm
+          provenance: false
+
+      - name: Build mcv-gaudi container image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/amd64
+          context: .
+          file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-gaudi
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test-gaudi
+          provenance: false
+
+      - name: Build mcv-cuda container image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/amd64
+          context: .
+          file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-cuda
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test-cuda
+          provenance: false
+
+      - name: Build mcv-unified container image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/amd64
+          context: .
+          file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-unified
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test-unified
           provenance: false
 
       - name: Build and validate cache images
@@ -97,9 +145,9 @@ jobs:
             image="localhost:5000/mcv-test:${tag}"
 
             echo "::group::Building ${image} from ${cache_dir}"
-            docker run --rm --privileged \
+            docker run --rm --privileged --user root \
               -v "${GITHUB_WORKSPACE}:/work:rw" \
-              ${{ env.IMAGE_NAME }}:test \
+              ${{ env.IMAGE_NAME }}:test-minimal \
               --create \
               --image "${image}" \
               --dir "/work/${cache_dir}" \

--- a/.github/workflows/mcv-docker-publish.yml
+++ b/.github/workflows/mcv-docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
             docker-compose --file docker-compose.test.yml build
             docker-compose --file docker-compose.test.yml run sut
           else
-            docker buildx build kernelcache/mcv --file kernelcache/mcv/mcv.Dockerfile
+            docker buildx build --target mcv-minimal --file kernelcache/mcv/mcv.Dockerfile .
           fi
 
   # Push image to GitHub Packages.
@@ -107,14 +107,62 @@ jobs:
           echo VERSION=$VERSION >> $GITHUB_ENV
           echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
 
-      - name: Build and push
+      - name: Build and push mcv-minimal
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           platforms: linux/amd64
-          context: kernelcache/mcv
+          context: .
           file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-minimal
           push: true
-          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
-          # https://github.com/docker/buildx/issues/1533
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}-minimal
+          provenance: false
+          sbom: true
+
+      - name: Build and push mcv-rocm
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/amd64
+          context: .
+          file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-rocm
+          push: false
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}-rocm
+          provenance: false
+          sbom: true
+
+      - name: Build and push mcv-gaudi
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/amd64
+          context: .
+          file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-gaudi
+          push: false
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}-gaudi
+          provenance: false
+          sbom: true
+
+      - name: Build and push mcv-cuda
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/amd64
+          context: .
+          file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-cuda
+          push: false
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}-cuda
+          provenance: false
+          sbom: true
+
+      - name: Build and push mcv-unified
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          platforms: linux/amd64
+          context: .
+          file: kernelcache/mcv/mcv.Dockerfile
+          target: mcv-unified
+          push: true
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}-unified
           provenance: false
           sbom: true

--- a/Makefile.image.mk
+++ b/Makefile.image.mk
@@ -129,11 +129,39 @@ docker-build-qpext:
 docker-build-push-qpext: docker-build-qpext
 	${ENGINE} push ${KO_DOCKER_REPO}/${QPEXT_IMG}:${TAG}
 
-docker-build-mcv:
-	${ENGINE} buildx build ${ARCH} -t ${KO_DOCKER_REPO}/${MCV_IMG} -f kernelcache/mcv/mcv.Dockerfile kernelcache/mcv
+docker-build-mcv-minimal:
+	${ENGINE} buildx build ${ARCH} --target mcv-minimal -t ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-minimal -f kernelcache/mcv/mcv.Dockerfile .
 
-docker-push-mcv: docker-build-mcv
-	${ENGINE} push ${KO_DOCKER_REPO}/${MCV_IMG}
+docker-push-mcv-minimal: docker-build-mcv-minimal
+	${ENGINE} push ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-minimal
+
+docker-build-mcv-rocm:
+	${ENGINE} buildx build ${ARCH} --target mcv-rocm -t ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-rocm -f kernelcache/mcv/mcv.Dockerfile .
+
+docker-push-mcv-rocm: docker-build-mcv-rocm
+	${ENGINE} push ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-rocm
+
+docker-build-mcv-gaudi:
+	${ENGINE} buildx build ${ARCH} --target mcv-gaudi -t ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-gaudi -f kernelcache/mcv/mcv.Dockerfile .
+
+docker-push-mcv-gaudi: docker-build-mcv-gaudi
+	${ENGINE} push ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-gaudi
+
+docker-build-mcv-cuda:
+	${ENGINE} buildx build ${ARCH} --target mcv-cuda -t ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-cuda -f kernelcache/mcv/mcv.Dockerfile .
+
+docker-push-mcv-cuda: docker-build-mcv-cuda
+	${ENGINE} push ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-cuda
+
+docker-build-mcv-unified:
+	${ENGINE} buildx build ${ARCH} --target mcv-unified -t ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-unified -f kernelcache/mcv/mcv.Dockerfile .
+
+docker-push-mcv-unified: docker-build-mcv-unified
+	${ENGINE} push ${KO_DOCKER_REPO}/${MCV_IMG}:${TAG}-unified
+
+docker-build-mcv: docker-build-mcv-minimal docker-build-mcv-rocm docker-build-mcv-gaudi docker-build-mcv-cuda docker-build-mcv-unified
+
+docker-push-mcv: docker-push-mcv-minimal docker-push-mcv-rocm docker-push-mcv-gaudi docker-push-mcv-cuda docker-push-mcv-unified
 
 docker-build-success-200-isvc:
 	cd python && ${ENGINE} buildx build ${ARCH} -t ${KO_DOCKER_REPO}/${SUCCESS_200_ISVC_IMG}:${TAG} -f success_200_isvc.Dockerfile .

--- a/kernelcache/mcv/README.md
+++ b/kernelcache/mcv/README.md
@@ -491,12 +491,35 @@ configuration. This is useful for testing or CI environments.
 Run MCV with the `--stub` flag. It will use the static config and behave as
 if those devices are present.
 
+## Container Image Variants
+
+MCV is built as a multi-target Dockerfile with five variants, each tailored
+to a specific GPU environment:
+
+| Variant | Target | Base Image | GPU Support | Make Target |
+|---------|--------|------------|-------------|-------------|
+| **minimal** | `mcv-minimal` | `debian:bookworm-slim` | None (use `--no-gpu`) | `make docker-build-mcv-minimal` |
+| **rocm** | `mcv-rocm` | `debian:bookworm-slim` | AMD (ROCm, `amd-smi`, `rocm-smi`) | `make docker-build-mcv-rocm` |
+| **gaudi** | `mcv-gaudi` | `ubuntu:24.04` | Intel Gaudi (`hl-smi`) | `make docker-build-mcv-gaudi` |
+| **cuda** | `mcv-cuda` | `nvidia/cuda:12.6.3-base-ubuntu24.04` | NVIDIA (CUDA, NVML) | `make docker-build-mcv-cuda` |
+| **unified** | `mcv-unified` | `nvidia/cuda:12.6.3-base-ubuntu24.04` | All vendors (NVIDIA + AMD + Gaudi) | `make docker-build-mcv-unified` |
+
+Build all variants at once:
+
+```bash
+make docker-build-mcv
+```
+
+All images run as non-root (`appuser`, UID 1000) and use the `vfs` storage
+driver for rootless buildah operation.
+
 ## Using MCV image to build cache images
 
-MCV provides a container image called `quay.io/gkm/mcv`. This image can be
-used to wrap a vLLM/Triton cache in an OCI container image that can then be
-pushed to a container registry (without having to install mcv locally). This
-image can also be used as part of a
+MCV provides container images that can be used to wrap a vLLM/Triton cache
+in an OCI container image that can then be pushed to a container registry
+(without having to install mcv locally). Use the **minimal** variant for
+cache creation (`--create`, `--no-gpu`) and a GPU-specific variant for
+extraction with preflight checks. These images can also be used as part of a
 [github workflow](../../.github/workflows/mcv-build-test.yml).
 
 ### MCV container image with docker
@@ -507,9 +530,9 @@ directory to the container and run the following command:
 ```bash
 docker run --rm -it --privileged \
   -v <path-to-cache>/example:/example \
-  quay.io/gkm/mcv bash -lc '
+  kserve/kserve-mcv:latest-minimal bash -lc '
     /mcv -c -i quay.io/gkm/vector-add-cache:rocm \
-        -d /example/vector-add-cache-rocm &&
+        -d /example/vector-add-cache-rocm --no-gpu &&
     buildah push containers-storage:quay.io/gkm/vector-add-cache:rocm \
         docker-archive:/example/vector-add-cache-rocm.tar:quay.io/gkm/vector-add-cache:rocm
   '

--- a/kernelcache/mcv/mcv.Dockerfile
+++ b/kernelcache/mcv/mcv.Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /go/src/github.com/kserve/kernelcache/mcv
-COPY go.mod  go.mod
-COPY go.sum  go.sum
+COPY kernelcache/mcv/go.mod  go.mod
+COPY kernelcache/mcv/go.sum  go.sum
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
@@ -21,8 +21,8 @@ FROM deps AS builder
 
 ARG CMD=mcv
 ARG GOTAGS=""
-COPY cmd/   cmd/
-COPY pkg/   pkg/
+COPY kernelcache/mcv/cmd/   cmd/
+COPY kernelcache/mcv/pkg/   pkg/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=1 GOOS=linux GOFLAGS=-mod=readonly go build -a -tags "${GOTAGS}" -o ${CMD} ./cmd/
@@ -35,45 +35,344 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go install github.com/google/go-licenses@v1.6.0
 
-COPY cmd/   cmd/
-COPY pkg/   pkg/
+COPY kernelcache/mcv/cmd/   cmd/
+COPY kernelcache/mcv/pkg/   pkg/
 COPY LICENSE LICENSE
 RUN --mount=type=cache,target=/go/pkg/mod \
     go-licenses save --save_path /third_party/library ./cmd/
 
-FROM debian:bookworm-slim
+
+# ============================================================================
+# MINIMAL TARGET: For cache creation/extraction with --no-gpu
+# No CUDA/ROCm libraries - uses cache metadata only
+# Build: docker build --target mcv-minimal -t mcv:minimal -f mcv.Dockerfile .
+# Usage: mcv --create --image foo --dir /cache --no-gpu
+#        mcv --extract --image foo --no-gpu
+# ============================================================================
+FROM debian:bookworm-slim AS mcv-minimal
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgpgme11 \
     libbtrfs0 \
+    libffi8 \
+    libc6 \
     ca-certificates \
-    pciutils \
-    hwdata \
     buildah \
     netavark aardvark-dns \
-    rsync \
-    wget \
-    fuse-overlayfs fuse3 \
+    hwdata \
+    python3 \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/containers && \
- printf '[storage]\ndriver="overlay"\nrunroot="/run/containers/storage"\ngraphroot="/var/lib/containers/storage"\n[storage.options]\nmount_program="/usr/bin/fuse-overlayfs"\n' \
+ printf '[storage]\ndriver="vfs"\nrunroot="/home/appuser/.local/share/containers/runroot"\ngraphroot="/home/appuser/.local/share/containers/storage"\n' \
    > /etc/containers/storage.conf
 
-# Install ROCm apt repo
+COPY --from=builder /go/src/github.com/kserve/kernelcache/mcv/mcv /mcv
+COPY --from=license /third_party/library /third_party/library
+COPY kernelcache/mcv/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+RUN groupadd -g 1000 appgroup && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash appuser
+RUN test "$(id -u appuser)" = "1000"
+RUN chown appuser:1000 /mcv /entrypoint.sh
+RUN mkdir -p /home/appuser/.local/share/containers/storage \
+             /home/appuser/.local/share/containers/runroot \
+             /home/appuser/.config/containers && \
+    chown -R appuser:1000 /home/appuser/.local /home/appuser/.config
+WORKDIR /app
+RUN chown -R appuser:1000 /app
+USER appuser
+
+LABEL description="MCV minimal - cache creation/extraction without GPU libraries (use --no-gpu flag)"
+LABEL variant="minimal"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/mcv"]
+
+
+# ============================================================================
+# AMD TARGET: For cache validation with AMD GPU hardware
+# Includes ROCm libraries for GPU detection and preflight checks
+# Build: docker build --target mcv-rocm -t mcv:rocm -f kernelcache/mcv/mcv.Dockerfile .
+# Usage: mcv --check-compat --image foo
+#        mcv --extract --image foo  (with preflight check)
+# ============================================================================
+FROM mcv-minimal AS mcv-rocm
+USER root
+
+ARG TARGETARCH
+# ROCm only publishes amd64 packages; fail fast on other architectures.
+RUN [ "$TARGETARCH" = "amd64" ] || \
+    { echo "ERROR: mcv-amd requires amd64 - ROCm does not support ${TARGETARCH}"; exit 1; }
+
 ARG ROCM_VERSION=7.0.1
 ARG AMDGPU_VERSION=7.0.1.70001
 ARG OPT_ROCM_VERSION=7.0.1
+# SHA-256 of amdgpu-install .deb from repo.radeon.com — update when bumping AMDGPU_VERSION
+ARG AMDGPU_INSTALLER_SHA256=f4cec24612039c03271e6ab494bc1e18cb5647d59188755aa8e31b6d74bb06df
 
-# Install ROCm apt repo
-RUN wget https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/ubuntu/jammy/amdgpu-install_${AMDGPU_VERSION}-1_all.deb
-RUN apt install -y ./amdgpu-install_${AMDGPU_VERSION}-1_all.deb
-RUN apt update &&  DEBIAN_FRONTEND=noninteractive apt install -y amd-smi-lib rocm-smi-lib
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf ./*.deb
-RUN ln -s /opt/rocm-${OPT_ROCM_VERSION}/bin/amd-smi /usr/bin/amd-smi
-RUN ln -s /opt/rocm-${OPT_ROCM_VERSION}/bin/rocm-smi /usr/bin/rocm-smi
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    pciutils \
+    python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN wget -O /tmp/amdgpu-install.deb \
+        https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/ubuntu/jammy/amdgpu-install_${AMDGPU_VERSION}-1_all.deb && \
+    echo "${AMDGPU_INSTALLER_SHA256}  /tmp/amdgpu-install.deb" | sha256sum -c - && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/amdgpu-install.deb && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        amd-smi-lib \
+        rocm-smi-lib \
+        libdrm2 && \
+    ln -s /opt/rocm-${OPT_ROCM_VERSION}/bin/amd-smi /usr/bin/amd-smi && \
+    ln -s /opt/rocm-${OPT_ROCM_VERSION}/bin/rocm-smi /usr/bin/rocm-smi && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/amdgpu-install.deb
+
+USER appuser
+
+LABEL description="MCV ROCm - includes ROCm libraries for GPU detection and validation"
+LABEL variant="rocm"
+
+
+# ============================================================================
+# GAUDI TARGET: For Intel Gaudi GPU validation with hl-smi
+# Includes Habana Labs tools for Gaudi device detection
+# Build: docker build --target mcv-gaudi -t mcv:gaudi -f kernelcache/mcv/mcv.Dockerfile .
+# Usage: mcv --check-compat --image foo (on Intel Gaudi systems)
+#        mcv --extract --image foo  (with Gaudi GPU preflight check)
+# ============================================================================
+FROM public.ecr.aws/docker/library/ubuntu:24.04 AS mcv-gaudi
+
+ARG TARGETARCH
+
+# Gaudi only publishes amd64 packages; fail fast on other architectures.
+RUN [ "$TARGETARCH" = "amd64" ] || \
+    { echo "ERROR: mcv-gaudi requires amd64 - Habana does not support ${TARGETARCH}"; exit 1; }
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgpgme11t64 \
+    libbtrfs0 \
+    libffi8 \
+    libc6 \
+    ca-certificates \
+    buildah \
+    netavark aardvark-dns \
+    hwdata \
+    wget \
+    gnupg2 \
+    pciutils \
+    python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/containers && \
+ printf '[storage]\ndriver="vfs"\nrunroot="/home/appuser/.local/share/containers/runroot"\ngraphroot="/home/appuser/.local/share/containers/storage"\n' \
+   > /etc/containers/storage.conf
+
+# Install hl-smi via Habana apt repo (pattern from HabanaAI/Setup_and_Install).
+# HABANA_SIGNING_FP must match the canonical fingerprint published in Intel/Habana
+# documentation (https://docs.habana.ai) — update it whenever the signing key rotates.
+ARG HABANA_SIGNING_FP="6D4D7C0F52A263F383D782791E676CE836A2DE65"
+RUN wget -q -O /tmp/habana-key.asc https://vault.habana.ai/artifactory/api/gpg/key/public && \
+    gpg --dearmor < /tmp/habana-key.asc > /tmp/habana-key.gpg && \
+    actual=$(gpg --no-default-keyring --keyring /tmp/habana-key.gpg --fingerprint 2>/dev/null \
+             | awk '/^      /{gsub(/ /,"",$0); print}' | head -1) && \
+    expected=$(printf '%s' "${HABANA_SIGNING_FP}" | tr -d ' :') && \
+    [ "$actual" = "$expected" ] || { echo "Habana GPG key fingerprint mismatch: got $actual expected $expected"; exit 1; } && \
+    mv /tmp/habana-key.gpg /usr/share/keyrings/habana-artifactory.gpg && \
+    rm /tmp/habana-key.asc && \
+    chmod 644 /usr/share/keyrings/habana-artifactory.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/habana-artifactory.gpg] https://vault.habana.ai/artifactory/debian noble main" \
+        > /etc/apt/sources.list.d/habana.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends habanalabs-firmware-tools && \
+    rm -f /etc/apt/sources.list.d/habana.list && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/github.com/kserve/kernelcache/mcv/mcv /mcv
-COPY entrypoint.sh /entrypoint.sh
+COPY --from=license /third_party/library /third_party/library
+COPY kernelcache/mcv/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+# Drop any pre-existing ubuntu user/group that claims UID/GID 1000 (present in
+# ubuntu:24.04 base images). Without this, useradd -u 1000 fails.
+RUN userdel -r ubuntu 2>/dev/null; groupdel ubuntu 2>/dev/null; \
+    groupadd -g 1000 appgroup && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash appuser
+RUN test "$(id -u appuser)" = "1000"
+RUN chown appuser:1000 /mcv /entrypoint.sh
+RUN mkdir -p /home/appuser/.local/share/containers/storage \
+             /home/appuser/.local/share/containers/runroot \
+             /home/appuser/.config/containers && \
+    chown -R appuser:1000 /home/appuser/.local /home/appuser/.config
+WORKDIR /app
+RUN chown -R appuser:1000 /app
+USER appuser
+
+LABEL description="MCV Gaudi - includes Habana Labs tools for Intel Gaudi GPU detection and validation"
+LABEL variant="gaudi"
 
 ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/mcv"]
+
+# ============================================================================
+# NVIDIA TARGET: For NVIDIA GPU validation with CUDA/NVML support
+# Includes CUDA runtime and NVML libraries for GPU detection
+# Build: docker build --target mcv-cuda -t mcv:cuda -f kernelcache/mcv/mcv.Dockerfile .
+# Usage: mcv --check-compat --image foo (on NVIDIA GPU systems)
+#        mcv --extract --image foo  (with NVIDIA GPU preflight check)
+# ============================================================================
+FROM nvcr.io/nvidia/cuda:12.6.3-base-ubuntu24.04 AS mcv-cuda
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgpgme11t64 \
+    libbtrfs0 \
+    ca-certificates \
+    buildah \
+    netavark aardvark-dns \
+    hwdata \
+    pciutils \
+    python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/containers && \
+ printf '[storage]\ndriver="vfs"\nrunroot="/home/appuser/.local/share/containers/runroot"\ngraphroot="/home/appuser/.local/share/containers/storage"\n' \
+   > /etc/containers/storage.conf
+
+COPY --from=builder /go/src/github.com/kserve/kernelcache/mcv/mcv /mcv
+COPY --from=license /third_party/library /third_party/library
+COPY kernelcache/mcv/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+# Drop any pre-existing ubuntu user/group that claims UID/GID 1000 (present in
+# ubuntu:24.04 and nvcr.io/nvidia/cuda:*-ubuntu24.04 base images).
+RUN userdel -r ubuntu 2>/dev/null; groupdel ubuntu 2>/dev/null; \
+    groupadd -g 1000 appgroup && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash appuser
+RUN test "$(id -u appuser)" = "1000"
+RUN chown appuser:1000 /mcv /entrypoint.sh
+RUN mkdir -p /home/appuser/.local/share/containers/storage \
+             /home/appuser/.local/share/containers/runroot \
+             /home/appuser/.config/containers && \
+    chown -R appuser:1000 /home/appuser/.local /home/appuser/.config
+WORKDIR /app
+RUN chown -R appuser:1000 /app
+USER appuser
+
+LABEL description="MCV NVIDIA - includes CUDA runtime and NVML for GPU detection"
+LABEL variant="cuda"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/mcv"]
+
+
+# ============================================================================
+# UNIFIED TARGET: For mixed GPU environments (NVIDIA + AMD + Gaudi support)
+# Includes CUDA/NVML, ROCm, and Habana libraries for auto-detection
+# Build: docker build --target mcv-unified -t mcv:unified -f kernelcache/mcv/mcv.Dockerfile .
+# Usage: mcv --check-compat --image foo (auto-detects GPU vendor)
+#        mcv --extract --image foo  (with auto GPU preflight check)
+# ============================================================================
+FROM nvcr.io/nvidia/cuda:12.6.3-base-ubuntu24.04 AS mcv-unified
+
+ARG TARGETARCH
+ARG ROCM_VERSION=7.0.1
+ARG AMDGPU_VERSION=7.0.1.70001
+ARG OPT_ROCM_VERSION=7.0.1
+# SHA-256 of amdgpu-install .deb from repo.radeon.com — update when bumping AMDGPU_VERSION
+ARG AMDGPU_INSTALLER_SHA256=f4cec24612039c03271e6ab494bc1e18cb5647d59188755aa8e31b6d74bb06df
+# Canonical fingerprint from Intel/Habana documentation (https://docs.habana.ai)
+ARG HABANA_SIGNING_FP="6D4D7C0F52A263F383D782791E676CE836A2DE65"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libgpgme11t64 \
+    libbtrfs0 \
+    buildah \
+    netavark aardvark-dns \
+    hwdata \
+    pciutils \
+    python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install ROCm + Habana tools for AMD/Gaudi GPU detection (amd64 only).
+# On arm64 the image still provides NVIDIA/NVML support via the CUDA base.
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    apt-get update && apt-get install -y --no-install-recommends \
+        wget gnupg2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget -O /tmp/amdgpu-install.deb \
+        https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/ubuntu/jammy/amdgpu-install_${AMDGPU_VERSION}-1_all.deb && \
+    echo "${AMDGPU_INSTALLER_SHA256}  /tmp/amdgpu-install.deb" | sha256sum -c - && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/amdgpu-install.deb && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        amd-smi-lib rocm-smi-lib libdrm2 && \
+    ln -s /opt/rocm-${OPT_ROCM_VERSION}/bin/amd-smi /usr/bin/amd-smi && \
+    ln -s /opt/rocm-${OPT_ROCM_VERSION}/bin/rocm-smi /usr/bin/rocm-smi && \
+    wget -q -O /tmp/habana-key.asc https://vault.habana.ai/artifactory/api/gpg/key/public && \
+    gpg --dearmor < /tmp/habana-key.asc > /tmp/habana-key.gpg && \
+    actual=$(gpg --no-default-keyring --keyring /tmp/habana-key.gpg --fingerprint 2>/dev/null \
+             | awk '/^      /{gsub(/ /,"",$0); print}' | head -1) && \
+    expected=$(printf '%s' "${HABANA_SIGNING_FP}" | tr -d ' :') && \
+    [ "$actual" = "$expected" ] || { echo "Habana GPG key fingerprint mismatch: got $actual expected $expected"; exit 1; } && \
+    mv /tmp/habana-key.gpg /usr/share/keyrings/habana-artifactory.gpg && \
+    rm /tmp/habana-key.asc && \
+    chmod 644 /usr/share/keyrings/habana-artifactory.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/habana-artifactory.gpg] https://vault.habana.ai/artifactory/debian noble main" \
+        > /etc/apt/sources.list.d/habana.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends habanalabs-firmware-tools && \
+    rm -f /etc/apt/sources.list.d/habana.list && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/amdgpu-install.deb; \
+fi
+
+RUN mkdir -p /etc/containers && \
+ printf '[storage]\ndriver="vfs"\nrunroot="/home/appuser/.local/share/containers/runroot"\ngraphroot="/home/appuser/.local/share/containers/storage"\n' \
+   > /etc/containers/storage.conf
+
+COPY --from=builder /go/src/github.com/kserve/kernelcache/mcv/mcv /mcv
+COPY --from=license /third_party/library /third_party/library
+COPY kernelcache/mcv/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+# Drop any pre-existing ubuntu user/group that claims UID/GID 1000 (present in
+# ubuntu:24.04 and nvcr.io/nvidia/cuda:*-ubuntu24.04 base images).
+RUN userdel -r ubuntu 2>/dev/null; groupdel ubuntu 2>/dev/null; \
+    groupadd -g 1000 appgroup && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash appuser
+RUN test "$(id -u appuser)" = "1000"
+RUN chown appuser:1000 /mcv /entrypoint.sh
+RUN mkdir -p /home/appuser/.local/share/containers/storage \
+             /home/appuser/.local/share/containers/runroot \
+             /home/appuser/.config/containers && \
+    chown -R appuser:1000 /home/appuser/.local /home/appuser/.config
+WORKDIR /app
+RUN chown -R appuser:1000 /app
+USER appuser
+
+LABEL description="MCV Unified - NVIDIA (CUDA/NVML), AMD (ROCm), and Intel Gaudi support"
+LABEL variant="unified"
+LABEL gpu-support="cuda,rocm,gaudi"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/mcv"]
+
+# Build examples:
+# Minimal (no GPU libs):  make docker-build-mcv-minimal
+# ROCm (AMD):             make docker-build-mcv-rocm
+# Gaudi (Intel):          make docker-build-mcv-gaudi
+# NVIDIA (CUDA):          make docker-build-mcv-cuda
+# Unified (all GPUs):     make docker-build-mcv-unified
+# All variants:           make docker-build-mcv


### PR DESCRIPTION
chore:	Restructure the MCV Dockerfile into five build targets to support
	different GPU environments: minimal (no GPU), rocm (AMD), gaudi
	(Intel), cuda (NVIDIA), and unified (all vendors). Each target installs
	only the libraries it needs, runs as non-root appuser, and uses vfs
	storage for rootless buildah.

	Update Makefile, GitHub Actions workflows, and .dockerignore to build,
	test, and publish all variants independently.

Commit ported from https://github.com/redhat-et/GKM/blob/main/mcv/images/Containerfile

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

- [x] Container builds

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
feat(kernelcache): add mcv container images based on gpu flavor
```
