### PR TITLE
chore: add KServe reviewers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,11 +15,13 @@ This list is a copy of the active maintainers from [MAINTAINERS.md file in kserv
 | Filippe Spolti         | [spolti](https://github.com/spolti)                   | Approver - KServe    | Red Hat     |
 | Pierangelo Di Pilato   | [pierDipi](https://github.com/pierDipi)               | Approver - KServe    | Red Hat     |
 | Bartosz Majsak         | [bartoszmajsak](https://github.com/bartoszmajsak)     | Approver - KServe    | Red Hat     |
+| Andres Llausas         | [andresllh](https://github.com/andresllh)             | Reviewer - KServe    | Red Hat     |
 | Andrews Arokiam        | [andyi2it](https://github.com/andyi2it)               | Reviewer - KServe    | Ideas2IT    |
 | Curtis Maddalozzo      | [cmaddalozzo](https://github.com/cmaddalozzo)         | Reviewer - KServe    | Bloomberg   |
 | Datta Nimmaturi        | [Datta0](https://github.com/Datta0)                   | Reviewer - KServe    | Nutanix     |
 | Gavrish Prabhu         | [gavrissh](https://github.com/gavrissh)               | Reviewer - KServe    | Nutanix     |
 | Jin Dong               | [greenmoon55](https://github.com/greenmoon55)         | Reviewer - KServe    | Bloomberg   |
 | Edgar Hernández        | [israel-hdez](https://github.com/israel-hdez)         | Reviewer - KServe    | Red Hat     |
+| James Ostrander        | [jlost](https://github.com/jlost)                     | Reviewer - KServe    | Red Hat     |
 | Johnu George           | [johnugeorge](https://github.com/johnugeorge)         | Reviewer - KServe    | Nutanix     |
 | Vivek Karunai Kiri Ragavan | [vivekk16](https://github.com/vivekk16)           | Reviewer - KServe    | Red Hat     |


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Andres Llausas (`andresllh`) and James Ostrander (`jlost`) to the KServe reviewer roster following their approved community membership requests.

**Which issue(s) this PR fixes** *(optional)*:
- https://github.com/kserve/community/issues/87
- https://github.com/kserve/community/issues/86

**Feature/Issue validation/testing**:

- [x] `make precommit`
- [x] `git diff --check`

**Special notes for your reviewer**:
The new entries preserve the existing alphabetical ordering by GitHub ID.

**Checklist**:
- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```