### PR TITLE
ci: raise test-llmisvc (helm) e2e step timeout

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -204,7 +204,7 @@ jobs:
 
   test-llmisvc:
     runs-on: cncf-ubuntu-16-64-x86
-    timeout-minutes: 125
+    timeout-minutes: 150
     needs: [detect-changes, llmisvc-image-build, seed-model-cache, seed-image-cache]
     strategy:
       fail-fast: false
@@ -318,7 +318,7 @@ jobs:
 
       - name: Run LLMInferenceService E2E tests
         id: llmisvc-e2e-tests
-        timeout-minutes: 90
+        timeout-minutes: 105
         env:
           OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

The `Run LLMInferenceService E2E tests` step in `test-llmisvc (helm)` is capped at 90 min while the suite itself now runs 86-89 min, so a run in which all 57 tests pass can still be killed and reported as a job failure.

Across the 19 helm samples since 2026-09-04 the step's median is 88.35 min against the 90 min cap, and the cap has been hit four times; two of those are on branches that do not modify the suite being measured (jobs `102233568699` and `101925590136`), and the other two are excluded because that branch changes the suite. Measured over the last 10 passing helm jobs on master-based branches: e2e step 86.28-89.30 min, setup + teardown overhead 14.23-23.80 min, job total 101.70-112.65 min.

Step cap: `ceil(89.30)` + 15 min headroom = **105**.

Job cap: the step may now legitimately run to 105, and the largest observed overhead is 23.80, so a worst-case job needs 129 min. That exceeds the current job cap of 125, which would convert a step-level raise into a job-level kill, so the job cap moves to 105 + 24 + 10 min headroom = 139, rounded to **140**.

This addresses the reported symptom only; splitting the suite or profiling its slowest tests would reduce the wall time itself and remain worth doing.

**Which issue(s) this PR fixes**:

Fixes #6166

**Feature/Issue validation/testing**:

No test behavior changes — timeout caps only. The numbers were measured from the GitHub Actions API following the methodology established in the issue thread: constrain the run list by `created`, and read `/runs/{id}/attempts/{n}/jobs`, since the plain `/runs/{id}/jobs` endpoint returns only the latest attempt and hides three of the four cap kills.

**Release note**:

```release-note
NONE
```
