### PR TITLE
fix: honor KEDA External and PodMetric target types

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -560,6 +560,16 @@ func validateScaleTarget(target MetricTarget) error {
 	return nil
 }
 
+func validateKedaScaleTarget(target MetricTarget) error {
+	if target.Type == UtilizationMetricType {
+		return errors.New("the target type Utilization is not supported for KEDA external or pod metrics")
+	}
+	if target.Type == "" && target.Value == nil {
+		return errors.New("the target threshold value should not be empty")
+	}
+	return validateScaleTarget(target)
+}
+
 func validateScalingHPACompExtension(compExtSpec *ComponentExtensionSpec) error {
 	metric := MetricCPU
 	if compExtSpec.ScaleMetric != nil {
@@ -641,10 +651,7 @@ func validateScalingKedaCompExtension(compExtSpec *ComponentExtensionSpec) error
 				if metric.External.Metric.Query == "" {
 					return errors.New("the query should not be empty")
 				}
-				if metric.External.Target.Value == nil {
-					return errors.New("the target threshold value should not be empty")
-				}
-				if err := validateScaleTarget(metric.External.Target); err != nil {
+				if err := validateKedaScaleTarget(metric.External.Target); err != nil {
 					return err
 				}
 			case PodMetricSourceType:
@@ -654,10 +661,7 @@ func validateScalingKedaCompExtension(compExtSpec *ComponentExtensionSpec) error
 				if metric.PodMetric.Metric.Query == "" {
 					return errors.New("the query should not be empty")
 				}
-				if metric.PodMetric.Target.Value == nil {
-					return errors.New("the target threshold value should not be empty")
-				}
-				if err := validateScaleTarget(metric.PodMetric.Target); err != nil {
+				if err := validateKedaScaleTarget(metric.PodMetric.Target); err != nil {
 					return err
 				}
 			default:

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1813,6 +1813,46 @@ func TestValidateScalingKedaCompExtension(t *testing.T) {
 			},
 		},
 	}
+	validExternalWithoutType := validExternal.DeepCopy()
+	validExternalWithoutType.AutoScaling.Metrics[0].External.Target.Type = ""
+	validExternalAverageValue := &ComponentExtensionSpec{
+		AutoScaling: &AutoScalingSpec{
+			Metrics: []MetricsSpec{
+				{
+					Type: ExternalMetricSourceType,
+					External: &ExternalMetricSource{
+						Metric: ExternalMetrics{
+							Backend: PrometheusBackend,
+							Query:   "avg(requests)",
+						},
+						Target: MetricTarget{
+							Type:         AverageValueMetricType,
+							AverageValue: NewMetricQuantity("10"),
+						},
+					},
+				},
+			},
+		},
+	}
+	invalidExternalUtilization := &ComponentExtensionSpec{
+		AutoScaling: &AutoScalingSpec{
+			Metrics: []MetricsSpec{
+				{
+					Type: ExternalMetricSourceType,
+					External: &ExternalMetricSource{
+						Metric: ExternalMetrics{
+							Backend: PrometheusBackend,
+							Query:   "avg(requests)",
+						},
+						Target: MetricTarget{
+							Type:               UtilizationMetricType,
+							AverageUtilization: ptr.To(int32(50)),
+						},
+					},
+				},
+			},
+		},
+	}
 	invalidPodMetric := &ComponentExtensionSpec{
 		AutoScaling: &AutoScalingSpec{
 			Metrics: []MetricsSpec{
@@ -1851,6 +1891,46 @@ func TestValidateScalingKedaCompExtension(t *testing.T) {
 			},
 		},
 	}
+	validPodMetricWithoutType := validPodMetric.DeepCopy()
+	validPodMetricWithoutType.AutoScaling.Metrics[0].PodMetric.Target.Type = ""
+	validPodMetricAverageValue := &ComponentExtensionSpec{
+		AutoScaling: &AutoScalingSpec{
+			Metrics: []MetricsSpec{
+				{
+					Type: PodMetricSourceType,
+					PodMetric: &PodMetricSource{
+						Metric: PodMetrics{
+							Backend: OpenTelemetryBackend,
+							Query:   "avg(requests)",
+						},
+						Target: MetricTarget{
+							Type:         AverageValueMetricType,
+							AverageValue: NewMetricQuantity("5"),
+						},
+					},
+				},
+			},
+		},
+	}
+	invalidPodMetricUtilization := &ComponentExtensionSpec{
+		AutoScaling: &AutoScalingSpec{
+			Metrics: []MetricsSpec{
+				{
+					Type: PodMetricSourceType,
+					PodMetric: &PodMetricSource{
+						Metric: PodMetrics{
+							Backend: OpenTelemetryBackend,
+							Query:   "avg(requests)",
+						},
+						Target: MetricTarget{
+							Type:               UtilizationMetricType,
+							AverageUtilization: ptr.To(int32(50)),
+						},
+					},
+				},
+			},
+		},
+	}
 	unknownMetricType := &ComponentExtensionSpec{
 		AutoScaling: &AutoScalingSpec{
 			Metrics: []MetricsSpec{
@@ -1876,8 +1956,14 @@ func TestValidateScalingKedaCompExtension(t *testing.T) {
 		{"invalid: unsupported resource", unsupportedResource, "resource type disk is not supported"},
 		{"invalid: external metric missing query/value", invalidExternal, "the query should not be empty"},
 		{"valid: external metric", validExternal, ""},
+		{"valid: external metric without target type", validExternalWithoutType, ""},
+		{"valid: external AverageValue metric", validExternalAverageValue, ""},
+		{"invalid: external Utilization metric", invalidExternalUtilization, "Utilization is not supported"},
 		{"invalid: pod metric missing query/value", invalidPodMetric, "the query should not be empty"},
 		{"valid: pod metric", validPodMetric, ""},
+		{"valid: pod metric without target type", validPodMetricWithoutType, ""},
+		{"valid: pod AverageValue metric", validPodMetricAverageValue, ""},
+		{"invalid: pod Utilization metric", invalidPodMetricUtilization, "Utilization is not supported"},
 		{"invalid: unknown metric type", unknownMetricType, "unknown KEDA metric type with value [UnknownType].Valid types are Resource,External,PodMetric"},
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler.go
@@ -80,6 +80,13 @@ func getOriginalStringMQ(mq *v1beta1.MetricQuantity, defaultValue string) string
 	return defaultValue
 }
 
+func getKedaMetricTarget(target v1beta1.MetricTarget) (autoscalingv2.MetricTargetType, *v1beta1.MetricQuantity) {
+	if target.Type == v1beta1.AverageValueMetricType {
+		return autoscalingv2.AverageValueMetricType, target.AverageValue
+	}
+	return autoscalingv2.MetricTargetType(target.Type), target.Value
+}
+
 func getKedaMetrics(componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec, configMap *corev1.ConfigMap,
 ) ([]kedav1alpha1.ScaleTriggers, error) {
 	var triggers []kedav1alpha1.ScaleTriggers
@@ -118,13 +125,15 @@ func getKedaMetrics(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compo
 				triggerType := string(metric.External.Metric.Backend)
 				serverAddress := metric.External.Metric.ServerAddress
 				query := metric.External.Metric.Query
+				metricType, targetValue := getKedaMetricTarget(metric.External.Target)
 
 				trigger := kedav1alpha1.ScaleTriggers{
-					Type: triggerType,
+					Type:       triggerType,
+					MetricType: metricType,
 					Metadata: map[string]string{
 						"serverAddress": serverAddress,
 						"query":         query,
-						"threshold":     getOriginalStringMQ(metric.External.Target.Value, "0"),
+						"threshold":     getOriginalStringMQ(targetValue, "0"),
 					},
 				}
 
@@ -157,10 +166,12 @@ func getKedaMetrics(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compo
 
 				triggerType := string(metric.PodMetric.Metric.Backend)
 				query := metric.PodMetric.Metric.Query
-				targetValue := getOriginalStringMQ(metric.PodMetric.Target.Value, "0")
+				metricType, target := getKedaMetricTarget(metric.PodMetric.Target)
+				targetValue := getOriginalStringMQ(target, "0")
 
 				trigger := kedav1alpha1.ScaleTriggers{
-					Metadata: map[string]string{},
+					MetricType: metricType,
+					Metadata:   map[string]string{},
 				}
 
 				if triggerType == string(constants.AutoScalerMetricsSourceOpenTelemetry) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/keda/keda_reconciler_test.go
@@ -90,6 +90,7 @@ func TestGetKedaMetrics_ExternalMetricSourceType(t *testing.T) {
 	assert.Equal(t, "http://prometheus-server", triggers[0].Metadata["serverAddress"])
 	assert.Equal(t, "http_requests_total", triggers[0].Metadata["query"])
 	assert.Equal(t, "100.9", triggers[0].Metadata["threshold"])
+	assert.Empty(t, triggers[0].MetricType)
 }
 
 func TestGetKedaMetrics_PodMetricSourceType(t *testing.T) {
@@ -108,6 +109,96 @@ func TestGetKedaMetrics_PodMetricSourceType(t *testing.T) {
 	// The metricQuery should now include namespace and deployment selectors
 	assert.Equal(t, "sum(otel_query{namespace=\"test-namespace\", deployment=\"test-component\"})", triggers[0].Metadata["metricQuery"])
 	assert.Equal(t, "200", triggers[0].Metadata["targetValue"])
+	assert.Empty(t, triggers[0].MetricType)
+}
+
+func TestGetKedaMetrics_ExternalAndPodMetricTargetTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		metricType    v1beta1.MetricSourceType
+		target        v1beta1.MetricTarget
+		expectedType  autoscalingv2.MetricTargetType
+		metadataKey   string
+		expectedValue string
+	}{
+		{
+			name:       "external Value",
+			metricType: v1beta1.ExternalMetricSourceType,
+			target: v1beta1.MetricTarget{
+				Type:  v1beta1.ValueMetricType,
+				Value: v1beta1.NewMetricQuantity("10"),
+			},
+			expectedType:  autoscalingv2.ValueMetricType,
+			metadataKey:   "threshold",
+			expectedValue: "10",
+		},
+		{
+			name:       "external AverageValue",
+			metricType: v1beta1.ExternalMetricSourceType,
+			target: v1beta1.MetricTarget{
+				Type:         v1beta1.AverageValueMetricType,
+				AverageValue: v1beta1.NewMetricQuantity("20"),
+			},
+			expectedType:  autoscalingv2.AverageValueMetricType,
+			metadataKey:   "threshold",
+			expectedValue: "20",
+		},
+		{
+			name:       "pod metric Value",
+			metricType: v1beta1.PodMetricSourceType,
+			target: v1beta1.MetricTarget{
+				Type:  v1beta1.ValueMetricType,
+				Value: v1beta1.NewMetricQuantity("30"),
+			},
+			expectedType:  autoscalingv2.ValueMetricType,
+			metadataKey:   "targetValue",
+			expectedValue: "30",
+		},
+		{
+			name:       "pod metric AverageValue",
+			metricType: v1beta1.PodMetricSourceType,
+			target: v1beta1.MetricTarget{
+				Type:         v1beta1.AverageValueMetricType,
+				AverageValue: v1beta1.NewMetricQuantity("40"),
+			},
+			expectedType:  autoscalingv2.AverageValueMetricType,
+			metadataKey:   "targetValue",
+			expectedValue: "40",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			componentExt := &v1beta1.ComponentExtensionSpec{
+				AutoScaling: &v1beta1.AutoScalingSpec{
+					Metrics: []v1beta1.MetricsSpec{{Type: tt.metricType}},
+				},
+			}
+			metric := &componentExt.AutoScaling.Metrics[0]
+			switch tt.metricType {
+			case v1beta1.ExternalMetricSourceType:
+				metric.External = &v1beta1.ExternalMetricSource{
+					Metric: v1beta1.ExternalMetrics{Backend: v1beta1.PrometheusBackend},
+					Target: tt.target,
+				}
+			case v1beta1.PodMetricSourceType:
+				metric.PodMetric = &v1beta1.PodMetricSource{
+					Metric: v1beta1.PodMetrics{Backend: v1beta1.OpenTelemetryBackend},
+					Target: tt.target,
+				}
+			}
+
+			triggers, err := getKedaMetrics(
+				metav1.ObjectMeta{Name: "test-component", Namespace: "test-namespace"},
+				componentExt,
+				&corev1.ConfigMap{},
+			)
+			require.NoError(t, err)
+			require.Len(t, triggers, 1)
+			assert.Equal(t, tt.expectedType, triggers[0].MetricType)
+			assert.Equal(t, tt.expectedValue, triggers[0].Metadata[tt.metadataKey])
+		})
+	}
 }
 
 func TestCreateKedaScaledObject(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

KServe currently omits `ScaleTrigger.MetricType` for External and PodMetric KEDA metrics, so KEDA defaults both to `AverageValue` even when the InferenceService specifies `target.type: Value`.

This PR:

- propagates explicit `Value` and `AverageValue` target types to generated KEDA triggers;
- selects `target.value` or `target.averageValue` to match that type;
- rejects unsupported `Utilization` targets during admission;
- preserves the existing behavior for omitted target types by leaving `MetricType` empty and continuing to use `target.value`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #6169

**Feature/Issue validation/testing**:

- [x] Added renderer regression coverage for External and PodMetric `Value`/`AverageValue` targets and omitted-type compatibility.
- [x] Added admission validation coverage for supported target types and rejected `Utilization` targets.
- [x] Ran focused Go tests for the KEDA reconciler and v1beta1 serving API packages.
- [x] Ran the broader inference-service and v1beta1 API test suites with envtest (122 controller specs).
- [x] Ran `make precommit` successfully.

**Special notes for your reviewer**:

This intentionally retains the legacy omitted-type behavior: an empty KServe target type produces an empty KEDA `MetricType`, allowing KEDA to keep applying its `AverageValue` default. Explicit types are honored.

Users who followed the existing documentation and explicitly configured `target.type: Value` should note that this fixes their generated KEDA trigger from `AverageValue` to `Value`. To retain the previous per-replica behavior, they should change the target to `AverageValue` and move the quantity from `target.value` to `target.averageValue`.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? No documentation change is needed; existing examples already specify `target.type: Value`.

**Release note**:

```release-note
action required: KEDA External and PodMetric autoscaling now honors explicitly configured Value and AverageValue target types. Configurations using target.type: Value previously received KEDA's AverageValue behavior; use target.type: AverageValue with target.averageValue to retain that per-replica behavior.
```
