### PR TITLE
feat(python): support pluggable TLS profiles

### DIFF
--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -45,6 +45,7 @@ from .protocol.grpc.server import GRPCServer
 from .protocol.model_repository_extension import ModelRepositoryExtension
 from .protocol.rest.multiprocess.server import RESTServerMultiProcess
 from .protocol.rest.server import RESTServer
+from .protocol.rest.tls_profile import TLSProfileProviderFactory
 from .utils import utils
 from .utils.inference_client_factory import InferenceClientFactory
 
@@ -252,6 +253,7 @@ class ModelServer:
         predictor_config: Optional[PredictorConfig] = None,
         ssl_certfile: Optional[str] = args.ssl_certfile,
         ssl_keyfile: Optional[str] = args.ssl_keyfile,
+        tls_profile_provider_factory: Optional[TLSProfileProviderFactory] = None,
     ):
         """KServe ModelServer Constructor
 
@@ -279,12 +281,15 @@ class ModelServer:
                           Falls back to KSERVE_TLS_CERT_FILE env var.
             ssl_keyfile: Path to the SSL private key file for serving HTTPS. Default: ``None``.
                          Falls back to KSERVE_TLS_KEY_FILE env var.
+            tls_profile_provider_factory: Optional factory for configuring and refreshing
+                                          the HTTPS server SSL context.
         """
         self.registered_models = (
             ModelRepository() if registered_models is None else registered_models
         )
         self.ssl_certfile = ssl_certfile
         self.ssl_keyfile = ssl_keyfile
+        self.tls_profile_provider_factory = tls_profile_provider_factory
         # When SSL is enabled and the port was not explicitly overridden, switch to the HTTPS port.
         if self.ssl_certfile and self.ssl_keyfile and http_port == DEFAULT_HTTP_PORT:
             http_port = DEFAULT_HTTPS_PORT
@@ -379,6 +384,7 @@ class ModelServer:
                 timeout_keep_alive=self.timeout_keep_alive,
                 ssl_certfile=self.ssl_certfile,
                 ssl_keyfile=self.ssl_keyfile,
+                tls_profile_provider_factory=self.tls_profile_provider_factory,
             )
             self.servers.append(self._rest_multiprocess_server.start())
         else:
@@ -394,6 +400,7 @@ class ModelServer:
                 timeout_keep_alive=self.timeout_keep_alive,
                 ssl_certfile=self.ssl_certfile,
                 ssl_keyfile=self.ssl_keyfile,
+                tls_profile_provider_factory=self.tls_profile_provider_factory,
             )
             self.servers.append(self._rest_server.start())
         if self.enable_grpc:

--- a/python/kserve/kserve/protocol/rest/multiprocess/server.py
+++ b/python/kserve/kserve/protocol/rest/multiprocess/server.py
@@ -25,6 +25,7 @@ from kserve.logging import logger
 from kserve.protocol.dataplane import DataPlane
 from kserve.protocol.model_repository_extension import ModelRepositoryExtension
 from kserve.protocol.rest.server import RESTServer
+from kserve.protocol.rest.tls_profile import TLSProfileProviderFactory
 
 mp.allow_connection_pickling()
 spawn = mp.get_context("spawn")
@@ -136,6 +137,7 @@ class RESTServerMultiProcess:
         timeout_keep_alive: int = 65,
         ssl_certfile: Optional[str] = None,
         ssl_keyfile: Optional[str] = None,
+        tls_profile_provider_factory: Optional[TLSProfileProviderFactory] = None,
     ) -> None:
         self.log_config_file = log_config_file
         self._rest_server = RESTServer(
@@ -150,6 +152,7 @@ class RESTServerMultiProcess:
             timeout_keep_alive,
             ssl_certfile=ssl_certfile,
             ssl_keyfile=ssl_keyfile,
+            tls_profile_provider_factory=tls_profile_provider_factory,
         )
         self._processes: List[RESTServerProcess] = []
         self.should_exit = asyncio.Event()

--- a/python/kserve/kserve/protocol/rest/server.py
+++ b/python/kserve/kserve/protocol/rest/server.py
@@ -51,6 +51,7 @@ from kserve.protocol.rest.timeseries.config import maybe_register_time_series_en
 from .v1_endpoints import register_v1_endpoints
 from .v2_endpoints import register_v2_endpoints
 from .ssl_cert_refresher import SSLCertRefresher
+from .tls_profile import TLSProfileProvider, TLSProfileProviderFactory
 from ..model_repository_extension import ModelRepositoryExtension
 
 
