### PR TITLE
feat(logger): add Prometheus metrics for the inference logger agent

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	flag "github.com/spf13/pflag"
 	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
@@ -49,6 +50,7 @@ import (
 	"github.com/kserve/kserve/pkg/agent/storage"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/batcher"
+	"github.com/kserve/kserve/pkg/constants"
 	kfslogger "github.com/kserve/kserve/pkg/logger"
 )
 
@@ -70,6 +72,7 @@ var (
 	logMarshallerPort   = flag.Int("log-marshaller-port", 9083, "Port for the embedded log marshaller HTTP server")
 	logBatchSize        = flag.Int("log-batch-size", 1, "Number of log records per batch for blob storage")
 	logBatchInterval    = flag.Duration("log-batch-interval", 0, "Max time to wait before flushing a partial batch")
+	metricsPort         = flag.Int("metrics-port", constants.LoggerMetricsPort, "Port for the logger's Prometheus /metrics endpoint")
 	inferenceService    = flag.String("inference-service", "", "The InferenceService name to add as header to log events")
 	namespace           = flag.String("namespace", "", "The namespace to add as header to log events")
 	endpoint            = flag.String("endpoint", "", "The endpoint name to add as header to log events")
@@ -162,6 +165,7 @@ func main() {
 		logger.Info("Starting logger")
 		loggerArgs = startLogger(*workers, logStorePath, *logMarshallerUrl, *logMarshallerPort,
 			*logBatchSize, *logBatchInterval, logger)
+		buildMetricsServer(*metricsPort, logger)
 	}
 
 	var batcherArgs *batcherArgs
@@ -375,6 +379,23 @@ func startLogger(workers int, logStorePath *string, marshallerUrl string, marsha
 		certName:         *CaCertFile,
 		tlsSkipVerify:    *TlsSkipVerify,
 	}
+}
+
+func buildMetricsServer(port int, logger *zap.SugaredLogger) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	addr := fmt.Sprintf(":%d", port)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		logger.Infof("Starting logger metrics server on %s", addr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Errorf("Logger metrics server failed: %v", err)
+		}
+	}()
 }
 
 func startModelPuller(logger *zap.SugaredLogger) {

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/open-telemetry/opentelemetry-operator v0.152.0
 	github.com/parquet-go/parquet-go v0.27.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/sigstore/cosign/v3 v3.0.6
 	github.com/sigstore/sigstore v1.10.5
 	github.com/spf13/cobra v1.10.2
@@ -192,8 +194,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.69.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -397,6 +397,7 @@ const (
 	InferenceServiceDefaultHttpPort     = "8080"
 	InferenceServiceDefaultAgentPortStr = "9081"
 	InferenceServiceDefaultAgentPort    = 9081
+	LoggerMetricsPort                   = 9089
 	CommonDefaultHttpPort               = 80
 	AggregateMetricsPortName            = "aggr-metric"
 )

--- a/pkg/logger/dispatcher.go
+++ b/pkg/logger/dispatcher.go
@@ -64,6 +64,7 @@ func StartDispatcher(nworkers int, store Store, batchStrategy BatchStrategy, log
 	// Dispatcher goroutine: read from WorkQueue, split HTTP vs blob.
 	go func() {
 		for work := range WorkQueue {
+			WorkQueueDepth.Set(float64(len(WorkQueue)))
 			strategy := GetStorageStrategy(work.Url.String())
 
 			if strategy == HttpStorage {

--- a/pkg/logger/metrics.go
+++ b/pkg/logger/metrics.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	metricsNamespace = "kserve"
+	metricsSubsystem = "logger"
+)
+
+var (
+	EventsSentTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "events_sent_total",
+		Help:      "Total number of CloudEvents successfully delivered to the log sink (HTTP 200).",
+	}, []string{"type"})
+
+	EventsFailedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "events_failed_total",
+		Help:      "Total number of CloudEvents that failed to deliver to the log sink (connection error, timeout, or non-200 response).",
+	}, []string{"type"})
+
+	// TODO: wire this in once #6173 (bounded dispatch) lands -- QueueLogRequest
+	// doesn't have a drop path yet, so this stays at 0.
+	EventsDroppedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "events_dropped_total",
+		Help:      "Total number of log requests dropped before delivery because the work queue was full.",
+	}, []string{"type"})
+
+	DeliveryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "delivery_duration_seconds",
+		Help:      "Time taken to deliver a CloudEvent to the log sink, regardless of outcome.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"type"})
+
+	WorkQueueDepth = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "work_queue_depth",
+		Help:      "Number of log requests currently buffered in the work queue, waiting for a worker.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(EventsSentTotal, EventsFailedTotal, EventsDroppedTotal, DeliveryDuration, WorkQueueDepth)
+}

