### PR TITLE
fix(logger): avoid double-copying and needless response buffering

### DIFF
--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package logger
 
 import (
-	"bufio"
 	"bytes"
 	"io"
 	"net/http"
@@ -45,12 +44,16 @@ type loggingResponseWriter struct {
 }
 
 func (w *loggingResponseWriter) Write(b []byte) (int, error) {
-	n, err := w.responseBuffer.Write(b)
-	if err != nil {
-		w.log.Error(err, "Failed to write response buffer")
-		return n, err
+	// responseBuffer is nil when the caller already knows the response body
+	// will never be logged (logMode == LogRequest): skip capturing it, since
+	// buffering a body nobody will read wastes memory on every request.
+	if w.responseBuffer != nil {
+		if _, err := w.responseBuffer.Write(b); err != nil {
+			w.log.Error(err, "Failed to write response buffer")
+			return 0, err
+		}
 	}
-	n, err = w.ResponseWriter.Write(b)
+	n, err := w.ResponseWriter.Write(b)
 	if err != nil {
 		w.log.Error(err, "Failed to write response")
 		return n, err
@@ -167,21 +170,29 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Proxy Request
 	r.Body = io.NopCloser(bytes.NewBuffer(body))
-	// TODO: Set a reasonable initial buffer size
-	var responseBuf bytes.Buffer
-	lrw := &loggingResponseWriter{ResponseWriter: w, responseBuffer: &responseBuf, log: eh.log}
-	eh.next.ServeHTTP(lrw, r)
-	// Read the response body from the buffer
-	reader := bufio.NewReader(lrw.responseBuffer)
-	responseBody, err := io.ReadAll(reader)
-	if err != nil {
-		eh.log.Error(err, "Failed to read response body")
+	// Only capture the response body when it might actually get logged --
+	// buffering it for logMode == LogRequest would hold the whole response
+	// in memory for nothing.
+	captureResponse := eh.logMode == v1beta1.LogAll || eh.logMode == v1beta1.LogResponse
+	var responseBuf *bytes.Buffer
+	if captureResponse {
+		// TODO: Set a reasonable initial buffer size
+		responseBuf = &bytes.Buffer{}
 	}
+	lrw := &loggingResponseWriter{ResponseWriter: w, responseBuffer: responseBuf, log: eh.log}
+	eh.next.ServeHTTP(lrw, r)
 	// Record the time when the response is received
 	responseTime := time.Now()
 	// log Response
 	if lrw.statusCode == http.StatusOK {
-		if eh.logMode == v1beta1.LogAll || eh.logMode == v1beta1.LogResponse {
+		if captureResponse {
+			// responseBuf already holds the full response body; no need to
+			// wrap it in another reader and copy it again. This aliases
+			// responseBuf's backing array instead of copying it, which is
+			// only safe because nothing writes to responseBuf (via lrw)
+			// after eh.next.ServeHTTP returns above -- if that ever changes,
+			// switch back to a copy (e.g. bytes.Clone(responseBuf.Bytes())).
+			responseBody := responseBuf.Bytes()
 			if err := QueueLogRequest(LogRequest{
 				Url:              eh.logUrl,
 				Bytes:            &responseBody,

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/onsi/gomega"
 	pkglogging "knative.dev/pkg/logging"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	pkgtest "github.com/kserve/kserve/pkg/testing"
@@ -273,6 +274,95 @@ func TestBadResponse(t *testing.T) {
 	oh.ServeHTTP(w, r)
 	g.Expect(w.Code).To(gomega.Equal(400))
 	g.Expect(w.Body.String()).To(gomega.Equal(predictorResponse))
+}
+
+// TestLoggingResponseWriterWriteWithNilBuffer covers the actual
+// behavior-changing half of the fix: loggingResponseWriter.Write must
+// tolerate a nil responseBuffer (set by ServeHTTP when logMode ==
+// LogRequest, since the response will never be logged) instead of
+// unconditionally calling Write on it. Without the fix this panics with a
+// nil pointer dereference.
+func TestLoggingResponseWriterWriteWithNilBuffer(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	rr := httptest.NewRecorder()
+	lrw := &loggingResponseWriter{ResponseWriter: rr, responseBuffer: nil, log: logf.Log.WithName("test")}
+
+	n, err := lrw.Write([]byte("hello"))
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(n).To(gomega.Equal(5))
+	g.Expect(rr.Body.String()).To(gomega.Equal("hello"))
+}
+
+// TestLoggerRequestOnlyDoesNotCaptureResponseBody covers the fix in
+// ServeHTTP that skips buffering the response body entirely when
+// logMode == LogRequest, since in that mode the response is never logged.
+// It asserts both that: (1) no response LogRequest ever reaches the log
+// service, and (2) the actual client still receives the full, unmodified
+// response body -- i.e. skipping the capture doesn't affect the proxied
+// response.
+func TestLoggerRequestOnlyDoesNotCaptureResponseBody(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	predictorRequest := []byte(`{"instances":[[0,0,0]]}`)
+	predictorResponse := []byte(`{"instances":[[4,5,6]]}`)
+
+	// Every CloudEvent type the log sink receives is pushed here, so the
+	// test can assert precisely which -- and how many -- events arrived,
+	// rather than relying on a timing-based "nothing else showed up" guess.
+	receivedTypes := make(chan string, 2)
+	logSvc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		b, err := io.ReadAll(req.Body)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(b).To(gomega.Equal(predictorRequest))
+		receivedTypes <- req.Header.Get("Ce-Type")
+		_, err = rw.Write([]byte(`ok`))
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+	}))
+	defer logSvc.Close()
+
+	predictor := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		b, err := io.ReadAll(req.Body)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(b).To(gomega.Equal(predictorRequest))
+		_, err = rw.Write(predictorResponse)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+	}))
+	defer predictor.Close()
+
+	reader := bytes.NewReader(predictorRequest)
+	r := httptest.NewRequest(http.MethodPost, "http://a", reader)
+	w := httptest.NewRecorder()
+	logger, _ := pkglogging.NewLogger("", "INFO")
+	pkgtest.SetupTestLogger()
+	logSvcUrl, err := url.Parse(logSvc.URL)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	sourceUri, err := url.Parse("http://localhost:9081/")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	targetUri, err := url.Parse(predictor.URL)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	StartDispatcher(5, &MockStore{}, &ImmediateBatch{}, logger)
+	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
+	oh := New(logSvcUrl, sourceUri, v1beta1.LogRequest, "mymodel", "default", "default",
+		"default", httpProxy, nil, "", nil, true)
+
+	oh.ServeHTTP(w, r)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	b2, err := io.ReadAll(resp.Body)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	// The client must still receive the full response even though the
+	// response body was never buffered for logging.
+	g.Expect(b2).To(gomega.Equal(predictorResponse))
+
+	// The request event must have reached the log service, and it must be
+	// the only one -- no response event should ever arrive in this mode.
+	var gotType string
+	g.Eventually(receivedTypes).Should(gomega.Receive(&gotType))
+	g.Expect(gotType).To(gomega.Equal(CEInferenceRequest))
+	g.Consistently(receivedTypes, 200*time.Millisecond).ShouldNot(gomega.Receive())
 }
 
 func TestLoggerWithS3Store(t *testing.T) {


### PR DESCRIPTION
## What

`LoggerHandler.ServeHTTP` copied the logged response body twice, and
buffered it even when it would never be logged:

- The response body was fully captured into `responseBuf`, then wrapped in
  a `bufio.Reader` and copied again via `io.ReadAll` -- a full extra copy
  of every logged response for no reason.
- The buffer was always allocated and written to, even when
  `logMode == LogRequest`, where the response is never logged at all.

## Why

Wasted CPU and memory per request, proportional to response size,
independent of whether the response is even eligible to be logged. On a
busy inference endpoint this adds up.

## How

- `ServeHTTP` now uses `responseBuf.Bytes()` directly instead of a second
  `bufio.Reader` + `io.ReadAll` pass.
- `responseBuf` is only allocated when `logMode` is `LogAll` or
  `LogResponse`; otherwise it's left `nil`.
- `loggingResponseWriter.Write` now tolerates a `nil` `responseBuffer` by
  skipping the capture, instead of unconditionally writing into it (which
  would panic on a nil buffer).

## Tests

- `TestLoggingResponseWriterWriteWithNilBuffer` (new): drives
  `loggingResponseWriter.Write` directly with a `nil` `responseBuffer`.
  Confirmed this panics with a nil pointer dereference without the fix.
- `TestLoggerRequestOnlyDoesNotCaptureResponseBody` (new): end-to-end
  regression test for `logMode == LogRequest` -- asserts the client still
  gets the full proxied response, and that only the request event (never
  a response event) reaches the log sink. Note: this test alone does not
  distinguish fixed from unfixed, since the pre-existing `logMode` gate
  already prevented the response event from being sent either way; it's
  included as a regression test for the end-to-end behavior, not as the
  proof of the fix.

Ran `go test ./pkg/logger/... -race -count=1`, all green.

Fixes #6179

Signed-off-by: Nacho Capilla <ignacio.capilla@cabify.com>