@@ -70,31 +71,45 @@ VALID_UVICORN_LOOPS = {"auto", "asyncio", "uvloop"}
 class _RefreshingServer(uvicorn.Server):
     """Uvicorn server that refreshes its SSL context when certificates change."""
 
-    def __init__(self, config: uvicorn.Config):
+    def __init__(
+        self,
+        config: uvicorn.Config,
+        tls_profile_provider_factory: Optional[TLSProfileProviderFactory] = None,
+    ):
         super().__init__(config)
         self._ssl_cert_refresher: Optional[SSLCertRefresher] = None
+        self._tls_profile_provider_factory = tls_profile_provider_factory
+        self._tls_profile_provider: Optional[TLSProfileProvider] = None
 
     async def serve(self, sockets: Optional[List[socket]] = None) -> None:
         if not self.config.loaded:
             self.config.load()
 
-        if (
-            self.config.ssl is not None
-            and self.config.ssl_keyfile is not None
-            and self.config.ssl_certfile is not None
-        ):
-            self._ssl_cert_refresher = SSLCertRefresher(
-                ssl_context=self.config.ssl,
-                key_path=str(self.config.ssl_keyfile),
-                cert_path=str(self.config.ssl_certfile),
-            )
-
         try:
+            if (
+                self.config.ssl is not None
+                and self.config.ssl_keyfile is not None
+                and self.config.ssl_certfile is not None
+            ):
+                self._ssl_cert_refresher = SSLCertRefresher(
+                    ssl_context=self.config.ssl,
+                    key_path=str(self.config.ssl_keyfile),
+                    cert_path=str(self.config.ssl_certfile),
+                )
+                if self._tls_profile_provider_factory is not None:
+                    self._tls_profile_provider = self._tls_profile_provider_factory(
+                        self.config.ssl
+                    )
+                    self._tls_profile_provider.start()
+
             await super().serve(sockets=sockets)
         finally:
             if self._ssl_cert_refresher is not None:
                 self._ssl_cert_refresher.stop()
                 self._ssl_cert_refresher = None
+            if self._tls_profile_provider is not None:
+                self._tls_profile_provider.stop()
+                self._tls_profile_provider = None
 
 
 class RESTServer:
@@ -111,6 +126,7 @@ class RESTServer:
         timeout_keep_alive: int = 65,
         ssl_certfile: Optional[str] = None,
         ssl_keyfile: Optional[str] = None,
+        tls_profile_provider_factory: Optional[TLSProfileProviderFactory] = None,
     ):
         self.dataplane = data_plane
         self.model_repository_extension = model_repository_extension
@@ -136,7 +152,7 @@ class RESTServer:
             ssl_certfile=ssl_certfile,
             ssl_keyfile=ssl_keyfile,
         )
-        self._server = _RefreshingServer(self.config)
+        self._server = _RefreshingServer(self.config, tls_profile_provider_factory)
 
     def _register_endpoints(self, app: fastapi.FastAPI):
         root_router = APIRouter()

--- a/python/kserve/kserve/protocol/rest/tls_profile.py
+++ b/python/kserve/kserve/protocol/rest/tls_profile.py
@@ -1,0 +1,44 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ssl
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class TLSProfile:
+    """TLS settings to apply to a server SSL context."""
+
+    minimum_version: ssl.TLSVersion
+    ciphers: Sequence[str] = ()
+
+
+def apply_tls_profile(ssl_context: ssl.SSLContext, profile: TLSProfile) -> None:
+    """Apply a TLS profile to an active SSL context."""
+    ssl_context.minimum_version = profile.minimum_version
+    if profile.ciphers and profile.minimum_version < ssl.TLSVersion.TLSv1_3:
+        ssl_context.set_ciphers(":".join(profile.ciphers))
+
+
+class TLSProfileProvider(Protocol):
+    """Lifecycle for a source that configures and refreshes an SSL context."""
+
+    def start(self) -> None: ...
+
+    def stop(self) -> None: ...
+
+
+TLSProfileProviderFactory = Callable[[ssl.SSLContext], TLSProfileProvider]

--- a/python/kserve/test/test_rest_server.py
+++ b/python/kserve/test/test_rest_server.py
@@ -115,3 +115,66 @@ async def test_ssl_cert_refresher_lifecycle(monkeypatch):
         cert_path="/etc/tls/tls.crt",
     )
     refresher.stop.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_tls_profile_provider_lifecycle(monkeypatch):