--- a/pkg/logger/metrics_test.go
+++ b/pkg/logger/metrics_test.go
@@ -78,6 +78,29 @@ func TestSendHttpCloudEventMetricsOnSuccess(t *testing.T) {
 	g.Expect(histogramSampleCount(t, CEInferenceRequest)).To(gomega.Equal(deliveryCountBefore + 1))
 }
 
+// TestSendHttpCloudEventMetricsOnAcceptedStatus covers the actual log sink
+// this runs against in production: Knative's broker ingress responds 202
+// Accepted, not 200, for a successfully delivered CloudEvent. Without the
+// fix, sendHttpCloudEvent treated anything other than exactly 200 as a
+// failure, so every real delivery was counted as failed.
+func TestSendHttpCloudEventMetricsOnAcceptedStatus(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	svc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+	defer svc.Close()
+
+	sentBefore := testutil.ToFloat64(EventsSentTotal.WithLabelValues(CEInferenceRequest))
+	failedBefore := testutil.ToFloat64(EventsFailedTotal.WithLabelValues(CEInferenceRequest))
+
+	w := newTestWorker(t)
+	g.Expect(w.sendHttpCloudEvent(newTestLogRequest(svc.URL))).To(gomega.Succeed())
+
+	g.Expect(testutil.ToFloat64(EventsSentTotal.WithLabelValues(CEInferenceRequest))).To(gomega.Equal(sentBefore + 1))
+	g.Expect(testutil.ToFloat64(EventsFailedTotal.WithLabelValues(CEInferenceRequest))).To(gomega.Equal(failedBefore))
+}
+
 func TestSendHttpCloudEventMetricsOnNonOKStatus(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/logger/metrics_test.go
+++ b/pkg/logger/metrics_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	pkglogging "knative.dev/pkg/logging"
+)
+
+func histogramSampleCount(t *testing.T, reqType string) uint64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := DeliveryDuration.WithLabelValues(reqType).(prometheus.Metric).Write(m); err != nil {
+		t.Fatalf("failed to read DeliveryDuration: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}
+
+func newTestWorker(t *testing.T) *Worker {
+	logger, _ := pkglogging.NewLogger("", "INFO")
+	return &Worker{Log: logger}
+}
+
+func newTestLogRequest(target string) LogRequest {
+	logUrl, _ := url.Parse(target)
+	body := []byte("payload")
+	return LogRequest{
+		Url:            logUrl,
+		SourceUri:      logUrl,
+		Bytes:          &body,
+		Id:             "req-1",
+		ReqType:        CEInferenceRequest,
+		OccurrenceTime: time.Now(),
+	}
+}
+
+func TestSendHttpCloudEventMetricsOnSuccess(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	svc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer svc.Close()
+
+	sentBefore := testutil.ToFloat64(EventsSentTotal.WithLabelValues(CEInferenceRequest))
+	failedBefore := testutil.ToFloat64(EventsFailedTotal.WithLabelValues(CEInferenceRequest))
+	deliveryCountBefore := histogramSampleCount(t, CEInferenceRequest)
+
+	w := newTestWorker(t)
+	g.Expect(w.sendHttpCloudEvent(newTestLogRequest(svc.URL))).To(gomega.Succeed())
+
+	g.Expect(testutil.ToFloat64(EventsSentTotal.WithLabelValues(CEInferenceRequest))).To(gomega.Equal(sentBefore + 1))
+	g.Expect(testutil.ToFloat64(EventsFailedTotal.WithLabelValues(CEInferenceRequest))).To(gomega.Equal(failedBefore))
+	g.Expect(histogramSampleCount(t, CEInferenceRequest)).To(gomega.Equal(deliveryCountBefore + 1))
+}
+
+func TestSendHttpCloudEventMetricsOnNonOKStatus(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	svc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer svc.Close()
+
+	sentBefore := testutil.ToFloat64(EventsSentTotal.WithLabelValues(CEInferenceRequest))
+	failedBefore := testutil.ToFloat64(EventsFailedTotal.WithLabelValues(CEInferenceRequest))
+
+	w := newTestWorker(t)
+	g.Expect(w.sendHttpCloudEvent(newTestLogRequest(svc.URL))).To(gomega.Succeed())
+
+	g.Expect(testutil.ToFloat64(EventsSentTotal.WithLabelValues(CEInferenceRequest))).To(gomega.Equal(sentBefore))
+	g.Expect(testutil.ToFloat64(EventsFailedTotal.WithLabelValues(CEInferenceRequest))).To(gomega.Equal(failedBefore + 1))
+}
+
+func TestSendHttpCloudEventMetricsOnConnectionFailure(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	svc := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {}))
+	svc.Close() // closed before use, so the send can never connect
+
+	failedBefore := testutil.ToFloat64(EventsFailedTotal.WithLabelValues(CEInferenceRequest))
+
+	w := newTestWorker(t)
+	g.Expect(w.sendHttpCloudEvent(newTestLogRequest(svc.URL))).To(gomega.Succeed())
+
+	g.Expect(testutil.ToFloat64(EventsFailedTotal.WithLabelValues(CEInferenceRequest))).To(gomega.Equal(failedBefore + 1))
+}
+
+func TestQueueLogRequestUpdatesWorkQueueDepth(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	original := WorkQueue
+	defer func() { WorkQueue = original }()
+	WorkQueue = make(chan LogRequest, 2)
+
+	req := newTestLogRequest("http://127.0.0.1:0")
+
+	g.Expect(QueueLogRequest(req)).To(gomega.Succeed())
+	g.Expect(testutil.ToFloat64(WorkQueueDepth)).To(gomega.Equal(float64(1)))
+
+	g.Expect(QueueLogRequest(req)).To(gomega.Succeed())
+	g.Expect(testutil.ToFloat64(WorkQueueDepth)).To(gomega.Equal(float64(2)))
+}

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -59,6 +59,7 @@ var WorkQueue = make(chan LogRequest, LoggerWorkerQueueSize)
 
 func QueueLogRequest(req LogRequest) error {
 	WorkQueue <- req
+	WorkQueueDepth.Set(float64(len(WorkQueue)))
 	return nil
 }
 
