### PR TITLE
fix: deduplicate isvc args that override ServingRuntime defaults

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -10007,6 +10007,157 @@ var _ = Describe("v1beta1 inference service controller", func() {
 		})
 	})
 
+	Context("When creating inference service with custom http_port that overrides the runtime default", func() {
+		It("Should deduplicate the --http_port arg and set the readiness probe to the ISVC port", func() {
+			ctx := context.Background()
+
+			configs := map[string]string{
+				"ingress": `{
+					"ingressGateway": "knative-serving/knative-ingress-gateway",
+					"localGateway": "knative-serving/knative-local-gateway",
+					"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
+				}`,
+				"storageInitializer": `{
+					"image": "kserve/storage-initializer:latest",
+					"memoryRequest": "100Mi",
+					"memoryLimit": "1Gi",
+					"cpuRequest": "100m",
+					"cpuLimit": "1",
+					"caBundleConfigMapName": "",
+					"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
+					"cpuModelcar": "10m",
+					"memoryModelcar": "15Mi"
+				}`,
+			}
+			configMap := createInferenceServiceConfigMap(configs)
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sklearn-runtime-custom-port",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "sklearn",
+							Version:    ptr.To("1"),
+							AutoSelect: ptr.To(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  constants.InferenceServiceContainerName,
+								Image: "kserve/sklearnserver:latest",
+								Args: []string{
+									"--model_name={{.Name}}",
+									"--model_dir=/mnt/models",
+									"--http_port=8080",
+								},
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(ctx, servingRuntime)).Should(Succeed())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			serviceName := "raw-custom-http-port"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: "default"}}
+			serviceKey := expectedRequest.NamespacedName
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						constants.DeploymentMode: string(constants.Standard),
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(1)),
+							MaxReplicas: 3,
+							Batcher: &v1beta1.Batcher{
+								MaxBatchSize: ptr.To(32),
+								MaxLatency:   ptr.To(5000),
+							},
+						},
+						Model: &v1beta1.ModelSpec{
+							ModelFormat: v1beta1.ModelFormat{
+								Name: "sklearn",
+							},
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI: ptr.To("s3://test/sklearn/model"),
+								Container: corev1.Container{
+									Name: constants.InferenceServiceContainerName,
+									Args: []string{"--http_port=5000"},
+									Ports: []corev1.ContainerPort{
+										{
+											ContainerPort: 5000,
+											Protocol:      corev1.ProtocolTCP,
+										},
+									},
+									Resources: defaultResource,
+								},
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			actualDeployment := &appsv1.Deployment{}
+			predictorDeploymentKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorDeploymentKey, actualDeployment)
+			}, timeout, interval).Should(Succeed())
+
+			var kserveContainer *corev1.Container
+			for i := range actualDeployment.Spec.Template.Spec.Containers {
+				if actualDeployment.Spec.Template.Spec.Containers[i].Name == constants.InferenceServiceContainerName {
+					kserveContainer = &actualDeployment.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			Expect(kserveContainer).NotTo(BeNil(), "kserve-container should exist in the deployment")
+
+			// Verify --http_port appears exactly once with the ISVC value (5000), not the runtime default (8080)
+			httpPortCount := 0
+			for _, arg := range kserveContainer.Args {
+				if len(arg) >= len("--http_port") && arg[:len("--http_port")] == "--http_port" {
+					httpPortCount++
+				}
+			}
+			Expect(httpPortCount).To(Equal(1), "--http_port should appear exactly once in container args: %v", kserveContainer.Args)
+
+			foundPort := false
+			for _, arg := range kserveContainer.Args {
+				if arg == "--http_port=5000" {
+					foundPort = true
+					break
+				}
+			}
+			Expect(foundPort).To(BeTrue(), "--http_port=5000 should be in container args: %v", kserveContainer.Args)
+
+			// Verify the readiness probe targets port 5000
+			Expect(kserveContainer.ReadinessProbe).NotTo(BeNil(), "readiness probe should be set")
+			Expect(kserveContainer.ReadinessProbe.TCPSocket).NotTo(BeNil(), "readiness probe should use TCPSocket")
+			Expect(kserveContainer.ReadinessProbe.TCPSocket.Port.IntValue()).To(Equal(5000),
+				"readiness probe should target port 5000, not the runtime default 8080")
+		})
+	})
+
 	Context("When creating an inference service with modelcar and raw deployment", func() {
 		configs := map[string]string{
 			"ingress": `{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -339,15 +339,19 @@ func setDefaultPodSpec(podSpec *corev1.PodSpec) {
 // getArgValue extracts the value for a CLI flag from an args slice.
 // It handles both "--flag value" (two elements) and "--flag=value" (single element) forms.
 func getArgValue(args []string, flag string) (string, bool) {
+	var lastVal string
+	found := false
 	for i, arg := range args {
 		if arg == flag && i+1 < len(args) {
-			return args[i+1], true
+			lastVal = args[i+1]
+			found = true
 		}
 		if strings.HasPrefix(arg, flag+"=") {
-			return strings.TrimPrefix(arg, flag+"="), true
+			lastVal = strings.TrimPrefix(arg, flag+"=")
+			found = true
 		}
 	}
-	return "", false
+	return lastVal, found
 }
 
 // setArgValue replaces the value of an existing "--flag value" pair in an args

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -1790,6 +1790,20 @@ func TestGetArgValue(t *testing.T) {
 			flag:   "--http_port",
 			wantOk: false,
 		},
+		{
+			name:    "duplicate flag returns last value",
+			args:    []string{"--http_port=8080", "--http_port=5000"},
+			flag:    "--http_port",
+			wantVal: "5000",
+			wantOk:  true,
+		},
+		{
+			name:    "duplicate mixed forms returns last value",
+			args:    []string{"--http_port", "8080", "--http_port=5000"},
+			flag:    "--http_port",
+			wantVal: "5000",
+			wantOk:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -271,7 +271,7 @@ func mergeArgs(runtimeArgs, isvcArgs []string) []string {
 	for i := 0; i < len(runtimeArgs); i++ {
 		name := flagName(runtimeArgs[i])
 		if name != "" && overridden[name] {
-			if !strings.Contains(runtimeArgs[i], "=") && i+1 < len(runtimeArgs) {
+			if !strings.Contains(runtimeArgs[i], "=") && i+1 < len(runtimeArgs) && !strings.HasPrefix(runtimeArgs[i+1], "-") {
 				i++
 			}
 			continue

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -249,17 +249,56 @@ func GetDeploymentMode(statusDeploymentMode string, annotations map[string]strin
 
 // MergeRuntimeContainers merges the runtime Container with the InferenceService Container,
 // allowing users to override runtime container settings from the predictor spec.
-// Args are concatenated (runtime + isvc) rather than replaced.
+// Args from the ISVC take precedence: any runtime flag that the ISVC also sets is
+// removed before concatenation so the final list contains no duplicate flags.
 func MergeRuntimeContainers(runtimeContainer *corev1.Container, isvcContainer *corev1.Container) (*corev1.Container, error) {
 	merged, err := kserveutils.MergeContainerWithPatch(*runtimeContainer, *isvcContainer)
 	if err != nil {
 		return nil, err
 	}
 
-	// Concatenate args rather than replacing — isvc extends runtime flags
-	merged.Args = append(append([]string{}, runtimeContainer.Args...), isvcContainer.Args...)
+	merged.Args = mergeArgs(runtimeContainer.Args, isvcContainer.Args)
 
 	return &merged, nil
+}
+
+// mergeArgs concatenates runtime and ISVC args, removing any runtime flags
+// that the ISVC also sets so the ISVC value takes precedence without duplicates.
+func mergeArgs(runtimeArgs, isvcArgs []string) []string {
+	overridden := flagNames(isvcArgs)
+
+	var merged []string
+	for i := 0; i < len(runtimeArgs); i++ {
+		name := flagName(runtimeArgs[i])
+		if name != "" && overridden[name] {
+			if !strings.Contains(runtimeArgs[i], "=") && i+1 < len(runtimeArgs) {
+				i++
+			}
+			continue
+		}
+		merged = append(merged, runtimeArgs[i])
+	}
+	return append(merged, isvcArgs...)
+}
+
+func flagName(arg string) string {
+	if !strings.HasPrefix(arg, "-") {
+		return ""
+	}
+	if idx := strings.Index(arg, "="); idx >= 0 {
+		return arg[:idx]
+	}
+	return arg
+}
+
+func flagNames(args []string) map[string]bool {
+	names := make(map[string]bool)
+	for _, arg := range args {
+		if name := flagName(arg); name != "" {
+			names[name] = true
+		}
+	}
+	return names
 }
 
 // MergePodSpec Merge the predictor PodSpec struct with the runtime PodSpec struct, allowing users

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -836,6 +836,30 @@ func TestMergeArgs(t *testing.T) {
 			isvcArgs:    nil,
 			expected:    nil,
 		},
+		{
+			name:        "valueless flag does not consume next flag",
+			runtimeArgs: []string{"--verbose", "--http_port=8080"},
+			isvcArgs:    []string{"--verbose"},
+			expected:    []string{"--http_port=8080", "--verbose"},
+		},
+		{
+			name:        "override equals form keeps two-element neighbours",
+			runtimeArgs: []string{"--model_name=foo", "--http_port=8080", "--model_dir=/mnt/models"},
+			isvcArgs:    []string{"--http_port=5000"},
+			expected:    []string{"--model_name=foo", "--model_dir=/mnt/models", "--http_port=5000"},
+		},
+		{
+			name:        "override two-element form keeps equals neighbours",
+			runtimeArgs: []string{"--model_name=foo", "--http_port", "8080", "--model_dir=/mnt/models"},
+			isvcArgs:    []string{"--http_port", "5000"},
+			expected:    []string{"--model_name=foo", "--model_dir=/mnt/models", "--http_port", "5000"},
+		},
+		{
+			name:        "multiple overrides mixed forms",
+			runtimeArgs: []string{"--http_port=8080", "--model_name", "default", "--workers=1"},
+			isvcArgs:    []string{"--http_port=5000", "--model_name", "custom"},
+			expected:    []string{"--workers=1", "--http_port=5000", "--model_name", "custom"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -787,6 +787,65 @@ func TestMergeRuntimeContainers(t *testing.T) {
 	}
 }
 
+func TestMergeArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		runtimeArgs []string
+		isvcArgs    []string
+		expected    []string
+	}{
+		{
+			name:        "no overlap",
+			runtimeArgs: []string{"--model_name=foo", "--model_dir=/mnt/models"},
+			isvcArgs:    []string{"--http_port=5000"},
+			expected:    []string{"--model_name=foo", "--model_dir=/mnt/models", "--http_port=5000"},
+		},
+		{
+			name:        "override equals form",
+			runtimeArgs: []string{"--model_name=foo", "--http_port=8080"},
+			isvcArgs:    []string{"--http_port=5000"},
+			expected:    []string{"--model_name=foo", "--http_port=5000"},
+		},
+		{
+			name:        "override two-element form",
+			runtimeArgs: []string{"--model_name", "foo", "--http_port", "8080"},
+			isvcArgs:    []string{"--http_port=5000"},
+			expected:    []string{"--model_name", "foo", "--http_port=5000"},
+		},
+		{
+			name:        "override mixed forms",
+			runtimeArgs: []string{"--model_name=foo", "--http_port", "8080", "--model_dir=/mnt/models"},
+			isvcArgs:    []string{"--http_port", "5000"},
+			expected:    []string{"--model_name=foo", "--model_dir=/mnt/models", "--http_port", "5000"},
+		},
+		{
+			name:        "empty isvc args",
+			runtimeArgs: []string{"--http_port=8080"},
+			isvcArgs:    nil,
+			expected:    []string{"--http_port=8080"},
+		},
+		{
+			name:        "empty runtime args",
+			runtimeArgs: nil,
+			isvcArgs:    []string{"--http_port=5000"},
+			expected:    []string{"--http_port=5000"},
+		},
+		{
+			name:        "both empty",
+			runtimeArgs: nil,
+			isvcArgs:    nil,
+			expected:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+			result := mergeArgs(tt.runtimeArgs, tt.isvcArgs)
+			g.Expect(result).To(gomega.Equal(tt.expected))
+		})
+	}
+}
+
 func TestMergePodSpec(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/test/e2e/batcher/test_batcher.py
+++ b/test/e2e/batcher/test_batcher.py
@@ -70,15 +70,19 @@ async def test_batcher(kserve_client, rest_v1_client, network_layer):
     try:
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
     except RuntimeError as e:
-        print(
-            kserve_client.api_instance.get_namespaced_custom_object(
-                "serving.knative.dev",
-                "v1",
-                KSERVE_TEST_NAMESPACE,
-                "services",
-                service_name + "-predictor",
+        try:
+            print(
+                kserve_client.api_instance.get_namespaced_custom_object(
+                    "serving.knative.dev",
+                    "v1",
+                    KSERVE_TEST_NAMESPACE,
+                    "services",
+                    service_name + "-predictor",
+                )
             )
-        )
+        except Exception:
+            isvc = kserve_client.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
+            print(isvc)
         pods = kserve_client.core_api.list_namespaced_pod(
             KSERVE_TEST_NAMESPACE,
             label_selector="serving.kserve.io/inferenceservice={}".format(service_name),

--- a/test/e2e/batcher/test_batcher_custom_port.py
+++ b/test/e2e/batcher/test_batcher_custom_port.py
@@ -74,15 +74,20 @@ async def test_batcher_custom_port(kserve_client, rest_v1_client, network_layer)
     try:
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
     except RuntimeError as e:
-        print(
-            kserve_client.api_instance.get_namespaced_custom_object(
-                "serving.knative.dev",
-                "v1",
-                KSERVE_TEST_NAMESPACE,
-                "services",
-                service_name + "-predictor",
+        try:
+            print(
+                kserve_client.api_instance.get_namespaced_custom_object(
+                    "serving.knative.dev",
+                    "v1",
+                    KSERVE_TEST_NAMESPACE,
+                    "services",
+                    service_name + "-predictor",
+                )
             )
-        )
+        # Fall back for Standard Deployments
+        except Exception:
+            isvc = kserve_client.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
+            print(isvc)
         pods = kserve_client.core_api.list_namespaced_pod(
             KSERVE_TEST_NAMESPACE,
             label_selector="serving.kserve.io/inferenceservice={}".format(service_name),

--- a/test/e2e/batcher/test_raw_batcher.py
+++ b/test/e2e/batcher/test_raw_batcher.py
@@ -78,15 +78,19 @@ async def test_batcher_raw(kserve_client, rest_v1_client, network_layer):
     try:
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
     except RuntimeError as e:
-        print(
-            kserve_client.api_instance.get_namespaced_custom_object(
-                "serving.knative.dev",
-                "v1",
-                KSERVE_TEST_NAMESPACE,
-                "services",
-                service_name + "-predictor",
+        try:
+            print(
+                kserve_client.api_instance.get_namespaced_custom_object(
+                    "serving.knative.dev",
+                    "v1",
+                    KSERVE_TEST_NAMESPACE,
+                    "services",
+                    service_name + "-predictor",
+                )
             )
-        )
+        except Exception:
+            isvc = kserve_client.get(service_name, namespace=KSERVE_TEST_NAMESPACE)
+            print(isvc)
         pods = kserve_client.core_api.list_namespaced_pod(
             KSERVE_TEST_NAMESPACE,
             label_selector="serving.kserve.io/inferenceservice={}".format(service_name),


### PR DESCRIPTION
**What this PR does / why we need it**:

When an ISVC overrides a flag already set by the ServingRuntime (e.g. --http_port), MergeRuntimeContainers now removes the runtime's copy before concatenating, so the ISVC value wins without duplicates. Previously the blind append produced --http_port=8080 --http_port=5000; the readiness probe picked the first (8080) while argparse used the last (5000), leaving the probe dialing an unbound port.  Also fixes the batcher e2e error handler to fall back to ISVC status when Knative Services are not available (Standard/RawDeployment mode).

**Feature/Issue validation/testing**:
- [x] unit tests added in pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
- [x] integration tests added in pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
fix: deduplicate isvc args that override ServingRuntime defaults
```
