### PR TITLE
test(llmisvc): fail readiness helpers that find no workload

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_test.go
@@ -30,6 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"github.com/kserve/kserve/pkg/constants"
 
@@ -1085,8 +1086,6 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				updatedRoute := expectedHTTPRoute.DeepCopy()
 				WithHTTPRouteReadyStatus(DefaultGatewayControllerName)(updatedRoute)
 				Expect(envTest.Client.Status().Update(ctx, updatedRoute)).To(Succeed())
-
-				ensureSchedulerDeploymentReady(ctx, envTest.Client, llmSvc)
 
 				Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha2.LLMInferenceService) {
 					g.Expect(current.Status).To(HaveCondition(string(v1alpha2.HTTPRoutesReady), "True"))
@@ -2461,14 +2460,24 @@ func ensureRouterManagedResourcesAreReady(ctx context.Context, c client.Client, 
 			g.Expect(c.Status().Update(ctx, updatedPool)).To(gomega.Succeed())
 		}
 
-		ensureSchedulerDeploymentReady(ctx, c, llmSvc)
-		ensureMainDeploymentAvailable(ctx, c, llmSvc)
+		// A managed InferencePool exists exactly when a scheduler Deployment does:
+		// reconcileSchedulerDeployment and reconcileSchedulerInferencePool are gated
+		// on the same predicate, and the Deployment is reconciled first. Specs
+		// without a scheduler spec, or with an external pool ref, have neither.
+		if len(infPools.Items) > 0 {
+			g.Expect(ensureSchedulerDeploymentReady(ctx, c, llmSvc)).To(gomega.Succeed())
+		}
+		g.Expect(ensureMainDeploymentAvailable(ctx, c, llmSvc)).To(gomega.Succeed())
 	}).WithContext(ctx).Should(gomega.Succeed())
 }
 