@@ -150,8 +151,11 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 		return fmt.Errorf("while setting cloudevents data: %w", err)
 	}
 	ceCtx := cloudevents.WithEncodingBinary(context.Background())
+	sendStart := time.Now()
 	res := c.Send(ceCtx, event)
+	DeliveryDuration.WithLabelValues(logReq.ReqType).Observe(time.Since(sendStart).Seconds())
 	if cloudevents.IsUndelivered(res) {
+		EventsFailedTotal.WithLabelValues(logReq.ReqType).Inc()
 		return fmt.Errorf("while sending event: %w", res)
 	} else {
 		var httpResult *cehttp.Result
@@ -159,9 +163,13 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 			var err error
 			if httpResult.StatusCode != http.StatusOK {
 				err = fmt.Errorf(httpResult.Format, httpResult.Args...)
+				EventsFailedTotal.WithLabelValues(logReq.ReqType).Inc()
+			} else {
+				EventsSentTotal.WithLabelValues(logReq.ReqType).Inc()
 			}
 			w.Log.Infof("Sent with status code %d, error: %v", httpResult.StatusCode, err)
 		} else {
+			EventsFailedTotal.WithLabelValues(logReq.ReqType).Inc()
 			w.Log.Infof("Send did not return an HTTP response: %s", res)
 		}
 	}

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -161,7 +161,10 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 		var httpResult *cehttp.Result
 		if cloudevents.ResultAs(res, &httpResult) {
 			var err error
-			if httpResult.StatusCode != http.StatusOK {
+			// Knative's broker ingress (the log sink in every real deployment
+			// of this) responds 202 Accepted, not 200 -- treat the whole 2xx
+			// range as success, not just an exact match on 200.
+			if httpResult.StatusCode < 200 || httpResult.StatusCode >= 300 {
 				err = fmt.Errorf(httpResult.Format, httpResult.Args...)
 				EventsFailedTotal.WithLabelValues(logReq.ReqType).Inc()
 			} else {

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -397,6 +397,21 @@ func (ag *AgentInjector) InjectAgent(pod *corev1.Pod) error {
 	// Make sure securityContext is initialized and valid
 	securityContext := pod.Spec.Containers[0].SecurityContext.DeepCopy()
 
+	agentPorts := []corev1.ContainerPort{
+		{
+			Name:          "agent-port",
+			ContainerPort: constants.InferenceServiceDefaultAgentPort,
+			Protocol:      "TCP",
+		},
+	}
+	if injectLogger {
+		agentPorts = append(agentPorts, corev1.ContainerPort{
+			Name:          "agent-metrics",
+			ContainerPort: constants.LoggerMetricsPort,
+			Protocol:      "TCP",
+		})
+	}
+
 	agentContainer := &corev1.Container{
 		Name:  constants.AgentContainerName,
 		Image: ag.agentConfig.Image,
@@ -411,13 +426,7 @@ func (ag *AgentInjector) InjectAgent(pod *corev1.Pod) error {
 				corev1.ResourceMemory: resource.MustParse(ag.agentConfig.MemoryRequest),
 			},
 		},
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "agent-port",
-				ContainerPort: constants.InferenceServiceDefaultAgentPort,
-				Protocol:      "TCP",
-			},
-		},
+		Ports:           agentPorts,
 		SecurityContext: securityContext,
 		Env:             agentEnvs,
 		ReadinessProbe: &corev1.Probe{

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -365,6 +365,11 @@ func TestAgentInjector(t *testing.T) {
 									ContainerPort: constants.InferenceServiceDefaultAgentPort,
 									Protocol:      "TCP",
 								},
+								{
+									Name:          "agent-metrics",
+									ContainerPort: constants.LoggerMetricsPort,
+									Protocol:      "TCP",
+								},
 							},
 							Env:       []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 							Resources: agentResourceRequirement,
@@ -493,6 +498,11 @@ func TestAgentInjector(t *testing.T) {
 								{
 									Name:          "agent-port",
 									ContainerPort: constants.InferenceServiceDefaultAgentPort,
+									Protocol:      "TCP",
+								},
+								{
+									Name:          "agent-metrics",
+									ContainerPort: constants.LoggerMetricsPort,
 									Protocol:      "TCP",
 								},
 							},
@@ -625,6 +635,11 @@ func TestAgentInjector(t *testing.T) {
 								{
 									Name:          "agent-port",
 									ContainerPort: constants.InferenceServiceDefaultAgentPort,
+									Protocol:      "TCP",
+								},
+								{
+									Name:          "agent-metrics",
+									ContainerPort: constants.LoggerMetricsPort,
 									Protocol:      "TCP",
 								},
 							},
@@ -1104,6 +1119,11 @@ func TestAgentInjector(t *testing.T) {
 									ContainerPort: constants.InferenceServiceDefaultAgentPort,
 									Protocol:      "TCP",
 								},
+								{
+									Name:          "agent-metrics",
+									ContainerPort: constants.LoggerMetricsPort,
+									Protocol:      "TCP",
+								},
 							},
 							Env:       []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 							Resources: agentResourceRequirement,
@@ -1233,6 +1253,11 @@ func TestAgentInjector(t *testing.T) {
 								{
 									Name:          "agent-port",
 									ContainerPort: constants.InferenceServiceDefaultAgentPort,
+									Protocol:      "TCP",
+								},
+								{
+									Name:          "agent-metrics",
+									ContainerPort: constants.LoggerMetricsPort,
 									Protocol:      "TCP",
 								},
 							},
@@ -1521,6 +1546,11 @@ func TestAgentInjector(t *testing.T) {
 									ContainerPort: constants.InferenceServiceDefaultAgentPort,
 									Protocol:      "TCP",
 								},
+								{
+									Name:          "agent-metrics",
+									ContainerPort: constants.LoggerMetricsPort,
+									Protocol:      "TCP",
+								},
 							},
 							Env:       []corev1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
 							Resources: agentResourceRequirement,