+    monkeypatch.setattr(rest_mod.RESTServer, "create_application", lambda self: None)
+    monkeypatch.setattr(rest_mod.uvicorn.Server, "serve", AsyncMock())
+    ssl_context = Mock()
+    provider = Mock()
+    provider_factory = Mock(return_value=provider)
+
+    rs = rest_mod.RESTServer(
+        app="dummy:app",
+        data_plane=Mock(),
+        model_repository_extension=Mock(),
+        http_port=8443,
+        ssl_certfile="/etc/tls/tls.crt",
+        ssl_keyfile="/etc/tls/tls.key",
+        tls_profile_provider_factory=provider_factory,
+    )
+
+    def load_config():
+        rs.config.loaded = True
+        rs.config.ssl = ssl_context
+
+    monkeypatch.setattr(rs.config, "load", load_config)
+
+    await rs.start()
+
+    provider_factory.assert_called_once_with(ssl_context)
+    provider.start.assert_called_once_with()
+    provider.stop.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_tls_profile_provider_start_failure_stops_refreshers(monkeypatch):
+    monkeypatch.setattr(rest_mod.RESTServer, "create_application", lambda self: None)
+    cert_refresher = Mock()
+    monkeypatch.setattr(rest_mod, "SSLCertRefresher", Mock(return_value=cert_refresher))
+    provider = Mock()
+    provider.start.side_effect = RuntimeError("provider failed")
+    ssl_context = Mock()
+
+    rs = rest_mod.RESTServer(
+        app="dummy:app",
+        data_plane=Mock(),
+        model_repository_extension=Mock(),
+        http_port=8443,
+        ssl_certfile="/etc/tls/tls.crt",
+        ssl_keyfile="/etc/tls/tls.key",
+        tls_profile_provider_factory=Mock(return_value=provider),
+    )
+
+    def load_config():
+        rs.config.loaded = True
+        rs.config.ssl = ssl_context
+
+    monkeypatch.setattr(rs.config, "load", load_config)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await rs.start()
+
+    cert_refresher.stop.assert_called_once_with()
+    provider.stop.assert_called_once_with()

--- a/python/kserve/test/test_tls_profile.py
+++ b/python/kserve/test/test_tls_profile.py
@@ -1,0 +1,46 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ssl
+
+from kserve.protocol.rest.tls_profile import TLSProfile, apply_tls_profile
+
+
+def test_apply_tls_profile_sets_minimum_version_and_ciphers():
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    profile = TLSProfile(
+        minimum_version=ssl.TLSVersion.TLSv1_2,
+        ciphers=("ECDHE-RSA-AES128-GCM-SHA256",),
+    )
+
+    apply_tls_profile(context, profile)
+
+    assert context.minimum_version == ssl.TLSVersion.TLSv1_2
+    assert "ECDHE-RSA-AES128-GCM-SHA256" in {
+        cipher["name"] for cipher in context.get_ciphers()
+    }
+
+
+def test_apply_tls_13_profile_ignores_cipher_list():
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+    apply_tls_profile(
+        context,
+        TLSProfile(
+            minimum_version=ssl.TLSVersion.TLSv1_3,
+            ciphers=("NOT-A-CIPHER",),
+        ),
+    )
+
+    assert context.minimum_version == ssl.TLSVersion.TLSv1_3


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds cluster-agnostic extension points for configuring and refreshing the Python REST server TLS profile. It introduces a generic `TLSProfile` model and SSL-context helper, plus an optional provider lifecycle wired through `ModelServer`, `RESTServer`, and the multiprocess REST server.

The provider is opt-in. Existing deployments behave exactly as before when no provider factory is supplied. The implementation intentionally has no Kubernetes or OpenShift dependencies, allowing platform-specific integrations to live outside the upstream server path.

**Which issue(s) this PR fixes**:

None.

**Feature/Issue validation/testing**:

- [x] `make precommit`
- [x] `UV_CACHE_DIR=/tmp/kserve-upstream-uv-cache uv run --project python/kserve pytest -q python/kserve/test/test_tls_profile.py python/kserve/test/test_rest_server.py python/kserve/test/test_model_server.py python/kserve/test/test_ssl_cert_refresher.py` (`21 passed`)

**Special notes for your reviewer**:

Follow-on integrations can implement a provider for an external TLS-policy source without adding platform assumptions to KServe. The provider starts only when HTTPS is configured and is stopped during normal shutdown and startup failure cleanup.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? Not required; this adds an integration API with no user-visible default behavior change.

**Release note**:

```release-note
Add an optional Python ModelServer TLS profile provider interface.
```