-func ensureSchedulerDeploymentReady(ctx context.Context, c client.Client, llmSvc *v1alpha2.LLMInferenceService) {
+// ensureSchedulerDeploymentReady writes ready status onto the scheduler Deployment,
+// standing in for the Deployment controller that envtest does not run. It errors when
+// there is none, so it cannot report success having written nothing. Only call it for
+// specs that configure a scheduler.
+func ensureSchedulerDeploymentReady(ctx context.Context, c client.Client, llmSvc *v1alpha2.LLMInferenceService) error {
 	if envTest.UsingExistingCluster() {
-		return
+		return nil
 	}
 
 	schedulerListOpts := &client.ListOptions{
@@ -2476,12 +2485,14 @@ func ensureSchedulerDeploymentReady(ctx context.Context, c client.Client, llmSvc
 		LabelSelector: labels.SelectorFromSet(llmisvc.SchedulerLabels(llmSvc)),
 	}
 	deployments := &appsv1.DeploymentList{}
-	err := c.List(ctx, deployments, schedulerListOpts)
-	if err != nil && !errors.IsNotFound(err) {
-		Expect(err).NotTo(gomega.HaveOccurred())
+	if err := c.List(ctx, deployments, schedulerListOpts); err != nil {
+		return fmt.Errorf("failed to list scheduler deployments for %s: %w", llmSvc.Name, err)
+	}
+	if len(deployments.Items) == 0 {
+		return fmt.Errorf("no scheduler Deployment for %s alongside the managed InferencePool", llmSvc.Name)
 	}
 
-	logf.FromContext(ctx).Info("Marking scheduler ready (if any)", "deployments", deployments)
+	logf.FromContext(ctx).Info("Marking scheduler ready", "deployments", deployments)
 	for _, d := range deployments.Items {
 		dep := d.DeepCopy()
 		dep.Status.Replicas = 1
@@ -2491,13 +2502,21 @@ func ensureSchedulerDeploymentReady(ctx context.Context, c client.Client, llmSvc
 			Type:   appsv1.DeploymentAvailable,
 			Status: corev1.ConditionTrue,
 		})
-		Expect(c.Status().Update(ctx, dep)).To(gomega.Succeed())
+		if err := c.Status().Update(ctx, dep); err != nil {
+			return fmt.Errorf("failed to update scheduler deployment %s status: %w", dep.Name, err)
+		}
 	}
+	return nil
 }
 
-func ensureMainDeploymentAvailable(ctx context.Context, c client.Client, llmSvc *v1alpha2.LLMInferenceService) {
+// ensureMainDeploymentAvailable writes available status onto the main workload
+// Deployment, standing in for the Deployment controller that envtest does not run. The
+// workload is a Deployment for single-node specs and a LeaderWorkerSet when spec.worker
+// is set, so it errors unless one of the two exists and cannot report success having
+// written nothing.
+func ensureMainDeploymentAvailable(ctx context.Context, c client.Client, llmSvc *v1alpha2.LLMInferenceService) error {
 	if envTest.UsingExistingCluster() {
-		return
+		return nil
 	}
 
 	workloadListOpts := &client.ListOptions{
@@ -2508,9 +2527,28 @@ func ensureMainDeploymentAvailable(ctx context.Context, c client.Client, llmSvc 
 		}),
 	}
 	deployments := &appsv1.DeploymentList{}
-	err := c.List(ctx, deployments, workloadListOpts)
-	if err != nil && !errors.IsNotFound(err) {
-		Expect(err).NotTo(gomega.HaveOccurred())
+	if err := c.List(ctx, deployments, workloadListOpts); err != nil {
+		return fmt.Errorf("failed to list workload deployments for %s: %w", llmSvc.Name, err)
+	}
+
+	if len(deployments.Items) == 0 {
+		// An LWS carries the kserve component label only when its leader template is
+		// nil, so the workload selector above cannot find it. App name and part-of are
+		// set unconditionally. This matches the prefill LWS too, which is fine for an
+		// existence check.
+		lwss := &lwsapi.LeaderWorkerSetList{}
+		if err := c.List(ctx, lwss, &client.ListOptions{
+			Namespace: llmSvc.Namespace,
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				constants.KubernetesAppNameLabelKey: llmSvc.Name,
+				constants.KubernetesPartOfLabelKey:  constants.LLMInferenceServicePartOfValue,
+			}),
+		}); err != nil {
+			return fmt.Errorf("failed to list leader worker sets for %s: %w", llmSvc.Name, err)
+		}
+		if len(lwss.Items) == 0 {
+			return fmt.Errorf("no main workload for %s as either a Deployment or a LeaderWorkerSet", llmSvc.Name)
+		}
 	}
 
 	for _, d := range deployments.Items {
@@ -2522,8 +2560,11 @@ func ensureMainDeploymentAvailable(ctx context.Context, c client.Client, llmSvc 
 			Type:   appsv1.DeploymentAvailable,
 			Status: corev1.ConditionTrue,
 		})
-		Expect(c.Status().Update(ctx, dep)).To(gomega.Succeed())
+		if err := c.Status().Update(ctx, dep); err != nil {
+			return fmt.Errorf("failed to update workload deployment %s status: %w", dep.Name, err)
+		}
 	}
+	return nil
 }
 
 func customRouteSpec(ctx context.Context, c client.Client, nsName, gatewayRefName, backendRefName string) *gwapiv1.HTTPRouteSpec {


### PR DESCRIPTION
**What this PR does / why we need it**:

Two envtest helpers, `ensureSchedulerDeploymentReady` and `ensureMainDeploymentAvailable`, reported success without having marked anything ready.

Both helpers now assert they matched something. The expectation is derived from what the controller already guarantees.

Bonus points: a related flake goes away with this fix: both helpers run inside the caller's `Eventually` but asserted with the package-level `Expect`, so a transient conflict on a status update failed the spec instead of being retried.

Test-only change - no controller or API behaviour is affected.

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [x] Full `pkg/controller/v1alpha2/llmisvc` suite green
- [x] The new assertion caught a real mismatch during development: a LeaderWorkerSet carries the kserve component label only when its leader template is nil, so a multi-node spec failed until the lookup was corrected.

**Special notes for your reviewer**:

A blanket assertion is not possible. Most call sites configure no scheduler at all, and multi-node specs have a LeaderWorkerSet rather than a Deployment. The two derivations that avoid a per-call-site flag are worth a look:

- A managed InferencePool exists exactly when a scheduler Deployment does - both are gated on the same predicate, and the Deployment is reconciled first - so the pool the helper already lists decides whether a scheduler is expected.
- The main workload is asserted to exist as either a Deployment or a LeaderWorkerSet.

One call site is removed rather than fixed: it ran the scheduler helper against a spec that configures no scheduler, so it had never marked anything.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```
