### PR TITLE
fix: keep a reference to the model server shutdown task

### DIFF
--- a/python/kserve/kserve/model_server.py
+++ b/python/kserve/kserve/model_server.py
@@ -329,6 +329,7 @@ class ModelServer:
         self._rest_server = None
         self._rest_multiprocess_server = None
         self._grpc_server = None
+        self._shutdown_task: Optional[asyncio.Task] = None
         self.servers = []
 
     def setup_event_loop(self):
@@ -426,7 +427,10 @@ class ModelServer:
                 logger.info("Stopping the grpc server")
                 await self._grpc_server.stop(sig)
 
-        asyncio.create_task(shutdown())
+        # Keep a reference: the event loop only holds a weak one, so an
+        # unreferenced task can be garbage collected before it finishes and
+        # the servers would never be stopped.
+        self._shutdown_task = asyncio.create_task(shutdown())
         for model_name in list(self.registered_models.get_models().keys()):
             self.registered_models.unload(model_name)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`ModelServer.stop()` schedules the shutdown coroutine without keeping a reference to the task:

```python
def stop(self, sig: int):
    async def shutdown():
        await InferenceClientFactory().close()
        if self._rest_multiprocess_server:
            await self._rest_multiprocess_server.stop(sig)
        if self._grpc_server:
            await self._grpc_server.stop(sig)

    asyncio.create_task(shutdown())        # result discarded
```

The event loop keeps only a *weak* reference to a task, so an unreferenced one can be garbage collected before it finishes. `asyncio.create_task`'s own documentation asks callers to save the returned task for exactly this reason, and `ruff` flags it as `RUF006 Store a reference to the return value of asyncio.create_task`.

This matters here because of what the coroutine does and when it runs: it closes the inference client and stops the REST and gRPC servers, and `stop()` is registered as the `SIGINT`/`SIGTERM`/`SIGQUIT` handler in `register_signal_handler`. So the code at risk is the graceful shutdown path of the model server.

The fix stores the task on the instance, alongside the existing `_rest_multiprocess_server` and `_grpc_server` attributes.

**Which issue(s) this PR fixes**:

Fixes #

**Feature/Issue validation/testing**:

Honest scope note: I have **not** reproduced a collected-mid-flight shutdown. The window is timing- and GC-dependent and I could not trigger it deterministically in a small reproducer, so I am not claiming an observed failure — this is the documented hazard and the documented remedy, applied to a path where the consequence would be servers that are never stopped cleanly.

- [x] `ruff --select RUF006` is clean on the file afterwards.
- [x] The module parses and the new attribute is declared with the other server attributes in `__init__`.

**Special notes for your reviewer**:

One adjacent thing I noticed but deliberately did not change: `stop()` schedules the shutdown task and then immediately unloads every registered model, so the unload races the in-flight shutdown regardless of this fix. Making that ordering deterministic looked like a larger behavioural change than this PR should carry — happy to open a separate issue if that is worth pursuing.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? — no test added; see the scope note above.
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
Keep a reference to the model server shutdown task so it cannot be garbage collected before the REST and gRPC servers are stopped.
```