@@ -1675,6 +1705,11 @@ func TestAgentInjector(t *testing.T) {
 								{
 									Name:          "agent-port",
 									ContainerPort: constants.InferenceServiceDefaultAgentPort,
+									Protocol:      "TCP",
+								},
+								{
+									Name:          "agent-metrics",
+									ContainerPort: constants.LoggerMetricsPort,
 									Protocol:      "TCP",
 								},
 							},


### PR DESCRIPTION
## What

Adds a `/metrics` endpoint to the inference logger agent (new `--metrics-port` flag, default 9089, `constants.LoggerMetricsPort`), on its own named container port (`agent-metrics`), exposing:

- `kserve_logger_events_sent_total{type}` / `kserve_logger_events_failed_total{type}` (Counters, `type=request|response`)
- `kserve_logger_delivery_duration_seconds{type}` (Histogram)
- `kserve_logger_work_queue_depth` (Gauge, recomputed from `len(WorkQueue)` on every enqueue/dequeue rather than tracked via separate Inc/Dec calls, so it can't drift out of sync)
- `kserve_logger_events_dropped_total{type}` (Counter, unused for now -- see the `TODO` in `metrics.go`; `QueueLogRequest` has no drop path until #6173 lands)

## Why

The inference logger agent had zero observability: no way to see how many events were sent/failed, delivery latency, or how full the work queue was running -- especially relevant now that a slow/stuck log endpoint can silently drop events (once #6167/#6173 land) instead of crashing, with no way to tell it's happening short of grepping logs.

Fixes #6181

## Scope notes / known limitations

- This port is intentionally **not** merged into `queue-proxy`'s metric aggregation (`qpext`): that mechanism hardcodes exactly one app metrics source (already used by `kserve-container`) and has no slot for a second one -- see the scoping comment on #6181. Scraping this port is a separate concern for whoever's Prometheus/Alloy setup this lands in.
- `DeliveryDuration` uses `prometheus.DefBuckets` (up to 10s). Since `sendHttpCloudEvent` has no client-side timeout on this branch (that's a separate, not-yet-merged PR, #6147/#6148), a genuinely stuck log endpoint could block far longer than that, and such observations would all land in the `+Inf` bucket with no further resolution on "how bad." Flagging rather than guessing at what bucket range makes sense before that other PR's timeout lands.
- Only the HTTP CloudEvents delivery path is instrumented. The blob-storage path (`Store()` in `dispatcher.go`, used when `logger.storage` is configured instead of an HTTP sink) has no metrics at all -- out of scope here, matches the original incident this was scoped from (HTTP delivery to a Knative broker).
- `WorkQueueDepth` is an approximation under concurrent load: two concurrent `QueueLogRequest` calls can interleave their `len(WorkQueue)` read and `Set()` call, so a given sample can be momentarily stale. It self-corrects on the next enqueue/dequeue (never drifts permanently), which is the standard trade-off for this kind of gauge, but it's not an atomic instantaneous reading.

## Testing

- `metrics_test.go`: drives `sendHttpCloudEvent` and `QueueLogRequest` directly, asserts the counters/histogram/gauge move as expected on success, non-200, and connection failure. `go test ./pkg/logger/... -race -count=1`: clean.
- `agent_injector_test.go`: updated every logger-enabled scenario's expected Pod to include the new `agent-metrics` port; puller/batcher-only and kserve-container port assertions are untouched, since the port is only added when the logger annotation is present. Verified against a real envtest control plane (`go run sigs.k8s.io/controller-runtime/tools/setup-envtest use`), not just `go build` -- the pre-existing suite fails identically on a clean `master` here due to a missing local `etcd` binary, unrelated to this change.
- `go build ./...`, `go vet ./...`, `gofmt -l` on all changed files: clean.

Signed-off-by: Nacho Capilla <ignacio.capilla@cabify.com>