### PR TITLE
test(isvc): de-flake model_status_churn

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/model_status_churn_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/model_status_churn_test.go
@@ -25,10 +25,12 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -125,33 +127,66 @@ var _ = Describe("InferenceService model status determinism", func() {
 
 			By("Creating two predictor pods that disagree about the model state")
 			appLabel := constants.GetRawServiceLabel(predictorKey.Name)
-			loading := predictorPod("churn-pod-loading", serviceKey.Namespace, appLabel, serviceName,
-				corev1.ContainerState{
-					Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()},
-				})
-			failed := predictorPod("churn-pod-failed", serviceKey.Namespace, appLabel, serviceName,
-				corev1.ContainerState{
-					Terminated: &corev1.ContainerStateTerminated{
-						Reason:   constants.StateReasonError,
-						Message:  "failed to pull model",
-						ExitCode: 1,
-					},
-				})
 
-			for _, pod := range []*corev1.Pod{loading, failed} {
-				status := pod.Status
-				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
-				defer k8sClient.Delete(ctx, pod)
-				pod.Status = status
-				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+			// Rebuilt per attempt: Create stamps name, UID and resourceVersion onto the
+			// object, so the same struct cannot be submitted twice.
+			disagreeingPods := func() (*corev1.Pod, *corev1.Pod) {
+				loading := predictorPod("churn-pod-loading", serviceKey.Namespace, appLabel, serviceName,
+					corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()},
+					})
+				failed := predictorPod("churn-pod-failed", serviceKey.Namespace, appLabel, serviceName,
+					corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   constants.StateReasonError,
+							Message:  "failed to pull model",
+							ExitCode: 1,
+						},
+					})
+				return loading, failed
 			}
 
-			// The bug only manifests when the pods tie on CreationTimestamp, which
-			// is what happens in a real ReplicaSet rollout. Creating them back to
-			// back makes that overwhelmingly likely, but assert it rather than
-			// silently passing if the two creates straddle a second boundary.
-			Expect(loading.CreationTimestamp.Equal(&failed.CreationTimestamp)).To(BeTrue(),
-				"pods must share a creation timestamp for this test to exercise the tie")
+			DeferCleanup(func() {
+				loading, failed := disagreeingPods()
+				for _, pod := range []*corev1.Pod{loading, failed} {
+					Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, pod))).To(Succeed())
+				}
+			})
+
+			// The bug only manifests when the pods tie on CreationTimestamp, which is
+			// what happens in a real ReplicaSet rollout. The API server stamps that
+			// field itself - a client-side value is dropped on create and rejected as
+			// immutable on update - and it only has second granularity, so the tie
+			// cannot be forced, only made overwhelmingly likely by creating the pods
+			// back to back. On a loaded runner the two creates can still straddle a
+			// second boundary, so keep retrying the pair rather than skipping: a skip
+			// would let a regression of the ordering fix pass as a green run.
+			Eventually(func(g Gomega) {
+				loading, failed := disagreeingPods()
+				pair := []*corev1.Pod{loading, failed}
+
+				// Every attempt starts from an empty slate, otherwise a leftover pair
+				// fails the creates and a third pod would break the tie being set up.
+				// These pods are never scheduled - envtest runs no scheduler or kubelet
+				// - so the API server deletes them outright, and k8sClient reads
+				// straight from it, making NotFound the signal that the names are free.
+				for _, pod := range pair {
+					g.Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, pod, client.GracePeriodSeconds(0)))).To(Succeed())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})).
+						To(MatchError(apierr.IsNotFound, "NotFound"),
+							"%s must be gone before the pair is recreated", pod.Name)
+				}
+
+				for _, pod := range pair {
+					status := pod.Status
+					g.Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+					pod.Status = status
+					g.Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+				}
+
+				g.Expect(loading.CreationTimestamp.Equal(&failed.CreationTimestamp)).To(BeTrue(),
+					"pods must share a creation timestamp for this test to exercise the tie")
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 
 			By("Reconciling repeatedly and sampling the reported model state")
 			settled := func() string {
@@ -163,17 +198,17 @@ var _ = Describe("InferenceService model status determinism", func() {
 				return string(cur.Status.ModelStatus.ModelRevisionStates.TargetModelState)
 			}
 
-			// Guard against a silent pass: if the pods never reach
-			// PropagateModelStatus the state stays "Pending" and the ordering is
-			// never exercised at all.
-			var first string
-			Eventually(func() string {
-				first = settled()
-				GinkgoWriter.Printf("observed target model state: %q\n", first)
-				return first
-			}, timeout, interval).Should(BeElementOf(
-				string(v1beta1.Loading), string(v1beta1.FailedToLoad),
-			), "predictor pods must drive status.modelStatus, otherwise this test proves nothing")
+			// Both pods tie on CreationTimestamp, so the ordering contract alone picks
+			// the winner: ties break on name ascending, which puts churn-pod-failed at
+			// Items[0] and makes its terminated storage-initializer the verdict every
+			// reconcile has to reach. Anchoring on that value rather than on whichever
+			// state is observed first also keeps the window where the controller can
+			// still see a single pod - between the two creates - from becoming the
+			// baseline and turning the catch-up into a false flip.
+			wantState := string(v1beta1.FailedToLoad)
+			Eventually(settled, timeout, interval).Should(Equal(wantState),
+				"status.modelStatus must settle on the tie-break winner churn-pod-failed; an empty or "+
+					"different state means either nothing propagated or Items[0] is not the expected pod")
 
 			// Each poll nudges the InferenceService to force a fresh reconcile and
 			// then reports what that reconcile concluded. With a random List order
@@ -191,7 +226,7 @@ var _ = Describe("InferenceService model status determinism", func() {
 					return k8sClient.Update(ctx, cur)
 				})).To(Succeed())
 				return settled()
-			}, 10*time.Second, 250*time.Millisecond).Should(Equal(first),
+			}, 10*time.Second, 250*time.Millisecond).Should(Equal(wantState),
 				"status.modelStatus flipped between reconciles without any pod change")
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

This test fails at random. It needs its two test pods to have the same creation time, because that's the only case where the bug #6021 fixed can show up at all. Creation time is set by the API server and only goes down to the second, so creating two pods back to back usually gets the same value... well... usually. On a busy machine the two creates land either side of a second tick, the values differ, and the test fails on its own setup check.

A second problem turned up while verifying this one, and it was the bigger of the two. The test took the first model state it happened to see and expected every later reading to match it. The controller works out that state from a single pod, so a reconcile landing in the gap between the two pod creations saw one pod and reported on just that one. When the second pod showed up the answer changed, and the test read that as the status flipping on its own. It now expects the answer the ordering rule actually produces, so the controller catching up is no longer mistaken for a bug.

The test stops failing for reasons unrelated to what it checks, and it gets better at catching what it was written for.

**Which issue(s) this PR fixes**:

N/A - flake surfaced by job 102866589337 on #6174, unrelated to that PR.

**Feature/Issue validation/testing**:

- [x] Focused spec, unmodified: 5/5 green
- [x] With a second-boundary straddle forced between the two creates: 3/3 green, where `master` fails every time
- [x] With the pre-#6021 comparator restored: 5/5 red on the flip assertion, where `master` catches it 2 times out of 3
- [x] `go test ./pkg/controller/v1beta1/inferenceservice/...` green, `make precommit` clean

**Special notes for your reviewer**:

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
